### PR TITLE
Capitainisation du document : stoa0040.stoa002

### DIFF
--- a/data/stoa0040/stoa002/stoa0040.stoa002.opp-lat1.xml
+++ b/data/stoa0040/stoa002/stoa0040.stoa002.opp-lat1.xml
@@ -145,19 +145,19 @@
 								<hi rend="italic">LIBER UNUS (a) .</hi>
 						</title>
 					</head>
-					<p>Rogatus Augustinus a diacono carthaginensi, catechizandi artem docendaM suscipit : ac
-						primo præcepta tradit, et id of­ <lb/> ficli non tantum certa methodo atque idonea
+					<p>Rogatus Augustinus a diacono Carthaginensi, catechizandi artem docendam suscipit : ac
+						primo præcepta tradit, et id of<lb/>ficii non tantum certa methodo atque idonea
 						ratione, sed eliam sine taedio et cum hilaritate impleatur. Postea revocatisad <lb/>
 						usum præceptis, profert ipse in exemplum sermones, ad cum erudiendum qui christianus
 						esse velit, comparatos duaM, <lb/> longiorem num, alterum brevissimu.u.</p>
-					<p>CAPUT PRIMUM. — 1. <hi rend="italic">Rogatus a diacono Cartha­<lb/> ginensi scribit de
-							catechizandis rudibus.</hi> Petisti me, fra. <lb/> ter Dcogralias <hi rend="italic">(b),</hi> ut aliquid ad te de catechizandis <lb/> rudibus, quod tibi usui esset,
+					<p>CAPUT PRIMUM. — 1. <hi rend="italic">Rogatus a diacono Cartha<lb/>ginensi scribit de
+							catechizandis rudibus.</hi> Petisti me, fra<lb/>ter Deogralias <hi rend="italic">(b),</hi> ut aliquid ad te de catechizandis <lb/> rudibus, quod tibi usui esset,
 						scriberem. Dixisti <lb/> euim quod sæpe apud Carthaginem, ubi diaconus es, <lb/> ad te
-						adducuntur, qui fide christiana primitus im­ <lb/> buendi sunt , eo quod existimeris
-						habere cale­ <lb/> chizandi uberem facultatem, ct doctrina fidei et sua­ <lb/> vitate
+						adducuntur, qui fide christiana primitus im<lb/>buendi sunt , eo quod existimeris
+						habere cale<lb/>chizandi uberem facultatem, ct doctrina fidei et sua<lb/>vitate
 						sermenis i : te autem pene semper angustias <lb/> pati, idipsum quod credendo christiani
 						sumus, quo <note type="footnote"> ADMONIO PP. BENEDICTINORUM. </note><note type="footnote"> Uiri de Catechizandis Rudibus contulimus colices manuscriptos
-							quatuordecim : Corbeiensem perquam egregium anno­ <lb/> rum 800, alium Ecclesiae
+							quatuordecim : Corbeiensem perquam egregium anno<lb/>rum 800, alium Ecclesiae
 							taudunensis annorum 700, Divionensem abbatiæ S. Benigni, Pratellensem, Fiscannensem,
 							<lb/> Michaelinum, Cisterciensem, Floriacenses duos, totidem victorinos, sorbonicum et
 							duos valicanos; lectiones variantes ex <lb/> tribus Belgicis cura Lovaniensium
@@ -173,13 +173,13 @@
 						</note>
 						<lb/>
 						<pb n="311"/> pacto commoIc intimandum sit ; unde exordienda , <lb/> quousque sit
-						perducenda narratio; utrum exhortatio­ <lb/> nem aliquam terminata narraliouc adhibere
-						debea­ <lb/> mus, an præcepta sola, quihus observandis cui lo­ <lb/> quimur noverit
+						perducenda narratio; utrum exhortatio<lb/>nem aliquam terminata narraliouc adhibere
+						debea<lb/>mus, an præcepta sola, quihus observandis cui lo<lb/>quimur noverit
 						christianam vitam professionemque <lb/> retineri l. Sæpe autem libi accidisse confessus
 						atque <lb/> conquestus cs, ut in sermone logo et tepido tibi ipse <lb/> vil scercs
-						essesque fastidio, nedum illi quem lo­ <lb/> quedo imbuebas, ct cæicris qui audientes
+						essesque fastidio, nedum illi quem lo<lb/>quedo imbuebas, ct cæicris qui audientes
 						aderant : <lb/> caque te necessitate fuisse compulsum , ul ea me <lb/> quam tibi debco
-						charitate compelleres, ne gravarer in­ <lb/> ter occupationes meas tibi dc hac re
+						charitate compelleres, ne gravarer in<lb/>ter occupationes meas tibi dc hac re
 						aliquid scrihcre.</p>
 					<p>2. Ego vero non ca tantum quam familiariter tilii, <lb/> sed clam quam matri Ecclesiæ
 						universaliter de- <lb/> beo charitate ac servitute compellor, si quid per <lb/> operam
@@ -190,26 +190,26 @@
 						in erogando scutire cognosco , <lb/> agere quantum in me est, ut facile atque expedite
 						<lb/> possint, quod impigre ac studiose volunt.</p>
 					<p>CAPUT II. — 3. <hi rend="italic">Sermo sæpe qui audienti placet, <lb/> displicet
-							dlcenti : unde id contingat. Qui sermonem na­ <lb/> bet, curet ut sine fastidio et
+							dlcenti : unde id contingat. Qui sermonem na<lb/>bet, curet ut sine fastidio et
 							hilariter dicat.</hi> Sed quod <lb/> ad tuam pn pric considerationem pertinet, nolim
-						te <lb/> moveri ex eo quod sa'pc tibi abjectum sermonem fa­ <lb/> stidiosumque hahere
+						te <lb/> moveri ex eo quod sa'pc tibi abjectum sermonem fa<lb/>stidiosumque hahere
 						visus cs. Fieri enim potest ut ci <lb/> quem instrucbas non ita sit visum , sed quia lu
-						ali­ <lb/> quid melius audiri desiderabas, eo libi quod dicebas <lb/> videretur indignum
+						ali<lb/>quid melius audiri desiderabas, eo libi quod dicebas <lb/> videretur indignum
 						auribus aliorum. Nam et mihi <lb/> prope semper sermo meus displicet. Melioris enim
 						<lb/> avidus sum, quo sæpe fruor interius, antequam eum <lb/> explicare verbis
 						sonantibus cœpero : quod ubi minus <lb/> quam mihi notus est evaluero, contristor
 						linguam <lb/> meam cordi meo non potuisse 2 suflicere. Totum enim <lb/> quod intelligo,
-						volo ut qui me audit intelligat; et sen­ <lb/> lio nic non ita loqui, ut hoc efficiam :
+						volo ut qui me audit intelligat; et sen<lb/>lio nic non ita loqui, ut hoc efficiam :
 						maxime quia <lb/> ille intellectus quasi rapida coruscatione perfundit <lb/> animum ;
-						illa autem locutio tarda et longa est, lon­ <lb/> geque dissimilis : et dnm ista
+						illa autem locutio tarda et longa est, lon<lb/>geque dissimilis : et dnm ista
 						volvitur, jam se ille in <lb/> secreta sua condidit: tamen quia vestigia quædem <lb/>
 						miro nodo impressit memoriæ, perdurant illa cun) <lb/> syllabarum morulis; atque ex
-						eisdem vestigiis sonan­ <lb/> lia signa peragimus, quæ lingua dicitur vel latina, <lb/>
-						vel græca, vel hebræa, vel alia quælibet ; sive cogi­ <lb/> lentur hec signa, sive cliam
+						eisdem vestigiis sonan<lb/>lia signa peragimus, quæ lingua dicitur vel latina, <lb/>
+						vel græca, vel hebræa, vel alia quælibet ; sive cogi<lb/>lentur hec signa, sive cliam
 						voce proferantur ; cum <lb/> illa vestigia nec latina, nec græca, vel hebræa, <lb/> nec
 						cujusque alterius gentis sint propria, sed ita <lb/> efficiantur in animo, ut vultus in
-						corpore. Aliter <lb/> enim latine ira dicitur, alilcr græce, aliter atque ali­ <lb/> ter
-						aliarum diversitate linguarum : non autem lati­ <lb/> nus ant gra'cus est vultus irati.
+						corpore. Aliter <lb/> enim latine ira dicitur, alilcr græce, aliter atque ali<lb/>ter
+						aliarum diversitate linguarum : non autem lati<lb/>nus ant gra'cus est vultus irati.
 						Non itaque omnes <lb/> gentes intelligunt, cum quisque dicit, Iratus sum, sed <note type="footnote"> I sic in vss. At In erhtis, <hi rend="italic">retinere.</hi>
 						</note><note type="footnote"> t rdiU, <hi rend="italic">eroqare.</hi> At Mss., eioqiti.
 							</note><note type="footnote"> 1 fcditi, non fto <hi rend="italic">rr.</hi> "SS., non
@@ -221,39 +221,39 @@
 						vestigia, quæ imprimit intellectus memoriæ, sicut <lb/> apertus et manifestus est vultus
 						: illa enim sunt iutus <lb/> in animo, iste foris in corpore. Quapropter conjicien­
 						<lb/> dum est quantum distet sonus oris nostri ab illo ictu <lb/> intelligentiæ, quando
-						ne ipsi quidem impressioni me­ <lb/> moriæ similis est. Nos autem plerumque in auditoris
+						ne ipsi quidem impressioni me<lb/>moriæ similis est. Nos autem plerumque in auditoris
 						<lb/> utilit item vehementer ardentes, ita loqui volumus, <lb/> quemadmodum tunc
-						intelligimus, cum per ipsam in­ <lb/> tentionem loqui non possuntus : et quia non succe­
+						intelligimus, cum per ipsam in<lb/>tentionem loqui non possuntus : et quia non succe­
 						<lb/> dit, angimur, et velut frustra operam insumamus, <lb/> tædio marcescimus: atque ex
 						ipso tadio languidior <lb/> tit idem sermo, et hebetior quam erat, unde perduxit <lb/>
 						ad tædium.</p>
 					<p>4. Sed mihi sæpe indicat eorum studium, qui me <lb/> audire cupiunt, non ita esse
 						frigidum eloquium <lb/> meum, ut videtur mihi : et cos inde aliquid utile <lb/> capere,
-						ex eorum delectatione cognosco; mecum­ <lb/> que ago sedulo, ut huic exhibendo
-						ministerio non <lb/> dcsim , in quo illos video bene accipere quod exhi­ <lb/> betur.
-						Sic et tu, eo ipso quod ad te sxpius addu­ <lb/> cuntur qui fide imbuendi sunt, debes
+						ex eorum delectatione cognosco; mecum<lb/>que ago sedulo, ut huic exhibendo
+						ministerio non <lb/> dcsim , in quo illos video bene accipere quod exhi<lb/>betur.
+						Sic et tu, eo ipso quod ad te sxpius addu<lb/>cuntur qui fide imbuendi sunt, debes
 						intelligere non <lb/> ita displicere aliis sermonem tuum ut displicet tibi : <lb/> nec
 						infructuosum te debes putaro, quod ea quae <lb/> cernis non explicas ita ut cupis;
 						quando forte ut <lb/> cupis nec cernere valeas. Quis enim in hac vita nisi <lb/> in
 						anigmate et per speculum videt (1 <hi rend="italic">Cor.</hi> XIII, 12) ? <lb/> Nec ipse
 						amor tantus est , ut carnis disrupta caligine <lb/> penetret in æternum serenum, unde
-						utcumque ful­ <lb/> gcut etiam ista quæ transcunt. Sed quia boni pro­ <lb/> ficiunt de
-						dic in diem ad videndum dicin sine volu­ <lb/> mine caTi et sine noctis incursu, quem
+						utcumque ful<lb/>gcut etiam ista quæ transcunt. Sed quia boni pro<lb/>ficiunt de
+						dic in diem ad videndum dicin sine volu<lb/>mine caTi et sine noctis incursu, quem
 						oculus uon <lb/> vidit, nec auris audivit, nec in cor hominis ascendit <lb/> (Jd. II.
-						9); nulla major causa cst cur nohis in imbuen­ <lb/> dis rudibus noster sermo vilescat,
-						nisi quia libet in­ <lb/> usitate cernere, et tædet usitate proloqui. Et re qui­ <lb/>
+						9); nulla major causa cst cur nohis in imbuen<lb/>dis rudibus noster sermo vilescat,
+						nisi quia libet in<lb/>usitate cernere, et tædet usitate proloqui. Et re qui­ <lb/>
 						dem vera multo gratius audimur, cuti et nos eodem <lb/> opere delectamur : afficitur
 						enim filum locutionis <lb/> nostr;e ipso nostro gaudio , et exit f cilius atquc ac­
 						<lb/> ceptius. Quapropter non arduutn est negotium, ea <lb/> quæ credenda insinuantur,
-						præcipere unde et quo­ <lb/> usque narranda sint; nec quomodo sit varianda nar. <lb/>
-						ratio, ut aliquando brevior, aliquando longior. sem­ <lb/> per tamen plena atque
-						perfecta sit ; et quando bre­ <lb/> viorc, et quando longiore sit utendum : sed quibus
+						præcipere unde et quo<lb/>usque narranda sint; nec quomodo sit varianda nar. <lb/>
+						ratio, ut aliquando brevior, aliquando longior. sem<lb/>per tamen plena atque
+						perfecta sit ; et quando bre<lb/>viorc, et quando longiore sit utendum : sed quibus
 						<lb/> modis faciendum sit, ut gaudens qni que catechim <lb/> (lanlo enim suavior crit,
 						quanto magis id potuerit), ea <lb/> cura maxima est Et preceptum quidem rei hujus in
 						<lb/> promptu est. Si enim in pet unia corporali, quanto <lb/> magis in spirituali
 						hilarem datorem diligit Deus (II <lb/> Cur. ix, 7 ) ? Sed hæc hilaritas ad horam ut
 						adsit, ejus <lb/> est misericordiæ qui ista præcepit. Itaque prius de <lb/> modo
-						narrationis quod te velle cognovi, tum de præ­ <lb/> cipiendo atque cohortando, postea
+						narrationis quod te velle cognovi, tum de præ<lb/>cipiendo atque cohortando, postea
 						de hac hilaritate <lb/> comparanda, quæ Deus suggesserit, disseremus. <note type="footnote">
 							<hi rend="italic">(/0</hi> Furto, <hi rend="italic">afficiat.</hi>
 						</note></p>
@@ -268,41 +268,41 @@
 						Regnormn et Esdræ 1 libros, totumque <lb/> Evangelium et Actus Apostolorum, vol, si ad
 						verbum <lb/> edidicimus, memoriter reddere, vel nostris verbis <lb/> onniia quæ his
 						continentur voluminibus narrando <lb/> evolvere et explicare; quod ncc tempus capit, nee
-						<lb/> ulla necessitas postulat : sed cuncta summatim gene­ <lb/> ratimque complecti, ita
-						ut eligantur quxdam mirabi­ <lb/> liora quæ suavius audiuntur, atque in ipsis articulis
+						<lb/> ulla necessitas postulat : sed cuncta summatim gene<lb/>ratimque complecti, ita
+						ut eligantur quxdam mirabi<lb/>liora quæ suavius audiuntur, atque in ipsis articulis
 						<lb/> constituta sunt <hi rend="italic">(a),</hi> ut ea 2 tanquam in involucris os­
-						<lb/> tendere, statimque a conspectu abripere non opor­ <lb/> teat, sed aliquantum
+						<lb/> tendere, statimque a conspectu abripere non opor<lb/>teat, sed aliquantum
 						immorando quasi resolvere atque <lb/> expandere , et inspicienda atque miranda offerre
-						ani­ <lb/> mis auditorum ; cætera vero celeri percursione inse­ <lb/> rendo contexere.
+						ani<lb/>mis auditorum ; cætera vero celeri percursione inse<lb/>rendo contexere.
 						Ita et illa quæ maxime commendari <lb/> volumus , aliorum submissione magis eminent; nec
-						<lb/> ad ea fatigatus pervenit, quem narrando volumus ex­ <lb/> citare; nec illius
-						memoria confunditur, quem do­ <lb/> cendo debemus instrucre.</p>
+						<lb/> ad ea fatigatus pervenit, quem narrando volumus ex<lb/>citare; nec illius
+						memoria confunditur, quem do<lb/>cendo debemus instrucre.</p>
 					<p>6. In omnibus sanc non tantum nos oportet intueri <lb/> præcepti finem , quod est
 						cbaritas de corde puro et <lb/> conscientia bona et fide uon ficta (I Tim. I, 5), quo ea
 						<lb/> quæ loquimur cuncta referamus; sed eliam illius <lb/> quem loquendo instruimus, ad
 						id movendus 3 atque <lb/> iiluc dirigendus aspectus est. Necque enim ob aliud <lb/> ante
 						adventum Domini scripta sunt omnia quæ in <lb/> sanctis Scripturis legimus, nisi ut
-						illius commenda­ <lb/> retur adventus, et futura præsignaretur Ecclesia , id <lb/> est,
+						illius commenda<lb/>retur adventus, et futura præsignaretur Ecclesia , id <lb/> est,
 						populus Dei per omnes gentes, quod est corpus <lb/> ejus; adjunctis atque annumeratis
 						omnibus sanctis , <lb/> qui etiam ante adventum ejus in boc s:rculo vixeruul, <lb/> ita
 						eum credentes venturum esse, sicut nos vcnisse. <lb/> Sicut cnim Jacob manum prius, dum
 						nasceretur, <lb/> emisit ex utero, qua eliam pedem prænascentis fratris <lb/> tenebat,
-						deinde utique secutum est caput, tum de­ <lb/> mum necessario membra cætera <hi rend="italic">(Gen.</hi> xxv, 25); sed <lb/> tamen caput non tantum ea membra quæ
+						deinde utique secutum est caput, tum de<lb/>mum necessario membra cætera <hi rend="italic">(Gen.</hi> xxv, 25); sed <lb/> tamen caput non tantum ea membra quæ
 						secuta sunt, <lb/> sed etiam ipsam manum quæ in nascendo præcessit , <lb/> dignitate ac
-						potestate præcedit; et quamvis non tem­ <lb/> pore apparendi, tamen naturæ ordine prius
+						potestate præcedit; et quamvis non tem<lb/>pore apparendi, tamen naturæ ordine prius
 						est: ita <lb/> et Dominus Jesus Christus ctsi antequam appareret <lb/> in carne, et
 						quodam modo ex utero secreti sui ad <lb/> hominum oculus Mediator Dci et hominum homo
-						pro­ <lb/> cederet, qui est super omnes Deus benedictus in sæ­ <lb/> cula <hi rend="italic">(Rom.</hi> ix, 5), præmisit in sanctis Patriarchis et <lb/> Prophetis
+						pro<lb/>cederet, qui est super omnes Deus benedictus in sæ<lb/>cula <hi rend="italic">(Rom.</hi> ix, 5), præmisit in sanctis Patriarchis et <lb/> Prophetis
 						quamdam partem corporis sui, qua velut <note type="footnote"> I In Mss., <hi rend="italic">Ezw.</hi>
-						</note><note type="footnote"> • YJT. et Lov., et <hi rend="italic">ea</hi> AtAm., <hi rend="italic">uten.</hi> Et sic potiores uss. <lb/> rx quitms posiea corrigimus, <hi rend="italic">non oporteat;</hi> ubi editi lerc­ <lb/> hant, <hi rend="italic">noM
+						</note><note type="footnote"> • YJT. et Lov., et <hi rend="italic">ea</hi> AtAm., <hi rend="italic">uten.</hi> Et sic potiores uss. <lb/> rx quitms posiea corrigimus, <hi rend="italic">non oporteat;</hi> ubi editi lerc<lb/>hant, <hi rend="italic">noM
 								oporM.</hi>
 						</note><note type="footnote"> » tu Mat., Editi vero, <hi rend="italic">monendus.</hi>
 						</note>
 						<note type="footnote">
 							<hi rend="italic">(a)</hi> Articuli temporum quinqiie nota iltir infra, u G et <lb/>
 							n. 3U. </note>
-						<lb/> manu se nasciturum esse prænuntians, etiam popu­ <lb/> lum præcedentem superbe,
-						vinculis Legis tanquam di­ <lb/> gitis quinque supplantavit1 (quia et per quinque tem­
+						<lb/> manu se nasciturum esse prænuntians, etiam popu<lb/>lum præcedentem superbe,
+						vinculis Legis tanquam di<lb/>gitis quinque supplantavit1 (quia et per quinque tem­
 						<lb/> porum articulos prænuntiari venturus prophetarique <lb/> non destitit; et huic rei
 						consonans per quem Lex data <lb/> est, quinque libros conscripsit : et superbi
 						carnaliter <lb/> sentientes, et suam justitiam volentes constituere <lb/>
@@ -316,54 +316,54 @@
 						enim præcurrendo <lb/> divulsi sunt, sed adjuncti potius obsequendo. Nam <lb/> etsi
 						manus a capite præmitti potest, connexio tamen <lb/> cjus sub capite cst. Quapropter
 						omnia quæ ante <lb/> scripta sunt, ut nos doceremur scripta sunt (Hom. <lb/> xv, 4), ct
-						figura nostræ fuerunt, et <hi rend="italic">in figura contin­ <lb/> gebant in eis1</hi>
+						figura nostræ fuerunt, et <hi rend="italic">in figura contin<lb/>gebant in eis1</hi>
 						I ; <hi rend="italic">scripta sunt autem propter nos, in quos<lb/> finis</hi> sæculorum
 							<hi rend="italic">obvenit</hi> (I <hi rend="italic">Cor.</hi> x, 11).</p>
 					<p>CAPUT IV.— 7. Præcipua <hi rend="italic">causa adventus Christi,<lb/> charitatis
 							commendatio. Ad dilectionem</hi> referenda <hi rend="italic">esse<lb/> quæ de Christo
 							ex Scripturis narrantur</hi> in <hi rend="italic">catechismo.</hi>
 						<lb/> Quæ autem major causa est adventus Domini, nisi ut <lb/> ostenderet Deus
-						dilectionem suam in nobis, commen­ <lb/> dans eam vehementer i quia cum adhuc inimici
-						esse­ <lb/> mus, Christus pro nobis mortuus est <hi rend="italic">(Rom.</hi> v, 6-9).
-						<lb/> Iloc autem ideo, quia finis præcepti et plenitudo le­ <lb/> gis, charitas est (I
+						dilectionem suam in nobis, commen<lb/>dans eam vehementer i quia cum adhuc inimici
+						esse<lb/>mus, Christus pro nobis mortuus est <hi rend="italic">(Rom.</hi> v, 6-9).
+						<lb/> Iloc autem ideo, quia finis præcepti et plenitudo le<lb/>gis, charitas est (I
 							<hi rend="italic">Tim.</hi> I, 5, <hi rend="italic">et Rom.</hi> XIII, 10) : ut ut
 						<lb/> nos invicem diligamus, et quemadmodum ille pro <lb/> nobis animam suam posuit, sic
 						et nos pro fratribus <lb/> animam ponamus (I Joan. III, 16); et ipsum Dcum , <lb/>
 						quoniam prior dilexit nos (Id. IV, 10), et Filio suo <lb/> unico non pepercit, sed pro
 						nobis omnibus tradidit <lb/> cum (Rom. vin, 32), si amare pigebat, saltem nunc <lb/>
-						redamare non pigeat'. Nulla est enim major ad amo­ <lb/> rcm invitatio, quam prævenire
-						amando; et nimis du­ <lb/> rus est animus qui dilectionem si nolebat impendere, <lb/>
+						redamare non pigeat'. Nulla est enim major ad amo<lb/>rcm invitatio, quam prævenire
+						amando; et nimis du<lb/>rus est animus qui dilectionem si nolebat impendere, <lb/>
 						nolit rependere. Quod si in ipsis flagitiosis et sordidis <lb/> amoribus videmus, nihil
-						aliud eos agere qui amari vi­ <lb/> cissirn volunt, nisi ut documentis quibus valent
-						ape­ <lb/> riant et ostendant quantum ament; eamque imaginem <lb/> justitie prætendere
-						affectant, ut vicem sibi reddi quo­ <lb/> dam modo flagitent ab cis animis quos
-						illecebrare <lb/> moliuntur; ipsique ardentius æstuant, cum jam mo­ <lb/> veri eodem
+						aliud eos agere qui amari vi<lb/>cissirn volunt, nisi ut documentis quibus valent
+						ape<lb/>riant et ostendant quantum ament; eamque imaginem <lb/> justitie prætendere
+						affectant, ut vicem sibi reddi quo<lb/>dam modo flagitent ab cis animis quos
+						illecebrare <lb/> moliuntur; ipsique ardentius æstuant, cum jam mo<lb/>veri eodem
 						igne etiam illos mentes quas appetunt <lb/> sentiunt : si ergo et animus qui torpebat,
 						cum se <lb/> amari senserit excitatur, et qui jam ferveba!, cum se <lb/> rcdamari
 						didicerit magis accenditur; manifestum cst <lb/> nullam esse majorem causam qua vel
 						inchnetur vel <lb/> augcatur amor, quam cum amari se cognoscit qui <note type="footnote"> I Aliquot Mss., <hi rend="italic">supplantaret.</hi>
 						</note><note type="footnote"> I hd!ti, <hi rend="italic">contvigebant</hi> ela ; omissa
-							particula, .w, quae ta­ <lb/> men hie reperitur in Mss. et in græco textu Apostoli.
+							particula, .w, quae ta<lb/>men hie reperitur in Mss. et in græco textu Apostoli.
 							</note><note type="footnote"> a Aui. fl'. et vss., <hi rend="italic">saltem redtmiare
 								non pigeal;</hi> omisso, <lb/> nwtc. </note>
 						<lb/>
 						<pb n="315"/> nondum amat, aut redamari se vel posse sperat, vel <lb/> jam probat qui
-						prior amat Et si boc etiam in turpi­ <lb/> bus amoribus, quanto plus 1 in amicitia? Quid
+						prior amat Et si boc etiam in turpi<lb/>bus amoribus, quanto plus 1 in amicitia? Quid
 						euim <lb/> aliud cavemus in offensione amicitiæ, nisi ne amicus <lb/> arbitretur quod
-						euin vel non diligimus, vel minus di­ <lb/> ligimus quam ipse nos diligit? Quod si
-						crediderit, <lb/> frigidior crit in eo amore quo invicem homines mu­ <lb/> tua
-						familiaritate perfruuntur : et si non ita est infir­ <lb/> mus , ut hæc illum offensio
+						euin vel non diligimus, vel minus di<lb/>ligimus quam ipse nos diligit? Quod si
+						crediderit, <lb/> frigidior crit in eo amore quo invicem homines mu<lb/>tua
+						familiaritate perfruuntur : et si non ita est infir<lb/>mus , ut hæc illum offensio
 						faciat ab omni dilectione <lb/> frigescere; in ca se tenet, qua non ut fruatur, sed ut
-						<lb/> consulat diligit. Operae pretium est autem animad­ <lb/> vertere, quomodo,
+						<lb/> consulat diligit. Operae pretium est autem animad<lb/>vertere, quomodo,
 						quanquam ct superiores velint se <lb/> ab inferioribus diligi , eorumque in se studioso
-						I de­ <lb/> lectentur obsequio, et quanto magis id senserint, <lb/> tanto magis cos
-						diligant, tamen quanto amore exar­ <lb/> descat inferior, cum a superiore se diligi
-						senserit. Ibi <lb/> enim gratior amor est, ubi non æstuat indigentiæ sic­ <lb/> citate,
-						sed ubertate beneficentiæ 3 profluit. Ille nam­ <lb/> que amor ex miseria est, iste ex
+						I de<lb/>lectentur obsequio, et quanto magis id senserint, <lb/> tanto magis cos
+						diligant, tamen quanto amore exar<lb/>descat inferior, cum a superiore se diligi
+						senserit. Ibi <lb/> enim gratior amor est, ubi non æstuat indigentiæ sic<lb/>citate,
+						sed ubertate beneficentiæ 3 profluit. Ille nam<lb/>que amor ex miseria est, iste ex
 						misericordia. Jam <lb/> vero si etiam se amari posse a superiore desperabat <lb/>
-						inferior, ineffabiliter commovebitur in amorem, si ut­ <lb/> tro ille fuerit dignatus
+						inferior, ineffabiliter commovebitur in amorem, si ut<lb/>tro ille fuerit dignatus
 						ostendere quantum diligat eum <lb/> qui nequaquam sibi tantum bonum promittere aude­
-						<lb/> ret. Quid autem superius Deu judicante, et quid de­ <lb/> speratius homine
+						<lb/> ret. Quid autem superius Deu judicante, et quid de<lb/>speratius homine
 						peccante? qui se tanto magis tuen- <lb/> dum et subjugandum superbis potestatibus
 						addixerat, <lb/> quæ beatificare non possunt, quanto magis despera. <lb/> vcrat posse
 						sui curam geri ab ea potestate quæ non <lb/> malitia sublimis esse vult, sed bonitate
@@ -372,15 +372,15 @@
 						diligat Deus; et ideo <lb/> cognosceret, ut in ejus dilectionem a quo prior dile­ <lb/>
 						ctus est, inardesceret, proximumque illo jubente et <lb/> demonstrante diligeret, qui
 						non proximum, scd longe <lb/> pcregrinantem diligendo factus est proximus; omnis­ <lb/>
-						que Scriptura divina quæ ante scripta est, ad prænun­ <lb/> tiandum adventum Domini
+						que Scriptura divina quæ ante scripta est, ad prænun<lb/>tiandum adventum Domini
 						scripta est; et quidquid <lb/> postea mandatum est litteris et divina auctoritate fir­
-						<lb/> matum, Christum narrat, et dilectionem monet: ma­ <lb/> nifestum est non tantum
-						totam Legem et Prophe­ <lb/> tas in illis duobus pendere præceptis dilectionis Dei <lb/>
+						<lb/> matum, Christum narrat, et dilectionem monet: ma<lb/>nifestum est non tantum
+						totam Legem et Prophe<lb/>tas in illis duobus pendere præceptis dilectionis Dei <lb/>
 						ct <hi rend="italic">proximi (Matth.</hi> XXII, 40), quæ adhuc sola Scriptura <lb/>
-						sancta erat cum hoc Dominus diceret, sed etiam qaae­ <lb/> cumquc posterius salubriter
-						conscripta 4 suut memo­ <lb/> riæque mandata divinarum volumina Litterarum. <lb/>
+						sancta erat cum hoc Dominus diceret, sed etiam qaae<lb/>cumquc posterius salubriter
+						conscripta 4 suut memo<lb/>riæque mandata divinarum volumina Litterarum. <lb/>
 						Quapropter in Veteri Testamento est occultatio Novi, <lb/> ill Novo Testamento est
-						manifestatio Veteris. Secun­ <lb/> dum iilam occultationem carnaliter intelligentes car­
+						manifestatio Veteris. Secun<lb/>dum iilam occultationem carnaliter intelligentes car­
 						<lb/> nales, et tunc et nunc poenali timore subjugati sunt. <lb/> Secundum hanc autem
 						manifestationem spirituales, et <lb/> tunc quibus pie pulsantibus ctiam occulta
 						patuerunt, <lb/> et nunc qui non superbe quærunt, ne etiam aperta <lb/> claudantur,
@@ -392,10 +392,10 @@
 							<lb/> ucula. </note>
 						<lb/> idem Dominus Jesus Christus, Deus homo, et divinæ <lb/> in nos dilectionis
 						indicium est , et humanæ apud no; <lb/> humilitatis exemplum , ut magnus tumor noster
-						ma­ <lb/> jnre contraria medicina sanaretur. Magna est enim <lb/> miseria, superbus
-						homo; sed major misericordia, hu­ <lb/> milis Deus. Hac ergo dilectione tibi tanquam
+						ma<lb/>jnre contraria medicina sanaretur. Magna est enim <lb/> miseria, superbus
+						homo; sed major misericordia, hu<lb/>milis Deus. Hac ergo dilectione tibi tanquam
 						line <lb/> proposito, quo rcferas omnia quæ dicis, quidquid <lb/> narras ita narra, ut
-						ille cui loqueris audiendo cre­ <lb/> dat, credendo speret, sperando amet.</p>
+						ille cui loqueris audiendo cre<lb/>dat, credendo speret, sperando amet.</p>
 					<p>CAPUT V. — 9. <hi rend="italic">Accedens ad catechismum</hi> scrutan­ <lb/>
 						<hi rend="italic">dua quo fine velit fieri christianus.</hi> De ipsa etiam sevc­ <lb/>
 						rilate Dei, qua corda mortalium saluberrimo terrore <lb/> quatiuntur, charitas
@@ -404,12 +404,12 @@
 						Rarissime quippe accidit, imo <lb/> vero nunquam, ut quisquam veniat volens fieri chri­
 						<lb/> stianus, qui non sit aliquo Dci timore perculsus. Si <lb/> enim aliquod commodum
 						exspectando ab hominibus, <lb/> quibus se aliter placiturum non putat, aut aliquod <lb/>
-						ab hominibus incommodum devitando, quorum offen­ <lb/> sionem aut inimicitias
-						reformidat, vult fieri christia­ <lb/> nus; non fieri vult potius qunm fingere. Fides
+						ab hominibus incommodum devitando, quorum offen<lb/>sionem aut inimicitias
+						reformidat, vult fieri christia<lb/>nus; non fieri vult potius qunm fingere. Fides
 						enim <lb/> non res est salutantis 1 corporis, sed credentis animi. <lb/> Scd plane sæpe
-						adest misericordia Dei pcr ministe­ <lb/> rium catechizantis, ut sermone commotus jam
+						adest misericordia Dei pcr ministe<lb/>rium catechizantis, ut sermone commotus jam
 						fleri <lb/> velit quod decreverat fingere : quod cum velle cœpe- <lb/> rit, tunc cum
-						venisse dcputcmus. Et occultum qui­ <lb/> dem nobis est quando 2 veniat animo, quem jain
+						venisse dcputcmus. Et occultum qui<lb/>dem nobis est quando 2 veniat animo, quem jain
 						<lb/> corpore præsentem videmus : sed tamen sic cnm co <lb/> debemus agere, ut fiat in
 						illo hæc voluntas, etiamsi <lb/> non est. Nihil enim dcperit, quando si cst, utique
 						<lb/> tali nostra actione firmatur, quamvis quo tempore. <lb/> vcl qua hora cæperit,
@@ -418,15 +418,15 @@
 						religionem venerit. Quod <lb/> si defuerit alius a quo id noverimus, etiam ipse in­
 						<lb/> terrogandus est, ut ex eo quod responderit ducamns <lb/> sermonis exordium. Sed si
 						ficto pectore accessit, <lb/> humana commoda cupicns , vel incommoda fugiens, <lb/>
-						utique mentiturus est : tamen es eo ipso quod men­ <lb/> titur, capiendum est principium
+						utique mentiturus est : tamen es eo ipso quod men<lb/>titur, capiendum est principium
 						; non ut refellatur <lb/> ejus mendacium, quasi tibi certum sit, sed ut si <lb/> dixerit
-						eo proposito se venisse quod vere approban­ <lb/> dum est, sive ille verum sive falsum
-						dicai, tale ta­ <lb/> men propositum quali se vcnisse respondit, appro­ <lb/> bantes
+						eo proposito se venisse quod vere approban<lb/>dum est, sive ille verum sive falsum
+						dicai, tale ta<lb/>men propositum quali se vcnisse respondit, appro<lb/>bantes
 						atque laudantes, faciamus cum delectari esse <lb/> se talem, qualem videri cupit. Si
 						autem aliud dixerit, <lb/> quam oportet esse in animo ejus qui christiana fide <lb/>
 						imbuendus cst; blandius et lenius reprchendendo <lb/> tanquam rudem et ignarum, et
 						christianæ doctrinæ <lb/> finem vcrissimum demonstrando atqne laudando <lb/> breviter et
-						graviter, ne aut tempera futuræ narratio­ <lb/> nis occupes, aut cam non prius collocato
+						graviter, ne aut tempera futuræ narratio<lb/>nis occupes, aut cam non prius collocato
 						animo <lb/> audeas imponere, facias eum velle quod ant per <note type="footnote"> 1
 							Edili Er. et Lpv.. <hi rend="italic">salvandi.</hi> Kounu!!! ccdices, <hi rend="italic">salutis.</hi>
 							<lb/> Quidam, <hi rend="italic">sattantis.</hi> sed plerique ac melioris notae Mss.
@@ -440,39 +440,39 @@
 							narratio</hi>
 						<lb/> ab <hi rend="italic">historia creationis mundi usque ad præsens tempus <lb/>
 							Ecclesia.</hi> Quod si forte se divinius admonitum vel <lb/> territum esse
-						responderit, ut fieret christianus, laetis­ <lb/> simum nobis exordiendi aditum præbet,
+						responderit, ut fieret christianus, laetis<lb/>simum nobis exordiendi aditum præbet,
 						quanta Deo <lb/> sit cura pro nobis. Sane ab bujusmodi miraculorum <lb/> sive somniorum,
 						ad Scripturarum solidiorem viam <lb/> et oracula certiora transferenda est ejus
 						intentio; ut <lb/> et illa admonitio quam misericorditer ei prærogata <lb/> sit, noverit
 						antequam Scripturis sanctis inhæreret. <lb/> Et utique demonstrandum est ei quod ipse
 						Dominus <lb/> non eum admoneret aut compelleret fieri christianum <lb/> et incorporari
 						Ecclesiae, seu talibus signis aut reve- <lb/> lationibus erudiret, nisi jam preparatum
-						iter in <lb/> Scripturis sanctis, ubi non quæreret visibilia mira­ <lb/> cula, sed
+						iter in <lb/> Scripturis sanctis, ubi non quæreret visibilia mira<lb/>cula, sed
 						invisibilia sperare consuesceret, neque <lb/> dormiens, sed vigilans moneretur, eum
-						securius et <lb/> tutius carpere voluisset. Inde jam exordienda narra­ <lb/> tio est, ab
+						securius et <lb/> tutius carpere voluisset. Inde jam exordienda narra<lb/>tio est, ab
 						eo quod fecit Deus omnia bona valde <lb/>
-						<hi rend="italic">(Gen.</hi> I), et perducenda, ut diximus, usque ad præ­ <lb/> sentia
+						<hi rend="italic">(Gen.</hi> I), et perducenda, ut diximus, usque ad præ<lb/>sentia
 						tempora Ecclesiae : ita ut singularum rerum <lb/> atque gestorum quæ narramus, causæ
-						rationesque <lb/> reddantur, quibus ea referamus ad illum finem dHe­ <lb/> ctionis, unde
+						rationesque <lb/> reddantur, quibus ea referamus ad illum finem dHe<lb/>ctionis, unde
 						neque agentis aliquid neque loquentis <lb/> oculus avertendus est. Si enim fictas
-						poctarum fabu­ <lb/> las, et ad voluptatcm I excogitatas animorum quo­ <lb/> rum cibus
+						poctarum fabu<lb/>las, et ad voluptatcm I excogitatas animorum quo<lb/>rum cibus
 						nugæ sunt, tamen boni qui habentur <lb/> atquc appellantur grammatici, ad aliquam
 						utilitatem <lb/> referre conantur, quanquam et ipsam vanam et <lb/> avidam saginæ
 						saecularis; quanto nos decet esse <lb/> cautiores, ne illa quae vera narramus, sine
 						snarum <lb/> . causarum redditione digesta, aut inani suavitate, <lb/> aut etiam
 						perniciosa cupiditate credantur ? Non <lb/> tamen sic asseramus has causas, ut relicto
-						narratio­ <lb/> nis tractu, cor nostrum et lingua in nodos diffici­ <lb/> liuris
-						disputationis excurrat; sed ipsa veritas adhi­ <lb/> bitæ rationis 2, quasi aurum sit
-						gemmarum ordinem <lb/> ligans, non tamen ornamenti sericin ulla immodera­ <lb/> tione
+						narratio<lb/>nis tractu, cor nostrum et lingua in nodos diffici<lb/>liuris
+						disputationis excurrat; sed ipsa veritas adhi<lb/>bitæ rationis 2, quasi aurum sit
+						gemmarum ordinem <lb/> ligans, non tamen ornamenti sericin ulla immodera<lb/>tione
 						perturbans.</p>
 					<p>CAPUT VII. — 11. <hi rend="italic">Resurrectio, judicium et alia <lb/> quædam post
-							narrationem intimanda.</hi> Narrtatione tini­ <lb/> t a, spes resurrectionis intimanda
-						est, et pro capaci­ <lb/> late ac viribus audientis, proque ipsius temporis <lb/>
+							narrationem intimanda.</hi> Narrtatione tini<lb/>t a, spes resurrectionis intimanda
+						est, et pro capaci<lb/>late ac viribus audientis, proque ipsius temporis <lb/>
 						modulo, adversus vanas irrisiones infidelium de <lb/> corporis resurrectione tractandum,
-						et futuri ultimi <lb/> judicii bonitate in bonos, severitate in malos, veri­ <lb/> tate
+						et futuri ultimi <lb/> judicii bonitate in bonos, severitate in malos, veri<lb/>tate
 						in omnes; commemoratisque cum detestatione <lb/> et horrore poenis impiorum, regnum
 						justorum atque <lb/> fidelium et superna illa civitas ejusque gaudium <lb/> cnm
-						desiderio prædicandum est. Tum vero instrucn­ <lb/> da et animanda est infirmitas
+						desiderio prædicandum est. Tum vero instrucn<lb/>da et animanda est infirmitas
 						hominis adversus <lb/> tentationes et scandala, sive foris sive in ipsa intus <lb/>
 						Ecclesia : foris adversus Gentiles vel Judaeos vel <lb/> hæreticos; intus autem adversus
 						areae dominicæ <note type="footnote"> I An. et 1.1erlque Mss., voluntatem. </note><note type="footnote"> • Sic vetus codex Corhciensis. At victorinus, <hi rend="italic">Qdhibitcz</hi>
@@ -480,7 +480,7 @@
 							Denique <lb/> LoV'f <hi rend="italic">adhibita ratiofiis.</hi>
 						</note>
 						<lb/> paleam. Nun ut contra singula perversorum genera <lb/> disputetur, omnesque
-						illorum pravæ opiniones pro­ <lb/> positis quæstionibus refellantur ; sed pro tempore
+						illorum pravæ opiniones pro<lb/>positis quæstionibus refellantur ; sed pro tempore
 						<lb/> brevi demonstrandum est ila esse prædictum, ct <lb/> quæ sit utilitas tentationum
 						erudiendis fidclibus, et <lb/> quae medicina in exemplo patientiæ Dei, qai stamit <lb/>
 						usque in tinem ista perinittere. Cum veru adversus <lb/> . eos instruitur, quorum
@@ -488,23 +488,23 @@
 						<lb/> decenter commemorentur christianæ atque honestæ <lb/> conversationis, ne ab
 						ebriosis, avaris, fraudatoribus <lb/> aleatoribus, adulteris, fornicatoribus,
 						spectaculorum <lb/> amatoribus, remcdiorum sacrilegurum alligatoribus, <lb/>
-						præcantatoribus, mathematicis, vel quarumlibet ar­ <lb/> tium vanarum et malarum
-						divinatoribus, atque hujus­ <lb/> modi cæteris ita facile seducatur, et impunitum sibi
+						præcantatoribus, mathematicis, vel quarumlibet ar<lb/>tium vanarum et malarum
+						divinatoribus, atque hujus<lb/>modi cæteris ita facile seducatur, et impunitum sibi
 						<lb/> fore arbitretur, qnia videt multos qui christiani <lb/> appellantur, hrec amare,
 						et agere, ct defendere , et <lb/> suadere, et persuadere. Quis enim finis præstitutus
 						<lb/> sit in tali vita perseverantibus, et quam sint in ipsa <lb/> Ecclesia tolerandi,
 						ex qua in finc separandi sunt, <lb/> divinorum Librorum testimoniis edocendum est. <lb/>
-						Prænuntiandum est etiam inventurum eum in Eccle­ <lb/> sia multos christianos bonos ,
-						verissimos cives cæle­ <lb/> stis Jerusalem, si esse ipse coeperit. Ad extremum <lb/> ne
+						Prænuntiandum est etiam inventurum eum in Eccle<lb/>sia multos christianos bonos ,
+						verissimos cives cæle<lb/>stis Jerusalem, si esse ipse coeperit. Ad extremum <lb/> ne
 						spes ejus in homine ponalur, sedulo monendus <lb/> est : quia neque facile ab homine
 						judicari potest <lb/> quis homo sil justus; et si facile posset, non ideo <lb/> nobis
-						proponi exempla justorum, ut ab eis justifice­ <lb/> mur, sed ut eos imitantes ab eorum
-						justificatore nos <lb/> quoque justificari sciamus. Hinc enim fiet, quod ma­ <lb/> xime
+						proponi exempla justorum, ut ab eis justifice<lb/>mur, sed ut eos imitantes ab eorum
+						justificatore nos <lb/> quoque justificari sciamus. Hinc enim fiet, quod ma<lb/>xime
 						commendandum est, ut cum ille qui nos audit, <lb/> imo per nos audit Deum, moribus et
-						scientia profi­ <lb/> cere coeperit, et viam Christi alacriter ingredi, nee <lb/> nobis
+						scientia profi<lb/>cere coeperit, et viam Christi alacriter ingredi, nee <lb/> nobis
 						id audeat assignare, nee sibi; sed ct se ipsum, <lb/> et no;, et quoscumque alios
 						diligit amicos, in illu ct <lb/> propter illum diligat, qui eum dilexit inimicum, ut
-						<lb/> justificans faceret amicum, Hic jam non te puto præ­ <lb/> ceptore indigere, ut
+						<lb/> justificans faceret amicum, Hic jam non te puto præ<lb/>ceptore indigere, ut
 						cum occupata sant tempora, vel <lb/> tua, vel eorum qui te audiunt, breviter agas; cum
 						<lb/> autem largiora, argius eloqualis : hoc euim nullo <lb/> admonente ipsa necessitas
 						præcipit.</p>
@@ -513,11 +513,11 @@
 						venerit liberalibus doctrinis <lb/> excultus, qui jam decreverit esse christianus, et
 						ideo <lb/> venerit ut fiat, difficillimum omnino cst ut hon multa <lb/> nostrarun,
 						scripturarum litterarumque cognoverit, <lb/> quibus jam instructus ad Sacramentorum
-						participa­ <lb/> tionem tantuminodo venerii. Tales enim non eadem <lb/> hora qua
-						christiani fiunt, sed ante solent omnia dili­ <lb/> genter inquircre, et motus animi
-						sui, cum quibus <lb/> possunt, communicare atque discutere. Cum his ita­ <lb/> que
+						participa<lb/>tionem tantuminodo venerii. Tales enim non eadem <lb/> hora qua
+						christiani fiunt, sed ante solent omnia dili<lb/>genter inquircre, et motus animi
+						sui, cum quibus <lb/> possunt, communicare atque discutere. Cum his ita<lb/>que
 						breviter agendum est, et non odiose 1 inculcando <lb/> quæ norunt. sed modeste
-						perstringendo; ita ut dica­ <lb/> mus nos credere quod jam noverint illud, atque <lb/>
+						perstringendo; ita ut dica<lb/>mus nos credere quod jam noverint illud, atque <lb/>
 						iJ nd ; atque hoc modo cursim enumerare omnia qua <note type="footnote"> 1 Aliquot Mss.,
 								<hi rend="italic">otiose­</hi>
 						</note>
@@ -528,8 +528,8 @@
 						interrogatur, quibus rcbus motus sit ut <lb/> v lit sse christianus : ut si libris ei
 						persuasum I esse <lb/> videris, sive canonicis. sive utilium tractatorum, de <lb/> bis
 						:liquid in principio loquaris, collaudans eos pro <lb/> diversitate meritorum canonicæ
-						auctoritatis et expo­ <lb/> nentium a solertissimæ diligentiæ ; maximeque com­ <lb/>
-						mendans in Scripturis canonicis admirandæ altitudi­ <lb/> nis saluberrimam humilitatem,
+						auctoritatis et expo<lb/>nentium a solertissimæ diligentiæ ; maximeque com­ <lb/>
+						mendans in Scripturis canonicis admirandæ altitudi<lb/>nis saluberrimam humilitatem,
 						in illis autempro <lb/> sua cujusque facultate aptum superbioribus, et per <lb/> hoc
 						infirmioribus animis, stilum sonanlioris et quasi <lb/> tornatioris eloquii 4.Sane cHam
 						exprimendum de <lb/> ilio est ut iudicet quem maxime legerit, et quibus <lb/> libris
@@ -538,18 +538,18 @@
 						accepimus a catholico aliquo memorabili viro esse <lb/> conscriptos, læti approbemus. Si
 						autem in alicujus <lb/> hæretici volumina incurrit, et nesciens forte quod <lb/> vera
 						fides improbat, tenuit animo, et catholicum <lb/> esse arhitralur; sedulo edocendus est,
-						prælataaucto­ <lb/> ritate universalis Ecclesiæ aliorumque doctissimorum <lb/> hominum
+						prælataaucto<lb/>ritate universalis Ecclesiæ aliorumque doctissimorum <lb/> hominum
 						el disputationibus ct scriptionibus in ejus <lb/> veriiale florentium. Quanquam et illi
-						qui catholici <lb/> ex bac vita migrarunt, et aliquid litterarum christia­ <lb/> narum
-						posteris reliquerunt, ill quibusdam locis opu­ <lb/> seniorum suorum, vel non
+						qui catholici <lb/> ex bac vita migrarunt, et aliquid litterarum christia<lb/>narum
+						posteris reliquerunt, ill quibusdam locis opu<lb/>seniorum suorum, vel non
 						intellecti, vel sicuti est <lb/> humana infirmitas, minus valentes acie mentis abdi­
 						<lb/> liora penetrare, et veri similitudine aberrantes a <lb/> veritate, præsumptoribus
-						et audacibus fuerunt occa­ <lb/> sioni ad aliquam hæresim moliendam atque gignen­ <lb/>
+						et audacibus fuerunt occa<lb/>sioni ad aliquam hæresim moliendam atque gignen­ <lb/>
 						dam. Quod mirum non est, cum de ip is canonicis <lb/> Litteris, ubi omnia sanissime
 						dicta sunt, noH quidem <lb/> aliter accipiendo quædam, quam vel scriptor sensit, <lb/>
 						vul se ipsa veritas habet ; (nam si hoc solum esset, <lb/> quis non humanae infirmitati
 						ad corrigendum paratæ <lb/> libenter ignosceret?) sed id quod perverse ac prave <lb/> op
-						nati sunt, animositate acerrima et pervicaci arro­ <lb/> gantia defensitantes, multi
+						nati sunt, animositate acerrima et pervicaci arro<lb/>gantia defensitantes, multi
 						multa pcruiciosa dogmata, <lb/> concisa communionis unitate pepererunt. Hæc omnia <lb/>
 						cum illo qui ad societatem populi christiani, non <lb/> idiota, ut aiunt, sed doctorum
 						libris expolitus atque <lb/> excultus accedit, modesta collatione tractanda sunt: <lb/>
@@ -569,33 +569,33 @@
 						<lb/>
 						<hi rend="italic">modo tractandi. Vox ad aures Da. animi</hi> affectus. Sunt <lb/> item
 						quidam de scholis usitatissimis grammaticorum <lb/> oratorumque venientes, quos neque
-						inter idiotas nu­ <lb/> merare audeas, ncque inter illos doctissimos, quorum <lb/> mens
+						inter idiotas nu<lb/>merare audeas, ncque inter illos doctissimos, quorum <lb/> mens
 						magnarum rerum cst exercitata quæstionibus. <lb/> His ergo qui loquendi arte cæteris
-						hominibus excel­ <lb/> lere videntur, cum veniunt ut christiani fiant, hoc <lb/> amplius
+						hominibus excel<lb/>lere videntur, cum veniunt ut christiani fiant, hoc <lb/> amplius
 						quam illis illitteratis impertire dcbemus, quod <lb/> ' scdulo monendi sunt ut
 						humilitate induti christiana, <lb/> discant non conteminere quos cognoverint morum vi­
 						<lb/> tia quam verborum amplius devitare; et cordi casto <lb/> linguam exercitatam nec
 						conferre 1 audeantv quam <lb/> etiam præferre consueverant. Maxime autem isti do­ <lb/>
 						cendi sunt Scripturas audire divinas, nc sordeat cis <lb/> solidum eloquium, quia uon
-						est inflatum ; neque ar­ <lb/> bitrentur carnalibus integumentis involuta atque <lb/>
-						operta dicta vel facta hominum, quæ iniliis libris le­ <lb/> guntur, non evolvenda atque
-						aperienda ut intelligan­ <lb/> tur, sed sic accipienda ut litteræ sonant; deque ipsa
+						est inflatum ; neque ar<lb/>bitrentur carnalibus integumentis involuta atque <lb/>
+						operta dicta vel facta hominum, quæ iniliis libris le<lb/>guntur, non evolvenda atque
+						aperienda ut intelligan<lb/>tur, sed sic accipienda ut litteræ sonant; deque ipsa
 						<lb/> utilitate secreti, unde etiam mysteria vocantur, quid <lb/> valeant aenigmatum
 						latebræ ad amorem veritatis <lb/> acuendum, decutiendumque 2 fastidii torporem, ipsa
 						<lb/> experientia probandum est talibus, cum aliquid eis <lb/> quod in promptu positum
-						non ita movebat, enoda­ <lb/> tione allegoriæ alicujus eruitur. Ilis enim maxime <lb/>
-						utile cst nosse, ita esse præponendas verbis senten­ <lb/> tias, ut præponituranimus
+						non ita movebat, enoda<lb/>tione allegoriæ alicujus eruitur. Ilis enim maxime <lb/>
+						utile cst nosse, ita esse præponendas verbis senten<lb/>tias, ut præponituranimus
 						corpori. Ex quo fit ut ita <lb/> malle debeant veriores quam disertiores audire ser­
-						<lb/> mones, sicut malle debeut prudentiores, quant for­ <lb/> mosiores habere amicos.
-						Noverint etiam non esse vo­ <lb/> cem ad aures Dei, nisi animi affectum : ita enim non
+						<lb/> mones, sicut malle debeut prudentiores, quant for<lb/>mosiores habere amicos.
+						Noverint etiam non esse vo<lb/>cem ad aures Dei, nisi animi affectum : ita enim non
 						<lb/> irridebunt, si aliquos antistites et ministres Ecclesiæ <lb/> forte
-						animadverterint, vel cum barbarismis et solœ­ <lb/> cismis Dcum invocare, vel cadem
+						animadverterint, vel cum barbarismis et solœ<lb/>cismis Dcum invocare, vel cadem
 						verba quæ pronun- <lb/> tiant non intelligere, perturbateque distinguere. Non <lb/> quia
 						ista minime corrigenda sunt, ut populus ad id <lb/> quod plane intelligit, dicat Amen;
-						sed tamen pie to­ <lb/> leranda sunt ab eis qui didicerint, ut sono in foro, sic <lb/>
+						sed tamen pie to<lb/>leranda sunt ab eis qui didicerint, ut sono in foro, sic <lb/>
 						volo in Ecclesia benedici. Itaque forensis illa nonnum. <lb/> quam forte bona dictio,
 						nunquam tamen Ienedictio <lb/> dici potest. De Sacramento autem quod accepturi <lb/>
-						suni, sufficit prudentioribus audirc quid res illa si­ <lb/> gnificet : cum tardioribus
+						suni, sufficit prudentioribus audirc quid res illa si<lb/>gnificet : cum tardioribus
 						autem aliquanto pluribus <lb/> verbis et similitudinibus agendum est, ne conteninant
 						<lb/> quod vident.</p>
 					<p>CAPUT X. — 14. <hi rend="italic">Jam de hilaritate comparanda.<lb/> Causæ</hi> sex <hi rend="italic">lædium afferentes catechizanti. Remedium <lb/> contra primam causam
@@ -610,41 +610,41 @@
 						</note>
 						<lb/>
 						<pb n="321"/> etiam ipse faciam in hoc volumine, quod fieri oportere <lb/> praecipio. Si
-						ergo fecero, ad cumulum valebit : cu­ <lb/> mulus autem quo pacto a me superfundi
-						potest, an­ <lb/> tequam mensuram debiti explevero ? Neque enim te <lb/> maxime conqueri
+						ergo fecero, ad cumulum valebit : cu<lb/>mulus autem quo pacto a me superfundi
+						potest, an<lb/>tequam mensuram debiti explevero ? Neque enim te <lb/> maxime conqueri
 						audivi, nisi qnod tibi sermo tuus <lb/> vilis abjectusquc videretur, cum aliqucm
 						christiano <lb/> nomine imbuercs. Hoc autem scio, non tam rerum <lb/> quae dicendæ sunt,
 						quibus te satis novi paratum et <lb/> instructum, neque ipsius locutionis inopia, sed
 						animi <lb/> tædio fieri; vel illa causa quam dixi, quia magis nos <lb/> delectat ct
 						tenet, quud in silentio mente cernimus, <lb/> nec inde volumus avocari ad verborum longe
-						dispa­ <lb/> rem strepitum; vel quia etiam cum sermo jucundus <lb/> est, magis nos libet
-						audire aut legere quæ melius di­ <lb/> cia sunt, et quae sine nostra cura et
-						sollicitudine pro­ <lb/> muntur, quam ad alienum sensum repentina verba <lb/> coaptare
-						incerto exitu, sive utrum occurrant pro sen­ <lb/> tentia, sive ulrum accipiantur
+						dispa<lb/>rem strepitum; vel quia etiam cum sermo jucundus <lb/> est, magis nos libet
+						audire aut legere quæ melius di<lb/>cia sunt, et quae sine nostra cura et
+						sollicitudine pro<lb/>muntur, quam ad alienum sensum repentina verba <lb/> coaptare
+						incerto exitu, sive utrum occurrant pro sen<lb/>tentia, sive ulrum accipiantur
 						utiliter; vel quia illa <lb/> quæ rudibus insinuantur, eo quod nohis notissima <lb/>
 						sunt, et provectui nostro jam non necessaria, piget <lb/> ad ea sæpissime redire, nec in
-						eis tam usitatis et tan­ <lb/> quam infantilibus cum aliqua voluptate jam gran­ <lb/>
-						disculus anianus graditur. Facit etiam loquenti tae­ <lb/> dium auditor [immobilis vel
-						quia non movetur affe­ <lb/> ctn, vel quia nullo motu corporis iudicat se intelligere
+						eis tam usitatis et tan<lb/>quam infantilibus cum aliqua voluptate jam gran­ <lb/>
+						disculus anianus graditur. Facit etiam loquenti tae<lb/>dium auditor [immobilis vel
+						quia non movetur affe<lb/>ctn, vel quia nullo motu corporis iudicat se intelligere
 						<lb/> vel sibi placere quæ dicuntur1 ] : non quia humanæ <lb/> laudis nos esse avidos
-						decet, sed quia ea quæ mini­ <lb/> stramus Dei sunt; et quanto magis diligimus eos qui­
+						decet, sed quia ea quæ mini<lb/>stramus Dei sunt; et quanto magis diligimus eos qui­
 						<lb/> bus loquimur, tanto magis eis cupimus ut placeant <lb/> quæ ad corum porriguntur
-						salutem : quod si non suc­ <lb/> cedit, contristamur, et in ipso cursu debilitamur et
-						<lb/> frangimur, quasi frustra operam conteramus. Nun­ <lb/> nunquam etiam cum avertimur
+						salutem : quod si non suc<lb/>cedit, contristamur, et in ipso cursu debilitamur et
+						<lb/> frangimur, quasi frustra operam conteramus. Nun<lb/>nunquam etiam cum avertimur
 						ab aliqua re quam <lb/> desideramus agere, et cujus actio aut delectabat nos, <lb/> aut
 						magis nobis necessaria videbatur, et cogimur aut <lb/> jussu ejus quem offendere
 						nolumus, aut aliquorum <lb/> inevitabili instantia catechizare aliquem jam contur­ <lb/>
 						bati accedimus ad negotium, cui magna tranquillitate <lb/> opus est, dolentes qnod ncque
-						ordinem actionum no­ <lb/> bis conceditur tenere quem volumus, nee sufficere <lb/>
+						ordinem actionum no<lb/>bis conceditur tenere quem volumus, nee sufficere <lb/>
 						omnibus possumus : atque ita ex ipsa tristitia sermo <lb/> procedens minus gratus est,
-						quia de ariditate mœsti­ <lb/> tiae minus exuberat. Aliquando item ex aliquo scan­ <lb/>
+						quia de ariditate mœsti<lb/>tiae minus exuberat. Aliquando item ex aliquo scan­ <lb/>
 						dalo mœror pectus obsedit2, et tunc nobis dicitur, <lb/> Venit loquere huic; christianus
 						vult fieri. Dicitur 2 <lb/> enim ab ignorantibus quid nos clausumintus exurat: <lb/>
 						quibus si affectum nostrum aperire non oportet, <lb/> suscipimus ingratius quod volunt
-						'; et profectolan­ <lb/> guidus et insuavis ille sermo erit pcr venam cordis <lb/>
-						aestuantem fumantemque trajectus. Tot igitur ex cau­ <lb/> sis, quælibet earum
-						serenitatem nostra; mentis obnu­ <lb/> bilet, secundum Deum sunt quxrenda remedia, qui­
-						<lb/> bus relaxetur illa contractio, et fervore spiritus ex­ <lb/> suitemus et
+						'; et profectolan<lb/>guidus et insuavis ille sermo erit pcr venam cordis <lb/>
+						aestuantem fumantemque trajectus. Tot igitur ex cau<lb/>sis, quælibet earum
+						serenitatem nostra; mentis obnu<lb/>bilet, secundum Deum sunt quxrenda remedia, qui­
+						<lb/> bus relaxetur illa contractio, et fervore spiritus ex<lb/>suitemus et
 						jucundemur in tranquillitate botri operis. <note type="footnote"> ' verba hic unds
 							indusa 4bsont a plerisque Mss. et ab <lb/> Atto. Ir. </note><note type="footnote"> '
 							Editi, obsidet. At Mss., <hi rend="italic">obsedit.</hi>
@@ -654,18 +654,18 @@
 						<lb/>
 						<hi rend="italic">Hilarem enim datorem diligit Deus</hi> (Il Cor. ix, 7).</p>
 					<p>15. Si enim causa illa contristat, quod intellectum <lb/> nostrum auditor non capit, a
-						cujus cacumine quodam <lb/> modo descendentes cogimur in syllabarum longe in­ <lb/> fra
+						cujus cacumine quodam <lb/> modo descendentes cogimur in syllabarum longe in<lb/>fra
 						distantium tarditate demorari, et curam gerimus <lb/> quemadmodum longis et per plexis
-						anfractibus proce­ <lb/> dat ex ore carnis, quod celerrimo haustu mentis im­ <lb/>
+						anfractibus proce<lb/>dat ex ore carnis, quod celerrimo haustu mentis im­ <lb/>
 						bibitur, et quia multum dissimiliter exit, tædet loqui, <lb/> et libet tacere; cogitemus
 						quid nobis prærogatum sit <lb/> ab illo qui demonstravit nobis exemplum, ut sequa­ <lb/>
 						mur vestigia'ejus ( I <hi rend="italic">Petr.</hi> II, 21). Quantumvis enim <lb/>
 						difierat articulata vox nostra aC intelligentiæ nostræ <lb/> vivacitate, longe
 						differentior est mortalitas carnis "b <lb/> æqualitate Dei. Et tamen cum in eadem <hi rend="italic">forma esset,<lb/> temetipsum exinanivit formam servi accipiens,</hi>
-						etc., us­ <lb/> que ad <hi rend="italic">(a)</hi> mortem <hi rend="italic">crucis</hi> (
+						etc., us<lb/>que ad <hi rend="italic">(a)</hi> mortem <hi rend="italic">crucis</hi> (
 							<hi rend="italic">Philipp.</hi> II, 6-8). Quam ob <lb/> causam, nisi quia factus est
-						infirmis infirmis,;ut in­ <lb/> firmos lucrificaret ( I <hi rend="italic">Cor.</hi> IX,
-						22 ) ? Audi ejus imita­ <lb/> torem alibi etiam dicentem : <hi rend="italic">Sive</hi>
+						infirmis infirmis,;ut in<lb/>firmos lucrificaret ( I <hi rend="italic">Cor.</hi> IX,
+						22 ) ? Audi ejus imita<lb/>torem alibi etiam dicentem : <hi rend="italic">Sive</hi>
 						enim <hi rend="italic">mente excessi­</hi>
 						<lb/> mus, <hi rend="italic">Deo; sive temperantes</hi> sumus, <hi rend="italic">vobis.
 							Charitas enim<lb/> Christi compellit nos, judicantes hoc, quia unus pro</hi> om­ <lb/>
@@ -673,69 +673,69 @@
 							<hi rend="italic">( Id. XII,</hi>
 						<lb/> 15), si eum pigeret inclinari ad aures eorum? Hinc <lb/> ergo factus est parvulus
 						in medio nostrum, tanquam <lb/> nutrix fovens filios suos (I <hi rend="italic">Thess.</hi> II, 7). Num enim <lb/> delectat, nisi amor invitet, decurtata et
-						multilata ver­ <lb/> ba immurmurare? Et tamen optant homines babere <lb/> infantes,
+						multilata ver<lb/>ba immurmurare? Et tamen optant homines babere <lb/> infantes,
 						quibus id exhibeant : et suavius est matri <lb/> minuta mansa inspuere parvulo filio,
 						quam ipsam <lb/> mandere ac devorare grandiora. Non ergo recedat de <lb/> pectore etiam
-						cogitatio gallinae illius, quæ languidu­ <lb/> lis plumis teneros fetus operit, et
-						susurrantes pullos <lb/> confracta voce advocat; cujus blandas alas refugien­ <lb/> tcs
+						cogitatio gallinae illius, quæ languidu<lb/>lis plumis teneros fetus operit, et
+						susurrantes pullos <lb/> confracta voce advocat; cujus blandas alas refugien<lb/>tcs
 						superbi, præda fiunt alitibus ( Matth. XXIII, 37). <lb/> Si enim intellectus delectat in
-						penetralibus sinceris­ <lb/> simis, hoc cHam intelligere delci tat, quomodo chari­ <lb/>
-						tas, quanto officiosius descendit in infima, tanto ro­ <lb/> bustius recurrit in intima
+						penetralibus sinceris<lb/>simis, hoc cHam intelligere delci tat, quomodo chari­ <lb/>
+						tas, quanto officiosius descendit in infima, tanto ro<lb/>bustius recurrit in intima
 						per bonam conscientiam <lb/> nihil quærendi1 ab eis ad quos descendit, præter eo­ <lb/>
 						rum sempiternam salutem.</p>
 					<p>CAPUT XI.- 16. <hi rend="italic">Remedium contra secundumtœdii<lb/> causam.</hi> Si
 						autem niagis appetimus, ea quæ jam parata <lb/> sunt et melius dicta legere vel audire,
-						et ideo piget <lb/> inecrto exitu ad tempus coaptare quae loquimur : tan­ <lb/> tum a
+						et ideo piget <lb/> inecrto exitu ad tempus coaptare quae loquimur : tan<lb/>tum a
 						veritnte rerum non aberret animus, facile est <lb/> ut si in verbis auditorem aliquid
-						offenderit, ex ipsa <lb/> occasione discat quam sit re intellectacontemnen­ <lb/> dum,
+						offenderit, ex ipsa <lb/> occasione discat quam sit re intellectacontemnen<lb/>dum,
 						si minus integre, aut si minus propric sonare <lb/> potuit, quod ideo sonabat ut res
 						intelligeretur Quod <lb/> si humanæ infirmitatis intentio enam ab ipsa reruni <lb/>
-						veritate aberraverit; quanquam in catechizandis ru­ <lb/> dibus, ubi via tritissima
+						veritate aberraverit; quanquam in catechizandis ru<lb/>dibus, ubi via tritissima
 						tenenda est, difficile potest <lb/> accidere : tamen ne forte accidat ut ctiam hinc
-						offen­ <lb/> datur auditor, non aliunde nohis debet vidcri acci­ <lb/> disse, nisi quia
+						offen<lb/>datur auditor, non aliunde nohis debet vidcri acci<lb/>disse, nisi quia
 						Deus experi ..os voluit, utrum cum <note type="footnote"> 1 sic Mss. Editi vero, <hi rend="italic">nihil n</hi> i:<hi rend="italic">ccrenda.</hi>
 						</note>
 						<note type="footnote"> (a) Istai voces, c!.c., unrue ed, librarii sunt prætereuntis,
 							<lb/> tit s.J..'!. vc:!a intermedi i I,...v </note>
 						<lb/>
-						<pb n="323"/> mentis placiditate corrigamur, ne in defensionem IIO­ <lb/> stri erroris
-						majore præcipitemur errore. Quod si ne­ <lb/> mo nobis dixerit, nosque et illos qui
+						<pb n="323"/> mentis placiditate corrigamur, ne in defensionem IIO<lb/>stri erroris
+						majore præcipitemur errore. Quod si ne<lb/>mo nobis dixerit, nosque et illos qui
 						audierunt omni- <lb/> IIO latuerit, nullus dolor est, si non fiat iterum. Ple­ <lb/>
-						rumque antem nos ipsi recolentes quae dixeri­ <lb/> mus, reprehendimus aliquid, et
-						ignoramus quo­ <lb/> modo cum diceretur acceptum sit; magisque do­ <lb/> lemus, quando
+						rumque antem nos ipsi recolentes quae dixeri<lb/>mus, reprehendimus aliquid, et
+						ignoramus quo<lb/>modo cum diceretur acceptum sit; magisque do<lb/>lemus, quando
 						in nobis fervet charitas , si cum <lb/> falsum esset, libenter acceptum est. Ideoque op­
-						<lb/> portunitate reperta , sicut nos ipsos in silentio re­ <lb/> prehendimus, ita
+						<lb/> portunitate reperta , sicut nos ipsos in silentio re<lb/>prehendimus, ita
 						curandum est ut etiam illi sensim <lb/> corrigantur, qui non Dei verbis, sed plane
-						nostris in <lb/> aliquam lapsi sunt falsitatem. Si vero aliqui livore ve­ <lb/> sano
-						cæci errasse nos gaudent, susurrones, detracto­ <lb/> res, Deo odibiles <hi rend="italic">( Rom.</hi> i, 50); præbcant nobis ma­ <lb/> teriam exercendæ patientiæ
+						nostris in <lb/> aliquam lapsi sunt falsitatem. Si vero aliqui livore ve<lb/>sano
+						cæci errasse nos gaudent, susurrones, detracto<lb/>res, Deo odibiles <hi rend="italic">( Rom.</hi> i, 50); præbcant nobis ma<lb/>teriam exercendæ patientiæ
 						cum misericordia, quia <lb/> et patientia Dei ad poenitentiam eos adducit. Quid <lb/>
 						enim est detestabilius, et quod magis thesaurizet <lb/> iram in die iræ et revelationis
 						justi judicii Dei <lb/>
 						<hi rend="italic">(Id.</hi> n, 4 <hi rend="italic">et</hi> 5), qnam de malo alterius
-						mala1 diaboli si­ <lb/> militudine atque imitatione laetari? Nonnunquam <lb/> etiam, cum
+						mala1 diaboli si<lb/>militudine atque imitatione laetari? Nonnunquam <lb/> etiam, cum
 						rectc omnia vereque dicantur, aut non <lb/> intellectum aliquid, aut contra opinionem et
-						consue­ <lb/> tudinem vetcris erroris ipsa novitate asperum, of­ <lb/> fendit et
+						consue<lb/>tudinem vetcris erroris ipsa novitate asperum, of<lb/>fendit et
 						perturbat audientem. Quod si apparuerit, <lb/> sanabilemque se præbet, auctoritatum
 						rationumque <lb/> copia sine ulla dilatione sanandus est. Si autem tacita <lb/> et
 						occulta offensio est, Dei medicina opitulari potest. <lb/> At si resiluerit2, et curari
 						recusaverit, consoletur <lb/> nos dominicum illud exemplum, qui offensis homi­ <lb/>
 						nibus ex verbo suo, et tanquam durum refugientibus, <lb/> etiam iis qui remanserant ait,
 							<hi rend="italic">Numquid et vos vultis<lb/> ire (Joan.</hi> vi, 68)? Salis enim fixum
-						atque immo­ <lb/> bile debet corde retineri, Jerusalem captivam ab hu­ <lb/> jus saeculi
+						atque immo<lb/>bile debet corde retineri, Jerusalem captivam ab hu<lb/>jus saeculi
 						Babylonia decursis temporibus liberari, <lb/> nullumque ex illa esse periturum; quia qui
 						perierit, <lb/> non ex illa erat. <hi rend="italic">Firmum</hi> enim <hi rend="italic">fundamentum Dei stat, <lb/> habens signaculum hoc</hi> : novit <hi rend="italic">Dominus</hi> qui <hi rend="italic">sunt ejus ; <lb/> et recedat ab iniquitate,
 							omnis</hi> qui <hi rend="italic">nominat</hi> nomen <hi rend="italic">Do­</hi>
 						<lb/> mini ( II Tim. II, 19). Ista cogitantes , ct invocantes <lb/> Dominum in cor
 						nostrum, minus timebimus incertos <lb/> exitus sermonis nostri propter incertos motus
-						audito­ <lb/> rum; delectabitque nos etiam ipsa perpessio mole­ <lb/> stiarum pro
+						audito<lb/>rum; delectabitque nos etiam ipsa perpessio mole<lb/>stiarum pro
 						misericordi opere, si non in eo nostram <lb/> gloriam rcquirainus. Tunc enim est vere
-						opus bo­ <lb/> num, cum a charitate jaculatur agentis intentio, et <lb/> tanquam ad
+						opus bo<lb/>num, cum a charitate jaculatur agentis intentio, et <lb/> tanquam ad
 						locum suum rediens, rursus in charitate <lb/> requiescit. Lectio vero quæ nos delectat,
 						aut aliqua <lb/> . auditio melioris eloquii, ut eam promendo, sermoni <lb/> nostro
-						præponere volentes, cum pigritia vel tædio lo­ <lb/> quamur, alacriores nos suscipiet;
+						præponere volentes, cum pigritia vel tædio lo<lb/>quamur, alacriores nos suscipiet;
 						jucundiorqne prae. <lb/> stabitur post laborem; et majore fiducia deprecabimur <lb/> ut
-						loquatur nobis Deus quomodo volumus , si susci­ <lb/> piamus hilariter ut loquatur per
-						nos quomodo possu­ <lb/> mus : ita lit ut diligentibus Deum omnia concurrant <lb/> in
+						loquatur nobis Deus quomodo volumus , si susci<lb/>piamus hilariter ut loquatur per
+						nos quomodo possu<lb/>mus : ita lit ut diligentibus Deum omnia concurrant <lb/> in
 						bonum (Rom. VIII, 28).</p>
 					<p>CAPUT XII.—17. <hi rend="italic">Remedium contra tertiam</hi> causam <note type="footnote"> I Ita in Mss. At in editis, <hi rend="italic">mera.</hi>
 						</note><note type="footnote"> 2 Editi, <hi rend="italic">rctilierit.</hi> Præstantieres
@@ -743,41 +743,41 @@
 						</note>
 						<lb/>
 						<hi rend="italic">tædii.</hi> Jam vcro si usitata et parvulis congruentia <lb/> sæpe
-						rcpetere faslidimus; congruamus eis per fra­ <lb/> ternum, paternum, maternumque amorem,
-						et copu­ <lb/> latis cordi eorum etiam nobis nova videbuntur. Tan­ <lb/> tum enim valet
+						rcpetere faslidimus; congruamus eis per fra<lb/>ternum, paternum, maternumque amorem,
+						et copu<lb/>latis cordi eorum etiam nobis nova videbuntur. Tan<lb/>tum enim valet
 						animi compatientis affectus, ut cum <lb/> illi afficiuntur nohis loquentibus, et nos
-						illis discenti­ <lb/> bus, habitemus in invicem; atque ita et illi quæ au. <lb/> diunt
+						illis discenti<lb/>bus, habitemus in invicem; atque ita et illi quæ au. <lb/> diunt
 						quasi loquantur in nobis, et nos in illis disca - <lb/> mus quodam modo quæ docemus.
 						Nonne accidere hoc <lb/> solet, cum loca quaedam ampla et pulchra, vel urbium <lb/> vel
-						quæ jam nos sæpe videndo sinealiquavo­ <lb/> luptate præteribamus, ostendimus eis qui
-						antea nun­ <lb/> quam viderant, ut nostra delectatio in eorum novita­ <lb/> tatis
+						quæ jam nos sæpe videndo sinealiquavo<lb/>luptate præteribamus, ostendimus eis qui
+						antea nun<lb/>quam viderant, ut nostra delectatio in eorum novita<lb/>tatis
 						delectatione rcnovetur? Et tanto magis, quanto <lb/> suut amiciores; quia per amoris
-						vinculum in quan­ <lb/> tum in illis sumus, in tantum et nobis nova Dunt quae <lb/>
-						vetera fuerunt. Sed si in rebus contemplandis ali­ <lb/> quantum profccimus, non volumus
+						vinculum in quan<lb/>tum in illis sumus, in tantum et nobis nova Dunt quae <lb/>
+						vetera fuerunt. Sed si in rebus contemplandis ali<lb/>quantum profccimus, non volumus
 						cos quos diligimus <lb/> lætari et stupere, cum intuentur opera manuum ho- <lb/> minum;
-						sed volumus eos in ipsam artem 1 consilium­ <lb/> ve institutoris attollere, atque inde
-						exsurgere in ad­ <lb/> miralionem laudemque omnicreantis Dei, ubi amoris <lb/>
+						sed volumus eos in ipsam artem 1 consilium<lb/>ve institutoris attollere, atque inde
+						exsurgere in ad<lb/>miralionem laudemque omnicreantis Dei, ubi amoris <lb/>
 						fructuosissimus finis est: quanto ergo magis delectari <lb/> nos oportet, cunt ipsum
 						Deum jam discere homines <lb/> accedunt, propter quem discenda sunt quæcumque <lb/>
 						discenda sunt; et in eorum novitate innovari, ut si <lb/> frigidior est solita I nostra
-						praedicatio, insolita eo­ <lb/> rum auditione fervescat? Huc accedit ad comparan­ <lb/>
+						praedicatio, insolita eo<lb/>rum auditione fervescat? Huc accedit ad comparan­ <lb/>
 						dam laetitiam, quod cogitamus et consideramus, de <lb/> qua erroris morte in vitam fidei
 						transeat homo. Et si <lb/> vicos usitatissimos cum benefica hilaritate transimus , <lb/>
-						quando alicui forte qui errando laboraverat, demon­ <lb/> stramus viam : quanto alacrius
-						et cum gaudio majo­ <lb/> re in doctrina salutari, etiam illa quæ propter nos re­ <lb/>
+						quando alicui forte qui errando laboraverat, demon<lb/>stramus viam : quanto alacrius
+						et cum gaudio majo<lb/>re in doctrina salutari, etiam illa quæ propter nos re­ <lb/>
 						texere nou opus est, perambulare debemus; cum <lb/> animam miserandam et crroribus
 						sacculi fatigatam <lb/> per itinera pacis, ipso qui nobis eam I praestitit ju­ <lb/>
 						bente3, deducimus?</p>
-					<p>CAPUT XIII.—18. <hi rend="italic">Remedium contra</hi> quartam <hi rend="italic">causam<lb/> fastidii. Auditor veI audiendo vel stando</hi> fatigatus, <hi rend="italic">quo­ <lb/> modo recreandus. Usus audiendi verbum Dei sedendo,<lb/> in
+					<p>CAPUT XIII.—18. <hi rend="italic">Remedium contra</hi> quartam <hi rend="italic">causam<lb/> fastidii. Auditor veI audiendo vel stando</hi> fatigatus, <hi rend="italic">quo<lb/>modo recreandus. Usus audiendi verbum Dei sedendo,<lb/> in
 							quibusdam</hi> Ecclesiis <hi rend="italic">receptus.</hi> Sed revera multum <lb/> est
 						perdurare in loquendo usque ad terminum præ. <lb/> stitutum, cum moveri non videmus
 						audientem; quod <lb/> sive nou audeat, religionis timore constrictus , voce <lb/> aut
 						aliquo motu corporis significare approbationem <lb/> suam, sive humana verecundia
-						reprimatur; sive di­ <lb/> cta nou intelligat, sive contemnat: quandoquidem <lb/> nobis
+						reprimatur; sive di<lb/>cta nou intelligat, sive contemnat: quandoquidem <lb/> nobis
 						non cernentibus auimum ejus incertum est, <lb/> omnia sermone tentanda sunt, quae ad eum
-						excitan­ <lb/> dum et tanquam de latebris eruendum possint valere. <lb/> Nam et timor
+						excitan<lb/>dum et tanquam de latebris eruendum possint valere. <lb/> Nam et timor
 						nimius atque impediens declarationem <lb/> judicii ejus, blanda exhortatione pellendus
-						est, et <lb/> insinuando fraternam societatem verecundia tempe­ <lb/> randa, et
+						est, et <lb/> insinuando fraternam societatem verecundia tempe<lb/>randa, et
 						interrogatione quærendum utrum intelligat, <lb/> et danda fiducia, ut si quid ei
 						contradiccudum vide­ <note type="footnote"> * Edi! i, <hi rend="italic">arcem.</hi>
 							Aptius Mss., aitem. </note><note type="footnote"> * SiC Am. ei plerique MSS. At t:r.
@@ -788,76 +788,76 @@
 						jam audierit, et fortassis eum tanquam <lb/> nota et pervulgata non moveant; et agendum
 						pro ejus <lb/> responsione, ut aut planius et enodatius loquamur, <lb/> aut opinionem
 						contrariam refellamus, aut ea quæ illi <lb/> nota sunt uon explicemus latius, sed
-						breviter com­ <lb/> plicemus, eligamusque aliqua ex bis quæ mystice <lb/> dicta sunt in
-						sanctis Libris, et maxime in ipsa nar­ <lb/> ratione, quae aperiendo et revelando noster
+						breviter com<lb/>plicemus, eligamusque aliqua ex bis quæ mystice <lb/> dicta sunt in
+						sanctis Libris, et maxime in ipsa nar<lb/>ratione, quae aperiendo et revelando noster
 						sermo <lb/> dulcescat. Quod si nimis tardus est, et ab omni tali <lb/> suavitate
-						absurdus et aversus, misericorditer suffe­ <lb/> rendus est, breviterque decursis
-						cæteris, ea quæ ma­ <lb/> sime necessaria sunt, de unitate Catholicæ de ten­ <lb/>
-						tationibns, de christiana conversatione propter futu­ <lb/> rum judicium terribiliter
+						absurdus et aversus, misericorditer suffe<lb/>rendus est, breviterque decursis
+						cæteris, ea quæ ma<lb/>sime necessaria sunt, de unitate Catholicæ de ten­ <lb/>
+						tationibns, de christiana conversatione propter futu<lb/>rum judicium terribiliter
 						inculcanda sunt, magisque <lb/> pro illo ad Deum, quam illi de Deo multa dicenda.</p>
 					<p>49. Saepe etiam fit ut qui primo libenter audiebat, <lb/> vel audiendo vel stando
 						fatigatus, non jam laudans, sed <lb/> oscitans labia diducat, et se abire velle etiam
 						invitus <lb/> ostendat. Quod ubi senserimus, aut renovare oportet <lb/> ejus animum,
-						dicendo aliquid honesta hilaritate con­ <lb/> ditum et aptum rei quæ agitur, vel aliquid
-						valde mi­ <lb/> randum et stupendum, vel etiam dolendum atque <lb/> plangendum; et magis
-						de ipso, ut propria cura pun­ <lb/> cius evigilet; quod tamen non offendat ejus verecun­
-						<lb/> diam asperitate aliqua, sed potius familiaritate con­ <lb/> ciliet ; aut oblata
+						dicendo aliquid honesta hilaritate con<lb/>ditum et aptum rei quæ agitur, vel aliquid
+						valde mi<lb/>randum et stupendum, vel etiam dolendum atque <lb/> plangendum; et magis
+						de ipso, ut propria cura pun<lb/>cius evigilet; quod tamen non offendat ejus verecun­
+						<lb/> diam asperitate aliqua, sed potius familiaritate con<lb/>ciliet ; aut oblata
 						sessione I succurrere ; quanquam <lb/> sine dubitatione melius fiat, ubi decenter fieri
 						potest, <lb/> ut a principio sedens audiat; longeque consultius in <lb/> quibusdam
-						Ecclesiis transmarinis non solum antisti­ <lb/> tes sedentes loquuntur ad populum, sed
-						ipsi eliam <lb/> populo sedilia subjacent, ne quisquam infirmior stan­ <lb/> do lassatus
+						Ecclesiis transmarinis non solum antisti<lb/>tes sedentes loquuntur ad populum, sed
+						ipsi eliam <lb/> populo sedilia subjacent, ne quisquam infirmior stan<lb/>do lassatus
 						a saluberrima intentione avertatur, aut <lb/> etiam cogatur abscedere. Et tamen multum
 						interest, <lb/> si se quisquam de magna multitudine subtrahat ad <lb/> reparandas vires,
 						qui jam sacramentorum societate <lb/> devinctus est; et si ille discedat (quod plerumque
-						in­ <lb/> evitabiliter urgetur, ne interiore defectu victus etiam <lb/> cadat) qui
-						primis sacramentis imbuendus est: et pu­ <lb/> dore enim non dicit cur eat, et
+						in<lb/>evitabiliter urgetur, ne interiore defectu victus etiam <lb/> cadat) qui
+						primis sacramentis imbuendus est: et pu<lb/>dore enim non dicit cur eat, et
 						imbecillitate stare nou <lb/> sinitur. Expertus hæc dico: nam fecit hoc quidam , <lb/>
-						cum eum catechizarem, homo rusticanus , unde ma­ <lb/> gnopere praecavendum esse didici.
+						cum eum catechizarem, homo rusticanus , unde ma<lb/>gnopere praecavendum esse didici.
 						Quis enim ferat <lb/> arrogantiam nostram, cum viros' fralres nostros, <lb/> vel eliam
 						quod majore solliciludine curandum est, ut <lb/> sint fratres nostri, coram nobis sedere
 						non facimus ; <lb/> et ipsum Dominum nostrum, cui assistunt Angeli, <lb/> sedens mulier
 						audiebat <hi rend="italic">(Luc.</hi> x, 59)? Sane si aut <lb/> brevis sermo futurus
 						est, aut consessui locus non est <lb/> aptus, stantesaudiant; sed cum multi audiunt, et
 						<lb/> non tunc initiandi \ Nam cum unus , aut duo, aui <lb/> pauci, qui propterea
-						venerunt ut christiani fiant, pe­ <lb/> riculose loquimur stantibus. Tamen si jam sic
-						cœpi- <lb/> mos. saltem animadverso auditoris tædio, et offe­ <lb/> renda sessio est,
+						venerunt ut christiani fiant, pe<lb/>riculose loquimur stantibus. Tamen si jam sic
+						cœpi- <lb/> mos. saltem animadverso auditoris tædio, et offe<lb/>renda sessio est,
 						iuto vero prorsus urgendus ut sedeat, <note type="footnote">1 toY., <hi rend="italic">eathoHcai pdeL</hi> EdM vero alII et plerique Mss. <lb/> MB ... babeat, <hi rend="italic">fidei:</hi> pro quo subauliiri debet, Ecclesiae. </note><note type="footnote"> Apud Lov. additur, <hi rend="italic">studeat.</hi> Sed subaudiendum,
 								<hi rend="italic">oporlel.</hi>
 						</note><note type="footnote"> I Nonuulti MM., <hi rend="italic">vero*.</hi>
 						</note><note type="footnote"> fc SOIa editio ijov., pro, tmc9 babet, sunt. </note>
 						<lb/> et dicendum aliquid quo renovetur, quo etiam curas, <lb/> si qua forte irruens eum
 						avocare coeperat, fugiat ex <lb/> animo. Cum enim causæ incertæ sint cur jam tacitus
-						<lb/> recuset audire, jam sedenti aliquid adversus inciden­ <lb/> tes cogitationes
+						<lb/> recuset audire, jam sedenti aliquid adversus inciden<lb/>tes cogitationes
 						sæcularium negotiorum dicatur, aut <lb/> hilari, ut dixi, aut tristi modo : ut si ipsae
-						sunt quae <lb/> mentem occupaverunt, cedant quasi nominatim ac­ <lb/> cusatæ; si autem
-						ipsæ non sunt, et audicndo fatiga­ <lb/> tus cst, cum de illis tanquam ipsæ sint
-						(quandoqui­ <lb/> dem ignoramus), inopinatum aliquid et extraordiua­ <lb/> rium, eo modo
+						sunt quae <lb/> mentem occupaverunt, cedant quasi nominatim ac<lb/>cusatæ; si autem
+						ipsæ non sunt, et audicndo fatiga<lb/>tus cst, cum de illis tanquam ipsæ sint
+						(quandoqui<lb/>dem ignoramus), inopinatum aliquid et extraordiua<lb/>rium, eo modo
 						quo dixi, loquimur, a tædio renovatur <lb/> intentio. Sed et breve sit, maxime quia
 						extra ordinem <lb/> inseritur, ne morbum fastidii cui subvenire volumus <lb/> eliam
 						augeat ipsa medicina: et acceleranda sunt cætera, <lb/> et promittendus atque exhibendus
 						finis propinquior.</p>
 					<p>CAPUT XIV. — 20. <hi rend="italic">Remedium adversus quintam <lb/> causam lædii.
 							Remedium contra</hi> sextam <hi rend="italic">causam tædii. <lb/> ltem adversus causam
-							sextam.</hi> Si autem confregit ani­ <lb/> mum tuum alterius actionis, cui tanquam
-						magis ne­ <lb/> cessariae jam suspensus eras, omissio, et propterea <lb/> tristis
+							sextam.</hi> Si autem confregit ani<lb/>mum tuum alterius actionis, cui tanquam
+						magis ne<lb/>cessariae jam suspensus eras, omissio, et propterea <lb/> tristis
 						insuaviter catechizas; cogitare debes, excepto <lb/> quod scimus misericorditer nobis
-						agendum esse quid­ <lb/> quid cum hominibus agimus, et ex officio sinceris­ <lb/> simae
+						agendum esse quid<lb/>quid cum hominibus agimus, et ex officio sinceris<lb/>simae
 						charitatis; hoc ergo excepto, incertum esse <lb/> quid utilius agamus, et quid
-						opportuniys aut inter­ <lb/> mittamus, aut omnino omittamus. Quia enim merita <lb/>
+						opportuniys aut inter<lb/>mittamus, aut omnino omittamus. Quia enim merita <lb/>
 						hominum pro quibus agimus, qualia sint apud Deum <lb/> non novimus, quid eis ad tempus
 						expediat aut nulla <lb/> aut tenuissima aut incertissima conjectura suspicamur <lb/>
-						potius , quam comprehendimus. Quapropter res qui­ <lb/> dem agendas pro nostro captu
+						potius , quam comprehendimus. Quapropter res qui<lb/>dem agendas pro nostro captu
 						ordinare debemus: <lb/> quas eo modo quo statuimus, si peragere potuerimus, <lb/> non
 						ideo gaudeamus quia nobis, sed quia Deo sic eas <lb/> agi placuit : si autem aliqua
 						inciderit necessitas, qua <lb/> noster ille ordo turbetur; flectamur facile, ne fran-
-						<lb/> gamur; ut quem Deus nostro (a) praeposuit, ipse sit no­ <lb/> ster. Æquius est
-						enim ut nos ejus, quam ut ille no­ <lb/> stram voluntatem sequatur. Quia et ordo
-						agendarum <lb/> rerum, quem nostro arbitrio tenere volumus, ille uti­ <lb/> que
+						<lb/> gamur; ut quem Deus nostro (a) praeposuit, ipse sit no<lb/>ster. Æquius est
+						enim ut nos ejus, quam ut ille no<lb/>stram voluntatem sequatur. Quia et ordo
+						agendarum <lb/> rerum, quem nostro arbitrio tenere volumus, ille uti<lb/>que
 						approbandus est, ubi jotiora præcedunt. Cur <lb/> ergo nos dolemus homines a Domino Deo
-						tanto po­ <lb/> tiore præcedi, ut eo ipso quo nostrum amamus ordi­ <lb/> nem, inordinati
-						esse cupiamus? Nemo enim melius or­ <lb/> dinat quid agat, nisi qui paratior est non
+						tanto po<lb/>tiore præcedi, ut eo ipso quo nostrum amamus ordi<lb/>nem, inordinati
+						esse cupiamus? Nemo enim melius or<lb/>dinat quid agat, nisi qui paratior est non
 						agere quod <lb/> divina potestate prohibetur, quam cupidior agere <lb/> quod humana
-						cogitatione meditatur. Quia <hi rend="italic">multæ</hi> co­ <lb/> gitationes sunt <hi rend="italic">in corde viri,</hi> consilium <hi rend="italic">autem Domim <lb/> manet
+						cogitatione meditatur. Quia <hi rend="italic">multæ</hi> co<lb/>gitationes sunt <hi rend="italic">in corde viri,</hi> consilium <hi rend="italic">autem Domim <lb/> manet
 							in æternum (Prov.</hi> xix, 21).</p>
 					<p>21. Si vero ex aliquo scandalo perturbatus animus <lb/> non valet edere serenum
 						jucundumque sermonem, <lb/> tantam esse charitatem oportet in cos pro quibus <lb/>
@@ -871,21 +871,21 @@
 						<lb/>
 						<pb n="327"/> perire aut pcr quem perire infirmam vel credimus <lb/> vel videmus. Ille
 						igitur qni initiandus advenit, dum <lb/> speratur po se proficere, dolorem deficientis
-						abster­ <lb/> gat. Quia «t si timor ille suggeritur, lie fiat proselytus <lb/> filius
+						abster<lb/>gat. Quia «t si timor ille suggeritur, lie fiat proselytus <lb/> filius
 						gehennæ <hi rend="italic">(Matth.</hi> XXIII, 15), dum mulli tales <lb/> versantur ante
 						oculos, ex quibus oriuntur ca quibus <lb/> urimur .caudata, non ad retardandos nos
-						pertincre <lb/> debet, sed magis ad excitandos et acuendos : quale­ <lb/> nns quem
-						imbuimus moneamus, ut caveat imitatio­ <lb/> nem eorum qui non ipsa veritate, sed solo
+						pertincre <lb/> debet, sed magis ad excitandos et acuendos : quale<lb/>nns quem
+						imbuimus moneamus, ut caveat imitatio<lb/>nem eorum qui non ipsa veritate, sed solo
 						nomine <lb/> christiani sunt; nec eorum turba commotus, aut <lb/> sectari velit eos, aut
 						Cbristum nolit sectari propter <lb/> eos; et aut nolit esse in Ecclesia Dei uhi illi
-						sunt, <lb/> aut talis ibi velit esse quales illi sunt. Et nescio quo­ <lb/> modo in
+						sunt, <lb/> aut talis ibi velit esse quales illi sunt. Et nescio quo<lb/>modo in
 						hujusmodi monitis 1 ardentior sermo est, <lb/> cui fomitem subministrat præsens dolor :
-						ut non so­ <lb/> lum pigriorcs non simus, sed co ipso dicamus accen­ <lb/> sitis atque
+						ut non so<lb/>lum pigriorcs non simus, sed co ipso dicamus accen<lb/>sitis atque
 						vehementius, quod securiores frigidius et <lb/> lentius diceremus; gaudeamusque nobis
 						occasionem <lb/> dari, ubi motus animi nostri sinc fructificatione non <lb/>
 						transeat.</p>
 					<p>22. Si autem de aliquo errato nostro vel peccato <lb/> nos moestitudo comprehendit, non
-						tantum memine­ <lb/> rimus sacrificium Deu spiritum esse contribulatum <lb/>
+						tantum memine<lb/>rimus sacrificium Deu spiritum esse contribulatum <lb/>
 						<hi rend="italic">(Ptal.</hi> L, 19), sed etiam illud, <hi rend="italic">Quia sicut aqua
 							ignem,<lb/> sic eleemosyna exstinguit peccatum (Eccli.</hi> III, 33); et, <lb/>
 						<hi rend="italic">Quia misericordiam</hi>, inquit, <hi rend="italic">volo quam
@@ -893,10 +893,10 @@
 						<hi rend="italic">(Osee</hi> vi, 6). Sicut ergo si periclitaremUr incendio, ad <lb/>
 						aquam uti'tue curreremus, quo posset exstingui, et <lb/> gratularemur si quis eam de
 						proximo offerret; ita si <lb/> de nostro feno aliqua peccati flamma surrexitJ, et <lb/>
-						propterea conturbamur, data occasione misericordis­ <lb/> simi operis, tanquam de oblato
+						propterea conturbamur, data occasione misericordis<lb/>simi operis, tanquam de oblato
 						fonte gaudeamus, ut <lb/> inde illud quod exarserat opprimatur. Nisi forte tam <lb/>
-						Stulti sumus, ut alacrius arbitremur cum pane cur­ <lb/> rendum, quo ventrem esurientis
-						impleamus, quam <lb/> cum verbo Dei, quo mentem istud edentis ' instrua­ <lb/> mus. lluc
+						Stulti sumus, ut alacrius arbitremur cum pane cur<lb/>rendum, quo ventrem esurientis
+						impleamus, quam <lb/> cum verbo Dei, quo mentem istud edentis ' instrua<lb/>mus. lluc
 						accedit , quia si tantummodo prodesset <lb/> hoc facere, non facere autem nibil obesset;
 						infeliciter <lb/> in periculo salutis, non jam proximi, sed nostræ, <lb/> oblatum
 						remedium sperneremus. Cum vero ex ore <lb/> Domini tam minaciter sonet, <hi rend="italic">Serve nequam et piger,<lb/> dares pecuniam meam nummulariis (Matth.</hi>
@@ -918,39 +918,39 @@
 						<lb/> ritum sanctum qui datus est nobis <hi rend="italic">(Rom.</hi> v, 5).</p>
 					<p>CAPUT X V. —23. <hi rend="italic">Pro personarum diversitate tem­</hi>
 						<lb/> peranda <hi rend="italic">oratio.</hi> Sed nunc etiam illud quod priusquam <lb/>
-						promitterem non debebam, jam fortasse debitum fla­ <lb/> gitas, ut aliquod sermonis
+						promitterem non debebam, jam fortasse debitum fla<lb/>gitas, ut aliquod sermonis
 						exemplum, tanquam si ego <lb/> aliquem catechizem, non me pigeat explicare, et in­ <lb/>
 						tuendum tibi proponere Quod priusquam faciam, volo <lb/> cogites aliam esse intentionem
 						dictantis, cum lector <lb/> futurus cogitatur; et aliam loquentis, cuti præsens <lb/>
-						auditor attenditur : et in eo ipso aliam in secreto mo­ <lb/> nentis, dum nullus alius
+						auditor attenditur : et in eo ipso aliam in secreto mo<lb/>nentis, dum nullus alius
 						qui de nobis judicet pra sto <lb/> est; aliam palam docentis aliquid, cum dissimiliter
 						<lb/> opinantium circumstat auditus : et in huc genere <lb/> aliam, cum ducetur unus,
-						cæteri autem tanq alii ju­ <lb/> dicantes aut attestantes quæ sibi nota sunt audiunt;
-						<lb/> aliam cum omnes communiter quid ad eos profera­ <lb/> mus exspectant: et rursus in
-						hoc ipso aliam, cum <lb/> quasi privatim consedetur, ut sermocinatio consera­ <lb/> tur;
-						aliam, cum populus tacens unum de loco supe­ <lb/> riore dicturum suspensus intuetur:
-						multumque in­ <lb/> terest, et cum ila dicimus, utrum pauci adsint an <lb/> multi; docti
+						cæteri autem tanq alii ju<lb/>dicantes aut attestantes quæ sibi nota sunt audiunt;
+						<lb/> aliam cum omnes communiter quid ad eos profera<lb/>mus exspectant: et rursus in
+						hoc ipso aliam, cum <lb/> quasi privatim consedetur, ut sermocinatio consera<lb/>tur;
+						aliam, cum populus tacens unum de loco supe<lb/>riore dicturum suspensus intuetur:
+						multumque in<lb/>terest, et cum ila dicimus, utrum pauci adsint an <lb/> multi; docti
 						an indocti, an ex utroque gcnere mixti; <lb/> urbani an rustici, an hi et illi simul; an
 						populus ex <lb/> omni hominum gcnere temperatus sit. Fieri enim non <lb/> potest, nisi
-						aliter atque aliter afik iant locuturum at­ <lb/> que dicturum, et ut sermo qui
+						aliter atque aliter afik iant locuturum at<lb/>que dicturum, et ut sermo qui
 						profertur, affectionis <lb/> animi a quo profertur, qucmdam quasi vultum Hera.., <lb/>
 						et pro eadem diversitate diversc afficiat auditores, <lb/> cum et ipsi se ipsos diverse
-						afficiant invicem prae­ <lb/> sentia sua. Sed quia de rudibus imbuendis nunc agi­ <lb/>
+						afficiant invicem prae<lb/>sentia sua. Sed quia de rudibus imbuendis nunc agi­ <lb/>
 						mus, de me ipso tibi testis sum, aliter atque aliter <lb/> me moveri, cum ante ine
-						catechizandum video erudi­ <lb/> lum, inertem, civem, peregrinum, divitem, paupe- <lb/>
-						rem, privatum, honoratum, in potestate aliqua consti­ <lb/> tutum, illius aut illius
+						catechizandum video erudi<lb/>lum, inertem, civem, peregrinum, divitem, paupe- <lb/>
+						rem, privatum, honoratum, in potestate aliqua consti<lb/>tutum, illius aut illius
 						gentis hominem, illius aut <lb/> illius ætatis aut sexus, ex illa aut illa serta, ex
 						illo <lb/> aut illo vulgari errore venientem : ac pro diversitate <lb/> mutus mei sermo
 						ipse et procedit, et progreatur, <lb/> et linitur. Et quia cum eadem omnibus debeatur
-						cha­ <lb/> ritas, non eadem est omnibus adhibenda medicina : <lb/> ipsa item charitas
+						cha<lb/>ritas, non eadem est omnibus adhibenda medicina : <lb/> ipsa item charitas
 						alios parturit, cum aliis infirmatur; <lb/> alios curat aedilicarc, alios contremiscit
 						offendere; <lb/> ad alios se inciinat, ad alios se erigit; aliis blanda, <lb/> aliis
 						severa, nulli inimica , omnibus mater. Et qui <lb/> non expertus est eadem charitate
 						quod dico, cum <lb/> videt nos, quia facultas aliqua nobis donata delectat <lb/>
 						laudabiliter innotescere in ore multitudinis, inde nos <lb/> beatos putat : Deus autem,
-						in cujtis conspecturn in­ <lb/> trat gemitus compeditorum <hi rend="italic">(Psal.</hi>
-						LXXVIII, 11), vi­ <lb/> deat humilitatem nostram et laborem nostrum, et di­ <lb/> mittat
-						omnia peCcata nostra <hi rend="italic">(Pul.</hi> XXIV, 18). Quam­ <lb/> obrem si quid
+						in cujtis conspecturn in<lb/>trat gemitus compeditorum <hi rend="italic">(Psal.</hi>
+						LXXVIII, 11), vi<lb/>deat humilitatem nostram et laborem nostrum, et di<lb/>mittat
+						omnia peCcata nostra <hi rend="italic">(Pul.</hi> XXIV, 18). Quam<lb/>obrem si quid
 						tibi in nobis placuit, ut aliquam <lb/> observationem sermonis tui a nobis audire
 						quæretes, <lb/> melius videndo et audiendo nos cum hæc agimus, <lb/> quam legendo cum
 						hæc dictamus. edisceres.</p>
@@ -959,79 +959,79 @@
 						<lb/> in <hi rend="italic">rebus inquietis non quærenda. Non in divitiis,</hi> noc in <lb/>
 						<pb n="329"/> honoribus. <hi rend="italic">Requiem quærentes</hi> in <hi rend="italic">oblectamentis earnis</hi>
 						<lb/> et in <hi rend="italic">spectaculis.</hi> Sed tamen faciamus aliquem venisse <lb/>
-						ad nos, qui vult esse christianus, et de genere qui­ <lb/> dem idiotarum, non tamen
-						rusticanorum, sed urba­ <lb/> norum, quales apud Carthaginem plures experiri te <lb/>
+						ad nos, qui vult esse christianus, et de genere qui<lb/>dem idiotarum, non tamen
+						rusticanorum, sed urba<lb/>norum, quales apud Carthaginem plures experiri te <lb/>
 						necesse est : interrogatum etiam utrum propter vitæ <lb/> præsentis aliquod commodum, an
-						propter requiem <lb/> quae post hanc vitam speratur, christianus esse de­ <lb/> sidcrat,
+						propter requiem <lb/> quae post hanc vitam speratur, christianus esse de<lb/>sidcrat,
 						propter futuram reqpiem respondisse: tali <lb/> fortasse a nobis instrueretur alloquio.
 						Deo gratias, <lb/> frater : valde tibi gratulor, et gaudeo de te, quod in <lb/> tantis
 						ac tam periculosis hujus sæculi tempestatibus <lb/> de aliqua vera et certa securitate
 						cogitasti. Nam et in <lb/> hac vita homines magnis laboribus requiem quaerunt <lb/> et
-						securitatem, sed pravis cupiditatibus non inve­ <lb/> niunt. Volunt enim requiescere in
-						rebus inquietis et <lb/> uon permanentibus : et quia illae tempore subtra­ <lb/> huntur
-						et transeunt, timoribus et doloribus eos agi­ <lb/> tant, nee quietos esse permiuunt.
-						Sive enim in di­ <lb/> viliis velit homo requiescere, magis superbus <lb/> efficitur,
+						securitatem, sed pravis cupiditatibus non inve<lb/>niunt. Volunt enim requiescere in
+						rebus inquietis et <lb/> uon permanentibus : et quia illae tempore subtra<lb/>huntur
+						et transeunt, timoribus et doloribus eos agi<lb/>tant, nee quietos esse permiuunt.
+						Sive enim in di<lb/>viliis velit homo requiescere, magis superbus <lb/> efficitur,
 						quam securus. Annon videmus quam multi <lb/> eas subito perdiderint, multi etiam propter
 						illas <lb/> perierint, aut cum eas habere cupiunt, aut cum eis <lb/> oppressis a
 						cupidioribus auferuntur 1? Quæ si etiam <lb/> per totam vitam cum homine permanerent, et
-						non <lb/> desererent dilectorem suum, ipse illas sua morte de­ <lb/> sereret. Quanta est
-						enim vita hominis, etiamsi sene­ <lb/> scat? Aut cum sibi homines optant senectutem,
-						quid <lb/> aliud optant nisi longam infirmitatem? Sic et hono­ <lb/> res hujus sacculi,
+						non <lb/> desererent dilectorem suum, ipse illas sua morte de<lb/>sereret. Quanta est
+						enim vita hominis, etiamsi sene<lb/>scat? Aut cum sibi homines optant senectutem,
+						quid <lb/> aliud optant nisi longam infirmitatem? Sic et hono<lb/>res hujus sacculi,
 						quid sunt nisi typhus, et inanitas2, <lb/> et ruinx periculum? Quia sic Scriptura sancta
 						dicit: <lb/>
 						<hi rend="italic">Omnis</hi> earo fenum, et claritas <hi rend="italic">hominis ut</hi>
-						flos feni. Fe­ <lb/> num <hi rend="italic">aruit, flos decidit; verbum</hi> autem <hi rend="italic">Domini</hi> manet <lb/> in æternum <hi rend="italic">[Isa. XL,</hi>
+						flos feni. Fe<lb/>num <hi rend="italic">aruit, flos decidit; verbum</hi> autem <hi rend="italic">Domini</hi> manet <lb/> in æternum <hi rend="italic">[Isa. XL,</hi>
 						6-8). Ideo qui veram requiem et <lb/> veram felicitatem desiderat, debet tollere spem
-						suam <lb/> de rebus mortalibus et praetereuntibus, et eam col­ <lb/> locare in verbo
+						suam <lb/> de rebus mortalibus et praetereuntibus, et eam col<lb/>locare in verbo
 						Domini; ut haerens ei quod manet in <lb/> æternum, etiam ipse cum illo maneat in
 						æternum.</p>
 					<p>25. Sunt etiam homines qui nee divites quaerunt <lb/> esse, nee ad vanas honorum pompas
-						ambiunt per­ <lb/> venire : sed gaudere et requiescere volunt in pop!­ <lb/> nis et in
-						fornicationibus, et in theatris atque specta­ <lb/> culis nugacitatis quæ in magnis
+						ambiunt per<lb/>venire : sed gaudere et requiescere volunt in pop!<lb/>nis et in
+						fornicationibus, et in theatris atque specta<lb/>culis nugacitatis quæ in magnis
 						civitatibus gratis <lb/> habent. Sed sic ctiam ipsi aut consumunt per <lb/> luxuriam
 						paupertatem suam, et ab egestate postea in <lb/> furta et effracturas, et aliquando
 						eLiam in latrocinia <lb/> prosiliunt, et subito multis et magnis timoribus iut­ <lb/>
 						pUnitur; et qui in popina paulo ante cantabant, jam <lb/> planctus carceris somniant.
-						Studiis autem spectacu­ <lb/> lorum fiunt dæmonibus similes, clamoribus suis in­ <lb/>
-						citando homines ut se invicem caedant, secumque ha­ <lb/> beant contentiosa certamina
+						Studiis autem spectacu<lb/>lorum fiunt dæmonibus similes, clamoribus suis in­ <lb/>
+						citando homines ut se invicem caedant, secumque ha<lb/>beant contentiosa certamina
 						qui se non laeserunt, <lb/> dnm placere insano populo cupiunt: quos si animad­ <lb/>
-						verterint esse concordes, tunc eos oderunt et per­ <lb/> sequuntur, et tanquam
+						verterint esse concordes, tunc eos oderunt et per<lb/>sequuntur, et tanquam
 						collusores ut fustibus verbe- <note type="footnote">1 Plerique diss., <hi rend="italic">aut ui eia oppressh</hi> a cupidioribus au­ <lb/>
 							<hi rend="italic">krrentur.</hi>
 						</note><note type="footnote"> s sic pierique Mss. At editi omittunt, <hi rend="italic">et viawta*</hi> : cujus <lb/> loco nonnulli Mss., et vomtas. </note>
 						<lb/> rentur exclamant, et hanc iniquitatem facere etiam <lb/> vindicem iniquitatum
 						judicem cogunt; si autem hor. <lb/> rendas adversus invicem inimicitias eos exercere
-						<lb/> cognoverint, sive sintae qui appellantur 1, sive sce­ <lb/> nici et thymelici,
+						<lb/> cognoverint, sive sintae qui appellantur 1, sive sce<lb/>nici et thymelici,
 						sive aurigæ, sive venatores, quos <lb/> miseros non solum homines cum hominibus, sed
-						etiam <lb/> homines cum bestiis in certamen pugnamque com­ <lb/> mittunt ; quo majore
-						adversus invicem discordia fu­ <lb/> rere senserint, eo magis amant et delectantur, et
-						in­ <lb/> citatis 2 favent, et faventes incitant, plus adversus se <lb/> ipsos
+						etiam <lb/> homines cum bestiis in certamen pugnamque com<lb/>mittunt ; quo majore
+						adversus invicem discordia fu<lb/>rere senserint, eo magis amant et delectantur, et
+						in<lb/>citatis 2 favent, et faventes incitant, plus adversus se <lb/> ipsos
 						insanicntes ipsi spectatores alter pro altero, <lb/> quam illi quorum insaniam insani
-						provocant, sed in - <lb/> saniendo 8 spectare desiderant. Quomodo ergo sani­ <lb/> tatem
+						provocant, sed in - <lb/> saniendo 8 spectare desiderant. Quomodo ergo sani<lb/>tatem
 						pacis tenere animus potest, qui discordiis et <lb/> certaminibus pascitur? Qualis enim
-						cibus sumitur, <lb/> talis valetudo consequitur. Postremo, quamvis in­ <lb/> sana gaudia
+						cibus sumitur, <lb/> talis valetudo consequitur. Postremo, quamvis in<lb/>sana gaudia
 						non sint gaudia, tamen qualiacumque <lb/> sint, et quantumlibet delectet jactantia
-						divitiarum, <lb/> i i tumor honorum, vorago popinarum, et bella thea­ <lb/> trorum I, et
+						divitiarum, <lb/> i i tumor honorum, vorago popinarum, et bella thea<lb/>trorum I, et
 						immunditia fornicationum, et prurigo <lb/> thermarum; aufert omnia ista una febricula,
-						et <lb/> adhuc viventibus totam rabam beatitudinem sublra­ <lb/> hit: remanet inanis et
-						saucia conscientia, Deum sen­ <lb/> sura judicem, quem noluit habere custodem; et in-
+						et <lb/> adhuc viventibus totam rabam beatitudinem sublra<lb/>hit: remanet inanis et
+						saucia conscientia, Deum sen<lb/>sura judicem, quem noluit habere custodem; et in-
 						<lb/> Tentura asperum Dominum, quem dulcem patrem <lb/> quærere et amare contempsit. Tu
-						autem quia veram <lb/> requiem quae post hanc vitam Christianis promitti­ <lb/> tur
+						autem quia veram <lb/> requiem quae post hanc vitam Christianis promitti<lb/>tur
 						qu;eris, etiam hic eam inter amarissimas vito <lb/> hujus molestias suavem jucundamque
-						gustabis, si ejus <lb/> qui eam promisit præcepta dilexeris. Cito enim sen­ <lb/> ties
+						gustabis, si ejus <lb/> qui eam promisit præcepta dilexeris. Cito enim sen<lb/>ties
 						dulciores esse justitiæ fructus quam iniquitatis, <lb/> et verius atque jucundius
 						gaudere homiuem de bona <lb/> conscientia inter molestias, quam de mala inter de. <lb/>
 						licias; quia non sic venisti conjungi Ecclesiae Dei, ut <lb/> ex ea temporalem aliquam
 						utilitatem requiras.</p>
 					<p>CAPUT XVII.-26. <hi rend="italic">Reprehenditur</hi> qui <hi rend="italic">velit
-							esseChri­<lb/> stianus propter commodum</hi> temporale. <hi rend="italic">Christianus</hi> vere <lb/>
+							esseChri<lb/>stianus propter commodum</hi> temporale. <hi rend="italic">Christianus</hi> vere <lb/>
 						<hi rend="italic">est, qui religionem profitetur propter futuram</hi> requiem. <lb/>
 						<hi rend="italic">Transit ad narrationem eorum quæ credenda sunt. <lb/> Filius</hi> Dei
 							<hi rend="italic">cur homo factus.</hi> Sunt enim qui propterea <lb/> volunt esse
 						cbristiani, ut aut promereantur homines <lb/> a quibus temporalia commoda exspectant,
 						aut quia <lb/> offendere nolunt quos timent. Sed isti reprobi sunt : <lb/> et si ad
 						tempus eos portat Ecclesia, sicut area usque <lb/> ad tempus ventilationis paleam
-						sustinet; si non se <lb/> correxerint, et propter futuram sempiternam re­ <lb/> quiem
+						sustinet; si non se <lb/> correxerint, et propter futuram sempiternam re<lb/>quiem
 						christiani esse coeperint, in fine separabuntur. <lb/> Nec sibi blandiantur quod in area
 						possunt esse cam <lb/> frumento Dei : quia in horreo cum illo non erunt, sed <lb/> igni
 						debito destinantur' <hi rend="italic">(Matth.</hi> III, 12). Sunt etiam <note type="footnote"> 1 to,., <hi rend="italic">sint aihleUB</hi> qui <hi rend="italic">appeUmdur.</hi> At plerique ae me- <lb/> Doris notae Mss., <hi rend="italic">sintce</hi> qvi <hi rend="italic">appeUantur.</hi> vox erat forsitaa <lb/> apud
@@ -1049,42 +1049,42 @@
 						<note type="footnote"> PATIIOL. XL. </note>
 						<note type="footnote"> (Unze.J </note>
 						<lb/>
-						<pb n="331"/> atii meliore quidem spc, scil lamcn non minore pe­ <lb/> riculo, qui jam
-						Deum timent, ct non irrident chri­ <lb/> stianum nomcn, nee simulalo cordc intrant
-						Eccle­ <lb/> siam Dei, sed in ista vita exspectant felicitatem, ut fe­ <lb/> liciores
+						<pb n="331"/> atii meliore quidem spc, scil lamcn non minore pe<lb/>riculo, qui jam
+						Deum timent, ct non irrident chri<lb/>stianum nomcn, nee simulalo cordc intrant
+						Eccle<lb/>siam Dei, sed in ista vita exspectant felicitatem, ut fe<lb/>liciores
 						sint in rchus terrenis, quam illi qui non colunt <lb/> Deum : ideoque cum viderint
 						quosdam sceleratos et <lb/> impios ista sæculi 1 prosperitate pollere ct excellere,
-						<lb/> . se autem vel minus habere ista vel amittere, pertur­ <lb/> bantur tanquam sine
+						<lb/> . se autem vel minus habere ista vel amittere, pertur<lb/>bantur tanquam sine
 						causa Deum colant , el facile a <lb/> fide deficiunt.</p>
 					<p>27. Qui autem propter beatitudinem sempiternam <lb/> ct perpetuam requiem, quæ post
 						hanc vitam sanctis <lb/> futura promittitur, vult fieri christianus, ut non eat <lb/> in
 						ignem aeternum cum diabolo, sod in regnum <lb/> æternum intret cum <hi rend="italic">Christo (Matth.</hi> xxv, 54, 41, 46), <lb/> vere ipse christianus est, cautus in
-						omni tentatione, <lb/> ne prosperis rebus corrumpatur, et ne frangatur ad­ <lb/> versis,
-						et in abundantia bonorum terrenorum mo­ <lb/> destus et temperans, et in tribulationibus
+						omni tentatione, <lb/> ne prosperis rebus corrumpatur, et ne frangatur ad<lb/>versis,
+						et in abundantia bonorum terrenorum mo<lb/>destus et temperans, et in tribulationibus
 						fortis et <lb/> patiens. Qui etiam proficiendo pervenict ad talem <lb/> animum, ut plus
-						amet Deum, quam timeat gehen­ <lb/> nam : ut ctiamsi dicat illi Dens, Ulcre dcliciis
-						car­ <lb/> nalibus sempiternis, et quantum potes pecca, nec <lb/> morieris, nee ia
-						gehennam mitteris, sed mecum tan­ <lb/> tummodo non cris; exhorrescat, et omnino non
-						pec­ <lb/> cet, non jam ut in illud quod timebat non incidat, <lb/> sed ne illum quem
+						amet Deum, quam timeat gehen<lb/>nam : ut ctiamsi dicat illi Dens, Ulcre dcliciis
+						car<lb/>nalibus sempiternis, et quantum potes pecca, nec <lb/> morieris, nee ia
+						gehennam mitteris, sed mecum tan<lb/>tummodo non cris; exhorrescat, et omnino non
+						pec<lb/>cet, non jam ut in illud quod timebat non incidat, <lb/> sed ne illum quem
 						sic amat offendat: in quo uno est <lb/> rcquics t, quam oculus non vidit, nec auris
 						audivit, <lb/> me in cor hominis ascendit, quam præparavit Dcus <lb/> diligentibus cum
 						(I <hi rend="italic">Cor.</hi> II, 9).</p>
 					<p>28. De qua requie significat 8 Scriptura, et non <lb/> tacet, quod ab mitio mundi ex
 						quo fecit Deus cœlum <lb/> et terram ct omnia quae in eis sunt, sex dicbus ope­ <lb/>
 						ratus est, ct septimo dic requievit <hi rend="italic">(Gen,</hi> i, <hi rend="italic">et</hi> II, 1-3). <lb/> Poterat cnim omnipotens et uno momento temporis <lb/> omnia
-						faccre. Non autem laboraverat, ut requiesce­ <lb/> rel, quando, <hi rend="italic">Dixit,
+						faccre. Non autem laboraverat, ut requiesce<lb/>rel, quando, <hi rend="italic">Dixit,
 							et facta sunt ; mandavit,</hi> et <hi rend="italic">creata<lb/> sunt (Psal.</hi>
 						CXLVIII, 5) : sed ut significaret, quia post <lb/> sex ætates mundi hujus, septima
-						actate tanquam se­ <lb/> ptimo die requicturus est in sanctis suis; quia ipsi <lb/> in
+						actate tanquam se<lb/>ptimo die requicturus est in sanctis suis; quia ipsi <lb/> in
 						illo requiescent post omnia bona opera, in quibus <lb/> ei servierunt, quae ipse in
 						illis operatur, qui vocat, <lb/> et præcipit, et delicta praetrita dimittit, et
 						justificat <lb/> cum qui prius erat impius. Sicut autem cum illi ex <lb/> duno ejus bene
 						opcrantur, recte dicitur ipse operari ; <lb/> sic cum in illo requiescunt *, recto
-						dicitur ipse re­ <lb/> quicscere. Nam quod ad ipsum attinet, pausationem <lb/> non
+						dicitur ipse re<lb/>quicscere. Nam quod ad ipsum attinet, pausationem <lb/> non
 						quærit, quia laborem non sentit. Fecit autcm <lb/> omnia per Verbum suum; et Verbum ejus
-						ipse Chri­ <lb/> stus, in quo requiescunt Angeli et omnes cœlestes <lb/> mundissimi
+						ipse Chri<lb/>stus, in quo requiescunt Angeli et omnes cœlestes <lb/> mundissimi
 						spiritus in sancto silentio. Homo autem <lb/> peecato lapsus perdidit requiem quam
-						habebat in cjus <lb/> divinitate, pt recipit eam 1 in ejus humanitate : ideo­ <lb/> que
+						habebat in cjus <lb/> divinitate, pt recipit eam 1 in ejus humanitate : ideo<lb/>que
 						opportuno tempore, quo ipse sciebat oportere <lb/> fieri, homo factus et de feniina
 						natus est. A carne <note type="footnote">1 Am. Er. et tres Mss., <hi rend="italic">tceculari.</hi>
 						</note><note type="footnote"> I sic Mss. Editi vero, <hi rend="italic">iri quo una</hi>
@@ -1106,75 +1106,75 @@
 							credendum. Homo</hi> in <hi rend="italic">paradiso</hi> constitu­ <lb/>
 						<hi rend="italic">tus. Cur creatus qui præsciebatur peccaturus. Lapsus <lb/> hominis et
 							angeli nihil Deo nocuit.</hi> Quoniam Deus <lb/> omnipotens, et bonus et justus et
-						misericors, qui fc­ <lb/> cit omnia bona, sive. magna sive parva, sive summa <lb/> sive
+						misericors, qui fc<lb/>cit omnia bona, sive. magna sive parva, sive summa <lb/> sive
 						infima ; sive quæ videntur, sicuti sunt cœlum et <lb/> terra ct mare, et in coelo sol et
-						luna, et cætera si­ <lb/> der:., in terra autem et mari arbores et frutices et <lb/>
+						luna, et cætera si<lb/>der:., in terra autem et mari arbores et frutices et <lb/>
 						animalia suæ cujusque naturæ, et omnia corpora vel <lb/> coelestia vel terrestria ; sive
 						quæ non videntur, sicuti <lb/> sunt spiritus quibus corpora vegetantur et vivifican­
-						<lb/> tur : fecit et hominem ad imaginem suam ; ut quem­ <lb/> admodum ipse per
-						omnipotentiam suam præest uni­ <lb/> versæ creaturæ, sic homo per intelligentiam suam,
-						<lb/> qua etiam Crcatorem suum cognoscit et colit, præes­ <lb/> set omnibus terrenis
+						<lb/> tur : fecit et hominem ad imaginem suam ; ut quem<lb/>admodum ipse per
+						omnipotentiam suam præest uni<lb/>versæ creaturæ, sic homo per intelligentiam suam,
+						<lb/> qua etiam Crcatorem suum cognoscit et colit, præes<lb/>set omnibus terrenis
 						animalibus. Fecit iili etiam ad. <lb/> jutorium feminam : non ad carnalem concupiscen­
 						<lb/> tiam, quandoquidem nec corruptibilia corpora tunc <lb/> hahenant, antequam eos
 						mortalitas invaderet poena <lb/> peccati; sed ut habcret et vir gloriam de femina, <lb/>
-						cum ei præiret ad Deum 2, seque i!li præberet imi­ <lb/> tandum in sanctitate atque
+						cum ei præiret ad Deum 2, seque i!li præberet imi<lb/>tandum in sanctitate atque
 						pietate; sicut ipse esset <lb/> gloria Dei, cum ejus sapientiam sequcretur.</p>
 					<p>. 50. Itaque constituit cos in quodam loco perpetuæ <lb/> beatitudinis, quem appellat
 						Scriptura paradisum ; <lb/> præceptumque illis dedit, quod si non transgrede­ <lb/>
-						rentur, in illa semper immoratlitatis beatitudine per­ <lb/> manerent: si autem
-						transgrederentur, supplicia mor­ <lb/> talitatis expenderent. Praesciebat autem Deus eos
-						<lb/> transgressuros : sed tamen quia conditor est et effe­ <lb/> ctor omnis boni, magis
-						eos fecit, quando fecit et be­ <lb/> stias, ut impleret terram bonis terrenis. Et utique
+						rentur, in illa semper immoratlitatis beatitudine per<lb/>manerent: si autem
+						transgrederentur, supplicia mor<lb/>talitatis expenderent. Praesciebat autem Deus eos
+						<lb/> transgressuros : sed tamen quia conditor est et effe<lb/>ctor omnis boni, magis
+						eos fecit, quando fecit et be<lb/>stias, ut impleret terram bonis terrenis. Et utique
 						<lb/> mclior est homo etiam peccator, quam bestia. Et <lb/> præceptum quod non erant
 						servaturi, magis dedit, ut <lb/> essent inexcusabiles, cum in eos vindicare coepisset.
-						<lb/> Quidquid enim homo fecerit, laudabilem in suis fa­ <lb/> ctis invenit Deum : si
-						recte egerit, laudabilem inve­ <lb/> nit per justitiam præmiorum ; si peccaverit, lauda­
+						<lb/> Quidquid enim homo fecerit, laudabilem in suis fa<lb/>ctis invenit Deum : si
+						recte egerit, laudabilem inve<lb/>nit per justitiam præmiorum ; si peccaverit, lauda­
 						<lb/> bilem invenit per justitiam suppliciorum ; si peccata <lb/> confessus ad recte
-						vivendum redierit, laudabilem in­ <lb/> venit pur misericordiam indulgentiarum. Cur ergo
+						vivendum redierit, laudabilem in<lb/>venit pur misericordiam indulgentiarum. Cur ergo
 						<lb/> non faceret Deus hominem, quamvis eum peccaturum <lb/> praenosceret, cum et
-						stantem coronaret, et caden­ <lb/> tem ordinaret, et surgentem adjuvaret, semper et
+						stantem coronaret, et caden<lb/>tem ordinaret, et surgentem adjuvaret, semper et
 						<lb/> ubique ipse gloriosus bonitate, justitia, clementia? <lb/> maxime quia et illud
-						præsciebat, de propagine mor- <note type="footnote"> I Ain. et Fr., <hi rend="italic">humanitate.</hi>
-						</note><note type="footnote"> ' Iv., domiui'm. Editi alii, ! <hi rend="italic">o.i.invn.</hi>
+						præsciebat, de propagine mor- <note type="footnote"> 1 AM. et Er., <hi rend="italic">humanitate</hi>.
+						</note><note type="footnote"> 2 Er., <hi rend="italic">dominium</hi>. Editi alii, <hi rend="italic">Dominum</hi>.
 						</note>
 						<lb/>
-						<pb n="333"/> . talitatis ejus futuro! sanctos, qui non ili qua-re­ <lb/> rent, sed
-						Creatori suo gloriam darent, et cum co­ <lb/> lendo ab omni corruptione liberati, cum
+						<pb n="333"/> . talitatis ejus futuro! sanctos, qui non ili qua-re<lb/>rent, sed
+						Creatori suo gloriam darent, et cum co<lb/>lendo ab omni corruptione liberati, cum
 						Angelis <lb/> sanctis semper vivere et beate vivere mererentur? <lb/> Qui enim hominibus
 						dedit liberum arbitrium, ut non <lb/> servili necessitate, sed ingenua voluntate Dcum
-						co­ <lb/> lerent, dedit ctiam Angelis. Et idco ncc angelus, qui <lb/> cum spiritibus
-						aliis satellitibus suis superbiendo de­ <lb/> seruit obedientiam Dei, et diabolus factus
-						est, aliquid <lb/> nocuit Dco, sed sibi : novit enim Deus ordinare de­ <lb/> serentes se
-						animas (a), et ex earum justa miscria in­ <lb/> feriores partes creaturæ
+						co<lb/>lerent, dedit ctiam Angelis. Et idco ncc angelus, qui <lb/> cum spiritibus
+						aliis satellitibus suis superbiendo de<lb/>seruit obedientiam Dei, et diabolus factus
+						est, aliquid <lb/> nocuit Dco, sed sibi : novit enim Deus ordinare de<lb/>serentes se
+						animas (a), et ex earum justa miscria in<lb/>feriores partes creaturæ
 						suæconvenientissimis et <lb/> congruentissimis Icgibus admirandæ dispensationis <lb/>
 						ornure1. ltaque nec diabol us aliquid Deo nocuit, quia <lb/> vcl ipse lapsus est, vel
 						hominem seduxit ad mortem : <lb/> nec ipse bomo in aliquo minuit veritatem aut pole­
 						<lb/> statom aut beatitatem 2Conditoris sui, quia conjugi <lb/> suæ seductæ a diabolo,
 						ad id quod Deus prohibuerat, <lb/> propria voluntate consensit. Justissimis enim Dei
-						<lb/> legibus omnes damnati sunt, Dco glorioso per æqui­ <lb/> tatem vindictæ, ipsi
+						<lb/> legibus omnes damnati sunt, Dco glorioso per æqui<lb/>tatem vindictæ, ipsi
 						ignominiosi per turpitudinem <lb/> pœnæ <hi rend="italic">(Gen.</hi> II, III) : ut et
-						homo a suo Creatore aver­ <lb/> sas victus diabolo subderetur, et diabolus homini ad
+						homo a suo Creatore aver<lb/>sas victus diabolo subderetur, et diabolus homini ad
 						<lb/> Creatorem suum converso vincendus proponeretur; <lb/> lit quicumque diabolo usque
 						in finem consentirent, <lb/> cum illo irent in æterna supplicia ; quicumque autem <lb/>
 						humiliarent se Deo, et per ejus gratiam diabolum <lb/> vincerent, æterna præmia
 						mererentur.</p>
 					<p>CAPUT XIX. — 31. In Ecclesia <hi rend="italic">boni et mali,</hi> in <lb/>
 						<hi rend="italic">fine separandi. Civitates duæ ab initio generis humani.<lb/> Diluvium
-							et arca sacramentum. De Abrahamo et Israe­ <lb/> litico populo. Horum dicta et facta,
+							et arca sacramentum. De Abrahamo et Israe<lb/>litico populo. Horum dicta et facta,
 							prophetia fuit.</hi>
 						<lb/> Neque hoc nos movere debet; quia multi diabolo <lb/> con entiunt, et pauci Deum
-						sequuntur : quia et fru­ <lb/> mentum in comparatione palearum valde pauciorem <lb/>
+						sequuntur : quia et fru<lb/>mentum in comparatione palearum valde pauciorem <lb/>
 						habet numerum. Sed sicut agricola novit quid faciat <lb/> cie ingenti acervo paleas, sic
 						nihil est Dco multitudo <lb/> peccatorum, qui novit quid de illis agat, ut admi­ <lb/>
-						nistatio regni ejus ex nulla parte turbetur atqu tur­ <lb/> petur. Nec idCo putandus.
+						nistatio regni ejus ex nulla parte turbetur atqu tur<lb/>petur. Nec idCo putandus.
 						cst vicissc diabolus, quia <lb/> secum plurcs, cum quibus a paucis vinceretur, at­ <lb/>
 						traxit. Duæ itaque civitates, una iniquorum, altera <lb/> sanctorum, ab initio generis
 						humani usque in finem <lb/> sæculi perducuntur, nunc permivtæcorporibus, sed <lb/>
-						voluntatibus separatæ, in die vero judicii etiam cor­ <lb/> pure separandae. Omnes enim
-						homincs amantes su­ <lb/> perbiam et temporalem dominationem cum vano ty­ <lb/> pho ct
+						voluntatibus separatæ, in die vero judicii etiam cor<lb/>pure separandae. Omnes enim
+						homincs amantes su<lb/>perbiam et temporalem dominationem cum vano ty<lb/>pho ct
 						pompa arrogantiæ, omnesque spiritus qui talia <lb/> diligunt, et gloriam suam
-						subjectione hominum quae­ <lb/> runt. simul una societate devincti sunt; sed et si <lb/>
-						sæpe 3 adversum se pro his rebus dimicant, pari ta­ <lb/> men pondere cupiditatis in
+						subjectione hominum quae<lb/>runt. simul una societate devincti sunt; sed et si <lb/>
+						sæpe 3 adversum se pro his rebus dimicant, pari ta<lb/>men pondere cupiditatis in
 						eamdem profunditatem <lb/> præcipitantur, et sibi morum et meritorum similitu­ <lb/>
 						dine conjunguntur. Et rursus omnes homines et <lb/> omnes spiritus humiliter Dei gloriam
 						quærentes, non <lb/> suam, et cum pictate sectantes, ad unam pertinent <note type="footnote"> 1 sola cditio Lov., <hi rend="italic">ordinare.</hi>
@@ -1183,26 +1183,26 @@
 								si sæpe;</hi> omisso. <hi rend="italic">sed.</hi>
 						</note>
 						<note type="footnote"> (a) n Retract. cap. t4. </note>
-						<lb/> societatem. Et tamen Dcus misericordissimus, et su­ <lb/> per impios homines
-						paticns est, et præbet eis pœni­ <lb/> tentiæatque correctionis locum.</p>
+						<lb/> societatem. Et tamen Dcus misericordissimus, et su<lb/>per impios homines
+						paticns est, et præbet eis pœni<lb/>tentiæatque correctionis locum.</p>
 					<p>32. Nam et quod omnes diluvio delevit, exceptu <lb/> uno justo cum suis, quos in arca
-						servari voluit, nove­ <lb/> rat quidem quod non se correcturi essent: verumta­ <lb/> men
+						servari voluit, nove<lb/>rat quidem quod non se correcturi essent: verumta<lb/>men
 						cum per centum annos arca fabricata est, præ- <lb/> dicabatur utique eis ira Dei ventura
 						super eos <lb/>
-						<hi rend="italic">(Gen.</hi> vi, VII); ct si converterentur 1 ad Deum, par­ <lb/> cerct
+						<hi rend="italic">(Gen.</hi> vi, VII); ct si converterentur 1 ad Deum, par<lb/>cerct
 						cis, sicut pepercit postea Ninive civitati agenti <lb/> pœnitentiam, cum ei per
-						prophetam futurum inter­ <lb/> itum prænuntiasset <hi rend="italic">(Jonæ</hi> III). Hoc
+						prophetam futurum inter<lb/>itum prænuntiasset <hi rend="italic">(Jonæ</hi> III). Hoc
 						autem facit Deus, <lb/> eliam illis quos novit in malitia-perseveraturos dans <lb/>
 						pœnitendi spatium, ut nostram paticntiam exerceat et <lb/> informet exemplo suo; quo
 						noverimus quantum nos <lb/> oporteat tolerabiliter malos sustinere, cum ignoremus <lb/>
 						quales postea futuri sunt, quando ille parcit ct sinil <lb/> cos vivcre, quem nihil
-						futurorum latet. Prænuntia­ <lb/> batur tamen etiam diluvii sacramento quo per Ii­ <lb/>
+						futurorum latet. Prænuntia<lb/>batur tamen etiam diluvii sacramento quo per Ii­ <lb/>
 						gnum justi liberati sunt, futura Ecclesia quam rex <lb/> ejus et Deus Christus mysterio
 						suae crucis ab hujus <lb/> sæculi submersione suspendit. Neque enim Deus <lb/> ignorabat
-						quod etiam ex illis qui fuerant in arca ser­ <lb/> vati, nascituri crant mali, qui
-						faciem terræ iniqnita­ <lb/> tibus iterum implerent : sed tamen et cxemplum fu­ <lb/>
+						quod etiam ex illis qui fuerant in arca ser<lb/>vati, nascituri crant mali, qui
+						faciem terræ iniqnita<lb/>tibus iterum implerent : sed tamen et cxemplum fu­ <lb/>
 						turi judicii dedit, et sanctorum liberationem ligni <lb/> mysterio prænuntiavit. Nam ct
-						post hæc non cassa­ <lb/> vit rcpullularc malilia per superbiam ct libidines ct <lb/>
+						post hæc non cassa<lb/>vit rcpullularc malilia per superbiam ct libidines ct <lb/>
 						illicitas impielatcs, cum homines deserto Creatore <lb/> suo, non solum ad creaturam
 						quam Deus condidit <lb/> lapsi sunt, ut pro Dco colerent quod fecit Deus.; sed <lb/>
 						etiam ad opera manuum hominum et ad fabrorum <lb/> artificia curvaverunt animas suas,
@@ -1210,19 +1210,19 @@
 						figmentis adorari venerarique letantur, dum errores <lb/> suos humanis crroribus pascunt
 						2.</p>
 					<p>33. Nequc tunc sane dcfucrunt justi qui Deum pie <lb/> quærerent, et superbiam diaboli
-						vincerent, cives it­ <lb/> lius sanctæ civitatis, quos rcgis sui Christi ventura <lb/>
+						vincerent, cives it<lb/>lius sanctæ civitatis, quos rcgis sui Christi ventura <lb/>
 						humilitas per Spiritum revelata sanavit. Ex quibus <lb/> Abraham pius et fidelis Dei
 						servus electus est <hi rend="italic">(Gen.</hi> XII). <lb/> cui demonstraretur
 						sacramentum Filii Dei, ut propter <lb/> imitationem fidei omnes fideles omnium gentium
 						filii <lb/> cjus futuri dicerentur. Ex illo natus est populus a <lb/> quo unus Deus
 						vcrus coleretur qui fecit coelum ct <lb/> terram, cum cæteræ gentes simulacris et
 						dnemoniis <lb/> servirent. In eo plane populo multo evidentius futura <lb/> Ecclesia
-						figurata est. Erat enim ibi multitudo carna­ <lb/> lis, quæ propter visibilia beneficia
+						figurata est. Erat enim ibi multitudo carna<lb/>lis, quæ propter visibilia beneficia
 						colebat Deum. <lb/> Erant ibi autem pauci futuram requiem cogitantes et <lb/> cælestem
 						patriam requirentes, quibus prophetando <lb/> revelabatur futura humilitas Dei, regis et
-						Domini <lb/> nostri Jesu Christi, ut per eam fidem ab omni fu­ <lb/> perbia et tumore
+						Domini <lb/> nostri Jesu Christi, ut per eam fidem ab omni fu<lb/>perbia et tumore
 						sanarentur. Horum sanctorum, qui <lb/> præcesserunt tempore nativitatem Domini, non so­
-						<lb/> lum sermo, sed etiam vita, et conjugia, et filii, et fa­ <lb/> cta, prophetia fuit
+						<lb/> lum sermo, sed etiam vita, et conjugia, et filii, et fa<lb/>cta, prophetia fuit
 						hujus temporis, quo per fidem <note type="footnote"> I Er. et Lov., <hi rend="italic">tU
 								si converterentur.</hi> Am. et Mss., <hi rend="italic">et Ii CQIU<lb/>
 								verterentur</hi> . </note><note type="footnote"> a Floriacensis oijidam Ms., <hi rend="italic">irriscent.</hi>
@@ -1231,29 +1231,29 @@
 						<pb n="335"/> passionis Christi ex gentibus congregatur Ecclesia. <lb/> Per illos
 						sanctos Patriarchas et Prophetas carnali <lb/> populo Israel, qui postea eliam Judaei
 						appellati sunt, <lb/> et visibilia beneficia ministrabantur quæ carnaliter a <lb/>
-						Domico desiderabant, et coercitiones poenarum cor­ <lb/> poralium quibus pro tempore
-						terrerentur, sicut eo­ <lb/> rum duritiæ congruebat. Et in his tamen omnibus <lb/>
+						Domico desiderabant, et coercitiones poenarum cor<lb/>poralium quibus pro tempore
+						terrerentur, sicut eo<lb/>rum duritiæ congruebat. Et in his tamen omnibus <lb/>
 						mysteria spiritualia significabantur, quæ ad Christum <lb/> et Ecclesiam pertinerent :
 						cujus Ecclesiae membra <lb/> etant etiam illi sancti, quamvis in hac vita fuerint <lb/>
-						antequam secundum carnem Christus Dominus na­ <lb/> sceretur. Ipse enim unigenitus Dei
+						antequam secundum carnem Christus Dominus na<lb/>sceretur. Ipse enim unigenitus Dei
 						Filius, Verbum <lb/> Patris, æquale et coæternum Patri, per quod facta <lb/> sunt omnia,
 						bomo propter nos factus est, ut totius <lb/> Ecclesiae tanquam totius corporis caput
 						esset. Sed <lb/> vclut totus homo dum nascitur, etiamsi manum in <lb/> nascendo
-						præmittat, tamen universo corpori sub ca­ <lb/> phe conjuncta atque compacta cst,
+						præmittat, tamen universo corpori sub ca<lb/>phe conjuncta atque compacta cst,
 						quemadmodum <lb/> etiam nonnulli in ipsis Patriarchis ad hujus ipsius rei <lb/> signum
 						mann præmissa nati suut <hi rend="italic">(Gen. XXV,</hi> 23) : ita <lb/> omnes sanct!
-						qui ante Domini nostri Jesu Christi na­ <lb/> livitatcm in terris fuerunt, quamvis ante
+						qui ante Domini nostri Jesu Christi na<lb/>livitatcm in terris fuerunt, quamvis ante
 						nati sunt, <lb/> tamen universo corpori, cujus ille caput cst1, sub <lb/> capite
 						cohæserunt.</p>
 					<p>CAPUT XX.- 34. Israelitarum <hi rend="italic">servitus in Ægypto,<lb/> et liberatio
-							viaque per mare Rubrum.</hi> Baptismus <hi rend="italic">figura­ <lb/> tus.</hi> Ovis
+							viaque per mare Rubrum.</hi> Baptismus <hi rend="italic">figura<lb/>tus.</hi> Ovis
 							<hi rend="italic">immolatio</hi> passionis Christi <hi rend="italic">figura. Lex
 							scripla <lb/> digito Dei. Jerusalem typus civitatis cœlesits.</hi> Populus <lb/> ergo
 						ille delatus in iEgyplum, servivit regi durissimo; <lb/> et gravissimis laboribus
-						eruditus, quæsivit libcrato­ <lb/> i em Deum : et missus est eis unus de ipso populo ,
+						eruditus, quæsivit libcrato<lb/>i em Deum : et missus est eis unus de ipso populo ,
 						<lb/> sanctus Dei servus Moyses, qui in virtute Dei magnis <lb/> miraculis terrens tunc
 						impiam gentem Ægyptiorum, <lb/> eduxit inde populum Dei per marc Rubrum ; ubi <lb/>
-						discedens aqua viam præbuit transeuntibus : Ægy­ <lb/> ptii autem cum eos
+						discedens aqua viam præbuit transeuntibus : Ægy<lb/>ptii autem cum eos
 						persequerentur, redeuntibus in <lb/> se fluctibus demersi exstincti sunt. Ita quemadmo­
 						<lb/> dum per diluvium aquis terra purgata est a nequitia. <lb/> peccatorum, qui tunc in
 						illa inundatione deleti sunt, <lb/> et juti evaserunt per lignum : sic ex Ægypto exiens
@@ -1261,9 +1261,9 @@
 						Nee ibi defuit ligni sacra. <lb/> mentum. Nam virga percussit Moyses, ut illud mira­
 						<lb/> culum fieret. Utrumque signum est sancti Baptismi, <lb/> pcr quod fideles in novam
 						vitam transeunt, peccata <lb/> vero eorum tanquam inimici delentur atque morim­ <lb/>
-						ur. Apertius autem Christi passio in illo populo figu­ <lb/> raia est, cum jussi sunt
+						ur. Apertius autem Christi passio in illo populo figu<lb/>raia est, cum jussi sunt
 						ovem occidere et manducare, <lb/> et de sanguine ejus postes suos signare, et hoc ccle­
-						<lb/> brare omni anno, et appellare Pascha Domini. Mani­ <lb/> festissime quippe
+						<lb/> brare omni anno, et appellare Pascha Domini. Mani<lb/>festissime quippe
 						prophetia I do Domino Jesu Christo <lb/> dicit, quia <hi rend="italic">tanquam ovis ad
 							immolandum ductus</hi> eat <lb/>
 						<hi rend="italic">(Isai.</hi> LIII, 7). Cujus passionis et crucis signo in fronte <lb/>
@@ -1275,7 +1275,7 @@
 						</note>
 						<lb/> scriptam <hi rend="italic">(Exod.</hi> i-xx, XXXII , xxxiv; Num. XIV, 33, <hi rend="italic">et<lb/> Deut.</hi> xxix, 5), quo nomine significatur Spiritus san­ <lb/>
 						ctus, sicut in Evangelio manifestissiine declaratur . <lb/>
-						<hi rend="italic">(Luc.</hi> XI, 20). Neque enim Deus forma corporis defl­ <lb/> nitus
+						<hi rend="italic">(Luc.</hi> XI, 20). Neque enim Deus forma corporis defl<lb/>nitus
 						est, nec sic in illo membra et digiti cogitandi <lb/> sunt, quemadmodum videmus in nobis
 						: sed quia pcr <lb/> Spiritum sancium dona Dei sanctis dividuntur, ut cum <lb/> diversa
 						possunt, non tamen discedant a concordia <lb/> charitatis, in digitis autem maxime
@@ -1283,29 +1283,29 @@
 						propter aliam quamcumque causam Spiritus <lb/> sanctus appellatus est digitus Dei, non
 						tamcn , cum <lb/> hoc audimus, humani corporis forma cogitanda est. <lb/> Accepit ergo
 						ille populus legem digito Dei scriptam <lb/> in tabulis sane lapideis, ad significandam
-						duritiam <lb/> cordis illorum, quod legem non erant impleturi. Cor­ <lb/> poralia quippe
-						dona desiderantes a Domino, magis car­ <lb/> nali timore quam spirituali charitate
+						duritiam <lb/> cordis illorum, quod legem non erant impleturi. Cor<lb/>poralia quippe
+						dona desiderantes a Domino, magis car<lb/>nali timore quam spirituali charitate
 						tenebantur : te- . <lb/> gem autem non implet nisi charitas. Ideo multis <lb/>
 						sacramentis visibilibus onerati sunt, quo servili jugo <lb/> premerentur, in
-						observationibus ciborum et in sacri­ <lb/> ficiis animaliqm, ct in aliis innumerabilibus
-						: quæ ta­ <lb/> men signa erant rerum spiritualium ad Dominum<lb/> Jesum Christum et ad
+						observationibus ciborum et in sacri<lb/>ficiis animaliqm, ct in aliis innumerabilibus
+						: quæ ta<lb/>men signa erant rerum spiritualium ad Dominum<lb/> Jesum Christum et ad
 						Ecclesiam perlinentium; quæ <lb/> tunc a paucis sanctis et intelligebantur ad fructum
 						<lb/> salutis, et observabantur ad congruentiam temporis , <lb/> a multitudine vero
-						carnalium tantummodo observa­ <lb/> bantur, non intelligebantur.</p>
-					<p>36. Per multa itaque et varia signa rerum futura­ <lb/> rum, quas longum est omnes
+						carnalium tantummodo observa<lb/>bantur, non intelligebantur.</p>
+					<p>36. Per multa itaque et varia signa rerum futura<lb/>rum, quas longum est omnes
 						commemorare, et eas <lb/> nunc in Ecclesia videmus impleri, perductus est ille <lb/>
 						populus ad terram promissionis, ubi temporaliter <lb/> I carnaliterque regnaret pro modo
 						desidcrii sul : quod <lb/> taman regnum terrenum regni spiritualis imaginem <lb/>
 						gessitJbi Jerusalem condita est famosissima civilasDei, <lb/> serviens in signo liberæ
-						civitatis,quæ cœelestis Jerusa­ <lb/> lem dicitur <hi rend="italic">(Galat.</hi> IV. 25,
+						civitatis,quæ cœelestis Jerusa<lb/>lem dicitur <hi rend="italic">(Galat.</hi> IV. 25,
 						26), quod verbum est lac.. <lb/> bræum, et interpretatur Vibio pacis. Cujus cives sunt
 						<lb/> omnes sanctificati homines qui fuerunt, ctqui sunt, et <lb/> qui futuri sunt; et
 						omnes sanctificati spiritus, ctiam <lb/> quicumque in excelsis coelorum partibus pia
-						devotione <lb/> obtemperant Deo, nec imitantur impiam diaboli su­ <lb/> perbiam et
+						devotione <lb/> obtemperant Deo, nec imitantur impiam diaboli su<lb/>perbiam et
 						angelorum ejus. Ilujus civitatis rex est <lb/> Dominus Jesus Christus, Verbum Dei quo
 						rcgunlur <lb/> summi Angeli, et Verbum hominem assumens ut eo <lb/> regerentur et
 						homines, qui simul omnes cum illo iu <lb/> æterna pace regnabunt. Ad hujus regis
-						praefiguratio­ <lb/> nem in illo terreno regno populi Israel maxime emi­ <lb/> nuit rex
+						praefiguratio<lb/>nem in illo terreno regno populi Israel maxime emi<lb/>nuit rex
 						David, de cujus semine secundum carnem <lb/> veniret verissimus rex noster Dominus Jesus
 						Christus, <lb/>
 						<hi rend="italic">qui est super omnia Deus benedictus</hi> in sæcula <hi rend="italic">(Rom.</hi>
@@ -1322,16 +1322,16 @@
 						varietate currentibus, et <lb/> ultimo judicio separandis, paulo ante jam diximus <lb/>
 						<hi rend="italic">(Cap.</hi> 19). Illa ergo captivitas Jerusalem civitatis, et <lb/> ;
 						lle populus in Babyloniam ductus ad servitutem ire <lb/> jubetur a Domino per Jcremiam
-						illius temporis pro­ <lb/> phetam. Et exstiterunt reges Babyloniae, sub quibus <lb/>
-						illi serviebant, qui ex eorum occasione commoti qui­ <lb/> busdam miraculis cognoscerent
-						et colerent et coli ju­ <lb/> berent unum verum Deum, qui condidit universam <lb/>
-						creaturam <hi rend="italic">(-Dan.</hi> II-VI, xiv). Jussi sunt autem et ora­ <lb/> te
+						illius temporis pro<lb/>phetam. Et exstiterunt reges Babyloniae, sub quibus <lb/>
+						illi serviebant, qui ex eorum occasione commoti qui<lb/>busdam miraculis cognoscerent
+						et colerent et coli ju<lb/>berent unum verum Deum, qui condidit universam <lb/>
+						creaturam <hi rend="italic">(-Dan.</hi> II-VI, xiv). Jussi sunt autem et ora<lb/>te
 						pro eis a quibus capiivi tenebantur, et in eorum <lb/> pace pacem sperare, ad gignendos
 						filios, et domns <lb/> aedilicandas, et plantandos hortos et vineas. Post se­ <lb/>
-						ptuaginta autem annos promittitur eis ab illa captivi­ <lb/> tate liberatio <hi rend="italic">( Jerem.</hi> xxv, XXIX). Hoc autem totum <lb/> figurate significabat
-						Ecclesiam Christi in omnibus san­ <lb/> ctis ejus, qui sunt cives Jerusalem coelestis,
-						servitu­ <lb/> ram fuisse sub regibus hujus sæculi. Dicit enim et <lb/> apostolica
-						doctrina, ut <hi rend="italic">omnis anima sublimioribus po­ <lb/> testatibus subdita
+						ptuaginta autem annos promittitur eis ab illa captivi<lb/>tate liberatio <hi rend="italic">( Jerem.</hi> xxv, XXIX). Hoc autem totum <lb/> figurate significabat
+						Ecclesiam Christi in omnibus san<lb/>ctis ejus, qui sunt cives Jerusalem coelestis,
+						servitu<lb/>ram fuisse sub regibus hujus sæculi. Dicit enim et <lb/> apostolica
+						doctrina, ut <hi rend="italic">omnis anima sublimioribus po<lb/>testatibus subdita
 							sit ;</hi> et ut reddantur <hi rend="italic">omnibus omnia;</hi>
 						<lb/> cui <hi rend="italic">tributum, tributum; cui vectigal, vectigal (Rom.</hi>
 						<lb/> XIII, i , 7); et caetera quæ salvo Dei nostri cultu, <lb/> constitutionis humanae
@@ -1340,21 +1340,21 @@
 						dedignatus est <hi rend="italic">(Matth.</hi> XVII, 26). <lb/> Jubentur autem etiam
 						servi christiani et boni fideles <lb/> dormis suis temporalibus æquanimiter fideliterque
 						<lb/> servire <hi rend="italic">(Ephes.</hi> vi, 5) : quos judicaturi sunt, si usque
-						<lb/> in finem iniquos invenerint; aut cnm quibus :.quali­ <lb/> ter regnaturi sunt, si
+						<lb/> in finem iniquos invenerint; aut cnm quibus :.quali<lb/>ter regnaturi sunt, si
 						et illi ad vcrum Deum conversi <lb/> fuerint. Omnibus tamen præcipitur servire humanis
 						<lb/> potestatibus atque terrenis, quousque post tempus <lb/> præfinitum, quod
 						significant septuaginta anni, ab <lb/> istius sæculi confusione tanquam de captivitate
-						Baby­ <lb/> loniæ, sicut Jerusalem liberetur Ecclesia. Ex cujus <lb/> captivitatis
+						Baby<lb/>loniæ, sicut Jerusalem liberetur Ecclesia. Ex cujus <lb/> captivitatis
 						occasione ipsi etiam terreni reges desertis <lb/> idolis, pro quibus persequebantur
 						Christianos, unum <lb/> vernm Deum et Christum Dominum cognoverunt et <lb/> colunt, pro
 						quibus apostolus Paulus jubet orari, etiam <lb/> cin persequerentur Ecclesiam. Sic enim
-						dicit: Ob­ <lb/> secro <hi rend="italic">itaque</hi> primum <hi rend="italic">fieri
+						dicit: Ob<lb/>secro <hi rend="italic">itaque</hi> primum <hi rend="italic">fieri
 							deprecationes, adorationes</hi> I, <lb/>
 						<hi rend="italic">interpellationes, graliarum actiones, pro regibus, pro <lb/> omnibus
 							hominibus, et</hi> omnibus <hi rend="italic">qui in sublimitate sunt,</hi>
-						<lb/> ut securam <hi rend="italic">et tranquillam vitam agamus cum omni pie­ <lb/> tete
+						<lb/> ut securam <hi rend="italic">et tranquillam vitam agamus cum omni pie<lb/>tete
 							et charitate</hi> a (I <hi rend="italic">Tim.</hi> II, 1, 2). Itaque per ipsos <lb/>
-						data pax est Ecclesiæ, quamvis temporalis, tranquil­ <lb/> litis temporalis 4 ad
+						data pax est Ecclesiæ, quamvis temporalis, tranquil<lb/>litis temporalis 4 ad
 						ædificandas spiritualiter domos <lb/> et plantandos hortos et vineas. Nam ct ecce te
 						modo <lb/> per istum sermuncm ædificamus atque pluitamus. Et <note type="footnote"> I
 							cic Mss. At cditi, <hi rend="italic">permixta.</hi>
@@ -1367,18 +1367,18 @@
 						<lb/> hoc fit per totum orbem terrarum cum pace regum <lb/> christianorum , sicut idem
 						dicit apostolus : <hi rend="italic">Dei agri - <lb/> cultura, Dei œdificatio estis</hi>
 						(I Cor. III, 9).</p>
-					<p>58. Et post annos quidem septuaginta, quos my­ <lb/> stice prophetaverat Jeremias, ut
+					<p>58. Et post annos quidem septuaginta, quos my<lb/>stice prophetaverat Jeremias, ut
 						finem temporum <lb/> præfiguraret, tamen ut ipsa figura integraretur, facia <lb/> est in
 						Jerusalem restitutio ædificationis templi Dei : <lb/> sed quia lotum figurate agebatur,
 						non erat firma pax <lb/> ac libertas reddita Judæis. Itaque postea a Romanis <lb/> victi
 						sunt, et tributarii facti. Ex illo sane tempore ex <lb/> quo terram promissionis
 						acceperunt, et reges habere <lb/> eœperunt, ne in aliquo regum suorum completum <lb/>
-						esse arbitrarentur quod eis liberator Christus pro­ <lb/> mittebatur, apertius per
-						multas prophetias propheta­ <lb/> tus est Christus; non solum ah ipso David in libro
+						esse arbitrarentur quod eis liberator Christus pro<lb/>mittebatur, apertius per
+						multas prophetias propheta<lb/>tus est Christus; non solum ah ipso David in libro
 						<lb/> Psalmorum, sed etiam a cæteris et magnis et sanctis <lb/> propbelis, usque ad
-						tempus eaptivitatis in Babylo­ <lb/> niam : et in ipsa captivitate fuerunt prophetæ, qui
+						tempus eaptivitatis in Babylo<lb/>niam : et in ipsa captivitate fuerunt prophetæ, qui
 						<lb/> venturum Dominum Jesum Christum liberatorem <lb/> omnium prophetarent. Et
-						posteaquam templum trans­ <lb/> actis septuaginta annis restitutum cst, tantas pres­
+						posteaquam templum trans<lb/>actis septuaginta annis restitutum cst, tantas pres­
 						<lb/> suras et calamitates a regibus Gentium Judæi perpessi <lb/> sunt, ut intelligerent
 						nondum venisse liheraiorem , <lb/> quem non spiritualiter liberaturum intelligebant, sed
 						<lb/> pro lihcralione carnali desiderabant.</p>
@@ -1387,66 +1387,66 @@
 							sempiternœ hœreditatis</hi> manifestans, <hi rend="italic">terrena contemnere <lb/>
 							exemplo docet. Nalivitas ejus. vita et mors.</hi> Peractis <lb/> crgo quinque
 						aetatibus sacculi, quarum prima est ab <lb/> initio generis humani, id est, ab Adam, qui
-						primus <lb/> homo factus est, usque ad Noe, qui fecit arcam in di­ <lb/> luvio <hi rend="italic">(Gen.</hi> VI) ; inde secunda est usque ad Abraham, <lb/> qui pater
+						primus <lb/> homo factus est, usque ad Noe, qui fecit arcam in di<lb/>luvio <hi rend="italic">(Gen.</hi> VI) ; inde secunda est usque ad Abraham, <lb/> qui pater
 						dictus est 1 omnium quidem gentium <hi rend="italic">( Id.</hi>
 						<lb/> XVII, 4), quæ fidem ipsius imitarentur ; sed tamen ex <lb/> propagine carnis suae
 						* futuri populi Judæorum : qui <lb/> ante fidem christianam gentium, unus inter omnes
 						<lb/> omnium terrarum populus unum verum Deum coluit, <lb/> ex quo populo Salvator
 						Christus secundum carnem <lb/> vcniret. isti enim articuli duarum ætatum eminent In-
-						<lb/> veteribus Libris, : reliquarum autem trium in Evan­ <lb/> gclio etiam declarantur,
+						<lb/> veteribus Libris, : reliquarum autem trium in Evan<lb/>gclio etiam declarantur,
 						cum carnalis origo Domini <lb/> Jesu Christi commemoratur <hi rend="italic">(Matth.</hi>
-						1, 17). N.un ter­ <lb/> tia est ab Abraham usque ad David regem : quarta a <lb/> David
+						1, 17). N.un ter<lb/>tia est ab Abraham usque ad David regem : quarta a <lb/> David
 						usque ad, illam captivitatem qua populus Dci in <lb/> Babyloniam transmigravit : quinta
-						ab illa transmigra­ <lb/> tione usque ad adventum Domini nostri Jesu Christi i <lb/> ex
-						cujus adventu sexta ætas agitur : ut jam spiritua­ <lb/> lis gratia, qiue paucis tunc
+						ab illa transmigra<lb/>tione usque ad adventum Domini nostri Jesu Christi i <lb/> ex
+						cujus adventu sexta ætas agitur : ut jam spiritua<lb/>lis gratia, qiue paucis tunc
 						Patriarchis et Prophetis <lb/> nota erat, manifestaretur omnibus gentibus : no quis­
 						<lb/> quam Deum nisi gratis coleret, non visibilia præmia <lb/> servitutis suæ et
 						præsentis vitas felitatem, sed solam <lb/> vitam æternam, in qua ipso Dea frueretur, ab
-						illo <lb/> desiderans ; ut hac sexta ætate mens humana rcno­ <lb/> vetur ad imaginem
+						illo <lb/> desiderans ; ut hac sexta ætate mens humana rcno<lb/>vetur ad imaginem
 						Dei, sicut sella dic homo factus <lb/> est ad imaginem Dei (Gen. 1, 27). Tunc enim et
 						lex <lb/> impletur, dum non cupiditate rerum temporalium <note type="footnote"> ' Mss.,
 								<hi rend="italic">electus est.</hi>
 						</note><note type="footnote"> ' Mss., e.r <hi rend="italic">progenie carmt</hi> sua. </note>
 						<lb/>
 						<pb n="339"/> sed charitate illius qui præcepit, fiunt quxcumquc <lb/> præcepit. Quis
-						autem non redamare affectet justissi­ <lb/> inum et misericordissimum Deum, qui prior
-						sic ama- <lb/> vit injustissimos et superbissimos homines, ut pro­ <lb/> pter eus
+						autem non redamare affectet justissi<lb/>inum et misericordissimum Deum, qui prior
+						sic ama- <lb/> vit injustissimos et superbissimos homines, ut pro<lb/>pter eus
 						mitteret unicum Filium, per quem fecit <lb/> omnia ; qui non sui mutatione, sed bominis
-						assum­ <lb/> ptione homo factus, non solum cum eis vivcre, sed <lb/> etiam pro eis et ab
+						assum<lb/>ptione homo factus, non solum cum eis vivcre, sed <lb/> etiam pro eis et ab
 						eis posset occidi?</p>
-					<p>40. Itaque novum testamentum hæredilatis sempi­ <lb/> ternæ manifestans, in quo
-						renovatus homo per gra­ <lb/> tiam Dei ageret novam vitam, hoc est vitam spiritua­ <lb/>
+					<p>40. Itaque novum testamentum hæredilatis sempi<lb/>ternæ manifestans, in quo
+						renovatus homo per gra<lb/>tiam Dei ageret novam vitam, hoc est vitam spiritua­ <lb/>
 						iem ; ut vetus ostenderet primum , in quo carnalis <lb/> populus agens veterem hominem ,
-						exceptis paucis in­ <lb/> telligentibus Patriarchis et Prophetis et nonnullis la­ <lb/>
+						exceptis paucis in<lb/>telligentibus Patriarchis et Prophetis et nonnullis la­ <lb/>
 						tentibus sanctis, carnaliter vivens carnalia præmia <lb/> desiderabat a Domino Deo, et
 						in figura spiritualium <lb/> bonorum accipiebat: omnia ergo bona terrena con­ <lb/>
-						tempsit bomo factus Dominus Christus, ut contc­ <lb/> mnenda monstraret ; et omnia
+						tempsit bomo factus Dominus Christus, ut contc<lb/>mnenda monstraret ; et omnia
 						terrena sustinuit mala , <lb/> quæ sustinenda præcipiebat : ut neque in illis quæ­ <lb/>
 						rcretur felicitas, neque in istis infelicitas timcretur. <lb/> Natus enim de matre quæ
 						quamvis a viro intacta <lb/> conceperit, semperque intacta permanserit , virgo <lb/>
-						concipiens, virgo pariens, virgo moriens, tamen fa­ <lb/> bro desponsata erat, omnem
-						typhum carnalis nobi!!­ <lb/> tatis exstinxit. Natus cHam in civitate Bethlehem, <lb/>
+						concipiens, virgo pariens, virgo moriens, tamen fa<lb/>bro desponsata erat, omnem
+						typhum carnalis nobi!!<lb/>tatis exstinxit. Natus cHam in civitate Bethlehem, <lb/>
 						quæ inter omnes Judææ civitates ita erat exigua , ut <lb/> hodieque villa appelletur,
-						noluit qucmquam de cujus­ <lb/> quam terrenæ civitatis sublimitate gloriari. Pauper
+						noluit qucmquam de cujus<lb/>quam terrenæ civitatis sublimitate gloriari. Pauper
 						<lb/> ctiam factus est, cujus sunt omnia, et per quem <lb/> creata suut omnia ; IIC
-						quisquam cum in cum credo­ <lb/> vet, de terrenis divitiis auderet extolli. Noluit rex
+						quisquam cum in cum credo<lb/>vet, de terrenis divitiis auderet extolli. Noluit rex
 						<lb/> ab hominibus fieri ; quia humilitatis ostendebat viam <lb/> tniscris, quos ab co I
 						superbia separaverat: quamvis <lb/> sempiternum ejus regnum universa cre tUra testetur.
 						<lb/> Esurivit, qui omnes pascit; sitivit, per quem creatur <lb/> omnis potus, et qui
 						spiritualiter panis est csuricnlium <lb/> fonsque sitientium : ab itinere terrestri
-						fatigatus cst, <lb/> qui se ipsum nobis viam fccit in cainum : velut obmu­ <lb/> tuit ct
+						fatigatus cst, <lb/> qui se ipsum nobis viam fccit in cainum : velut obmu<lb/>tuit ct
 						cbsurduit coram conviciantibus, per quem <lb/> mutus locutus est et surdus audivit :
 						vinctus est, qui <lb/> dc infirmitatum vinculis solvit : flagellatus est, qui <lb/>
-						omnium dolorum flagella de hominum corporibus cx­ <lb/> pulit : crucifixus est, qui
+						omnium dolorum flagella de hominum corporibus cx<lb/>pulit : crucifixus est, qui
 						cruciafus nostros finivit : <lb/> mortuus cst, qui mortuos suscita vit. Scd ct resur­
 						<lb/> rexit nunquam moriturus, ne ab illo quisquam sic <lb/> disceret mortem contemuere,
-						quasi nunquam vi­ <lb/> eturus '.</p>
+						quasi nunquam vi<lb/>eturus '.</p>
 					<p>CAPUT XXIII. — 41. Spiritus <hi rend="italic">sanctus die quinqua-<lb/> gcsima post
-							resurrectionem Christi missus. Judœi prœ­<lb/> dicutione Apostolorum conversi, vitœ
+							resurrectionem Christi missus. Judœi prœ<lb/>dicutione Apostolorum conversi, vitœ
 							evangelicœ sindio<lb/> flagrantes. Ecclesiœ apud Gentes per Paulum constitutre-</hi>
-						<lb/> Inde confirmatis discipulis, couversatus cum eis qua­ <lb/> draginta diebus ,
-						eisdem spectantibus ascendit in cœ­ <lb/> lum ; et completis a resurrectione
-						quiuquaginta dic­ <lb/> bus misit eis Spiritum sanctum (promiserat enim) , <note type="footnote"> 1 sic Mss. At clJiti, <hi rend="italic">fib ea.</hi>
+						<lb/> Inde confirmatis discipulis, couversatus cum eis qua<lb/>draginta diebus ,
+						eisdem spectantibus ascendit in cœ<lb/>lum ; et completis a resurrectione
+						quiuquaginta dic<lb/>bus misit eis Spiritum sanctum (promiserat enim) , <note type="footnote"> 1 sic Mss. At clJiti, <hi rend="italic">fib ea.</hi>
 						</note><note type="footnote"> 2AM. ".r. RL !c!'C mnucs p. ,....,<hi rend="italic">fiJr.rwi.</hi> I uus Yaii'*a;ris <lb/> U* , nniinectu; ia. </note>
 						<lb/> per quem diffusa charitate in cordibus eorum, non <lb/> solum sinc onere, sed cHam
 						cum jucunditate legem <lb/> possent implere. Quae data est Judæis in decem præ­ <lb/>
@@ -1454,84 +1454,84 @@
 						ex toto corde, ex <lb/> tota anima, ex tota mente ; et diligamus proximum <lb/> sicut
 						nos ipsos. Nam in his duobus præceptis totam <lb/> Legem Prophetasque pendere, ipse
 						Dominus et dixit <lb/> in Evangelio <hi rend="italic">(Matth.</hi> XXII, 37-40), et suo
-						manifesta- <lb/> vit exemplo. Namf et populus Israel ex die quo pri­ <lb/> mum pascha in
+						manifesta- <lb/> vit exemplo. Namf et populus Israel ex die quo pri<lb/>mum pascha in
 						imagine celebrarunt, ovcm occidentes <lb/> et manducantes, cujus sanguine postes corum
-						ad sa­ <lb/> lutis tutelam signati sunt <hi rend="italic">(Exod.</hi> XII); ex ipso ergo
-						<lb/> dic quinquagesimus dies impletus est , et legem acce­ <lb/> peruut scriptam digito
-						Dei <hi rend="italic">(Id.</hi> xix, xx), quo no­ <lb/> niine jam diximus significari
+						ad sa<lb/>lutis tutelam signati sunt <hi rend="italic">(Exod.</hi> XII); ex ipso ergo
+						<lb/> dic quinquagesimus dies impletus est , et legem acce<lb/>peruut scriptam digito
+						Dei <hi rend="italic">(Id.</hi> xix, xx), quo no<lb/>niine jam diximus significari
 						Spiritum sanctum (Su­ <lb/>
 						<hi rend="italic">pra, cap.</hi> xx, n. 55) : sicut post Domini passionem ei <lb/>
-						resurrectionem , quod est verum pascha , quinquage­ <lb/> simo die ipse Spiritus sanctus
+						resurrectionem , quod est verum pascha , quinquage<lb/>simo die ipse Spiritus sanctus
 						discipulis missus est : <lb/> non jam lapidcis tabulis corda dura significans ; sed,
-						<lb/> cnm cssent unum in locum, congregati in ipsa Jerusa­ <lb/> lem , factus est subito
+						<lb/> cnm cssent unum in locum, congregati in ipsa Jerusa<lb/>lem , factus est subito
 						de coelo sonus, quasi ferretur <lb/> flatus vehenens, ct visae sunt illis linguæ divisæ
 						quasi <lb/> ignis, et cœpcrunt linguis loqui, ita ut omnes qui ad <lb/> illos venerant,
 						suam linguam quisque cognoscerct (ad <lb/> illam enim civitatem ex omni terra
-						conveniebant Ju­ <lb/> daei, quacumque dispersi crant, et diversas lingu. s <lb/>
+						conveniebant Ju<lb/>daei, quacumque dispersi crant, et diversas lingu. s <lb/>
 						gentium diversarum didicerant <hi rend="italic">[Act.</hi> II, 1-1 1]): deinde <lb/> cum
-						tota fiducia Christum prædicantes, in ejus no­ <lb/> mine multa signa faciebant, ita ut
-						quemdam mor­ <lb/> tuum transennte Petro umbra ejus tetigerit, et resur­ <lb/> rexerit
+						tota fiducia Christum prædicantes, in ejus no<lb/>mine multa signa faciebant, ita ut
+						quemdam mor<lb/>tuum transennte Petro umbra ejus tetigerit, et resur<lb/>rexerit
 							<hi rend="italic">(Id.</hi> v, 15).</p>
 					<p>42. Sed cum viderent Judxi tan!a signa fieri in ejus <lb/> nomine , quem partim per
-						invidiam , partim per er­ <lb/> rorem crucifixerunt, alii irritati sunt ad persequendos
-						<lb/> prædicatores ejus Apostolos, alii vero idipsum am­ <lb/> plius admirantes, quod in
+						invidiam , partim per er<lb/>rorem crucifixerunt, alii irritati sunt ad persequendos
+						<lb/> prædicatores ejus Apostolos, alii vero idipsum am<lb/>plius admirantes, quod in
 						ejus nomine, quem veluti <lb/> a se oppressum et victum riserant, tanta miracula <lb/>
-						fit'rent , poenitendo conversi crediderunt in eum mil­ <lb/> lia 1 Judœorum. Non erant
-						jam illi temporalii benefi­ <lb/> cia terrenumque regnum desiderantes a Ico, nec <lb/>
+						fit'rent , poenitendo conversi crediderunt in eum mil<lb/>lia 1 Judœorum. Non erant
+						jam illi temporalii benefi<lb/>cia terrenumque regnum desiderantes a Ico, nec <lb/>
 						promissum regem Christum carnaliter exspectantes : <lb/> sed immertaliter intelligentes
 						ei diligentes eum qui <lb/> pro ipsis ab ipsis tanta mortaliter pertulit, et cis <lb/>
-						usque ad sui sanguinis ' peccata donavit , et immor­ <lb/> talitatem a se sperandam et
+						usque ad sui sanguinis ' peccata donavit , et immor<lb/>talitatem a se sperandam et
 						desiderandam exemplo <lb/> suæ resurrectionis ostendit. ltaque jam veteris homi­ <lb/>
 						nis terrena desideria mortificantes, et spiritualis vitæ <lb/> novitate flagrantes ,
 						sicut præceperat in Evangelio <lb/> Dominus, vendebant omnia quæ habebant, et pretia
 						<lb/> rerum suarum ante pedes Apostolorum poncbant, ut <lb/> ipsi distribuerent
 						unicuique , sicut cuique opus erat <lb/>
 						<hi rend="italic">(Id.</hi> II , 44, <hi rend="italic">ct</hi> IV , 34) : viventesque in
-						christiana di­ <lb/> lectione concorditer , non dicebant aliquid suum, scd <lb/> crant
+						christiana di<lb/>lectione concorditer , non dicebant aliquid suum, scd <lb/> crant
 						illis omnia communia , et anima et cor unum in <lb/> Deum <hi rend="italic">(Id.</hi> IV
-						, 32 35). Deiade etiam ipsi a Judæis car- <note type="footnote">1 LOV., jost, <hi rend="italic">crediderunt i.., cum miUill,</hi> addidcnau, <lb/>
-							<hi rend="italic">niulluy</hi> ('X uno cotiic: MJS. </note><note type="footnote"> !
-							nie i!l editione 1.0Y. aMiuun ,<hi rend="italic">cfT sioncm</hi> : inirrLi <lb/>
-							l&gt;cnc.- </note>
+						, 32 35). Deiade etiam ipsi a Judæis car<note type="footnote">1 Lov., post, <hi rend="italic">crediderunt in eum millia</hi>, addiderunt,<lb/>
+							<hi rend="italic">multa</hi>, ex uno codice Ms.</note><note type="footnote"> 2
+							Hic in editione Lov. additum fuerat,<hi rend="italic">effusionem</hi> : minus<lb/>
+							bene.</note>
 						<lb/>
-						<pb n="341"/> nalibus civibus carnis suae persecutionem passi atque <lb/> dispersi sunt,
+						<pb n="341"/>nalibus civibus carnis suae persecutionem passi atque <lb/> dispersi sunt,
 						ut tatius Christus eorum dispersione <lb/> prædicaretur, et imitarentur etiam ipsi
 						patientiam <lb/> Domini sui : quia qui eos 1 mansuetus passus fuerat , <lb/>
 						mansuefactos pro se pati jubebat.</p>
 					<p>43. Ex ipsis sanctorum persecutoribus fuerat etiam <lb/> apostolus Paulus, et in
-						Christianos maxime soevio­ <lb/> bat : sed postea credens et apostolus factus, missus
-						<lb/> cst ut Gentibus Evangelium prædicaret, graviora per­ <lb/> pessus pro nomine
-						Christi, quam fecerat contra no­ <lb/> men Christi. Ecclesias autem constituens per
-						omnes <lb/> gentes qua Evangelium seminabat, impense præcipie­ <lb/> bat, ut quoniam
+						Christianos maxime soevio<lb/>bat : sed postea credens et apostolus factus, missus
+						<lb/> cst ut Gentibus Evangelium prædicaret, graviora per<lb/>pessus pro nomine
+						Christi, quam fecerat contra no<lb/>men Christi. Ecclesias autem constituens per
+						omnes <lb/> gentes qua Evangelium seminabat, impense præcipie<lb/>bat, ut quoniam
 						ipsi ex idolorum cultu venientes, et <lb/> ad unum Deum colendum rudes , non facile
-						potcrant <lb/> rehus suis venditis et distributis servire Deo , obla­ <lb/> tiones
+						potcrant <lb/> rehus suis venditis et distributis servire Deo , obla<lb/>tiones
 						facerent in pauperes sanctorum qui erant in <lb/> Ecclesiis Judrrae, quæ Christo
 						crediderant : ita illos <lb/> tanquam milites, illos autem tanquam stipendiarios <lb/>
 						provinciales apostolica doctrina constituit; inserens <lb/> cis Christum velut lapidem
-						angularem , sicut per pro­ <lb/> phetam prænuntiatus crat, in quo ambo quasi parietes
-						<lb/> dc diverso venientes, de Judæis videlicet atque Gen­ <lb/> tibus, germana
-						charitate copularentur <hi rend="italic">(Psal.</hi> CXVII, <lb/> 22, <hi rend="italic">et Isai.</hi> XXVIII, 16). Sed postea graviores et cre­ <lb/> briores persecutiones
+						angularem , sicut per pro<lb/>phetam prænuntiatus crat, in quo ambo quasi parietes
+						<lb/> dc diverso venientes, de Judæis videlicet atque Gen<lb/>tibus, germana
+						charitate copularentur <hi rend="italic">(Psal.</hi> CXVII, <lb/> 22, <hi rend="italic">et Isai.</hi> XXVIII, 16). Sed postea graviores et cre<lb/>briores persecutiones
 						ex incredulis gontibus adversus <lb/> Christi Ecclesiam surrexerunt, et implebatur in
 						dies <lb/> singulos verbum Domini prædicentis, <hi rend="italic">Ecce ego mitto</hi>
 						<lb/> vos <hi rend="italic">velut oves in medio luporum (Math.</hi> x, 16).</p>
 					<p>CAPUT XXIV. — 44. <hi rend="italic">Ecclesia quasi vitis pullulat, <lb/> et putatur. Ex
-							iis quæ videntur impleta, credantur præ­ <lb/> dicta qum restant implenda, præsertim
-							judicium</hi> futu­ <lb/> rum. Sed illa vitis quæ per orbem terrarum, sicut de <lb/>
+							iis quæ videntur impleta, credantur præ<lb/>dicta qum restant implenda, præsertim
+							judicium</hi> futu<lb/>rum. Sed illa vitis quæ per orbem terrarum, sicut de <lb/>
 						illa prophetatum, ct ab ip o Domino prænuntiatum <lb/> crat, fructuosos palmites
-						diffundebat, tanto pullula­ <lb/> lat amplius, quanto uberiore' martyrum sanguinc <lb/>
+						diffundebat, tanto pullula<lb/>lat amplius, quanto uberiore' martyrum sanguinc <lb/>
 						rigabatur. Qnibus per omnes terras innumerabiliter <lb/> pro fidei vcritatc morientibus,
 						etiam ipsa persequentia <lb/> regna cesserunt, et ad Christum cognoscendum atque <lb/>
 						venerandum fracta superbiæ cervice conversa sunt. <lb/> Oportebat antemi ut cadem vitis,
 						sicut a Domino <lb/> identidem prædictum erat, putaretur , ct ex ea proc­ <lb/>
-						ciderentur infructuosa sarmenta <hi rend="italic">(Joan.</hi> xv, 2) , qui­ <lb/> bus
+						ciderentur infructuosa sarmenta <hi rend="italic">(Joan.</hi> xv, 2) , qui<lb/>bus
 						hæreses ct schismata per loca facta sunt, sub <lb/> Christi nomine, non ipsius gloriam ,
-						sed suain quæ­ <lb/> rentium, pur quorum adversitates magis magisque <lb/> exerceretur
+						sed suain quæ<lb/>rentium, pur quorum adversitates magis magisque <lb/> exerceretur
 						Ecclesia. et probaretur alqucillustrarclur <lb/> il doctrina ejus et patientia.</p>
-					<p>45. Omnia ergo hæc, sicut tanto antc prædicta le­ <lb/> gimus, sic ct facta cognoscimus
-						: et quemadmodum <lb/> primi christiani, quia nondum ista provenisse vidc­ <lb/> bant,
+					<p>45. Omnia ergo hæc, sicut tanto antc prædicta le<lb/>gimus, sic ct facta cognoscimus
+						: et quemadmodum <lb/> primi christiani, quia nondum ista provenisse vidc<lb/>bant,
 						miraculis movchantur ut crederent; sic nos <lb/> quia omnia ista ita completa sunt,
-						sicut ea inLibris <lb/> legimus, qui longe antequam hæc implerentur con­ <lb/> scripti
-						sunt, uhi omnia futura dicebantur, ct præsen­ <lb/> tia jam videntur, ædificamur ad
+						sicut ea inLibris <lb/> legimus, qui longe antequam hæc implerentur con<lb/>scripti
+						sunt, uhi omnia futura dicebantur, ct præsen<lb/>tia jam videntur, ædificamur ad
 						fidcm, ut etiam illa <note type="footnote"> 1 Am. ct Er., <hi rend="italic">qui anle
 								COSo</hi> Lov., <hi rend="italic">qui pro</hi> * is, Aliquot Mss. <lb/> qui <hi rend="italic">prr</hi> cos; et quidam, <hi rend="italic">qui propter</hi> c- s; I
 							leriqiichahenl <lb/>
@@ -1542,13 +1542,13 @@
 						ventura credamus. Siquidem adhuc <lb/> tribulationes futurae in eisdem Scripturis
 						leguntur, et <lb/> ipse ultimus judicii dies, ubi omnes cives ambarum <lb/> illarum
 						civitatum receptis corporibus surrecturi sunt, <lb/> et rationem vitae suæ ante tribunal
-						Christi judicis red­ <lb/> dituri. Veniet enim in claritate potestatis, qui prius <lb/>
+						Christi judicis red<lb/>dituri. Veniet enim in claritate potestatis, qui prius <lb/>
 						in humilitate humanitatis venire dignatus est; et <lb/> omnes pios ab impiis segregabit
 						: non tautum eis qui <lb/> in eum credere omnino noluerunt, sed etiam eis qui <lb/>
-						frustra et infructuose crediderunt in eum ; illis datu­ <lb/> rus regnum secum æternum,
-						illis autem poenam <lb/> aeternam cum diabolo. Sed sicut nullum gaudium re­ <lb/> rum
-						temporalium ex aliqua parte simile potest inve­ <lb/> uiri gaudio vitae æternæ , quam
-						sancti accepturi <lb/> sunt ; ita nullus cruciatus poenarum temporalium po­ <lb/> test
+						frustra et infructuose crediderunt in eum ; illis datu<lb/>rus regnum secum æternum,
+						illis autem poenam <lb/> aeternam cum diabolo. Sed sicut nullum gaudium re<lb/>rum
+						temporalium ex aliqua parte simile potest inve<lb/>uiri gaudio vitae æternæ , quam
+						sancti accepturi <lb/> sunt ; ita nullus cruciatus poenarum temporalium po<lb/>test
 						sempiternis iniquorum cruciatibus comparari.</p>
 					<p>CAPUT XXV. — 46. Fides <hi rend="italic">resurrectionis suadetur.<lb/> Mors
 							perpetua</hi> in <hi rend="italic">tormentis. Vita æterna sanctornm. <lb/> Cavendum
@@ -1556,16 +1556,16 @@
 							<lb/> ticis, sed etiam a malis Christianis. Societas</hi> sit <hi rend="italic">cum
 							bonis;</hi>
 						<lb/> non <hi rend="italic">tamen</hi> spes in <hi rend="italic">ipsis ponatur.</hi>
-						Itaque, frater, confir­ <lb/> ma te ipsum in ejus nomine atque adjutorio cui cre­ <lb/>
+						Itaque, frater, confir<lb/>ma te ipsum in ejus nomine atque adjutorio cui cre­ <lb/>
 						dis, adversus linguas eorum qui fidem nostram irrident, <lb/> de quibus diabolus
 						seductoria verba loquitur, maxime <lb/> volens irridere fidem resurrectionis. Sad cx te
 						ipso <lb/> erede futurum te esse cum fueris , quando cum aute <lb/> non fueris, nunc
-						esse te vides. Ubi enim erat ista mo­ <lb/> les corporis lui et ista forma membrorumque
+						esse te vides. Ubi enim erat ista mo<lb/>les corporis lui et ista forma membrorumque
 						compa - <lb/> go ante paucos annos, priusquam natus, vel etiam <lb/> priusquam in matris
 						utero conceptus esses ? ubi erat <lb/> hæc moles et hæc statura corporis tui? Nonne de
 						oc-. <lb/> cultis hujus creaturae secretis, Domino Deo invisibili . <lb/> ter formante ,
 						processit in lucem, certisque ætatum <lb/> incrementis in istam magnitudinem formamque
-						surre­ <lb/> xit? Numquid ergo difficile est Deo, qui etiam aggeres <lb/> nubium ex
+						surre<lb/>xit? Numquid ergo difficile est Deo, qui etiam aggeres <lb/> nubium ex
 						occulto in momento contrahit, et contegit <lb/> cælum in ictu temporis, reddere istam
 						quantitatem <lb/> corporis tui sicut crat, qui eam facere potuit sicut non <lb/> crat 1?
 						Crede ergo fortiter et inconcusse quia omnia <lb/> quæ videntur quasi pcreundo humanis
@@ -1573,66 +1573,65 @@
 						voluerit, sine ulla mora et difficultate reparabit, <lb/> ea duntaxat quæ justitia ejus
 						reparanda esse judicat : <lb/> ut in his corporibus reddant homines factorum suorum
 						<lb/> rationem, in quibus ea fecerunt; et in his mereantur <lb/> aut commutationem
-						cœlestis incorruptionis pro me­ <lb/> ritis pietatis, aut corruptibilem I corporis
+						cœlestis incorruptionis pro me<lb/>ritis pietatis, aut corruptibilem I corporis
 						conditioneui <lb/> pro meritis iniquitatis, non quae morte solvatur, sed <lb/> quae
 						materiam sempiternis doloribus præbeat.</p>
 					<p>47. Fuge ergo per immobilem fidem et mores bo - <lb/> nos', fuge, frater, illatormenta,
-						ubi nec tortores de­ <lb/> ficiant, nec torti moriuntur; quibus sinc fine mors <lb/>
+						ubi nec tortores de<lb/>ficiant, nec torti moriuntur; quibus sinc fine mors <lb/>
 						est, non posse in cruciatibus mori. Et exardesce <lb/> amore atque desiderio sempiternæ
-						vitæ sanctorum, <note type="footnote"> I vic Arn. Fr. ct plures Mss. At Lov., <hi rend="italic">potuit cr.ut tion cen!,</hi>
-							<lb/> Corbeiensis &lt;;oiJex a secunda mauu, <hi rend="italic">sic</hi> fWU <hi rend="italic">non erut.</hi>
-						</note><note type="footnote"> * Aliqunt <hi rend="italic">Mss., corruptibilis.</hi>
-						</note><note type="footnote"> 3 *\&gt;; Mss. !'.'!iH vero, <hi rend="italic">rtri</hi>
-							morcs <hi rend="italic">bonos.</hi>
+						vitæ sanctorum, <note type="footnote"> 1 Sic Am. Er. et plures Mss. At Lov., <hi rend="italic">potuit cum non erat,</hi>
+							<lb/> Corbeiensis codex a secunda manu, <hi rend="italic">sic cum non erat.</hi>
+						</note><note type="footnote"> 2 Aliquot Mss., <hi rend="italic">corruptibilis.</hi>
+						</note><note type="footnote"> 3 Sic Mss. Editi vero, <hi rend="italic">ad mores bonos.</hi>
 						</note>
 						<lb/>
 						<pb n="343"/> ubi nec operosa erit actio, nec requies desidiosa; <lb/> laus erit Dei
 						sine fastidio, sine defectu : nullum in <lb/> animo tædium , nullus labor in corpore;
-						nulla indi­ <lb/> gentia, nec tua cui subveniri desideres, nec proximi <lb/> rui
-						subvenire festines. Omnes deliciæ Deus erit et sa­ <lb/> tictas1 sanctæ civitatis in
-						illo et de illo sapienter bea­ <lb/> teque viventis. Efficiemur enim, sicut ab illo
-						promis­ <lb/> sum speramus ct exspectamus , aequales Angelis Dei <lb/>
+						nulla indi<lb/>gentia, nec tua cui subveniri desideres, nec proximi <lb/> rui
+						subvenire festines. Omnes deliciæ Deus erit et sa<lb/>tictas1 sanctæ civitatis in
+						illo et de illo sapienter bea<lb/>teque viventis. Efficiemur enim, sicut ab illo
+						promis<lb/>sum speramus ct exspectamus , aequales Angelis Dei <lb/>
 						<hi rend="italic">(Luc.</hi> xx, 36), et cum cis pariter illa Trinitate per... <lb/>
 						fruemur jam per speciem, in qua nunc per fidem <lb/> ambulamus ( II <hi rend="italic">Cor.</hi> v, 7). Credimus cnim quod non <lb/> videmus, ut ipsis meritis fidei etiam
-						videre quod cre­ <lb/> dimus et inhaerere mereamur; ut aequalitatem Patris <lb/> et
+						videre quod cre<lb/>dimus et inhaerere mereamur; ut aequalitatem Patris <lb/> et
 						Filii et Spiritus sancti, et ipsius Trinitatis unitatem, <lb/> quomodo sint hxc tria
-						unus Deus, non jam verbis fi­ <lb/> dci et strepentibus syllabis personemus, sed contem­
-						<lb/> platione purissima et ardentissima in illo silentio sor­ <lb/> beamus1.</p>
+						unus Deus, non jam verbis fi<lb/>dci et strepentibus syllabis personemus, sed contem­
+						<lb/> platione purissima et ardentissima in illo silentio sor<lb/>beamus1.</p>
 					<p>48. Hæc tene fixa in corde tuo, et invoca Deum <lb/> cui credis, ut tucatur te adversus
 						tentationes diaboli: <lb/> et esto cautus, ne tibi aliunde hostis ille subrepat, <lb/>
 						qui ad solatium malevolentissimum damnationis suæ, <lb/> cum quibus damnetur inquirit.
-						Non enim per eos so­ <lb/> los qui christianum nomen oderunt, et dolent eo no­ <lb/>
-						mine occupatum esse orbem terrarum, et adhuc si­ <lb/> mulacris et daemoniorum
-						curiositatibus servire desi­ <lb/> derant, audet ille tentare christianos : sed etiam
+						Non enim per eos so<lb/>los qui christianum nomen oderunt, et dolent eo no­ <lb/>
+						mine occupatum esse orbem terrarum, et adhuc si<lb/>mulacris et daemoniorum
+						curiositatibus servire desi<lb/>derant, audet ille tentare christianos : sed etiam
 						per <lb/> eos quos paulo ante commemoravimus, de unitate <lb/> Ecclesiæ, velut putata
 						vite, præcisos, qui hæretici vel <lb/> schismatici dicuntur, conatur etiam id quidem
-						inter­ <lb/> dum, Sed tamen id etiam aliquando conatur et per <lb/> Judaeos tentare,
-						atque seduccre. Sed maxime caven­ <lb/> dum est ne per homines qui sunt in ipsa
-						catholica <lb/> Ecclesia, quos velut paleam usque ad tempus ventila­ <lb/> tionis suæ
-						sustinet, unusquisque tentetur et decipia­ <lb/> tur. Propterea enim Deus patiens est in
-						illus, ut et <lb/> suorum electorum fidem atque prudentiam per illo­ <lb/> rum
+						inter<lb/>dum, Sed tamen id etiam aliquando conatur et per <lb/> Judaeos tentare,
+						atque seduccre. Sed maxime caven<lb/>dum est ne per homines qui sunt in ipsa
+						catholica <lb/> Ecclesia, quos velut paleam usque ad tempus ventila<lb/>tionis suæ
+						sustinet, unusquisque tentetur et decipia<lb/>tur. Propterea enim Deus patiens est in
+						illus, ut et <lb/> suorum electorum fidem atque prudentiam per illo<lb/>rum
 						perversitatem exercendo confirmet; et quia de <lb/> numero eorum multi proficiunt, et ad
 						placendum Dee <lb/> miserati I animas suas, magno impetu convertuntur. <lb/> Non enim
 						omnes sibi per patientiam Dei thesaurizant <lb/> iram in die iræ justi judicii ejus :
-						sed multos eadem Om­ <lb/> nipotentis patientia perducit ad saluberrimum poeni­ <lb/>
+						sed multos eadem Om<lb/>nipotentis patientia perducit ad saluberrimum poeni­ <lb/>
 						tentiæ dolorem (Rom. II, 5, 4). Quod donec fiat, <lb/> exercetur per eos illorum qni jam
 						rectam viam tenent, <lb/> non solum tolerantia , sed etiam misericordia. Multos <lb/>
-						ergo visurus es ebriosos, avaros, frandatores, aleato­ <lb/> res, adulteros,
-						fornicatores, remedia sacrilega sibi al­ <lb/> ligantes, præcantatoribus et mathematicis
-						vel quarum­ <lb/> libet impiarum artium diviuatoribus dcditos. Animad­ <lb/> versurus
+						ergo visurus es ebriosos, avaros, frandatores, aleato<lb/>res, adulteros,
+						fornicatores, remedia sacrilega sibi al<lb/>ligantes, præcantatoribus et mathematicis
+						vel quarum<lb/>libet impiarum artium diviuatoribus dcditos. Animad<lb/>versurus
 						etiam qnod illac turbæ impleant ecclesias per <lb/> dies festos Christianorum, quæ
 						implent et theatra <lb/> per dies solemnes Paganorum; et haec videndo ad <lb/> imitandum
 						tentaberis. Et quid dicam , vidcbis , quod <lb/> etiam nunc jam utique nosti ? non enim
 						nescis nullos <note type="footnote"> * Editi, <hi rend="italic">soactas.</hi> Aptius
 							forte quinque Mss., satietas. </note><note type="footnote"> 'sic duoMss. At editi <hi rend="italic">sorbeamur.</hi>
 						</note><note type="footnote">toY., <hi rend="italic">mifcranti.</hi> Metius Am. Er. et
-							aliquot Mss., <hi rend="italic">irrije­<lb/> rut;.</hi> Alludit ad illud
+							aliquot Mss., <hi rend="italic">irrije<lb/>rut;.</hi> Alludit ad illud
 							Ecclesiastici, ca rw), v. : vis-mr <lb/>
 							<hi rend="italic">WtirtW 'lilt! placeus nco.</hi>
 						</note>
 						<lb/> qui appellantur christiani, hæc omnia mala operari. <lb/> quae breviter
 						commemoravi. Et aliquando1 fortasse <lb/> graviora facere homines non ignoras, quos
-						nosti ap­ <lb/> pellari christianos. Sed si hoc animo venisti, ut quasi <lb/> securus
+						nosti ap<lb/>pellari christianos. Sed si hoc animo venisti, ut quasi <lb/> securus
 						talia facias, multum erras : nec tibi proderit <lb/> nomen Christi, cum coeperit ille
 						severissime judicare, <lb/> qni prius dignatus est misericordissime subvenire. <lb/>
 						Praedixit enim ista , et ait in Evan gelio : <hi rend="italic">Non omnis<lb/> qui dicit
@@ -1640,15 +1639,15 @@
 							bibimus (Matth.</hi> VII, 21,22). <lb/> Omnibus ergo qui in talibus opcrihus
 						perseverant, <lb/> damnatio finis est. Cum ergo videris multos non so. <lb/> lum hæc
 						facere, sed etiam defendere atque suadere, <lb/> tene te ad legem Dei, et non seqnaris
-						prævaricatores <lb/> ejus. Non enim secundum illorum sensum. sed secun­ <lb/> dum
+						prævaricatores <lb/> ejus. Non enim secundum illorum sensum. sed secun<lb/>dum
 						illitis veritatem judicabci is.</p>
-					<p>49. Conjungere bonis, quos vidcsamnre tecum re­ <lb/> gem tuum. Multos enim inventurus
+					<p>49. Conjungere bonis, quos vidcsamnre tecum re<lb/>gem tuum. Multos enim inventurus
 						es, si et tu talis <lb/> esse coeperis. Nam si in spectaculis cum illis esse cu­ <lb/>
 						picbas et eis inhærere 2, qui tecum vel aurigam, vcl <lb/> venatorem, vel aliquem
 						histrionem simul amabant; <lb/> quanto magis te delectare debet eorum conjunctio, <lb/>
 						qui tecum amant Deum , de quo nunquam erubescet <lb/> amator ejus, quia non solum ipse
 						non potest vinci, <lb/> sed eliam dilectores suos reddet invictos? Nec tamen <lb/> etiam
-						in ipsis bonis, qui te vel praecedunt vel tibi co­ <lb/> mitanturad Deum2, spem tuam
+						in ipsis bonis, qui te vel praecedunt vel tibi co<lb/>mitanturad Deum2, spem tuam
 						collocare debes, quia <lb/> nee in te ipso debes quantumcumque profeceris, sed <lb/> in
 						illo qui eos et te justificando tales facit. Securus es <lb/> enim de Deo, quia non
 						mutatur : de homine autem <lb/> nemo prudenter securus est. Sed si illos qni nondum
@@ -1658,13 +1657,13 @@
 						insultationes vcl tribulationes pro nomine <lb/> Christi passus non defeceris a fide,
 						nec a bona via 4 <lb/> deviaveris, majorem mercedem acceplurus es : qni <lb/> autem in
 						his diabolo cesserint, etiam minorem perdunt. <lb/> Sed humilis esto Dco, ut non te
-						permittat tentari ut­ <lb/> tra vires tuas.</p>
-					<p>CAi'UT XXVI. - 50. <hi rend="italic">Initiatio catechumeni, cum<lb/> expositione
-							signorum. Sermo quandoque</hi> brevior adhi­ <lb/> bendus. <hi rend="italic">Incipit
+						permittat tentari ut<lb/>tra vires tuas.</p>
+					<p>CAPUT XXVI. - 50. <hi rend="italic">Initiatio catechumeni, cum<lb/> expositione
+							signorum. Sermo quandoque</hi> brevior adhi<lb/>bendus. <hi rend="italic">Incipit
 							sermo alius brevior. Filius Dei</hi> immissus, <lb/>
 						<hi rend="italic">ut a morte qnce per Adamum intravit,</hi> liberaremur. Ilis <lb/>
-						dictis, interrogandus cst an hæc credat atque obser­ <lb/> vare desideret Quod cum
-						responderit, solemniter uti­ <lb/> quesignandus est et Ecclesiæ more tractandus. De sa­
+						dictis, interrogandus cst an hæc credat atque obser<lb/>vare desideret Quod cum
+						responderit, solemniter uti<lb/>quesignandus est et Ecclesiæ more tractandus. De sa­
 						<lb/> cramento sane <hi rend="italic">(a)</hi> quod accipit5, cum ei bene commen­ <lb/>
 						datum fuerit, signacula quidem rerum divinarum es, a <lb/> visibilia, sed res ipsas
 						invisibiles in eis honorari; nec <lb/> sic habendam esse illam speciem benedictione
@@ -1678,39 +1677,39 @@
 						</note>
 						<lb/>
 						<pb n="345"/> ficalnm , quemadmodum habetur in usu quolibet : <lb/> dicendum eliam quid
-						significet et sermo ille qucm au­ <lb/> divit, quid in illo condiat1, cujus illa res
-						siinilitudi­ <lb/> nem gerit. Deinde monendus est cx hac occasione, <lb/> ut si quid
+						significet et sermo ille qucm au<lb/>divit, quid in illo condiat1, cujus illa res
+						siinilitudi<lb/>nem gerit. Deinde monendus est cx hac occasione, <lb/> ut si quid
 						etiam in Scripturis audiat quod carnaliter <lb/> sonet, etiamsi non intelligit, credat
 						tamen spirituale <lb/> aliquid significari, quod ad sanctos morcs futuramque <lb/> vitam
 						pertineat. Hoc autem ita breviter discit 2, ut <lb/> quidquid audierit ex Libris
-						canonicis quod ad dilectio­ <lb/> nem æternitatis et veritatis et sanctitatis, et ad
-						dile­ <lb/> ctionem proximi referre non possit, figurale dictum <lb/> vel gestum esse
+						canonicis quod ad dilectio<lb/>nem æternitatis et veritatis et sanctitatis, et ad
+						dile<lb/>ctionem proximi referre non possit, figurale dictum <lb/> vel gestum esse
 						credat; atque ita conetur intelligere, <lb/> ut ad illam gcminam referat dilectionem.
 						Ita sane ut <lb/> proximum non carnaliter intelligat, sed omnem quicum <lb/> eo in illa
-						sancta civitate potest esse, sive jam, sive non­ <lb/> dum appareat : ct ut de nullius
+						sancta civitate potest esse, sive jam, sive non<lb/>dum appareat : ct ut de nullius
 						hominis correcliono <lb/> desperet, quem patientia Dci videt vivere, non ob <lb/> aliud,
-						sicut Apostolus ait, nisi ut adducatur ad pœni­ <lb/> tentiam <hi rend="italic">(Rom.</hi> 11, 4).</p>
+						sicut Apostolus ait, nisi ut adducatur ad pœni<lb/>tentiam <hi rend="italic">(Rom.</hi> 11, 4).</p>
 					<p>51. Si longus tibi videtur iste sermo, quo tanquam <lb/> præsentem rudcm hominem
-						instruxi, licet ea tibi di­ <lb/> cere brevius, longiorem tamen esse debere non puto :
+						instruxi, licet ea tibi di<lb/>cere brevius, longiorem tamen esse debere non puto :
 						<lb/> quanquam mullum interest quid res ipsa, cum agitur, <lb/> moneat, ei quid
-						audiiorum præsentia non solum fer­ <lb/> re, sed etiam desiderare se ostendat. Cum autem
-						ce­ <lb/> leritate opus est, vide quam facile explicari tota res <lb/> possit. Fac
-						rursas adesse aliqucm, qui velit esse chri­ <lb/> stianus: ergo et interrogatum, illud
-						quod superior re­ <lb/> spondissc; quia et si non hoc respondet, huc eum re­ <lb/>
+						audiiorum præsentia non solum fer<lb/>re, sed etiam desiderare se ostendat. Cum autem
+						ce<lb/>leritate opus est, vide quam facile explicari tota res <lb/> possit. Fac
+						rursas adesse aliqucm, qui velit esse chri<lb/>stianus: ergo et interrogatum, illud
+						quod superior re<lb/>spondissc; quia et si non hoc respondet, huc eum re­ <lb/>
 						spondere debuisse dicendum est. Dcinde hoc modo ct <lb/> cætera contexenda.</p>
 					<p>52. Vere, frater, illa magna et vera beatitudo est, <lb/> quæ in futuro saeculo sanctis
 						promittitur. Omnia vero <lb/> visibilia transeunt, et omnis hujus sacculi pompa et <lb/>
-						deliciæ et curiositas interibunt, et secum ad inter­ <lb/> itum trahunt amatores suos. A
+						deliciæ et curiositas interibunt, et secum ad inter<lb/>itum trahunt amatores suos. A
 						quo interitu, hoc est, <lb/> poenis sempiternis Deus misericors volens homines <lb/>
-						liberare , si sibi ipsi non sint inimici, et non resi­ <lb/> stant misericordiæ
-						Creatoris sui, misit unigcnilumFi­ <lb/> lium suum, hoc est, Verbum suum aequale sibi,
+						liberare , si sibi ipsi non sint inimici, et non resi<lb/>stant misericordiæ
+						Creatoris sui, misit unigcnilumFi<lb/>lium suum, hoc est, Verbum suum aequale sibi,
 						per <lb/> quod condidit omnia. Et manens quidem in divinitate <lb/> sua, et non recedens
 						a Patre, nec in aliquo mutatus, <lb/> assumendo tamen hominem, et in carne mortali' ho­
-						<lb/> minibus apparendo venit ad homines : ut quemad­ <lb/> modum per unum hominem qui
+						<lb/> minibus apparendo venit ad homines : ut quemad<lb/>modum per unum hominem qui
 						primus factus est, id <lb/> cst Adam, mors intravit in genus humanum, quia <lb/>
-						consensit mulieri suae seductae a diabolo, ut præce­ <lb/> ptum Dei transgrederentur;
-						sic per unum homi­ <lb/> nen qui eUam Deus est Dei Filius, Jesum Chri­ <lb/> stum,
-						deletis omnibus peccatis præteritis, creden­ <lb/> tes in cum omnes in æternam vitam
+						consensit mulieri suae seductae a diabolo, ut præce<lb/>ptum Dei transgrederentur;
+						sic per unum homi<lb/>nen qui eUam Deus est Dei Filius, Jesum Chri<lb/>stum,
+						deletis omnibus peccatis præteritis, creden<lb/>tes in cum omnes in æternam vitam
 						ingrederentur <lb/>
 						<hi rend="italic">(Id.</hi> v, 12-19). <note type="footnote"> I Fr. <hi rend="italic">et
 								Lov., condatur.</hi> verius MSS. et Am., <hi rend="italic">condiat.</hi> Nam <lb/>
@@ -1728,89 +1727,89 @@
 							rum quæ ventura restant, judicii</hi> ultimi <hi rend="italic">et resurrectio­ <lb/>
 							nis. Cavendæ</hi> tentationes <hi rend="italic">a</hi> malis <hi rend="italic">etiam
 							in Ecclesia re-</hi>
-						<lb/> perlis. <hi rend="italic">Societas cum bonis. Spes</hi> omnis in <hi rend="italic">Deo.</hi> Omnia <lb/> enim 1 qu v nunc vides in Ecclesia Dei, et sub Chri­ <lb/> sti
-						nominc p er totum orbem terrarum geri2, ante sæ­ <lb/> cula jam prædicta sunt, et sicut
+						<lb/> perlis. <hi rend="italic">Societas cum bonis. Spes</hi> omnis in <hi rend="italic">Deo.</hi> Omnia <lb/> enim 1 qu v nunc vides in Ecclesia Dei, et sub Chri<lb/>sti
+						nominc p er totum orbem terrarum geri2, ante sæ<lb/>cula jam prædicta sunt, et sicut
 						ca legimus, ita ct <lb/> vidcmus; et inde ædificamur in fidem. Factum cst ali­ <lb/>
-						quando diluvium per totam terram, ut peccatores de­ <lb/> lerentur : et tamen illi qui
-						evaserunt in arca : sacra­ <lb/> mentum futuræ Ecclesiæ demonstrabant, quæ nunc <lb/> in
-						fluctibus sæculi natat, et per lignum crucis Chri­ <lb/> sli a submersione liberatur.
+						quando diluvium per totam terram, ut peccatores de<lb/>lerentur : et tamen illi qui
+						evaserunt in arca : sacra<lb/>mentum futuræ Ecclesiæ demonstrabant, quæ nunc <lb/> in
+						fluctibus sæculi natat, et per lignum crucis Chri<lb/>sli a submersione liberatur.
 						Prædictum est Abrahæ <lb/> fidcli Servo Dei, uni homini, quod de illo esset po­ <lb/>
-						pulus nasciturus, qui coleret unum Deum inter cæ­ <lb/> teras gentes quæ idola colebant
+						pulus nasciturus, qui coleret unum Deum inter cæ<lb/>teras gentes quæ idola colebant
 						: et omnia quæ illi <lb/> populo ventura prædicta sunt, sic evenerunt ut præ­ <lb/>
-						dicta sunt. Prophetatus est in illo populo etiam Chri­ <lb/> stus rex omnium sanctorum
-						et Deus venturus ex se­ <lb/> mine ipsius Abraham secundum carnem, quam as­ <lb/>
+						dicta sunt. Prophetatus est in illo populo etiam Chri<lb/>stus rex omnium sanctorum
+						et Deus venturus ex se<lb/>mine ipsius Abraham secundum carnem, quam as­ <lb/>
 						sumpsit, ut omnes etiam filii essent Abrahæ, qui fidem <lb/> ejus imitarentur; et sic
-						est factum : natus est Chri­ <lb/> stus de Maria virgine, quæ ex illo genere fuit. Præ­
+						est factum : natus est Chri<lb/>stus de Maria virgine, quæ ex illo genere fuit. Præ­
 						<lb/> dictum est per Prophetas quod in cruce passurus es. <lb/> set ab eodem populo
-						Judæorum , de cujus genere se­ <lb/> cundum carnem veniebat; et sic est factum. Prædi­
-						<lb/> ctum est quod resurrecturus esset; resurrexit: et se­ <lb/> cundum ipsa prædicta
+						Judæorum , de cujus genere se<lb/>cundum carnem veniebat; et sic est factum. Prædi­
+						<lb/> ctum est quod resurrecturus esset; resurrexit: et se<lb/>cundum ipsa prædicta
 						Prophetarum ascendit in coelum, <lb/> et discipulis suis Spiritum sanctum misit.
 						Prædictum <lb/> est non solum a Prophetis, sed eliam ab ipso Domino <lb/> Jesu Christo,
-						quod Ecclesia ejus pcr universum or­ <lb/> bem terrarum esset futura, pcr*sanctorum
+						quod Ecclesia ejus pcr universum or<lb/>bem terrarum esset futura, pcr*sanctorum
 						martyria <lb/> passionesque disseminata; et tunc praedictum, quando <lb/> adhuc nomen
 						ejus et latebat gentes, et ubi notum erat <lb/> irridebatur: et tamen in virtutibus
 						miraculorum cjus, <lb/> sive quæ per se ipse, sive quæ per servos suos fecit, <lb/> dum
 						annuntiantur hoec et creduntur, jam videmus <lb/> quod prædictum est esse completum,
 						regesque ipsos <lb/> terræ, qui antea persequebantur Christianos, jam <lb/> Christi
 						nomini subjugatos. Prædictum est etiam quod <lb/> schismata et hæreses ex ejus Ecclesia
-						essent exitu­ <lb/> ræ, et sub ejus nominc per loca ubi possent, suam, <lb/> non
+						essent exitu<lb/>ræ, et sub ejus nominc per loca ubi possent, suam, <lb/> non
 						Christi, gloriam quæsituræ; et ista completa <lb/> sunt.</p>
-					<p>54. Numquid ergo illa qunc restant n n sunt ven­ <lb/> tura ? Manifestum est quia sicut
-						ista pr:rdicta vene­ <lb/> runt, sic etiam illa ventura sunt: quæcumque tri­ <lb/>
+					<p>54. Numquid ergo illa qunc restant n n sunt ven<lb/>tura ? Manifestum est quia sicut
+						ista pr:rdicta vene<lb/>runt, sic etiam illa ventura sunt: quæcumque tri­ <lb/>
 						bulationes juslormn adhuc restant; el judicii dies, <lb/> qui separabit omnes impius a
 						justis in resurrectione <lb/> mortuorum; et non solum cos qui sunt extra Eccle­ <lb/>
-						siarn , sed etiam ipsius Ecclesiæ palcas, quas opor­ <lb/> tet us iae ad novissimam
+						siarn , sed etiam ipsius Ecclesiæ palcas, quas opor<lb/>tet us iae ad novissimam
 						ventilatienem patientissime <lb/> sufferat, ad ignem debitum segregabit. Qui autem ir­
 						<lb/> rident resurrectionem , putantes quod caro ista quia <lb/> putrescit, resurgere
-						non potest, ad pœnas in ca re­ <lb/> surrecturi sunt : et ostendet eis Deus quia qui
+						non potest, ad pœnas in ca re<lb/>surrecturi sunt : et ostendet eis Deus quia qui
 						potuit <note type="footnote"> t rorbciensisMs., <hi rend="italic">omnia ergo.</hi>
 						</note><note type="footnote"> I Abest, geri, a HSS. </note>
 						<lb/>
-						<pb n="347"/> hæc corpora facere antequam essent, potest ca in mo­ <lb/> mento
-						restiluerc sicut erant. Omnes autem fideles re­ <lb/> gnaturi cum Christo, iia resurgent
+						<pb n="347"/> hæc corpora facere antequam essent, potest ca in mo<lb/>mento
+						restiluerc sicut erant. Omnes autem fideles re<lb/>gnaturi cum Christo, iia resurgent
 						in eodem corpore, <lb/> ut etiam commutari mereantur ad incorruptionem <lb/> angelicam :
-						ut fiant æquales Angelis Dei, sicut Do­ <lb/> minus &lt;psc promisit <hi rend="italic">(Luc.</hi> xx, 36) ; ct Llaudent eum <lb/> sine aliquo defectu et sine aliquo
+						ut fiant æquales Angelis Dei, sicut Do<lb/>minus &lt;psc promisit <hi rend="italic">(Luc.</hi> xx, 36) ; ct Llaudent eum <lb/> sine aliquo defectu et sine aliquo
 						fastidio, semper <lb/> viventes in illo et de illo, cum tali gaudio et bca­ <lb/>
 						titudine, quali nee dici' nec cogitari ab homine <lb/> potest.</p>
 					<p>55. Tu itaque credens ista, cave tentationes (quia <lb/> diabolus quærit qui secum
 						pereant): ut non solum per <lb/> eus qui extra Ecclesiam sunt, sive Pagani, sive Ju­
 						<lb/> dæi,sive hæretici , non te hostis ille seducat ; sed <lb/> ctiam quos in ipsa
-						Ecclesia catholica vidcris malc vi­ <lb/> ventes, aut immoderatos 2voluptatibus veptris
-						et gut­ <lb/> turis, aut impudicos, aut vanis curiositatibus vel i!­ <lb/> licitis
+						Ecclesia catholica vidcris malc vi<lb/>ventes, aut immoderatos 2voluptatibus veptris
+						et gut<lb/>turis, aut impudicos, aut vanis curiositatibus vel i!<lb/>licitis
 						deditos sive spectaculorum, sive remediorum a <lb/> aut divinationum diabolicarum , sive
-						in pompa et ty­ <lb/> pho avaritiæ atque superbiæ, sive in aliqua vila quam <lb/> lex 4
+						in pompa et ty<lb/>pho avaritiæ atque superbiæ, sive in aliqua vila quam <lb/> lex 4
 						damnat et punit, non eos irnitcris : sed potius <lb/> conjungaris honis, quos inventurus
 						es facile, si ct tu <lb/> talis fucris; ut simul colatis et diligatis Dcum gratis :
 						<lb/> quia lotum præmium nostrum ipse erit, ut in illa vita I <lb/> honilate ejus et
-						pulchritudine perfruamur. Sed aman­ <lb/> dus est, non sicut aliquid quod videtur
+						pulchritudine perfruamur. Sed aman<lb/>dus est, non sicut aliquid quod videtur
 						oculis; sed <lb/> bicut amatur sapientia , et veritas, et sanctitas, et <note type="footnote"> 1 sic Mss. At editi, <hi rend="italic">gualis nec dici.</hi>
 						</note><note type="footnote">s Ms.;., <hi rend="italic">immoderatis</hi> : fortasse pro,
 								<hi rend="italic">in immoderatis.</hi>
 						</note><note type="footnote">a Editi, <hi rend="italic">sive remediorum
-								sacrilegorum.</hi>Abest, <hi rend="italic">sacrileqo­ <lb/> rvm,</hi> a Mss , ut
+								sacrilegorum.</hi>Abest, <hi rend="italic">sacrileqo<lb/>rvm,</hi> a Mss , ut
 							illa quai post adhibetur,vox, <hi rend="italic">diabolicurwll,</hi>
 							<lb/> ct aJ <hi rend="italic">divinationum</hi> referatur, et ad remcdwrum.
 							</note><note type="footnote"> 4 corbeiensis Ms., <hi rend="italic">lex Dei:</hi> sed
-							atlJilulll, <hi rend="italic">Dci,</hi> a secun­ <lb/> da manu. </note><note type="footnote"> Ii Editi, <hi rend="italic">ill illa (vlerna vita.</hi> Abest, <hi rend="italic">ælerlla,</hi> a Mss. </note>
+							atlJilulll, <hi rend="italic">Dci,</hi> a secun<lb/>da manu. </note><note type="footnote"> Ii Editi, <hi rend="italic">ill illa (vlerna vita.</hi> Abest, <hi rend="italic">ælerlla,</hi> a Mss. </note>
 						<lb/> justitia, et charitas I , et si quid aliud talc dicitur : <lb/> non qucmadmodunf
 						sant ista in hominibus; sed quem - <lb/> admodum sunt in ipso fonte incorruptibilis et
-						in­ <lb/> commutabilis sapientiae. Quoscumque ergo videris hæc <lb/> amare, illis
+						in<lb/>commutabilis sapientiae. Quoscumque ergo videris hæc <lb/> amare, illis
 						conjungere, ut per Christum qui homo <lb/> factus est, ut esset Mediator Dei et hominum,
 						re- <lb/> coucilieris Deo. Homines autem perversos, etiamsi <lb/> intrent parietes
-						ecclesiæ,non cos arbitreris intratu­ <lb/> ros in regnum coelorum; quia suo tempore
-						separa­ <lb/> buntur, si se in melius non commutaverint. Homines <lb/> ergo bonos
-						imitare, malos tolera, omnes ama; quo­ <lb/> niam nescis quid cras futurus sit qui hodie
+						ecclesiæ,non cos arbitreris intratu<lb/>ros in regnum coelorum; quia suo tempore
+						separa<lb/>buntur, si se in melius non commutaverint. Homines <lb/> ergo bonos
+						imitare, malos tolera, omnes ama; quo<lb/>niam nescis quid cras futurus sit qui hodie
 						malus est. <lb/> Nec corum ames injustitiam; sed ipsos ideo ama, ut <lb/> apprehendant
 						justitiam : quia non solum dilectio Dei <lb/> nobis præcepta est, sed cHam dilectio
-						proximi, in <lb/> quibus duobus præceptis tota Lex pendet ei Prophe­ <lb/> tæ <hi rend="italic">(Matth.</hi> XXII, 37-40). Quam non imp'et nisi qui <lb/> donum'
+						proximi, in <lb/> quibus duobus præceptis tota Lex pendet ei Prophe<lb/>tæ <hi rend="italic">(Matth.</hi> XXII, 37-40). Quam non imp'et nisi qui <lb/> donum'
 						acceperit Spiritum sanctum, Patri ct Filio <lb/> uliqne aequalem; quia ipsa Trinitas
-						Deus est : in quo <lb/> Dco spes omnis ponenda cst. In hominc non est po­ <lb/> nenda,
+						Deus est : in quo <lb/> Dco spes omnis ponenda cst. In hominc non est po<lb/>nenda,
 						qualiscumque ille fuerit. Aliud est enim ille a <lb/> quo justificamur, aliud illi cum
 						quibus justificamur. <lb/> Non autcm solum per cupiditates diabolus tentat, sed <lb/>
 						etiam pcr terrores insultationum et dolorum et. ipsius <lb/> mortis. Quidquid autem homo
-						passus fuerit pro no­ <lb/> mine Christi, et pro spe vitæ æternæ,et permaners <lb/>
-						toleravcrit, major ei merces dabitur : quod si cesse­ <lb/> rit diabolo, cum illo
-						damnabitur. Sed opera miseri­ <lb/> cordiæ cum pia humilitate impetrant a Domino, ut
+						passus fuerit pro no<lb/>mine Christi, et pro spe vitæ æternæ,et permaners <lb/>
+						toleravcrit, major ei merces dabitur : quod si cesse<lb/>rit diabolo, cum illo
+						damnabitur. Sed opera miseri<lb/>cordiæ cum pia humilitate impetrant a Domino, ut
 						<lb/> non permittat servos suos tentari plus quam possunt <lb/> sustinere (I <hi rend="italic">Cor.</hi> x, 13). <note type="footnote"> I Mss. omittiuit, <hi rend="italic">et sanctitas, etjusdtii, ct ch&gt;</hi> rit is. </note><note type="footnote"> * sola editio Lov. pro, <hi rend="italic">donum,</hi> iiabet, <hi rend="italic">Lominum.</hi>
 						</note></p>
 				</div>

--- a/data/stoa0040/stoa002/stoa0040.stoa002.opp-lat1.xml
+++ b/data/stoa0040/stoa002/stoa0040.stoa002.opp-lat1.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-  <teiHeader>
-    <fileDesc>
+	<teiHeader>
+		<fileDesc>
 			<titleStmt>
 				<title>Patrologiae Cursus Completus. Series Latina (PL)</title>
 				<sponsor>University of Leipzig</sponsor>
@@ -29,8 +29,9 @@
 				<authority>University of Leipzig</authority>
 				<idno type="filename">PL40.xml</idno>
 				<availability>
-					<licence target="https://creativecommons.org/licenses/by-sa/4.0/">Available under a
-						Creative Commons Attribution-ShareAlike 4.0 International License</licence>
+					<licence target="https://creativecommons.org/licenses/by-sa/4.0/">Available
+						under a Creative Commons Attribution-ShareAlike 4.0 International
+						License</licence>
 				</availability>
 				<date>2014</date>
 				<publisher>University of Leipzig</publisher>
@@ -45,7 +46,8 @@
 									<name xml:lang="fr">Jacques Paul Migne</name>
 								</persName>
 							</editor>
-							<author ref="http://data.perseus.org/catalog/urn:cts:latinLit:stoa0040">Augustinus</author>
+							<author ref="http://data.perseus.org/catalog/urn:cts:latinLit:stoa0040"
+								>Augustinus</author>
 							<title>De Diversis Quaestionibus LXXXIII Liber Unus</title>
 							<title>De Diversis Quaestionibus Ad Simplicianum. Monitum</title>
 							<title>De Diversis Quaestionibus Ad Simplicianum</title>
@@ -62,7 +64,8 @@
 							<title>Sermones. De Symbolo Ad Catechumenos Sermo Alius</title>
 							<title>Sermones. De Symbolo Ad Catechumenos Sermo Alius II</title>
 							<title>Sermones. Sermo De Disciplina Christiana</title>
-							<title>Sermones. De Cantico Novo Et De Redditu Ad Coelestem Patriam</title>
+							<title>Sermones. De Cantico Novo Et De Redditu Ad Coelestem
+								Patriam</title>
 							<title>Sermones Dubii. De Cultura Agri Dominici</title>
 							<title>Sermones Dubii. De Cataclysmo Sermo Ad Catechumenos</title>
 							<title>Sermones Dubii. Sermo De Tempore Barbarico</title>
@@ -86,7 +89,8 @@
 							<title>De Vita Christiana [Incertus]</title>
 							<title>De Salutaribus Documentis [Incertus]</title>
 							<title>De Duodecim Abusionum Gradibus [Incertus]</title>
-							<title>Tractatus De Septem Vitiis Et Septem Donis Spiritus Sancti [Incertus]</title>
+							<title>Tractatus De Septem Vitiis Et Septem Donis Spiritus Sancti
+								[Incertus]</title>
 							<title>De Sobrietate Et Castitate [Incertus]</title>
 							<title>De Vera Et Falsa Poenitentia Ad Christum Devotam</title>
 							<title>De Antichristo [Incertus. Adso Derviensis]</title>
@@ -94,12 +98,14 @@
 							<title>Cantici Magnificat Expositio [Incertus]</title>
 							<title>De Assumptione Beatae Mariae Virginis [incertus]</title>
 							<title>De Visitatione Infirmorum [Incertus]</title>
-							<title>De Consolatione Mortuorum [Incertus. Joannes Chrisostomus]</title>
-							<title>De Rectitudine Catholicae Conversationis Tractatus [Incertus]</title>
+							<title>De Consolatione Mortuorum [Incertus. Joannes
+								Chrisostomus]</title>
+							<title>De Rectitudine Catholicae Conversationis Tractatus
+								[Incertus]</title>
 							<title>Sermo De Symbolo [Incertus]</title>
 							<title>In Psalmum XLI Ad Neophytos [Incertus]</title>
-							<title>Sermo De Eo Quod Neophytis Ex Oleo Sancto Aures Et Nares A Sacerdotibus
-								Illiniantur [Incertus]</title>
+							<title>Sermo De Eo Quod Neophytis Ex Oleo Sancto Aures Et Nares A
+								Sacerdotibus Illiniantur [Incertus]</title>
 							<title>Sermo De Mysterio Baptisimatis [ncertus]</title>
 							<title>Sermo De Unctione Capitis Et De Pedibus Lavandis</title>
 							<title>Tractatus De Creatione Primi Hominis [Incertus]</title>
@@ -112,7 +118,8 @@
 							<title>Sermo De Generalitate Eleemosynarum [Incertus]</title>
 							<title>Tractatus De Duodecim Lapidibus [Incertus]</title>
 							<title>Miscellanea Sententiae [Incertus]</title>
-							<title>Sermones Ad Fratres In Eremo Commorantes Et Quosdam Alios [Incertus]</title>
+							<title>Sermones Ad Fratres In Eremo Commorantes Et Quosdam Alios
+								[Incertus]</title>
 							<imprint>
 								<publisher>Garnier</publisher>
 								<pubPlace>Paris</pubPlace>
@@ -126,1780 +133,2111 @@
 			</sourceDesc>
 		</fileDesc>
 		<encodingDesc>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
-				Architecture.</p>
-	  <refsDecl n="CTS">
-        <cRefPattern n="chapitre" matchPattern="(\w+)" 
-        	replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
-        	<p>Cette unité de citation correspond au niveau chapitre du texte</p>
-        </cRefPattern> 
-      </refsDecl>
+			<p>The following text is encoded in accordance with EpiDoc standards and with the
+				CTS/CITE Architecture.</p>
+			<refsDecl n="CTS">
+				<cRefPattern n="chapitre" matchPattern="(\w+)"
+					replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
+					<p>Cette unité de citation correspond au niveau chapitre du texte</p>
+				</cRefPattern>
+			</refsDecl>
 			<refsDecl>
 				<refState unit="chapitre"/>
 			</refsDecl>
-    </encodingDesc>
+		</encodingDesc>
 		<profileDesc>
 			<langUsage>
 				<language ident="la">Latin</language>
 			</langUsage>
 		</profileDesc>
-  	<revisionDesc>
-  		<change who="Segolene-Albouy" when="2019-02-18">CapiTainS : Ajout du découpage au niveau chapitre du document</change>
-  		<change who="Segolene-Albouy" when="2019-02-18">OCR : Corrections des erreurs d'OCR</change>
-  	</revisionDesc>
+		<revisionDesc>
+			<change who="Segolene-Albouy" when="2019-02-18">CapiTainS : Ajout du découpage au niveau
+				chapitre du document</change>
+			<change who="Segolene-Albouy" when="2019-02-18">OCR : Corrections des erreurs
+				d'OCR</change>
+		</revisionDesc>
 	</teiHeader>
-  <text>
-    <body>
-    	<div type="edition" n="urn:cts:latinLit:stoa0040.stoa002.opp-lat1" xml:lang="la">
-					<head>
-						<title type="main">S. AURELII AUGUSTINI HIPPONENSIS EPISCOPI DE CATECHIZANDIS RUDIBUS
-								<hi rend="italic">LIBER UNUS (a) .</hi>
-						</title>
-					</head>
-					<p>Rogatus Augustinus a diacono Carthaginensi, catechizandi artem docendam suscipit : ac
-						primo præcepta tradit, et id of<lb/>ficii non tantum certa methodo atque idonea
-						ratione, sed eliam sine taedio et cum hilaritate impleatur. Postea revocatisad <lb/>
-						usum præceptis, profert ipse in exemplum sermones, ad cum erudiendum qui christianus
-						esse velit, comparatos duaM, <lb/> longiorem num, alterum brevissimu.u.</p>
-    	
-    	<div type="textpart" subtype="chapter" n="1"><p>1. <hi rend="italic">Rogatus a diacono Cartha<lb/>ginensi scribit de
-							catechizandis rudibus.</hi> Petisti me, fra<lb/>ter Deogralias <hi rend="italic">(b),</hi> ut aliquid ad te de catechizandis <lb/> rudibus, quod tibi usui esset,
-						scriberem. Dixisti <lb/> euim quod sæpe apud Carthaginem, ubi diaconus es, <lb/> ad te
-						adducuntur, qui fide christiana primitus im<lb/>buendi sunt , eo quod existimeris
-						habere cale<lb/>chizandi uberem facultatem, ct doctrina fidei et sua<lb/>vitate
-						sermenis i : te autem pene semper angustias <lb/> pati, idipsum quod credendo christiani
-						sumus, quo
-						
-	    		<note type="footnote"> ADMONIO PP. BENEDICTINORUM. </note>
-	    		<note type="footnote"> Uiri de Catechizandis Rudibus contulimus colices manuscriptos
-								quatuordecim : Corbeiensem perquam egregium anno<lb/>rum 800, alium Ecclesiae
-								taudunensis annorum 700, Divionensem abbatiæ S. Benigni, Pratellensem, Fiscannensem,
-								<lb/> Michaelinum, Cisterciensem, Floriacenses duos, totidem victorinos, sorbonicum et
-								duos valicanos; lectiones variantes ex <lb/> tribus Belgicis cura Lovaniensium
-								decerptas; et postremo editiones primarias Amerbachii, Erasmi ac Lovaniensium.</note>
-	    		<note type="footnote"><hi rend="italic">Comparavimus prœterea eas omnes editiones initio</hi> Retr. <hi rend="italic">et</hi> Confess. <hi rend="italic">t.</hi> 1, <hi rend="italic">memoratas.</hi> M. </note>
-    			<note type="footnote"><hi rend="italic">(u)</hi> Scriptus circiter anuum 400.</note>
-    			<note type="footnote"><hi rend="italic">( Į,)</hi> Mem Hie lorsilan est Dcogratias, cui presi&gt;ytero Au­
-								<lb/> gustinus, iost aanum Cliristi circUler .wu, ad qu:pst)(j!tcs i'a- <lb/>
-								p:mot't!m ab eo sil.i Carthasine missas respondet epistula <lb/> nunu ordine 102.</note>
-	    		<note type="footnote"> I Lov , ri (iortii.ium <hi rend="italic">[idei et suavitatem MHMIU.</hi></note><lb/>
-						
+	<text>
+		<body>
+			<div type="edition" n="urn:cts:latinLit:stoa0040.stoa002.opp-lat1" xml:lang="la">
+				<head>
+					<title type="main">S. AURELII AUGUSTINI HIPPONENSIS EPISCOPI DE CATECHIZANDIS
+						RUDIBUS <hi rend="italic">LIBER UNUS (a) .</hi>
+					</title>
+				</head>
+				<p>Rogatus Augustinus a diacono Carthaginensi, catechizandi artem docendam suscipit
+					: ac primo præcepta tradit, et id of<lb/>ficii non tantum certa methodo atque
+					idonea ratione, sed eliam sine taedio et cum hilaritate impleatur. Postea
+					revocatisad <lb/> usum præceptis, profert ipse in exemplum sermones, ad cum
+					erudiendum qui christianus esse velit, comparatos duaM, <lb/> longiorem num,
+					alterum brevissimu.u.</p>
 
-		<pb n="311"/> pacto commoIc intimandum sit ; unde exordienda , <lb/> quousque sit
-						perducenda narratio; utrum exhortatio<lb/>nem aliquam terminata narraliouc adhibere
-						debea<lb/>mus, an præcepta sola, quihus observandis cui lo<lb/>quimur noverit
-						christianam vitam professionemque <lb/> retineri l. Sæpe autem libi accidisse confessus
-						atque <lb/> conquestus cs, ut in sermone logo et tepido tibi ipse <lb/> vil scercs
-						essesque fastidio, nedum illi quem lo<lb/>quedo imbuebas, ct cæicris qui audientes
-						aderant : <lb/> caque te necessitate fuisse compulsum , ul ea me <lb/> quam tibi debco
-						charitate compelleres, ne gravarer in<lb/>ter occupationes meas tibi dc hac re
-						aliquid scrihcre.</p>
-					<p>2. Ego vero non ca tantum quam familiariter tilii, <lb/> sed clam quam matri Ecclesiæ
-						universaliter de- <lb/> beo charitate ac servitute compellor, si quid per <lb/> operam
-						meam quam Donnini nostri largitate possum <lb/> exhibere, idem cos Dominus quos mihi
-						fratres fecit, <lb/> adjuvari jubet, nullo modo recusare, scd potus <lb/> prompta et
-						devota voluntate suscipere. Quanto enim <lb/> cupio latius crogari I pecuniam dominicam,
-						tanto <lb/> magis me oportet, si quani dispensatores conservos <lb/> meos difficultatem
-						in erogando scutire cognosco , <lb/> agere quantum in me est, ut facile atque expedite
-						<lb/> possint, quod impigre ac studiose volunt.</p></div>
-    	<div type="textpart" subtype="chapter" n="2"><p>3. <hi rend="italic">Sermo sæpe qui audienti placet, <lb/> displicet
-							dlcenti : unde id contingat. Qui sermonem na<lb/>bet, curet ut sine fastidio et
-							hilariter dicat.</hi> Sed quod <lb/> ad tuam pn pric considerationem pertinet, nolim
-						te <lb/> moveri ex eo quod sa'pc tibi abjectum sermonem fa<lb/>stidiosumque hahere
-						visus cs. Fieri enim potest ut ci <lb/> quem instrucbas non ita sit visum , sed quia lu
-						ali<lb/>quid melius audiri desiderabas, eo libi quod dicebas <lb/> videretur indignum
-						auribus aliorum. Nam et mihi <lb/> prope semper sermo meus displicet. Melioris enim
-						<lb/> avidus sum, quo sæpe fruor interius, antequam eum <lb/> explicare verbis
-						sonantibus cœpero : quod ubi minus <lb/> quam mihi notus est evaluero, contristor
-						linguam <lb/> meam cordi meo non potuisse 2 suflicere. Totum enim <lb/> quod intelligo,
-						volo ut qui me audit intelligat; et sen<lb/>lio nic non ita loqui, ut hoc efficiam :
-						maxime quia <lb/> ille intellectus quasi rapida coruscatione perfundit <lb/> animum ;
-						illa autem locutio tarda et longa est, lon<lb/>geque dissimilis : et dnm ista
-						volvitur, jam se ille in <lb/> secreta sua condidit: tamen quia vestigia quædem <lb/>
-						miro nodo impressit memoriæ, perdurant illa cun) <lb/> syllabarum morulis; atque ex
-						eisdem vestigiis sonan<lb/>lia signa peragimus, quæ lingua dicitur vel latina, <lb/>
-						vel græca, vel hebræa, vel alia quælibet ; sive cogi<lb/>lentur hec signa, sive cliam
-						voce proferantur ; cum <lb/> illa vestigia nec latina, nec græca, vel hebræa, <lb/> nec
-						cujusque alterius gentis sint propria, sed ita <lb/> efficiantur in animo, ut vultus in
-						corpore. Aliter <lb/> enim latine ira dicitur, alilcr græce, aliter atque ali<lb/>ter
-						aliarum diversitate linguarum : non autem lati<lb/>nus ant gra'cus est vultus irati.
-						Non itaque omnes <lb/> gentes intelligunt, cum quisque dicit, Iratus sum, sed
-    		
-	    		<note type="footnote"> I sic in vss. At In erhtis, <hi rend="italic">retinere.</hi></note>
-	    		<note type="footnote"> t rdiU, <hi rend="italic">eroqare.</hi> At Mss., eioqiti.</note>
-	    		<note type="footnote"> 1 fcditi, non fto <hi rend="italic">rr.</hi> "SS., non <hi rend="italic">ZrW. iw.</hi></note>
-    		
-						<lb/> Latin! tantum: at si affectus excandescentis animi exeat <lb/> in faciem,
-						vultumque faciat (a). omnes sentiunt qui <lb/> intuentur iratum. Sed neque ita licet
-						educere et quasi <lb/> exporrigere in sensum audientium per sonum vocis <lb/> illa
-						vestigia, quæ imprimit intellectus memoriæ, sicut <lb/> apertus et manifestus est vultus
-						: illa enim sunt iutus <lb/> in animo, iste foris in corpore. Quapropter conjicien­
-						<lb/> dum est quantum distet sonus oris nostri ab illo ictu <lb/> intelligentiæ, quando
-						ne ipsi quidem impressioni me<lb/>moriæ similis est. Nos autem plerumque in auditoris
-						<lb/> utilit item vehementer ardentes, ita loqui volumus, <lb/> quemadmodum tunc
-						intelligimus, cum per ipsam in<lb/>tentionem loqui non possuntus : et quia non succe­
-						<lb/> dit, angimur, et velut frustra operam insumamus, <lb/> tædio marcescimus: atque ex
-						ipso tadio languidior <lb/> tit idem sermo, et hebetior quam erat, unde perduxit <lb/>
-						ad tædium.</p>
-					<p>4. Sed mihi sæpe indicat eorum studium, qui me <lb/> audire cupiunt, non ita esse
-						frigidum eloquium <lb/> meum, ut videtur mihi : et cos inde aliquid utile <lb/> capere,
-						ex eorum delectatione cognosco; mecum<lb/>que ago sedulo, ut huic exhibendo
-						ministerio non <lb/> dcsim , in quo illos video bene accipere quod exhi<lb/>betur.
-						Sic et tu, eo ipso quod ad te sxpius addu<lb/>cuntur qui fide imbuendi sunt, debes
-						intelligere non <lb/> ita displicere aliis sermonem tuum ut displicet tibi : <lb/> nec
-						infructuosum te debes putaro, quod ea quae <lb/> cernis non explicas ita ut cupis;
-						quando forte ut <lb/> cupis nec cernere valeas. Quis enim in hac vita nisi <lb/> in
-						anigmate et per speculum videt (1 <hi rend="italic">Cor.</hi> XIII, 12) ? <lb/> Nec ipse
-						amor tantus est , ut carnis disrupta caligine <lb/> penetret in æternum serenum, unde
-						utcumque ful<lb/>gcut etiam ista quæ transcunt. Sed quia boni pro<lb/>ficiunt de
-						dic in diem ad videndum dicin sine volu<lb/>mine caTi et sine noctis incursu, quem
-						oculus uon <lb/> vidit, nec auris audivit, nec in cor hominis ascendit <lb/> (Jd. II.
-						9); nulla major causa cst cur nohis in imbuen<lb/>dis rudibus noster sermo vilescat,
-						nisi quia libet in<lb/>usitate cernere, et tædet usitate proloqui. Et re qui­ <lb/>
-						dem vera multo gratius audimur, cuti et nos eodem <lb/> opere delectamur : afficitur
-						enim filum locutionis <lb/> nostr;e ipso nostro gaudio , et exit f cilius atquc ac­
-						<lb/> ceptius. Quapropter non arduutn est negotium, ea <lb/> quæ credenda insinuantur,
-						præcipere unde et quo<lb/>usque narranda sint; nec quomodo sit varianda nar. <lb/>
-						ratio, ut aliquando brevior, aliquando longior. sem<lb/>per tamen plena atque
-						perfecta sit ; et quando bre<lb/>viorc, et quando longiore sit utendum : sed quibus
-						<lb/> modis faciendum sit, ut gaudens qni que catechim <lb/> (lanlo enim suavior crit,
-						quanto magis id potuerit), ea <lb/> cura maxima est Et preceptum quidem rei hujus in
-						<lb/> promptu est. Si enim in pet unia corporali, quanto <lb/> magis in spirituali
-						hilarem datorem diligit Deus (II <lb/> Cur. ix, 7 ) ? Sed hæc hilaritas ad horam ut
-						adsit, ejus <lb/> est misericordiæ qui ista præcepit. Itaque prius de <lb/> modo
-						narrationis quod te velle cognovi, tum de præ<lb/>cipiendo atque cohortando, postea
-						de hac hilaritate <lb/> comparanda, quæ Deus suggesserit, disseremus.
-						
-				<note type="footnote"><hi rend="italic">(/0</hi> Furto, <hi rend="italic">afficiat.</hi></note></p></div>
-					
-
-		<pb n="313"/>
-    	<div type="textpart" subtype="chapter" n="3"><p>5. <hi rend="italic">Narratio plena quai fieri debeat <lb/> catechizando.
-							Ad charitatis finem dirigenda narratio. <lb/> Scripturæ veteres propter
-							commendandum</hi> Christi <hi rend="italic">ad.<lb/> ventum, cujus finis
-							charitas.</hi> Narratio plena est, cnm <lb/> quisque primo catechizatur ab eo quod
-						scriptum est, <lb/> In <hi rend="italic">principio fecit Deus</hi> coelum <hi rend="italic">et terram (Gen.</hi> I. 1), <lb/> usque ad præsentia tempora Ecclesiæ.
-						Non tamen <lb/> propterea ilcbemus totum Pentateuchum, totosque <lb/> Judicum et
-						Regnormn et Esdræ 1 libros, totumque <lb/> Evangelium et Actus Apostolorum, vol, si ad
-						verbum <lb/> edidicimus, memoriter reddere, vel nostris verbis <lb/> onniia quæ his
-						continentur voluminibus narrando <lb/> evolvere et explicare; quod ncc tempus capit, nee
-						<lb/> ulla necessitas postulat : sed cuncta summatim gene<lb/>ratimque complecti, ita
-						ut eligantur quxdam mirabi<lb/>liora quæ suavius audiuntur, atque in ipsis articulis
-						<lb/> constituta sunt <hi rend="italic">(a),</hi> ut ea 2 tanquam in involucris os­
-						<lb/> tendere, statimque a conspectu abripere non opor<lb/>teat, sed aliquantum
-						immorando quasi resolvere atque <lb/> expandere , et inspicienda atque miranda offerre
-						ani<lb/>mis auditorum ; cætera vero celeri percursione inse<lb/>rendo contexere.
-						Ita et illa quæ maxime commendari <lb/> volumus , aliorum submissione magis eminent; nec
-						<lb/> ad ea fatigatus pervenit, quem narrando volumus ex<lb/>citare; nec illius
-						memoria confunditur, quem do<lb/>cendo debemus instrucre.</p>
-					<p>6. In omnibus sanc non tantum nos oportet intueri <lb/> præcepti finem , quod est
-						cbaritas de corde puro et <lb/> conscientia bona et fide uon ficta (I Tim. I, 5), quo ea
-						<lb/> quæ loquimur cuncta referamus; sed eliam illius <lb/> quem loquendo instruimus, ad
-						id movendus 3 atque <lb/> iiluc dirigendus aspectus est. Necque enim ob aliud <lb/> ante
-						adventum Domini scripta sunt omnia quæ in <lb/> sanctis Scripturis legimus, nisi ut
-						illius commenda<lb/>retur adventus, et futura præsignaretur Ecclesia , id <lb/> est,
-						populus Dei per omnes gentes, quod est corpus <lb/> ejus; adjunctis atque annumeratis
-						omnibus sanctis , <lb/> qui etiam ante adventum ejus in boc s:rculo vixeruul, <lb/> ita
-						eum credentes venturum esse, sicut nos vcnisse. <lb/> Sicut cnim Jacob manum prius, dum
-						nasceretur, <lb/> emisit ex utero, qua eliam pedem prænascentis fratris <lb/> tenebat,
-						deinde utique secutum est caput, tum de<lb/>mum necessario membra cætera <hi rend="italic">(Gen.</hi> xxv, 25); sed <lb/> tamen caput non tantum ea membra quæ
-						secuta sunt, <lb/> sed etiam ipsam manum quæ in nascendo præcessit , <lb/> dignitate ac
-						potestate præcedit; et quamvis non tem<lb/>pore apparendi, tamen naturæ ordine prius
-						est: ita <lb/> et Dominus Jesus Christus ctsi antequam appareret <lb/> in carne, et
-						quodam modo ex utero secreti sui ad <lb/> hominum oculus Mediator Dci et hominum homo
-						pro<lb/>cederet, qui est super omnes Deus benedictus in sæ<lb/>cula <hi rend="italic">(Rom.</hi> ix, 5), præmisit in sanctis Patriarchis et <lb/> Prophetis
-						quamdam partem corporis sui, qua velut
-						
-				<note type="footnote"> I In Mss., <hi rend="italic">Ezw.</hi></note>
-				<note type="footnote"> • YJT. et Lov., et <hi rend="italic">ea</hi> AtAm., <hi rend="italic">uten.</hi> Et sic potiores uss. <lb/> rx quitms posiea corrigimus, <hi rend="italic">non oporteat;</hi> ubi editi lerc<lb/>hant, <hi rend="italic">noM
-								oporM.</hi></note>
-				<note type="footnote"> » tu Mat., Editi vero, <hi rend="italic">monendus.</hi></note>
-				<note type="footnote"><hi rend="italic">(a)</hi> Articuli temporum quinqiie nota iltir infra, u G et <lb/>
-							n. 3U. </note>
-						
-						<lb/> manu se nasciturum esse prænuntians, etiam popu<lb/>lum præcedentem superbe,
-						vinculis Legis tanquam di<lb/>gitis quinque supplantavit1 (quia et per quinque tem­
-						<lb/> porum articulos prænuntiari venturus prophetarique <lb/> non destitit; et huic rei
-						consonans per quem Lex data <lb/> est, quinque libros conscripsit : et superbi
-						carnaliter <lb/> sentientes, et suam justitiam volentes constituere <lb/>
-						<hi rend="italic">[Rom.</hi> x, 5], non aperta manu Christi repleti sunt be­ <lb/>
-						nedictione, sed constricta atque conclusa retenti <lb/> sunt : itaque illis obligati
-						sunt pedes , et ceciderunt; <lb/> nos autem surreximus et erecti sumus [Psal xix, 9]):
-						<lb/> quamvis ergo, ut dixi, præmiserit Dominus Christus <lb/> quamdam partem corporis
-						sui in sanctis, qui enim <lb/> nascendi tempore prxierunt; tamen ipse est caput <lb/>
-						corporis Ecclesiæ <hi rend="italic">(Coloaa.</hi> i, 18); illique omnes eidem <lb/>
-						corpori cujus ille caput es!. cohxserunt, credendo in <lb/> cum quem prænuntiabant. Non
-						enim præcurrendo <lb/> divulsi sunt, sed adjuncti potius obsequendo. Nam <lb/> etsi
-						manus a capite præmitti potest, connexio tamen <lb/> cjus sub capite cst. Quapropter
-						omnia quæ ante <lb/> scripta sunt, ut nos doceremur scripta sunt (Hom. <lb/> xv, 4), ct
-						figura nostræ fuerunt, et <hi rend="italic">in figura contin<lb/>gebant in eis1</hi>
-						I ; <hi rend="italic">scripta sunt autem propter nos, in quos<lb/> finis</hi> sæculorum
-							<hi rend="italic">obvenit</hi> (I <hi rend="italic">Cor.</hi> x, 11).</p></div>
-    	<div type="textpart" subtype="chapter" n="4"><p>7. Præcipua <hi rend="italic">causa adventus Christi,<lb/> charitatis
-							commendatio. Ad dilectionem</hi> referenda <hi rend="italic">esse<lb/> quæ de Christo
-							ex Scripturis narrantur</hi> in <hi rend="italic">catechismo.</hi>
-						<lb/> Quæ autem major causa est adventus Domini, nisi ut <lb/> ostenderet Deus
-						dilectionem suam in nobis, commen<lb/>dans eam vehementer i quia cum adhuc inimici
-						esse<lb/>mus, Christus pro nobis mortuus est <hi rend="italic">(Rom.</hi> v, 6-9).
-						<lb/> Iloc autem ideo, quia finis præcepti et plenitudo le<lb/>gis, charitas est (I
-							<hi rend="italic">Tim.</hi> I, 5, <hi rend="italic">et Rom.</hi> XIII, 10) : ut ut
-						<lb/> nos invicem diligamus, et quemadmodum ille pro <lb/> nobis animam suam posuit, sic
-						et nos pro fratribus <lb/> animam ponamus (I Joan. III, 16); et ipsum Dcum , <lb/>
-						quoniam prior dilexit nos (Id. IV, 10), et Filio suo <lb/> unico non pepercit, sed pro
-						nobis omnibus tradidit <lb/> cum (Rom. vin, 32), si amare pigebat, saltem nunc <lb/>
-						redamare non pigeat'. Nulla est enim major ad amo<lb/>rcm invitatio, quam prævenire
-						amando; et nimis du<lb/>rus est animus qui dilectionem si nolebat impendere, <lb/>
-						nolit rependere. Quod si in ipsis flagitiosis et sordidis <lb/> amoribus videmus, nihil
-						aliud eos agere qui amari vi<lb/>cissirn volunt, nisi ut documentis quibus valent
-						ape<lb/>riant et ostendant quantum ament; eamque imaginem <lb/> justitie prætendere
-						affectant, ut vicem sibi reddi quo<lb/>dam modo flagitent ab cis animis quos
-						illecebrare <lb/> moliuntur; ipsique ardentius æstuant, cum jam mo<lb/>veri eodem
-						igne etiam illos mentes quas appetunt <lb/> sentiunt : si ergo et animus qui torpebat,
-						cum se <lb/> amari senserit excitatur, et qui jam ferveba!, cum se <lb/> rcdamari
-						didicerit magis accenditur; manifestum cst <lb/> nullam esse majorem causam qua vel
-						inchnetur vel <lb/> augcatur amor, quam cum amari se cognoscit qui
-    		
-	    		<note type="footnote"> I Aliquot Mss., <hi rend="italic">supplantaret.</hi></note>
-	    		<note type="footnote"> I hd!ti, <hi rend="italic">contvigebant</hi> ela ; omissa
-								particula, .w, quae ta<lb/>men hie reperitur in Mss. et in græco textu Apostoli.</note>
-	    		<note type="footnote"> a Aui. fl'. et vss., <hi rend="italic">saltem redtmiare
-									non pigeal;</hi> omisso, <lb/> nwtc.</note><lb/>
-						
-
-		<pb n="315"/> nondum amat, aut redamari se vel posse sperat, vel <lb/> jam probat qui
-						prior amat Et si boc etiam in turpi<lb/>bus amoribus, quanto plus 1 in amicitia? Quid
-						euim <lb/> aliud cavemus in offensione amicitiæ, nisi ne amicus <lb/> arbitretur quod
-						euin vel non diligimus, vel minus di<lb/>ligimus quam ipse nos diligit? Quod si
-						crediderit, <lb/> frigidior crit in eo amore quo invicem homines mu<lb/>tua
-						familiaritate perfruuntur : et si non ita est infir<lb/>mus , ut hæc illum offensio
-						faciat ab omni dilectione <lb/> frigescere; in ca se tenet, qua non ut fruatur, sed ut
-						<lb/> consulat diligit. Operae pretium est autem animad<lb/>vertere, quomodo,
-						quanquam ct superiores velint se <lb/> ab inferioribus diligi , eorumque in se studioso
-						I de<lb/>lectentur obsequio, et quanto magis id senserint, <lb/> tanto magis cos
-						diligant, tamen quanto amore exar<lb/>descat inferior, cum a superiore se diligi
-						senserit. Ibi <lb/> enim gratior amor est, ubi non æstuat indigentiæ sic<lb/>citate,
-						sed ubertate beneficentiæ 3 profluit. Ille nam<lb/>que amor ex miseria est, iste ex
-						misericordia. Jam <lb/> vero si etiam se amari posse a superiore desperabat <lb/>
-						inferior, ineffabiliter commovebitur in amorem, si ut<lb/>tro ille fuerit dignatus
-						ostendere quantum diligat eum <lb/> qui nequaquam sibi tantum bonum promittere aude­
-						<lb/> ret. Quid autem superius Deu judicante, et quid de<lb/>speratius homine
-						peccante? qui se tanto magis tuen- <lb/> dum et subjugandum superbis potestatibus
-						addixerat, <lb/> quæ beatificare non possunt, quanto magis despera. <lb/> vcrat posse
-						sui curam geri ab ea potestate quæ non <lb/> malitia sublimis esse vult, sed bonitate
-						sublimis cst.</p>
-					<p>8. Si ergo maxime propterea Christus advenit, ut <lb/> cognosceret horno quantum eum
-						diligat Deus; et ideo <lb/> cognosceret, ut in ejus dilectionem a quo prior dile­ <lb/>
-						ctus est, inardesceret, proximumque illo jubente et <lb/> demonstrante diligeret, qui
-						non proximum, scd longe <lb/> pcregrinantem diligendo factus est proximus; omnis­ <lb/>
-						que Scriptura divina quæ ante scripta est, ad prænun<lb/>tiandum adventum Domini
-						scripta est; et quidquid <lb/> postea mandatum est litteris et divina auctoritate fir­
-						<lb/> matum, Christum narrat, et dilectionem monet: ma<lb/>nifestum est non tantum
-						totam Legem et Prophe<lb/>tas in illis duobus pendere præceptis dilectionis Dei <lb/>
-						ct <hi rend="italic">proximi (Matth.</hi> XXII, 40), quæ adhuc sola Scriptura <lb/>
-						sancta erat cum hoc Dominus diceret, sed etiam qaae<lb/>cumquc posterius salubriter
-						conscripta 4 suut memo<lb/>riæque mandata divinarum volumina Litterarum. <lb/>
-						Quapropter in Veteri Testamento est occultatio Novi, <lb/> ill Novo Testamento est
-						manifestatio Veteris. Secun<lb/>dum iilam occultationem carnaliter intelligentes car­
-						<lb/> nales, et tunc et nunc poenali timore subjugati sunt. <lb/> Secundum hanc autem
-						manifestationem spirituales, et <lb/> tunc quibus pie pulsantibus ctiam occulta
-						patuerunt, <lb/> et nunc qui non superbe quærunt, ne etiam aperta <lb/> claudantur,
-						spiritualiter intelligentes donata charitate <lb/> liberali sunt. Quia ergo charitati
-						nihil adversius quam <lb/> invidentia; mater autem invidentiæ superbia est :
-						
-				<note type="footnote"> ' ilerkpie Mss., ""rim? Am. et Mss. vatfcani, plurius? </note>
-				<note type="footnote"> ' NC Mss. At edili, <hi rend="italic">studiose.</hi></note>
-				<note type="footnote"> 9 Veteres libri, <hi rend="italic">bcnefieenliæ.</hi></note>
-				<note type="footnote"> * Am. Er et iluro Mss., <hi rend="italic">consecrata.</hi>
-							Alii duoMss.. <hi rend="italic">corr­</hi><lb/> ucula.</note>
-						
-						<lb/> idem Dominus Jesus Christus, Deus homo, et divinæ <lb/> in nos dilectionis
-						indicium est , et humanæ apud no; <lb/> humilitatis exemplum , ut magnus tumor noster
-						ma<lb/>jnre contraria medicina sanaretur. Magna est enim <lb/> miseria, superbus
-						homo; sed major misericordia, hu<lb/>milis Deus. Hac ergo dilectione tibi tanquam
-						line <lb/> proposito, quo rcferas omnia quæ dicis, quidquid <lb/> narras ita narra, ut
-						ille cui loqueris audiendo cre<lb/>dat, credendo speret, sperando amet.</p></div>
-    	<div type="textpart" subtype="chapter" n="5"><p>9. <hi rend="italic">Accedens ad catechismum</hi> scrutan­ <lb/>
-						<hi rend="italic">dua quo fine velit fieri christianus.</hi> De ipsa etiam sevc­ <lb/>
-						rilate Dei, qua corda mortalium saluberrimo terrore <lb/> quatiuntur, charitas
-						ædificanda est; ut ab.co quem <lb/> timet, amari se gaudens, eum rcdamare audeat, cjus­
-						<lb/> que in se dilectioni, etiamsi impune posset, tamen <lb/> displicere vereatur.
-						Rarissime quippe accidit, imo <lb/> vero nunquam, ut quisquam veniat volens fieri chri­
-						<lb/> stianus, qui non sit aliquo Dci timore perculsus. Si <lb/> enim aliquod commodum
-						exspectando ab hominibus, <lb/> quibus se aliter placiturum non putat, aut aliquod <lb/>
-						ab hominibus incommodum devitando, quorum offen<lb/>sionem aut inimicitias
-						reformidat, vult fieri christia<lb/>nus; non fieri vult potius qunm fingere. Fides
-						enim <lb/> non res est salutantis 1 corporis, sed credentis animi. <lb/> Scd plane sæpe
-						adest misericordia Dei pcr ministe<lb/>rium catechizantis, ut sermone commotus jam
-						fleri <lb/> velit quod decreverat fingere : quod cum velle cœpe- <lb/> rit, tunc cum
-						venisse dcputcmus. Et occultum qui<lb/>dem nobis est quando 2 veniat animo, quem jain
-						<lb/> corpore præsentem videmus : sed tamen sic cnm co <lb/> debemus agere, ut fiat in
-						illo hæc voluntas, etiamsi <lb/> non est. Nihil enim dcperit, quando si cst, utique
-						<lb/> tali nostra actione firmatur, quamvis quo tempore. <lb/> vcl qua hora cæperit,
-						ignoremus. Utile est sane ut <lb/> praemoncamur antea, si fieri potest, ab iis qui eum
-						<lb/> norunt, in quo statu animi sit, vel quibus causis <lb/> commotus ad suscipicndam
-						religionem venerit. Quod <lb/> si defuerit alius a quo id noverimus, etiam ipse in­
-						<lb/> terrogandus est, ut ex eo quod responderit ducamns <lb/> sermonis exordium. Sed si
-						ficto pectore accessit, <lb/> humana commoda cupicns , vel incommoda fugiens, <lb/>
-						utique mentiturus est : tamen es eo ipso quod men<lb/>titur, capiendum est principium
-						; non ut refellatur <lb/> ejus mendacium, quasi tibi certum sit, sed ut si <lb/> dixerit
-						eo proposito se venisse quod vere approban<lb/>dum est, sive ille verum sive falsum
-						dicai, tale ta<lb/>men propositum quali se vcnisse respondit, appro<lb/>bantes
-						atque laudantes, faciamus cum delectari esse <lb/> se talem, qualem videri cupit. Si
-						autem aliud dixerit, <lb/> quam oportet esse in animo ejus qui christiana fide <lb/>
-						imbuendus cst; blandius et lenius reprchendendo <lb/> tanquam rudem et ignarum, et
-						christianæ doctrinæ <lb/> finem vcrissimum demonstrando atqne laudando <lb/> breviter et
-						graviter, ne aut tempera futuræ narratio<lb/>nis occupes, aut cam non prius collocato
-						animo <lb/> audeas imponere, facias eum velle quod ant per
-    		
-	    		<note type="footnote"> 1 Edili Er. et Lpv.. <hi rend="italic">salvandi.</hi> Kounu!!! ccdices, <hi rend="italic">salutis.</hi>
-								<lb/> Quidam, <hi rend="italic">sattantis.</hi> sed plerique ac melioris notae Mss.
-								cnin <lb/> editione. AIH., <hi rend="italic">satultmiis</hi> : id est, saiutctu sivc
-								asaeu..n <lb/> gestu significant is.</note>
-				<note type="footnote"> 1 hie Mrn. Kr. cl Mss. At !jov., <hi rend="italic">quo.</hi></note><lb/>
-						
-
-		<pb n="317"/> errorem aut per simulationem nondum volebat.</p></div>
-    	<div type="textpart" subtype="chapter" n="6"><p>10. <hi rend="italic">Exordium</hi> catechismi, <hi rend="italic">et
-							narratio</hi>
-						<lb/> ab <hi rend="italic">historia creationis mundi usque ad præsens tempus <lb/>
-							Ecclesia.</hi> Quod si forte se divinius admonitum vel <lb/> territum esse
-						responderit, ut fieret christianus, laetis<lb/>simum nobis exordiendi aditum præbet,
-						quanta Deo <lb/> sit cura pro nobis. Sane ab bujusmodi miraculorum <lb/> sive somniorum,
-						ad Scripturarum solidiorem viam <lb/> et oracula certiora transferenda est ejus
-						intentio; ut <lb/> et illa admonitio quam misericorditer ei prærogata <lb/> sit, noverit
-						antequam Scripturis sanctis inhæreret. <lb/> Et utique demonstrandum est ei quod ipse
-						Dominus <lb/> non eum admoneret aut compelleret fieri christianum <lb/> et incorporari
-						Ecclesiae, seu talibus signis aut reve- <lb/> lationibus erudiret, nisi jam preparatum
-						iter in <lb/> Scripturis sanctis, ubi non quæreret visibilia mira<lb/>cula, sed
-						invisibilia sperare consuesceret, neque <lb/> dormiens, sed vigilans moneretur, eum
-						securius et <lb/> tutius carpere voluisset. Inde jam exordienda narra<lb/>tio est, ab
-						eo quod fecit Deus omnia bona valde <lb/>
-						<hi rend="italic">(Gen.</hi> I), et perducenda, ut diximus, usque ad præ<lb/>sentia
-						tempora Ecclesiae : ita ut singularum rerum <lb/> atque gestorum quæ narramus, causæ
-						rationesque <lb/> reddantur, quibus ea referamus ad illum finem dHe<lb/>ctionis, unde
-						neque agentis aliquid neque loquentis <lb/> oculus avertendus est. Si enim fictas
-						poctarum fabu<lb/>las, et ad voluptatcm I excogitatas animorum quo<lb/>rum cibus
-						nugæ sunt, tamen boni qui habentur <lb/> atquc appellantur grammatici, ad aliquam
-						utilitatem <lb/> referre conantur, quanquam et ipsam vanam et <lb/> avidam saginæ
-						saecularis; quanto nos decet esse <lb/> cautiores, ne illa quae vera narramus, sine
-						snarum <lb/> . causarum redditione digesta, aut inani suavitate, <lb/> aut etiam
-						perniciosa cupiditate credantur ? Non <lb/> tamen sic asseramus has causas, ut relicto
-						narratio<lb/>nis tractu, cor nostrum et lingua in nodos diffici<lb/>liuris
-						disputationis excurrat; sed ipsa veritas adhi<lb/>bitæ rationis 2, quasi aurum sit
-						gemmarum ordinem <lb/> ligans, non tamen ornamenti sericin ulla immodera<lb/>tione
-						perturbans.</p></div>
-    	<div type="textpart" subtype="chapter" n="7"><p>11. <hi rend="italic">Resurrectio, judicium et alia <lb/> quædam post
-							narrationem intimanda.</hi> Narrtatione tini<lb/>t a, spes resurrectionis intimanda
-						est, et pro capaci<lb/>late ac viribus audientis, proque ipsius temporis <lb/>
-						modulo, adversus vanas irrisiones infidelium de <lb/> corporis resurrectione tractandum,
-						et futuri ultimi <lb/> judicii bonitate in bonos, severitate in malos, veri<lb/>tate
-						in omnes; commemoratisque cum detestatione <lb/> et horrore poenis impiorum, regnum
-						justorum atque <lb/> fidelium et superna illa civitas ejusque gaudium <lb/> cnm
-						desiderio prædicandum est. Tum vero instrucn<lb/>da et animanda est infirmitas
-						hominis adversus <lb/> tentationes et scandala, sive foris sive in ipsa intus <lb/>
-						Ecclesia : foris adversus Gentiles vel Judaeos vel <lb/> hæreticos; intus autem adversus
-						areae dominicæ
-    		
-	    		<note type="footnote"> I An. et 1.1erlque Mss., voluntatem. </note>
-	    		<note type="footnote"> • Sic vetus codex Corhciensis. At victorinus, <hi rend="italic">Qdhibitcz</hi>
-								<lb/> narrationis. Editiones Ain. et Kr., <hi rend="italic">ndnihita rniiom.</hi>
-								Denique <lb/> LoV'f <hi rend="italic">adhibita ratiofiis.</hi></note>
-    		
-						<lb/> paleam. Nun ut contra singula perversorum genera <lb/> disputetur, omnesque
-						illorum pravæ opiniones pro<lb/>positis quæstionibus refellantur ; sed pro tempore
-						<lb/> brevi demonstrandum est ila esse prædictum, ct <lb/> quæ sit utilitas tentationum
-						erudiendis fidclibus, et <lb/> quae medicina in exemplo patientiæ Dei, qai stamit <lb/>
-						usque in tinem ista perinittere. Cum veru adversus <lb/> . eos instruitur, quorum
-						perversæ turbe corporaliter <lb/> implent ecclesias, simul etiam præcepta breviter et
-						<lb/> decenter commemorentur christianæ atque honestæ <lb/> conversationis, ne ab
-						ebriosis, avaris, fraudatoribus <lb/> aleatoribus, adulteris, fornicatoribus,
-						spectaculorum <lb/> amatoribus, remcdiorum sacrilegurum alligatoribus, <lb/>
-						præcantatoribus, mathematicis, vel quarumlibet ar<lb/>tium vanarum et malarum
-						divinatoribus, atque hujus<lb/>modi cæteris ita facile seducatur, et impunitum sibi
-						<lb/> fore arbitretur, qnia videt multos qui christiani <lb/> appellantur, hrec amare,
-						et agere, ct defendere , et <lb/> suadere, et persuadere. Quis enim finis præstitutus
-						<lb/> sit in tali vita perseverantibus, et quam sint in ipsa <lb/> Ecclesia tolerandi,
-						ex qua in finc separandi sunt, <lb/> divinorum Librorum testimoniis edocendum est. <lb/>
-						Prænuntiandum est etiam inventurum eum in Eccle<lb/>sia multos christianos bonos ,
-						verissimos cives cæle<lb/>stis Jerusalem, si esse ipse coeperit. Ad extremum <lb/> ne
-						spes ejus in homine ponalur, sedulo monendus <lb/> est : quia neque facile ab homine
-						judicari potest <lb/> quis homo sil justus; et si facile posset, non ideo <lb/> nobis
-						proponi exempla justorum, ut ab eis justifice<lb/>mur, sed ut eos imitantes ab eorum
-						justificatore nos <lb/> quoque justificari sciamus. Hinc enim fiet, quod ma<lb/>xime
-						commendandum est, ut cum ille qui nos audit, <lb/> imo per nos audit Deum, moribus et
-						scientia profi<lb/>cere coeperit, et viam Christi alacriter ingredi, nee <lb/> nobis
-						id audeat assignare, nee sibi; sed ct se ipsum, <lb/> et no;, et quoscumque alios
-						diligit amicos, in illu ct <lb/> propter illum diligat, qui eum dilexit inimicum, ut
-						<lb/> justificans faceret amicum, Hic jam non te puto præ<lb/>ceptore indigere, ut
-						cum occupata sant tempora, vel <lb/> tua, vel eorum qui te audiunt, breviter agas; cum
-						<lb/> autem largiora, argius eloqualis : hoc euim nullo <lb/> admonente ipsa necessitas
-						præcipit.</p></div>
-    	<div type="textpart" subtype="chapter" n="8"><p>12. <hi rend="italic">Eruditi quomodo catechizandi.</hi>
-						<lb/> Sed illud plane non prætereundum est, ut si ad te <lb/> quisquam catechizandus
-						venerit liberalibus doctrinis <lb/> excultus, qui jam decreverit esse christianus, et
-						ideo <lb/> venerit ut fiat, difficillimum omnino cst ut hon multa <lb/> nostrarun,
-						scripturarum litterarumque cognoverit, <lb/> quibus jam instructus ad Sacramentorum
-						participa<lb/>tionem tantuminodo venerii. Tales enim non eadem <lb/> hora qua
-						christiani fiunt, sed ante solent omnia dili<lb/>genter inquircre, et motus animi
-						sui, cum quibus <lb/> possunt, communicare atque discutere. Cum his ita<lb/>que
-						breviter agendum est, et non odiose 1 inculcando <lb/> quæ norunt. sed modeste
-						perstringendo; ita ut dica<lb/>mus nos credere quod jam noverint illud, atque <lb/>
-						iJ nd ; atque hoc modo cursim enumerare omnia qua
-    		
-    			<note type="footnote"> 1 Aliquot Mss., <hi rend="italic">otiose­</hi></note><lb/>
-						
-
-		<pb n="319"/> rudibus indoctisque inculcanda sunt : ut etsi quid <lb/> novit eruditus
-						iste, non tanquam a doctore audiat ; <lb/> ct si quid adhuc ignorat 1. dum ea
-						commemoramus <lb/> quæ illum nosse jam credimus, discat. Noc ipse sane <lb/> inutilter
-						interrogatur, quibus rcbus motus sit ut <lb/> v lit sse christianus : ut si libris ei
-						persuasum I esse <lb/> videris, sive canonicis. sive utilium tractatorum, de <lb/> bis
-						:liquid in principio loquaris, collaudans eos pro <lb/> diversitate meritorum canonicæ
-						auctoritatis et expo<lb/>nentium a solertissimæ diligentiæ ; maximeque com­ <lb/>
-						mendans in Scripturis canonicis admirandæ altitudi<lb/>nis saluberrimam humilitatem,
-						in illis autempro <lb/> sua cujusque facultate aptum superbioribus, et per <lb/> hoc
-						infirmioribus animis, stilum sonanlioris et quasi <lb/> tornatioris eloquii 4.Sane cHam
-						exprimendum de <lb/> ilio est ut iudicet quem maxime legerit, et quibus <lb/> libris
-						familiarius innæserit, undc illi persuasum est <lb/> ut sociari vellet Ecclesiæ Quod cum
-						dixerit, tum si <lb/> nobis noti sunl illi libri, aut ecclesiastica fama saltem <lb/>
-						accepimus a catholico aliquo memorabili viro esse <lb/> conscriptos, læti approbemus. Si
-						autem in alicujus <lb/> hæretici volumina incurrit, et nesciens forte quod <lb/> vera
-						fides improbat, tenuit animo, et catholicum <lb/> esse arhitralur; sedulo edocendus est,
-						prælataaucto<lb/>ritate universalis Ecclesiæ aliorumque doctissimorum <lb/> hominum
-						el disputationibus ct scriptionibus in ejus <lb/> veriiale florentium. Quanquam et illi
-						qui catholici <lb/> ex bac vita migrarunt, et aliquid litterarum christia<lb/>narum
-						posteris reliquerunt, ill quibusdam locis opu<lb/>seniorum suorum, vel non
-						intellecti, vel sicuti est <lb/> humana infirmitas, minus valentes acie mentis abdi­
-						<lb/> liora penetrare, et veri similitudine aberrantes a <lb/> veritate, præsumptoribus
-						et audacibus fuerunt occa<lb/>sioni ad aliquam hæresim moliendam atque gignen­ <lb/>
-						dam. Quod mirum non est, cum de ip is canonicis <lb/> Litteris, ubi omnia sanissime
-						dicta sunt, noH quidem <lb/> aliter accipiendo quædam, quam vel scriptor sensit, <lb/>
-						vul se ipsa veritas habet ; (nam si hoc solum esset, <lb/> quis non humanae infirmitati
-						ad corrigendum paratæ <lb/> libenter ignosceret?) sed id quod perverse ac prave <lb/> op
-						nati sunt, animositate acerrima et pervicaci arro<lb/>gantia defensitantes, multi
-						multa pcruiciosa dogmata, <lb/> concisa communionis unitate pepererunt. Hæc omnia <lb/>
-						cum illo qui ad societatem populi christiani, non <lb/> idiota, ut aiunt, sed doctorum
-						libris expolitus atque <lb/> excultus accedit, modesta collatione tractanda sunt: <lb/>
-						tantum assumpta præcipiendi auctoritate, ut caveat <lb/> præsumptionis errores ; quantum
-						ejus humilitas quæ <lb/> illum adduxit, jam sentitur admittere. Cætera vero <lb/>
-						secundum regulas doctrinæ salutaris, sive de fide, <lb/> quæcumque narranda vel
-						disserenda sunt, sive de <lb/> moribus, sive de tentationibus, eo modo percurrendo <lb/>
-						quo dixi, ad illati supereminentiorem viam omnia <lb/> rererenda sunt.</p></div>
-    	<div type="textpart" subtype="chapter" n="9"><p>13. <hi rend="italic">Grammatici</hi> et <hi rend="italic">oratores
-							quo­</hi>
-						
-	    		<note type="footnote"> s Editi, <hi rend="italic">et</hi> si <hi rend="italic">quid
-									forts adhuc ignorai.</hi> Abest, <hi rend="italic">forte,</hi>
-								<lb/> a MV.</note>
-	    		<note type="footnote"> * a;,s., 'I' <hi rend="italic">:-i libr" ettm persuasum.</hi></note>
-	    		<note type="footnote"> * Pim es codiccs, <hi rend="italic">ci ad exponendum.</hi></note>
-	    		<note type="footnote"> * L-iV., <hi rend="italic">ornationis</hi> eloquii.</note><lb/>
-    		
-						<hi rend="italic">modo tractandi. Vox ad aures Da. animi</hi> affectus. Sunt <lb/> item
-						quidam de scholis usitatissimis grammaticorum <lb/> oratorumque venientes, quos neque
-						inter idiotas nu<lb/>merare audeas, ncque inter illos doctissimos, quorum <lb/> mens
-						magnarum rerum cst exercitata quæstionibus. <lb/> His ergo qui loquendi arte cæteris
-						hominibus excel<lb/>lere videntur, cum veniunt ut christiani fiant, hoc <lb/> amplius
-						quam illis illitteratis impertire dcbemus, quod <lb/> ' scdulo monendi sunt ut
-						humilitate induti christiana, <lb/> discant non conteminere quos cognoverint morum vi­
-						<lb/> tia quam verborum amplius devitare; et cordi casto <lb/> linguam exercitatam nec
-						conferre 1 audeantv quam <lb/> etiam præferre consueverant. Maxime autem isti do­ <lb/>
-						cendi sunt Scripturas audire divinas, nc sordeat cis <lb/> solidum eloquium, quia uon
-						est inflatum ; neque ar<lb/>bitrentur carnalibus integumentis involuta atque <lb/>
-						operta dicta vel facta hominum, quæ iniliis libris le<lb/>guntur, non evolvenda atque
-						aperienda ut intelligan<lb/>tur, sed sic accipienda ut litteræ sonant; deque ipsa
-						<lb/> utilitate secreti, unde etiam mysteria vocantur, quid <lb/> valeant aenigmatum
-						latebræ ad amorem veritatis <lb/> acuendum, decutiendumque 2 fastidii torporem, ipsa
-						<lb/> experientia probandum est talibus, cum aliquid eis <lb/> quod in promptu positum
-						non ita movebat, enoda<lb/>tione allegoriæ alicujus eruitur. Ilis enim maxime <lb/>
-						utile cst nosse, ita esse præponendas verbis senten<lb/>tias, ut præponituranimus
-						corpori. Ex quo fit ut ita <lb/> malle debeant veriores quam disertiores audire ser­
-						<lb/> mones, sicut malle debeut prudentiores, quant for<lb/>mosiores habere amicos.
-						Noverint etiam non esse vo<lb/>cem ad aures Dei, nisi animi affectum : ita enim non
-						<lb/> irridebunt, si aliquos antistites et ministres Ecclesiæ <lb/> forte
-						animadverterint, vel cum barbarismis et solœ<lb/>cismis Dcum invocare, vel cadem
-						verba quæ pronun- <lb/> tiant non intelligere, perturbateque distinguere. Non <lb/> quia
-						ista minime corrigenda sunt, ut populus ad id <lb/> quod plane intelligit, dicat Amen;
-						sed tamen pie to<lb/>leranda sunt ab eis qui didicerint, ut sono in foro, sic <lb/>
-						volo in Ecclesia benedici. Itaque forensis illa nonnum. <lb/> quam forte bona dictio,
-						nunquam tamen Ienedictio <lb/> dici potest. De Sacramento autem quod accepturi <lb/>
-						suni, sufficit prudentioribus audirc quid res illa si<lb/>gnificet : cum tardioribus
-						autem aliquanto pluribus <lb/> verbis et similitudinibus agendum est, ne conteninant
-						<lb/> quod vident.</p></div>
-    	<div type="textpart" subtype="chapter" n="10"><p>14. <hi rend="italic">Jam de hilaritate comparanda.<lb/> Causæ</hi> sex <hi rend="italic">lædium afferentes catechizanti. Remedium <lb/> contra primam causam
-							tædii.</hi> Hic tu fortasse exem­ <lb/>
-						<lb/> plum aliquod sermonis desideras, ut ipso tibi opere <lb/> ostendam quomodo
-						facienda sint ista quæ monni. <lb/> Quod quidem faciam, quantum Domino adjuvante po­
-						<lb/> tuero : sed prius de iila hilaritate comparanda, quod <lb/> pollicitus sum, dicere
-						dehco. Jam euim de ipsis prae. <lb/> ceptis explicandi sermonis, in catechizando eo qui
-						<lb/> sic verit ut christianus fiat, quantum satis visum cst, <lb/> quod promiseram
-						exsolvi. Indebitum quippe eat, ut
-    		
-	    		<note type="footnote"> I Praecipui Mss., <hi rend="italic">linguam exerntam nec</hi> conferrc.</note>
-	    		<note type="footnote"> 'bic plures v.gs. At eiliti, <hi rend="italic">discutiendumque</hi></note><lb/>
-						
-
-		<pb n="321"/> etiam ipse faciam in hoc volumine, quod fieri oportere <lb/> praecipio. Si
-						ergo fecero, ad cumulum valebit : cu<lb/>mulus autem quo pacto a me superfundi
-						potest, an<lb/>tequam mensuram debiti explevero ? Neque enim te <lb/> maxime conqueri
-						audivi, nisi qnod tibi sermo tuus <lb/> vilis abjectusquc videretur, cum aliqucm
-						christiano <lb/> nomine imbuercs. Hoc autem scio, non tam rerum <lb/> quae dicendæ sunt,
-						quibus te satis novi paratum et <lb/> instructum, neque ipsius locutionis inopia, sed
-						animi <lb/> tædio fieri; vel illa causa quam dixi, quia magis nos <lb/> delectat ct
-						tenet, quud in silentio mente cernimus, <lb/> nec inde volumus avocari ad verborum longe
-						dispa<lb/>rem strepitum; vel quia etiam cum sermo jucundus <lb/> est, magis nos libet
-						audire aut legere quæ melius di<lb/>cia sunt, et quae sine nostra cura et
-						sollicitudine pro<lb/>muntur, quam ad alienum sensum repentina verba <lb/> coaptare
-						incerto exitu, sive utrum occurrant pro sen<lb/>tentia, sive ulrum accipiantur
-						utiliter; vel quia illa <lb/> quæ rudibus insinuantur, eo quod nohis notissima <lb/>
-						sunt, et provectui nostro jam non necessaria, piget <lb/> ad ea sæpissime redire, nec in
-						eis tam usitatis et tan<lb/>quam infantilibus cum aliqua voluptate jam gran­ <lb/>
-						disculus anianus graditur. Facit etiam loquenti tae<lb/>dium auditor [immobilis vel
-						quia non movetur affe<lb/>ctn, vel quia nullo motu corporis iudicat se intelligere
-						<lb/> vel sibi placere quæ dicuntur1 ] : non quia humanæ <lb/> laudis nos esse avidos
-						decet, sed quia ea quæ mini<lb/>stramus Dei sunt; et quanto magis diligimus eos qui­
-						<lb/> bus loquimur, tanto magis eis cupimus ut placeant <lb/> quæ ad corum porriguntur
-						salutem : quod si non suc<lb/>cedit, contristamur, et in ipso cursu debilitamur et
-						<lb/> frangimur, quasi frustra operam conteramus. Nun<lb/>nunquam etiam cum avertimur
-						ab aliqua re quam <lb/> desideramus agere, et cujus actio aut delectabat nos, <lb/> aut
-						magis nobis necessaria videbatur, et cogimur aut <lb/> jussu ejus quem offendere
-						nolumus, aut aliquorum <lb/> inevitabili instantia catechizare aliquem jam contur­ <lb/>
-						bati accedimus ad negotium, cui magna tranquillitate <lb/> opus est, dolentes qnod ncque
-						ordinem actionum no<lb/>bis conceditur tenere quem volumus, nee sufficere <lb/>
-						omnibus possumus : atque ita ex ipsa tristitia sermo <lb/> procedens minus gratus est,
-						quia de ariditate mœsti<lb/>tiae minus exuberat. Aliquando item ex aliquo scan­ <lb/>
-						dalo mœror pectus obsedit2, et tunc nobis dicitur, <lb/> Venit loquere huic; christianus
-						vult fieri. Dicitur 2 <lb/> enim ab ignorantibus quid nos clausumintus exurat: <lb/>
-						quibus si affectum nostrum aperire non oportet, <lb/> suscipimus ingratius quod volunt
-						'; et profectolan<lb/>guidus et insuavis ille sermo erit pcr venam cordis <lb/>
-						aestuantem fumantemque trajectus. Tot igitur ex cau<lb/>sis, quælibet earum
-						serenitatem nostra; mentis obnu<lb/>bilet, secundum Deum sunt quxrenda remedia, qui­
-						<lb/> bus relaxetur illa contractio, et fervore spiritus ex<lb/>suitemus et
-						jucundemur in tranquillitate botri operis.
-    		
-	    		<note type="footnote"> ' verba hic unds indusa 4bsont a plerisque Mss. et ab <lb/> Atto. Ir. </note>
-	    		<note type="footnote"> ' Editi, obsidet. At Mss., <hi rend="italic">obsedit.</hi></note>
-	    		<note type="footnote"> 3 Sola editio LOT., <hi rend="italic">nescitur.</hi></note>
-	    		<note type="footnote"> k rhiroa Mss., <hi rend="italic">sust-ipimu? ingrati</hi>",..oJ volent </note><lb/>
-    		
-						<hi rend="italic">Hilarem enim datorem diligit Deus</hi> (Il Cor. ix, 7).</p>
-					<p>15. Si enim causa illa contristat, quod intellectum <lb/> nostrum auditor non capit, a
-						cujus cacumine quodam <lb/> modo descendentes cogimur in syllabarum longe in<lb/>fra
-						distantium tarditate demorari, et curam gerimus <lb/> quemadmodum longis et per plexis
-						anfractibus proce<lb/>dat ex ore carnis, quod celerrimo haustu mentis im­ <lb/>
-						bibitur, et quia multum dissimiliter exit, tædet loqui, <lb/> et libet tacere; cogitemus
-						quid nobis prærogatum sit <lb/> ab illo qui demonstravit nobis exemplum, ut sequa­ <lb/>
-						mur vestigia'ejus ( I <hi rend="italic">Petr.</hi> II, 21). Quantumvis enim <lb/>
-						difierat articulata vox nostra aC intelligentiæ nostræ <lb/> vivacitate, longe
-						differentior est mortalitas carnis "b <lb/> æqualitate Dei. Et tamen cum in eadem <hi rend="italic">forma esset,<lb/> temetipsum exinanivit formam servi accipiens,</hi>
-						etc., us<lb/>que ad <hi rend="italic">(a)</hi> mortem <hi rend="italic">crucis</hi> (
-							<hi rend="italic">Philipp.</hi> II, 6-8). Quam ob <lb/> causam, nisi quia factus est
-						infirmis infirmis,;ut in<lb/>firmos lucrificaret ( I <hi rend="italic">Cor.</hi> IX,
-						22 ) ? Audi ejus imita<lb/>torem alibi etiam dicentem : <hi rend="italic">Sive</hi>
-						enim <hi rend="italic">mente excessi­</hi>
-						<lb/> mus, <hi rend="italic">Deo; sive temperantes</hi> sumus, <hi rend="italic">vobis.
-							Charitas enim<lb/> Christi compellit nos, judicantes hoc, quia unus pro</hi> om­ <lb/>
-						<hi rend="italic">nibus mortuus eat</hi> (II <hi rend="italic">Cor.</hi> v, 13 <hi rend="italic">et</hi> 14). Quomodo enim <lb/> paratus esset impendi pro animabus eorum
-							<hi rend="italic">( Id. XII,</hi>
-						<lb/> 15), si eum pigeret inclinari ad aures eorum? Hinc <lb/> ergo factus est parvulus
-						in medio nostrum, tanquam <lb/> nutrix fovens filios suos (I <hi rend="italic">Thess.</hi> II, 7). Num enim <lb/> delectat, nisi amor invitet, decurtata et
-						multilata ver<lb/>ba immurmurare? Et tamen optant homines babere <lb/> infantes,
-						quibus id exhibeant : et suavius est matri <lb/> minuta mansa inspuere parvulo filio,
-						quam ipsam <lb/> mandere ac devorare grandiora. Non ergo recedat de <lb/> pectore etiam
-						cogitatio gallinae illius, quæ languidu<lb/>lis plumis teneros fetus operit, et
-						susurrantes pullos <lb/> confracta voce advocat; cujus blandas alas refugien<lb/>tcs
-						superbi, præda fiunt alitibus ( Matth. XXIII, 37). <lb/> Si enim intellectus delectat in
-						penetralibus sinceris<lb/>simis, hoc cHam intelligere delci tat, quomodo chari­ <lb/>
-						tas, quanto officiosius descendit in infima, tanto ro<lb/>bustius recurrit in intima
-						per bonam conscientiam <lb/> nihil quærendi1 ab eis ad quos descendit, præter eo­ <lb/>
-						rum sempiternam salutem.</p></div>
-    	<div type="textpart" subtype="chapter" n="11"><p>16. <hi rend="italic">Remedium contra secundumtœdii<lb/> causam.</hi> Si
-						autem niagis appetimus, ea quæ jam parata <lb/> sunt et melius dicta legere vel audire,
-						et ideo piget <lb/> inecrto exitu ad tempus coaptare quae loquimur : tan<lb/>tum a
-						veritnte rerum non aberret animus, facile est <lb/> ut si in verbis auditorem aliquid
-						offenderit, ex ipsa <lb/> occasione discat quam sit re intellectacontemnen<lb/>dum,
-						si minus integre, aut si minus propric sonare <lb/> potuit, quod ideo sonabat ut res
-						intelligeretur Quod <lb/> si humanæ infirmitatis intentio enam ab ipsa reruni <lb/>
-						veritate aberraverit; quanquam in catechizandis ru<lb/>dibus, ubi via tritissima
-						tenenda est, difficile potest <lb/> accidere : tamen ne forte accidat ut ctiam hinc
-						offen<lb/>datur auditor, non aliunde nohis debet vidcri acci<lb/>disse, nisi quia
-						Deus experi ..os voluit, utrum cum
-    		
-	    		<note type="footnote"> 1 sic Mss. Editi vero, <hi rend="italic">nihil n</hi> i:<hi rend="italic">ccrenda.</hi></note>
-				<note type="footnote"> (a) Istai voces, c!.c., unrue ed, librarii sunt prætereuntis,
-								<lb/> tit s.J..'!. vc:!a intermedi i I,...v </note><lb/>
-						
-						
-		<pb n="323"/> mentis placiditate corrigamur, ne in defensionem IIO<lb/>stri erroris
-						majore præcipitemur errore. Quod si ne<lb/>mo nobis dixerit, nosque et illos qui
-						audierunt omni- <lb/> IIO latuerit, nullus dolor est, si non fiat iterum. Ple­ <lb/>
-						rumque antem nos ipsi recolentes quae dixeri<lb/>mus, reprehendimus aliquid, et
-						ignoramus quo<lb/>modo cum diceretur acceptum sit; magisque do<lb/>lemus, quando
-						in nobis fervet charitas , si cum <lb/> falsum esset, libenter acceptum est. Ideoque op­
-						<lb/> portunitate reperta , sicut nos ipsos in silentio re<lb/>prehendimus, ita
-						curandum est ut etiam illi sensim <lb/> corrigantur, qui non Dei verbis, sed plane
-						nostris in <lb/> aliquam lapsi sunt falsitatem. Si vero aliqui livore ve<lb/>sano
-						cæci errasse nos gaudent, susurrones, detracto<lb/>res, Deo odibiles <hi rend="italic">( Rom.</hi> i, 50); præbcant nobis ma<lb/>teriam exercendæ patientiæ
-						cum misericordia, quia <lb/> et patientia Dei ad poenitentiam eos adducit. Quid <lb/>
-						enim est detestabilius, et quod magis thesaurizet <lb/> iram in die iræ et revelationis
-						justi judicii Dei <lb/>
-						<hi rend="italic">(Id.</hi> n, 4 <hi rend="italic">et</hi> 5), qnam de malo alterius
-						mala1 diaboli si<lb/>militudine atque imitatione laetari? Nonnunquam <lb/> etiam, cum
-						rectc omnia vereque dicantur, aut non <lb/> intellectum aliquid, aut contra opinionem et
-						consue<lb/>tudinem vetcris erroris ipsa novitate asperum, of<lb/>fendit et
-						perturbat audientem. Quod si apparuerit, <lb/> sanabilemque se præbet, auctoritatum
-						rationumque <lb/> copia sine ulla dilatione sanandus est. Si autem tacita <lb/> et
-						occulta offensio est, Dei medicina opitulari potest. <lb/> At si resiluerit2, et curari
-						recusaverit, consoletur <lb/> nos dominicum illud exemplum, qui offensis homi­ <lb/>
-						nibus ex verbo suo, et tanquam durum refugientibus, <lb/> etiam iis qui remanserant ait,
-							<hi rend="italic">Numquid et vos vultis<lb/> ire (Joan.</hi> vi, 68)? Salis enim fixum
-						atque immo<lb/>bile debet corde retineri, Jerusalem captivam ab hu<lb/>jus saeculi
-						Babylonia decursis temporibus liberari, <lb/> nullumque ex illa esse periturum; quia qui
-						perierit, <lb/> non ex illa erat. <hi rend="italic">Firmum</hi> enim <hi rend="italic">fundamentum Dei stat, <lb/> habens signaculum hoc</hi> : novit <hi rend="italic">Dominus</hi> qui <hi rend="italic">sunt ejus ; <lb/> et recedat ab iniquitate,
-							omnis</hi> qui <hi rend="italic">nominat</hi> nomen <hi rend="italic">Do­</hi>
-						<lb/> mini ( II Tim. II, 19). Ista cogitantes , ct invocantes <lb/> Dominum in cor
-						nostrum, minus timebimus incertos <lb/> exitus sermonis nostri propter incertos motus
-						audito<lb/>rum; delectabitque nos etiam ipsa perpessio mole<lb/>stiarum pro
-						misericordi opere, si non in eo nostram <lb/> gloriam rcquirainus. Tunc enim est vere
-						opus bo<lb/>num, cum a charitate jaculatur agentis intentio, et <lb/> tanquam ad
-						locum suum rediens, rursus in charitate <lb/> requiescit. Lectio vero quæ nos delectat,
-						aut aliqua <lb/> . auditio melioris eloquii, ut eam promendo, sermoni <lb/> nostro
-						præponere volentes, cum pigritia vel tædio lo<lb/>quamur, alacriores nos suscipiet;
-						jucundiorqne prae. <lb/> stabitur post laborem; et majore fiducia deprecabimur <lb/> ut
-						loquatur nobis Deus quomodo volumus , si susci<lb/>piamus hilariter ut loquatur per
-						nos quomodo possu<lb/>mus : ita lit ut diligentibus Deum omnia concurrant <lb/> in
-						bonum (Rom. VIII, 28).</p></div>
-    	<div type="textpart" subtype="chapter" n="12"><p>17. <hi rend="italic">Remedium contra tertiam</hi> causam
-    		
-	    		<note type="footnote"> I Ita in Mss. At in editis, <hi rend="italic">mera.</hi></note>
-	    		<note type="footnote"> 2 Editi, <hi rend="italic">rctilierit.</hi> Præstantieres ua . <hi rend="italic">resiluerit.</hi></note><lb/>
-    		
-						<hi rend="italic">tædii.</hi> Jam vcro si usitata et parvulis congruentia <lb/> sæpe
-						rcpetere faslidimus; congruamus eis per fra<lb/>ternum, paternum, maternumque amorem,
-						et copu<lb/>latis cordi eorum etiam nobis nova videbuntur. Tan<lb/>tum enim valet
-						animi compatientis affectus, ut cum <lb/> illi afficiuntur nohis loquentibus, et nos
-						illis discenti<lb/>bus, habitemus in invicem; atque ita et illi quæ au. <lb/> diunt
-						quasi loquantur in nobis, et nos in illis disca - <lb/> mus quodam modo quæ docemus.
-						Nonne accidere hoc <lb/> solet, cum loca quaedam ampla et pulchra, vel urbium <lb/> vel
-						quæ jam nos sæpe videndo sinealiquavo<lb/>luptate præteribamus, ostendimus eis qui
-						antea nun<lb/>quam viderant, ut nostra delectatio in eorum novita<lb/>tatis
-						delectatione rcnovetur? Et tanto magis, quanto <lb/> suut amiciores; quia per amoris
-						vinculum in quan<lb/>tum in illis sumus, in tantum et nobis nova Dunt quae <lb/>
-						vetera fuerunt. Sed si in rebus contemplandis ali<lb/>quantum profccimus, non volumus
-						cos quos diligimus <lb/> lætari et stupere, cum intuentur opera manuum ho- <lb/> minum;
-						sed volumus eos in ipsam artem 1 consilium<lb/>ve institutoris attollere, atque inde
-						exsurgere in ad<lb/>miralionem laudemque omnicreantis Dei, ubi amoris <lb/>
-						fructuosissimus finis est: quanto ergo magis delectari <lb/> nos oportet, cunt ipsum
-						Deum jam discere homines <lb/> accedunt, propter quem discenda sunt quæcumque <lb/>
-						discenda sunt; et in eorum novitate innovari, ut si <lb/> frigidior est solita I nostra
-						praedicatio, insolita eo<lb/>rum auditione fervescat? Huc accedit ad comparan­ <lb/>
-						dam laetitiam, quod cogitamus et consideramus, de <lb/> qua erroris morte in vitam fidei
-						transeat homo. Et si <lb/> vicos usitatissimos cum benefica hilaritate transimus , <lb/>
-						quando alicui forte qui errando laboraverat, demon<lb/>stramus viam : quanto alacrius
-						et cum gaudio majo<lb/>re in doctrina salutari, etiam illa quæ propter nos re­ <lb/>
-						texere nou opus est, perambulare debemus; cum <lb/> animam miserandam et crroribus
-						sacculi fatigatam <lb/> per itinera pacis, ipso qui nobis eam I praestitit ju­ <lb/>
-						bente3, deducimus?</p></div>
-    	<div type="textpart" subtype="chapter" n="13"><p>18. <hi rend="italic">Remedium contra</hi> quartam <hi rend="italic">causam<lb/> fastidii. Auditor veI audiendo vel stando</hi> fatigatus, <hi rend="italic">quo<lb/>modo recreandus. Usus audiendi verbum Dei sedendo,<lb/> in
-							quibusdam</hi> Ecclesiis <hi rend="italic">receptus.</hi> Sed revera multum <lb/> est
-						perdurare in loquendo usque ad terminum præ. <lb/> stitutum, cum moveri non videmus
-						audientem; quod <lb/> sive nou audeat, religionis timore constrictus , voce <lb/> aut
-						aliquo motu corporis significare approbationem <lb/> suam, sive humana verecundia
-						reprimatur; sive di<lb/>cta nou intelligat, sive contemnat: quandoquidem <lb/> nobis
-						non cernentibus auimum ejus incertum est, <lb/> omnia sermone tentanda sunt, quae ad eum
-						excitan<lb/>dum et tanquam de latebris eruendum possint valere. <lb/> Nam et timor
-						nimius atque impediens declarationem <lb/> judicii ejus, blanda exhortatione pellendus
-						est, et <lb/> insinuando fraternam societatem verecundia tempe<lb/>randa, et
-						interrogatione quærendum utrum intelligat, <lb/> et danda fiducia, ut si quid ei
-						contradiccudum vide
-    		
-	    		<note type="footnote"> * Edi! i, <hi rend="italic">arcem.</hi> Aptius Mss., aitem. </note>
-	    		<note type="footnote"> * SiC Am. ei plerique MSS. At t:r. et tov., <hi rend="italic">solito.</hi></note>
-	    		<note type="footnote"> I Codex Corbeiensis, ea &gt; </note><lb/>
-						
-
-		<pb n="325"/>tur, libere proferat. Quaerendam etiam de illo utrum <lb/> hæc aliquando
-						jam audierit, et fortassis eum tanquam <lb/> nota et pervulgata non moveant; et agendum
-						pro ejus <lb/> responsione, ut aut planius et enodatius loquamur, <lb/> aut opinionem
-						contrariam refellamus, aut ea quæ illi <lb/> nota sunt uon explicemus latius, sed
-						breviter com<lb/>plicemus, eligamusque aliqua ex bis quæ mystice <lb/> dicta sunt in
-						sanctis Libris, et maxime in ipsa nar<lb/>ratione, quae aperiendo et revelando noster
-						sermo <lb/> dulcescat. Quod si nimis tardus est, et ab omni tali <lb/> suavitate
-						absurdus et aversus, misericorditer suffe<lb/>rendus est, breviterque decursis
-						cæteris, ea quæ ma<lb/>sime necessaria sunt, de unitate Catholicæ de ten­ <lb/>
-						tationibns, de christiana conversatione propter futu<lb/>rum judicium terribiliter
-						inculcanda sunt, magisque <lb/> pro illo ad Deum, quam illi de Deo multa dicenda.</p>
-					<p>49. Saepe etiam fit ut qui primo libenter audiebat, <lb/> vel audiendo vel stando
-						fatigatus, non jam laudans, sed <lb/> oscitans labia diducat, et se abire velle etiam
-						invitus <lb/> ostendat. Quod ubi senserimus, aut renovare oportet <lb/> ejus animum,
-						dicendo aliquid honesta hilaritate con<lb/>ditum et aptum rei quæ agitur, vel aliquid
-						valde mi<lb/>randum et stupendum, vel etiam dolendum atque <lb/> plangendum; et magis
-						de ipso, ut propria cura pun<lb/>cius evigilet; quod tamen non offendat ejus verecun­
-						<lb/> diam asperitate aliqua, sed potius familiaritate con<lb/>ciliet ; aut oblata
-						sessione I succurrere ; quanquam <lb/> sine dubitatione melius fiat, ubi decenter fieri
-						potest, <lb/> ut a principio sedens audiat; longeque consultius in <lb/> quibusdam
-						Ecclesiis transmarinis non solum antisti<lb/>tes sedentes loquuntur ad populum, sed
-						ipsi eliam <lb/> populo sedilia subjacent, ne quisquam infirmior stan<lb/>do lassatus
-						a saluberrima intentione avertatur, aut <lb/> etiam cogatur abscedere. Et tamen multum
-						interest, <lb/> si se quisquam de magna multitudine subtrahat ad <lb/> reparandas vires,
-						qui jam sacramentorum societate <lb/> devinctus est; et si ille discedat (quod plerumque
-						in<lb/>evitabiliter urgetur, ne interiore defectu victus etiam <lb/> cadat) qui
-						primis sacramentis imbuendus est: et pu<lb/>dore enim non dicit cur eat, et
-						imbecillitate stare nou <lb/> sinitur. Expertus hæc dico: nam fecit hoc quidam , <lb/>
-						cum eum catechizarem, homo rusticanus , unde ma<lb/>gnopere praecavendum esse didici.
-						Quis enim ferat <lb/> arrogantiam nostram, cum viros' fralres nostros, <lb/> vel eliam
-						quod majore solliciludine curandum est, ut <lb/> sint fratres nostri, coram nobis sedere
-						non facimus ; <lb/> et ipsum Dominum nostrum, cui assistunt Angeli, <lb/> sedens mulier
-						audiebat <hi rend="italic">(Luc.</hi> x, 59)? Sane si aut <lb/> brevis sermo futurus
-						est, aut consessui locus non est <lb/> aptus, stantesaudiant; sed cum multi audiunt, et
-						<lb/> non tunc initiandi \ Nam cum unus , aut duo, aui <lb/> pauci, qui propterea
-						venerunt ut christiani fiant, pe<lb/>riculose loquimur stantibus. Tamen si jam sic
-						cœpi- <lb/> mos. saltem animadverso auditoris tædio, et offe<lb/>renda sessio est,
-						iuto vero prorsus urgendus ut sedeat,
-						
-				<note type="footnote">1 toY., <hi rend="italic">eathoHcai pdeL</hi> EdM vero alII et plerique Mss. <lb/>
-							MB ... babeat, <hi rend="italic">fidei:</hi> pro quo subauliiri debet, Ecclesiae.</note>
-				<note type="footnote"> Apud Lov. additur, <hi rend="italic">studeat.</hi> Sed subaudiendum,
-								<hi rend="italic">oporlel.</hi></note>
-				<note type="footnote"> I Nonuulti MM., <hi rend="italic">vero*.</hi></note>
-				<note type="footnote"> fc SOIa editio ijov., pro, tmc9 babet, sunt.</note>
-						
-						<lb/> et dicendum aliquid quo renovetur, quo etiam curas, <lb/> si qua forte irruens eum
-						avocare coeperat, fugiat ex <lb/> animo. Cum enim causæ incertæ sint cur jam tacitus
-						<lb/> recuset audire, jam sedenti aliquid adversus inciden<lb/>tes cogitationes
-						sæcularium negotiorum dicatur, aut <lb/> hilari, ut dixi, aut tristi modo : ut si ipsae
-						sunt quae <lb/> mentem occupaverunt, cedant quasi nominatim ac<lb/>cusatæ; si autem
-						ipsæ non sunt, et audicndo fatiga<lb/>tus cst, cum de illis tanquam ipsæ sint
-						(quandoqui<lb/>dem ignoramus), inopinatum aliquid et extraordiua<lb/>rium, eo modo
-						quo dixi, loquimur, a tædio renovatur <lb/> intentio. Sed et breve sit, maxime quia
-						extra ordinem <lb/> inseritur, ne morbum fastidii cui subvenire volumus <lb/> eliam
-						augeat ipsa medicina: et acceleranda sunt cætera, <lb/> et promittendus atque exhibendus
-						finis propinquior.</p></div>
-    	<div type="textpart" subtype="chapter" n="14"><p>20. <hi rend="italic">Remedium adversus quintam <lb/> causam lædii.
-							Remedium contra</hi> sextam <hi rend="italic">causam tædii. <lb/> ltem adversus causam
-							sextam.</hi> Si autem confregit ani<lb/>mum tuum alterius actionis, cui tanquam
-						magis ne<lb/>cessariae jam suspensus eras, omissio, et propterea <lb/> tristis
-						insuaviter catechizas; cogitare debes, excepto <lb/> quod scimus misericorditer nobis
-						agendum esse quid<lb/>quid cum hominibus agimus, et ex officio sinceris<lb/>simae
-						charitatis; hoc ergo excepto, incertum esse <lb/> quid utilius agamus, et quid
-						opportuniys aut inter<lb/>mittamus, aut omnino omittamus. Quia enim merita <lb/>
-						hominum pro quibus agimus, qualia sint apud Deum <lb/> non novimus, quid eis ad tempus
-						expediat aut nulla <lb/> aut tenuissima aut incertissima conjectura suspicamur <lb/>
-						potius , quam comprehendimus. Quapropter res qui<lb/>dem agendas pro nostro captu
-						ordinare debemus: <lb/> quas eo modo quo statuimus, si peragere potuerimus, <lb/> non
-						ideo gaudeamus quia nobis, sed quia Deo sic eas <lb/> agi placuit : si autem aliqua
-						inciderit necessitas, qua <lb/> noster ille ordo turbetur; flectamur facile, ne fran-
-						<lb/> gamur; ut quem Deus nostro (a) praeposuit, ipse sit no<lb/>ster. Æquius est
-						enim ut nos ejus, quam ut ille no<lb/>stram voluntatem sequatur. Quia et ordo
-						agendarum <lb/> rerum, quem nostro arbitrio tenere volumus, ille uti<lb/>que
-						approbandus est, ubi jotiora præcedunt. Cur <lb/> ergo nos dolemus homines a Domino Deo
-						tanto po<lb/>tiore præcedi, ut eo ipso quo nostrum amamus ordi<lb/>nem, inordinati
-						esse cupiamus? Nemo enim melius or<lb/>dinat quid agat, nisi qui paratior est non
-						agere quod <lb/> divina potestate prohibetur, quam cupidior agere <lb/> quod humana
-						cogitatione meditatur. Quia <hi rend="italic">multæ</hi> co<lb/>gitationes sunt <hi rend="italic">in corde viri,</hi> consilium <hi rend="italic">autem Domim <lb/> manet
-							in æternum (Prov.</hi> xix, 21).</p>
-					<p>21. Si vero ex aliquo scandalo perturbatus animus <lb/> non valet edere serenum
-						jucundumque sermonem, <lb/> tantam esse charitatem oportet in cos pro quibus <lb/>
-						Christus mortuus est, volens eos pretio sanguinis sai <lb/> ab errorum saecularium
-						niorte redimere; at hoc ipsum <lb/> quod nobis tristibus nuntiatur, præsto esse aliquem
-						<lb/> quidesiderct fieri christianus, ad consolationem illius <lb/> resolutionemque
-						tristitiae valere debeat, sicut solent <lb/> lucrorum gaudia dolorem lenire damnorum.
-						Non <lb/> cnitn scandalum nos contristat alicujus, nisi quem
-						
-				<note type="footnote"> (a) Subaudiciulum, <hi rend="italic">ortliJli.</hi></note><lb/>
-						
-
-		<pb n="327"/> perire aut pcr quem perire infirmam vel credimus <lb/> vel videmus. Ille
-						igitur qni initiandus advenit, dum <lb/> speratur po se proficere, dolorem deficientis
-						abster<lb/>gat. Quia «t si timor ille suggeritur, lie fiat proselytus <lb/> filius
-						gehennæ <hi rend="italic">(Matth.</hi> XXIII, 15), dum mulli tales <lb/> versantur ante
-						oculos, ex quibus oriuntur ca quibus <lb/> urimur .caudata, non ad retardandos nos
-						pertincre <lb/> debet, sed magis ad excitandos et acuendos : quale<lb/>nns quem
-						imbuimus moneamus, ut caveat imitatio<lb/>nem eorum qui non ipsa veritate, sed solo
-						nomine <lb/> christiani sunt; nec eorum turba commotus, aut <lb/> sectari velit eos, aut
-						Cbristum nolit sectari propter <lb/> eos; et aut nolit esse in Ecclesia Dei uhi illi
-						sunt, <lb/> aut talis ibi velit esse quales illi sunt. Et nescio quo<lb/>modo in
-						hujusmodi monitis 1 ardentior sermo est, <lb/> cui fomitem subministrat præsens dolor :
-						ut non so<lb/>lum pigriorcs non simus, sed co ipso dicamus accen<lb/>sitis atque
-						vehementius, quod securiores frigidius et <lb/> lentius diceremus; gaudeamusque nobis
-						occasionem <lb/> dari, ubi motus animi nostri sinc fructificatione non <lb/>
-						transeat.</p>
-					<p>22. Si autem de aliquo errato nostro vel peccato <lb/> nos moestitudo comprehendit, non
-						tantum memine<lb/>rimus sacrificium Deu spiritum esse contribulatum <lb/>
-						<hi rend="italic">(Ptal.</hi> L, 19), sed etiam illud, <hi rend="italic">Quia sicut aqua
-							ignem,<lb/> sic eleemosyna exstinguit peccatum (Eccli.</hi> III, 33); et, <lb/>
-						<hi rend="italic">Quia misericordiam</hi>, inquit, <hi rend="italic">volo quam
-							sacrificium</hi> 2 <lb/>
-						<hi rend="italic">(Osee</hi> vi, 6). Sicut ergo si periclitaremUr incendio, ad <lb/>
-						aquam uti'tue curreremus, quo posset exstingui, et <lb/> gratularemur si quis eam de
-						proximo offerret; ita si <lb/> de nostro feno aliqua peccati flamma surrexitJ, et <lb/>
-						propterea conturbamur, data occasione misericordis<lb/>simi operis, tanquam de oblato
-						fonte gaudeamus, ut <lb/> inde illud quod exarserat opprimatur. Nisi forte tam <lb/>
-						Stulti sumus, ut alacrius arbitremur cum pane cur<lb/>rendum, quo ventrem esurientis
-						impleamus, quam <lb/> cum verbo Dei, quo mentem istud edentis ' instrua<lb/>mus. lluc
-						accedit , quia si tantummodo prodesset <lb/> hoc facere, non facere autem nibil obesset;
-						infeliciter <lb/> in periculo salutis, non jam proximi, sed nostræ, <lb/> oblatum
-						remedium sperneremus. Cum vero ex ore <lb/> Domini tam minaciter sonet, <hi rend="italic">Serve nequam et piger,<lb/> dares pecuniam meam nummulariis (Matth.</hi>
-						xxv, 26, <lb/> 27); quæ tandem dementia est, quoniam peccatum <lb/> nostrum nos angit,
-						ideo rursus velle peccare, non <lb/> dando pecuniam dominicam volenti et petenti? lIis
-						<lb/> atque hujusmodi cogitationibus et considerationibus <lb/> depulsa caligine
-						tædiorum, ad catechizandum aptatur <lb/> intentio, ut suaviter imbibatur, quod impigre
-						atque <lb/> hilariter de charitatis ubertate prorumpit. Haec enim <lb/> non tam ego
-						tibi, quam omnibus nobis dicit 3 ipsa di. <lb/> lectio, quae diffusa est in cordibus
-						nostris per Spi
-						
-				<note type="footnote">1 Rditi, <hi rend="italic">motu:</hi> quam vocem
-							prætereunt Mss.; plures alii <lb/> ,Mem ejus loco babeni, <hi rend="italic">monitis.
-							</hi> Paulo past, ex verbb, <lb/> suunwiul at, sive uti scribi solet in antiquis codicibus, <lb/>
-							<hi rend="italic">swimuwstrat,</hi> factum erat in eJitis, suum <hi rend="italic">muristrat.</hi></note>
-				<note type="footnote"> I Ediii, <hi rend="italic">volo magis quam</hi>
-							satrifictum. At Mss., constantEr <lb/> practereimt, <hi rend="italic">magis.</hi></note>
-				<note type="footnote"> • Apud Ex. Lugd. ven. Lov., <hi rend="italic">surrexerit.</hi> M. </note>
-				<note type="footnote"> • sic Mas. Editi vero, <hi rend="italic">mentem studentis.</hi></note>
-				<note type="footnote"> • Edui fcre soli, <hi rend="italic">dictat.</hi></note>
-						
-						<lb/>ritum sanctum qui datus est nobis <hi rend="italic">(Rom.</hi> v, 5).</p></div>
-    	<div type="textpart" subtype="chapter" n="15"><p>23. <hi rend="italic">Pro personarum diversitate tem­</hi>
-						<lb/> peranda <hi rend="italic">oratio.</hi> Sed nunc etiam illud quod priusquam <lb/>
-						promitterem non debebam, jam fortasse debitum fla<lb/>gitas, ut aliquod sermonis
-						exemplum, tanquam si ego <lb/> aliquem catechizem, non me pigeat explicare, et in­ <lb/>
-						tuendum tibi proponere Quod priusquam faciam, volo <lb/> cogites aliam esse intentionem
-						dictantis, cum lector <lb/> futurus cogitatur; et aliam loquentis, cuti præsens <lb/>
-						auditor attenditur : et in eo ipso aliam in secreto mo<lb/>nentis, dum nullus alius
-						qui de nobis judicet pra sto <lb/> est; aliam palam docentis aliquid, cum dissimiliter
-						<lb/> opinantium circumstat auditus : et in huc genere <lb/> aliam, cum ducetur unus,
-						cæteri autem tanq alii ju<lb/>dicantes aut attestantes quæ sibi nota sunt audiunt;
-						<lb/> aliam cum omnes communiter quid ad eos profera<lb/>mus exspectant: et rursus in
-						hoc ipso aliam, cum <lb/> quasi privatim consedetur, ut sermocinatio consera<lb/>tur;
-						aliam, cum populus tacens unum de loco supe<lb/>riore dicturum suspensus intuetur:
-						multumque in<lb/>terest, et cum ila dicimus, utrum pauci adsint an <lb/> multi; docti
-						an indocti, an ex utroque gcnere mixti; <lb/> urbani an rustici, an hi et illi simul; an
-						populus ex <lb/> omni hominum gcnere temperatus sit. Fieri enim non <lb/> potest, nisi
-						aliter atque aliter afik iant locuturum at<lb/>que dicturum, et ut sermo qui
-						profertur, affectionis <lb/> animi a quo profertur, qucmdam quasi vultum Hera.., <lb/>
-						et pro eadem diversitate diversc afficiat auditores, <lb/> cum et ipsi se ipsos diverse
-						afficiant invicem prae<lb/>sentia sua. Sed quia de rudibus imbuendis nunc agi­ <lb/>
-						mus, de me ipso tibi testis sum, aliter atque aliter <lb/> me moveri, cum ante ine
-						catechizandum video erudi<lb/>lum, inertem, civem, peregrinum, divitem, paupe- <lb/>
-						rem, privatum, honoratum, in potestate aliqua consti<lb/>tutum, illius aut illius
-						gentis hominem, illius aut <lb/> illius ætatis aut sexus, ex illa aut illa serta, ex
-						illo <lb/> aut illo vulgari errore venientem : ac pro diversitate <lb/> mutus mei sermo
-						ipse et procedit, et progreatur, <lb/> et linitur. Et quia cum eadem omnibus debeatur
-						cha<lb/>ritas, non eadem est omnibus adhibenda medicina : <lb/> ipsa item charitas
-						alios parturit, cum aliis infirmatur; <lb/> alios curat aedilicarc, alios contremiscit
-						offendere; <lb/> ad alios se inciinat, ad alios se erigit; aliis blanda, <lb/> aliis
-						severa, nulli inimica , omnibus mater. Et qui <lb/> non expertus est eadem charitate
-						quod dico, cum <lb/> videt nos, quia facultas aliqua nobis donata delectat <lb/>
-						laudabiliter innotescere in ore multitudinis, inde nos <lb/> beatos putat : Deus autem,
-						in cujtis conspecturn in<lb/>trat gemitus compeditorum <hi rend="italic">(Psal.</hi>
-						LXXVIII, 11), vi<lb/>deat humilitatem nostram et laborem nostrum, et di<lb/>mittat
-						omnia peCcata nostra <hi rend="italic">(Pul.</hi> XXIV, 18). Quam<lb/>obrem si quid
-						tibi in nobis placuit, ut aliquam <lb/> observationem sermonis tui a nobis audire
-						quæretes, <lb/> melius videndo et audiendo nos cum hæc agimus, <lb/> quam legendo cum
-						hæc dictamus. edisceres.</p></div>
-    	<div type="textpart" subtype="chapter" n="16"><p>24. <hi rend="italic">Formula orationis catechistæ. <lb/> Exordium ductum
-							a laudabili proposito suscipiendæ <lb/> christianæ</hi> religionis, <hi rend="italic">propter futuram requiem. Requies</hi>
-						<lb/> in <hi rend="italic">rebus inquietis non quærenda. Non in divitiis,</hi> noc in <lb/>
-						
-
-		<pb n="329"/> honoribus. <hi rend="italic">Requiem quærentes</hi> in <hi rend="italic">oblectamentis earnis</hi>
-						<lb/> et in <hi rend="italic">spectaculis.</hi> Sed tamen faciamus aliquem venisse <lb/>
-						ad nos, qui vult esse christianus, et de genere qui<lb/>dem idiotarum, non tamen
-						rusticanorum, sed urba<lb/>norum, quales apud Carthaginem plures experiri te <lb/>
-						necesse est : interrogatum etiam utrum propter vitæ <lb/> præsentis aliquod commodum, an
-						propter requiem <lb/> quae post hanc vitam speratur, christianus esse de<lb/>sidcrat,
-						propter futuram reqpiem respondisse: tali <lb/> fortasse a nobis instrueretur alloquio.
-						Deo gratias, <lb/> frater : valde tibi gratulor, et gaudeo de te, quod in <lb/> tantis
-						ac tam periculosis hujus sæculi tempestatibus <lb/> de aliqua vera et certa securitate
-						cogitasti. Nam et in <lb/> hac vita homines magnis laboribus requiem quaerunt <lb/> et
-						securitatem, sed pravis cupiditatibus non inve<lb/>niunt. Volunt enim requiescere in
-						rebus inquietis et <lb/> uon permanentibus : et quia illae tempore subtra<lb/>huntur
-						et transeunt, timoribus et doloribus eos agi<lb/>tant, nee quietos esse permiuunt.
-						Sive enim in di<lb/>viliis velit homo requiescere, magis superbus <lb/> efficitur,
-						quam securus. Annon videmus quam multi <lb/> eas subito perdiderint, multi etiam propter
-						illas <lb/> perierint, aut cum eas habere cupiunt, aut cum eis <lb/> oppressis a
-						cupidioribus auferuntur 1? Quæ si etiam <lb/> per totam vitam cum homine permanerent, et
-						non <lb/> desererent dilectorem suum, ipse illas sua morte de<lb/>sereret. Quanta est
-						enim vita hominis, etiamsi sene<lb/>scat? Aut cum sibi homines optant senectutem,
-						quid <lb/> aliud optant nisi longam infirmitatem? Sic et hono<lb/>res hujus sacculi,
-						quid sunt nisi typhus, et inanitas2, <lb/> et ruinx periculum? Quia sic Scriptura sancta
-						dicit: <lb/>
-						<hi rend="italic">Omnis</hi> earo fenum, et claritas <hi rend="italic">hominis ut</hi>
-						flos feni. Fe<lb/>num <hi rend="italic">aruit, flos decidit; verbum</hi> autem <hi rend="italic">Domini</hi> manet <lb/> in æternum <hi rend="italic">[Isa. XL,</hi>
-						6-8). Ideo qui veram requiem et <lb/> veram felicitatem desiderat, debet tollere spem
-						suam <lb/> de rebus mortalibus et praetereuntibus, et eam col<lb/>locare in verbo
-						Domini; ut haerens ei quod manet in <lb/> æternum, etiam ipse cum illo maneat in
-						æternum.</p>
-					<p>25. Sunt etiam homines qui nee divites quaerunt <lb/> esse, nee ad vanas honorum pompas
-						ambiunt per<lb/>venire : sed gaudere et requiescere volunt in pop!<lb/>nis et in
-						fornicationibus, et in theatris atque specta<lb/>culis nugacitatis quæ in magnis
-						civitatibus gratis <lb/> habent. Sed sic ctiam ipsi aut consumunt per <lb/> luxuriam
-						paupertatem suam, et ab egestate postea in <lb/> furta et effracturas, et aliquando
-						eLiam in latrocinia <lb/> prosiliunt, et subito multis et magnis timoribus iut­ <lb/>
-						pUnitur; et qui in popina paulo ante cantabant, jam <lb/> planctus carceris somniant.
-						Studiis autem spectacu<lb/>lorum fiunt dæmonibus similes, clamoribus suis in­ <lb/>
-						citando homines ut se invicem caedant, secumque ha<lb/>beant contentiosa certamina
-						qui se non laeserunt, <lb/> dnm placere insano populo cupiunt: quos si animad­ <lb/>
-						verterint esse concordes, tunc eos oderunt et per<lb/>sequuntur, et tanquam
-						collusores ut fustibus verbe
-						
-				<note type="footnote">1 Plerique diss., <hi rend="italic">aut ui eia oppressh</hi> a cupidioribus au<lb/>
-							<hi rend="italic">krrentur.</hi></note>
-				<note type="footnote"> s sic pierique Mss. At editi omittunt, <hi rend="italic">et viawta*</hi>
-							: cujus <lb/> loco nonnulli Mss., et vomtas. </note>
-						
-						<lb/> rentur exclamant, et hanc iniquitatem facere etiam <lb/> vindicem iniquitatum
-						judicem cogunt; si autem hor. <lb/> rendas adversus invicem inimicitias eos exercere
-						<lb/> cognoverint, sive sintae qui appellantur 1, sive sce<lb/>nici et thymelici,
-						sive aurigæ, sive venatores, quos <lb/> miseros non solum homines cum hominibus, sed
-						etiam <lb/> homines cum bestiis in certamen pugnamque com<lb/>mittunt ; quo majore
-						adversus invicem discordia fu<lb/>rere senserint, eo magis amant et delectantur, et
-						in<lb/>citatis 2 favent, et faventes incitant, plus adversus se <lb/> ipsos
-						insanicntes ipsi spectatores alter pro altero, <lb/> quam illi quorum insaniam insani
-						provocant, sed in - <lb/> saniendo 8 spectare desiderant. Quomodo ergo sani<lb/>tatem
-						pacis tenere animus potest, qui discordiis et <lb/> certaminibus pascitur? Qualis enim
-						cibus sumitur, <lb/> talis valetudo consequitur. Postremo, quamvis in<lb/>sana gaudia
-						non sint gaudia, tamen qualiacumque <lb/> sint, et quantumlibet delectet jactantia
-						divitiarum, <lb/> i i tumor honorum, vorago popinarum, et bella thea<lb/>trorum I, et
-						immunditia fornicationum, et prurigo <lb/> thermarum; aufert omnia ista una febricula,
-						et <lb/> adhuc viventibus totam rabam beatitudinem sublra<lb/>hit: remanet inanis et
-						saucia conscientia, Deum sen<lb/>sura judicem, quem noluit habere custodem; et in-
-						<lb/> Tentura asperum Dominum, quem dulcem patrem <lb/> quærere et amare contempsit. Tu
-						autem quia veram <lb/> requiem quae post hanc vitam Christianis promitti<lb/>tur
-						qu;eris, etiam hic eam inter amarissimas vito <lb/> hujus molestias suavem jucundamque
-						gustabis, si ejus <lb/> qui eam promisit præcepta dilexeris. Cito enim sen<lb/>ties
-						dulciores esse justitiæ fructus quam iniquitatis, <lb/> et verius atque jucundius
-						gaudere homiuem de bona <lb/> conscientia inter molestias, quam de mala inter de. <lb/>
-						licias; quia non sic venisti conjungi Ecclesiae Dei, ut <lb/> ex ea temporalem aliquam
-						utilitatem requiras.</p></div>
-    	<div type="textpart" subtype="chapter" n="17"><p>26. <hi rend="italic">Reprehenditur</hi> qui <hi rend="italic">velit
-							esseChri<lb/>stianus propter commodum</hi> temporale. <hi rend="italic">Christianus</hi> vere <lb/>
-						<hi rend="italic">est, qui religionem profitetur propter futuram</hi> requiem. <lb/>
-						<hi rend="italic">Transit ad narrationem eorum quæ credenda sunt. <lb/> Filius</hi> Dei
-							<hi rend="italic">cur homo factus.</hi> Sunt enim qui propterea <lb/> volunt esse
-						cbristiani, ut aut promereantur homines <lb/> a quibus temporalia commoda exspectant,
-						aut quia <lb/> offendere nolunt quos timent. Sed isti reprobi sunt : <lb/> et si ad
-						tempus eos portat Ecclesia, sicut area usque <lb/> ad tempus ventilationis paleam
-						sustinet; si non se <lb/> correxerint, et propter futuram sempiternam re<lb/>quiem
-						christiani esse coeperint, in fine separabuntur. <lb/> Nec sibi blandiantur quod in area
-						possunt esse cam <lb/> frumento Dei : quia in horreo cum illo non erunt, sed <lb/> igni
-						debito destinantur' <hi rend="italic">(Matth.</hi> III, 12). Sunt etiam
-    		
-	    		<note type="footnote"> 1 to,., <hi rend="italic">sint aihleUB</hi> qui <hi rend="italic">appeUmdur.</hi> At plerique ae me<lb/>
-	    			Doris notae Mss., <hi rend="italic">sintce</hi> qvi <hi rend="italic">appeUantur.</hi> vox erat forsitaa <lb/> apud
-								Afros tunc vulgaris. In corbeiensi codice scribitur, <lb/>
-								<hi rend="italic">sinthæ.</hi> In MSS. qulbusdam et apud Am. legitur, sb* mqki <lb/>
-								<hi rend="italic">appiilantur.</hi> Apud Er., <hi rend="italic">sint</hi> qui <hi rend="italic">appelUmtur.</hi></note>
-	    		<note type="footnote"> * Am Er. et aliquot Mss., <hi rend="italic">et incitati.</hi> Alii plures ibs., <hi rend="italic">ei <lb/> incitanies.</hi>
-							</note><note type="footnote">a sic Mss. At editi, <hi rend="italic">provocani, et</hi> insamendo.</note>
-	    		<note type="footnote"> * Er. et Lov., <hi rend="italic">delectent.</hi> At An. et Mss., <hi rend="italic">delectet.</hi></note>
-	    		<note type="footnote"> * sic Ain. Er. et plerique Mss. 'L Lov., theatncorum.</note>
-	    		<note type="footnote">e IJOV., <hi rend="italic">desiinabuntur.</hi> At Am. Er.
-								et MSS. habent pr. <lb/> tenti tempore, <hi rend="italic">destinantur.</hi></note>
-				<note type="footnote"> PATIIOL. XL. </note>
-				<note type="footnote"> (Unze.J </note><lb/>
-
-
-		<pb n="331"/> atii meliore quidem spc, scil lamcn non minore pe<lb/>riculo, qui jam
-						Deum timent, ct non irrident chri<lb/>stianum nomcn, nee simulalo cordc intrant
-						Eccle<lb/>siam Dei, sed in ista vita exspectant felicitatem, ut fe<lb/>liciores
-						sint in rchus terrenis, quam illi qui non colunt <lb/> Deum : ideoque cum viderint
-						quosdam sceleratos et <lb/> impios ista sæculi 1 prosperitate pollere ct excellere,
-						<lb/> . se autem vel minus habere ista vel amittere, pertur<lb/>bantur tanquam sine
-						causa Deum colant , el facile a <lb/> fide deficiunt.</p>
-					<p>27. Qui autem propter beatitudinem sempiternam <lb/> ct perpetuam requiem, quæ post
-						hanc vitam sanctis <lb/> futura promittitur, vult fieri christianus, ut non eat <lb/> in
-						ignem aeternum cum diabolo, sod in regnum <lb/> æternum intret cum <hi rend="italic">Christo (Matth.</hi> xxv, 54, 41, 46), <lb/> vere ipse christianus est, cautus in
-						omni tentatione, <lb/> ne prosperis rebus corrumpatur, et ne frangatur ad<lb/>versis,
-						et in abundantia bonorum terrenorum mo<lb/>destus et temperans, et in tribulationibus
-						fortis et <lb/> patiens. Qui etiam proficiendo pervenict ad talem <lb/> animum, ut plus
-						amet Deum, quam timeat gehen<lb/>nam : ut ctiamsi dicat illi Dens, Ulcre dcliciis
-						car<lb/>nalibus sempiternis, et quantum potes pecca, nec <lb/> morieris, nee ia
-						gehennam mitteris, sed mecum tan<lb/>tummodo non cris; exhorrescat, et omnino non
-						pec<lb/>cet, non jam ut in illud quod timebat non incidat, <lb/> sed ne illum quem
-						sic amat offendat: in quo uno est <lb/> rcquics t, quam oculus non vidit, nec auris
-						audivit, <lb/> me in cor hominis ascendit, quam præparavit Dcus <lb/> diligentibus cum
-						(I <hi rend="italic">Cor.</hi> II, 9).</p>
-					<p>28. De qua requie significat 8 Scriptura, et non <lb/> tacet, quod ab mitio mundi ex
-						quo fecit Deus cœlum <lb/> et terram ct omnia quae in eis sunt, sex dicbus ope­ <lb/>
-						ratus est, ct septimo dic requievit <hi rend="italic">(Gen,</hi> i, <hi rend="italic">et</hi> II, 1-3). <lb/> Poterat cnim omnipotens et uno momento temporis <lb/> omnia
-						faccre. Non autem laboraverat, ut requiesce<lb/>rel, quando, <hi rend="italic">Dixit,
-							et facta sunt ; mandavit,</hi> et <hi rend="italic">creata<lb/> sunt (Psal.</hi>
-						CXLVIII, 5) : sed ut significaret, quia post <lb/> sex ætates mundi hujus, septima
-						actate tanquam se<lb/>ptimo die requicturus est in sanctis suis; quia ipsi <lb/> in
-						illo requiescent post omnia bona opera, in quibus <lb/> ei servierunt, quae ipse in
-						illis operatur, qui vocat, <lb/> et præcipit, et delicta praetrita dimittit, et
-						justificat <lb/> cum qui prius erat impius. Sicut autem cum illi ex <lb/> duno ejus bene
-						opcrantur, recte dicitur ipse operari ; <lb/> sic cum in illo requiescunt *, recto
-						dicitur ipse re<lb/>quicscere. Nam quod ad ipsum attinet, pausationem <lb/> non
-						quærit, quia laborem non sentit. Fecit autcm <lb/> omnia per Verbum suum; et Verbum ejus
-						ipse Chri<lb/>stus, in quo requiescunt Angeli et omnes cœlestes <lb/> mundissimi
-						spiritus in sancto silentio. Homo autem <lb/> peecato lapsus perdidit requiem quam
-						habebat in cjus <lb/> divinitate, pt recipit eam 1 in ejus humanitate : ideo<lb/>que
-						opportuno tempore, quo ipse sciebat oportere <lb/> fieri, homo factus et de feniina
-						natus est. A carne
-						
-				<note type="footnote">1 Am. Er. et tres Mss., <hi rend="italic">tceculari.</hi></note>
-				<note type="footnote"> I sic Mss. Editi vero, <hi rend="italic">iri quo una</hi>
-							est <hi rend="italic">requies.</hi></note>
-				<note type="footnote"> a Am. Er. et fere omnes Has., Dequa <hi rend="italic">re
-								sigmficat.</hi></note>
-				<note type="footnote"> * Ita Mss. At editi, <hi rend="italic">si cimi iUi
-								reqniescwit.</hi></note>
-				<note type="footnote"> s sic M.M. At editi, <hi rend="italic">et rprepn eam.</hi></note>
-						
-						<lb/> quippe contaminari nun poterat, ipse cariem potius <lb/> mundaturus. Ipsum antiqui
-						sancti venturum in rcte" <lb/> latione Spiritus cognoverunt, et prophetaverunt, et <lb/>
-						sic salvi facti sunt credendo quia veniet, sicut nos <lb/> salvi efficimur credendo quia
-						venit : ut diligeremus <lb/> Deum, qui sic nos dilexit, ut unicum Filium suma <lb/>
-						mitteret, qui humililale1 nostræ mortalitatis indultis , <lb/> et a peccatoribus et pro
-						peccatoribus moreretur. Jam <lb/> enim olim ab incuniibus sæculis mysterii hujus alti­
-						<lb/> tudo præfigurari prænuntiarique non cessat.</p></div>
-    	<div type="textpart" subtype="chapter" n="18"><p>29. <hi rend="italic">De hominis et rerum aliarum<lb/> creatione quid
-							credendum. Homo</hi> in <hi rend="italic">paradiso</hi> constitu­ <lb/>
-						<hi rend="italic">tus. Cur creatus qui præsciebatur peccaturus. Lapsus <lb/> hominis et
-							angeli nihil Deo nocuit.</hi> Quoniam Deus <lb/> omnipotens, et bonus et justus et
-						misericors, qui fc<lb/>cit omnia bona, sive. magna sive parva, sive summa <lb/> sive
-						infima ; sive quæ videntur, sicuti sunt cœlum et <lb/> terra ct mare, et in coelo sol et
-						luna, et cætera si<lb/>der:., in terra autem et mari arbores et frutices et <lb/>
-						animalia suæ cujusque naturæ, et omnia corpora vel <lb/> coelestia vel terrestria ; sive
-						quæ non videntur, sicuti <lb/> sunt spiritus quibus corpora vegetantur et vivifican­
-						<lb/> tur : fecit et hominem ad imaginem suam ; ut quem<lb/>admodum ipse per
-						omnipotentiam suam præest uni<lb/>versæ creaturæ, sic homo per intelligentiam suam,
-						<lb/> qua etiam Crcatorem suum cognoscit et colit, præes<lb/>set omnibus terrenis
-						animalibus. Fecit iili etiam ad. <lb/> jutorium feminam : non ad carnalem concupiscen­
-						<lb/> tiam, quandoquidem nec corruptibilia corpora tunc <lb/> hahenant, antequam eos
-						mortalitas invaderet poena <lb/> peccati; sed ut habcret et vir gloriam de femina, <lb/>
-						cum ei præiret ad Deum 2, seque i!li præberet imi<lb/>tandum in sanctitate atque
-						pietate; sicut ipse esset <lb/> gloria Dei, cum ejus sapientiam sequcretur.</p>
-					<p>. 50. Itaque constituit cos in quodam loco perpetuæ <lb/> beatitudinis, quem appellat
-						Scriptura paradisum ; <lb/> præceptumque illis dedit, quod si non transgrede­ <lb/>
-						rentur, in illa semper immoratlitatis beatitudine per<lb/>manerent: si autem
-						transgrederentur, supplicia mor<lb/>talitatis expenderent. Praesciebat autem Deus eos
-						<lb/> transgressuros : sed tamen quia conditor est et effe<lb/>ctor omnis boni, magis
-						eos fecit, quando fecit et be<lb/>stias, ut impleret terram bonis terrenis. Et utique
-						<lb/> mclior est homo etiam peccator, quam bestia. Et <lb/> præceptum quod non erant
-						servaturi, magis dedit, ut <lb/> essent inexcusabiles, cum in eos vindicare coepisset.
-						<lb/> Quidquid enim homo fecerit, laudabilem in suis fa<lb/>ctis invenit Deum : si
-						recte egerit, laudabilem inve<lb/>nit per justitiam præmiorum ; si peccaverit, lauda­
-						<lb/> bilem invenit per justitiam suppliciorum ; si peccata <lb/> confessus ad recte
-						vivendum redierit, laudabilem in<lb/>venit pur misericordiam indulgentiarum. Cur ergo
-						<lb/> non faceret Deus hominem, quamvis eum peccaturum <lb/> praenosceret, cum et
-						stantem coronaret, et caden<lb/>tem ordinaret, et surgentem adjuvaret, semper et
-						<lb/> ubique ipse gloriosus bonitate, justitia, clementia? <lb/> maxime quia et illud
-						præsciebat, de propagine mor
-						
-						<note type="footnote"> 1 AM. et Er., <hi rend="italic">humanitate</hi>.</note>
-						<note type="footnote"> 2 Er., <hi rend="italic">dominium</hi>. Editi alii, <hi rend="italic">Dominum</hi>.</note><lb/>
-						
-
-		<pb n="333"/>talitatis ejus futuro! sanctos, qui non ili qua-re<lb/>rent, sed
-						Creatori suo gloriam darent, et cum co<lb/>lendo ab omni corruptione liberati, cum
-						Angelis <lb/> sanctis semper vivere et beate vivere mererentur? <lb/> Qui enim hominibus
-						dedit liberum arbitrium, ut non <lb/> servili necessitate, sed ingenua voluntate Dcum
-						co<lb/>lerent, dedit ctiam Angelis. Et idco ncc angelus, qui <lb/> cum spiritibus
-						aliis satellitibus suis superbiendo de<lb/>seruit obedientiam Dei, et diabolus factus
-						est, aliquid <lb/> nocuit Dco, sed sibi : novit enim Deus ordinare de<lb/>serentes se
-						animas (a), et ex earum justa miscria in<lb/>feriores partes creaturæ
-						suæconvenientissimis et <lb/> congruentissimis Icgibus admirandæ dispensationis <lb/>
-						ornure1. ltaque nec diabol us aliquid Deo nocuit, quia <lb/> vcl ipse lapsus est, vel
-						hominem seduxit ad mortem : <lb/> nec ipse bomo in aliquo minuit veritatem aut pole­
-						<lb/> statom aut beatitatem 2Conditoris sui, quia conjugi <lb/> suæ seductæ a diabolo,
-						ad id quod Deus prohibuerat, <lb/> propria voluntate consensit. Justissimis enim Dei
-						<lb/> legibus omnes damnati sunt, Dco glorioso per æqui<lb/>tatem vindictæ, ipsi
-						ignominiosi per turpitudinem <lb/> pœnæ <hi rend="italic">(Gen.</hi> II, III) : ut et
-						homo a suo Creatore aver<lb/>sas victus diabolo subderetur, et diabolus homini ad
-						<lb/> Creatorem suum converso vincendus proponeretur; <lb/> lit quicumque diabolo usque
-						in finem consentirent, <lb/> cum illo irent in æterna supplicia ; quicumque autem <lb/>
-						humiliarent se Deo, et per ejus gratiam diabolum <lb/> vincerent, æterna præmia
-						mererentur.</p></div>
-    	<div type="textpart" subtype="chapter" n="19"><p>31. In Ecclesia <hi rend="italic">boni et mali,</hi> in <lb/>
-						<hi rend="italic">fine separandi. Civitates duæ ab initio generis humani.<lb/> Diluvium
-							et arca sacramentum. De Abrahamo et Israe<lb/>litico populo. Horum dicta et facta,
-							prophetia fuit.</hi>
-						<lb/> Neque hoc nos movere debet; quia multi diabolo <lb/> con entiunt, et pauci Deum
-						sequuntur : quia et fru<lb/>mentum in comparatione palearum valde pauciorem <lb/>
-						habet numerum. Sed sicut agricola novit quid faciat <lb/> cie ingenti acervo paleas, sic
-						nihil est Dco multitudo <lb/> peccatorum, qui novit quid de illis agat, ut admi­ <lb/>
-						nistatio regni ejus ex nulla parte turbetur atqu tur<lb/>petur. Nec idCo putandus.
-						cst vicissc diabolus, quia <lb/> secum plurcs, cum quibus a paucis vinceretur, at­ <lb/>
-						traxit. Duæ itaque civitates, una iniquorum, altera <lb/> sanctorum, ab initio generis
-						humani usque in finem <lb/> sæculi perducuntur, nunc permivtæcorporibus, sed <lb/>
-						voluntatibus separatæ, in die vero judicii etiam cor<lb/>pure separandae. Omnes enim
-						homincs amantes su<lb/>perbiam et temporalem dominationem cum vano ty<lb/>pho ct
-						pompa arrogantiæ, omnesque spiritus qui talia <lb/> diligunt, et gloriam suam
-						subjectione hominum quae<lb/>runt. simul una societate devincti sunt; sed et si <lb/>
-						sæpe 3 adversum se pro his rebus dimicant, pari ta<lb/>men pondere cupiditatis in
-						eamdem profunditatem <lb/> præcipitantur, et sibi morum et meritorum similitu­ <lb/>
-						dine conjunguntur. Et rursus omnes homines et <lb/> omnes spiritus humiliter Dei gloriam
-						quærentes, non <lb/> suam, et cum pictate sectantes, ad unam pertinent
-    		
-    		<note type="footnote"> 1 sola cditio Lov., <hi rend="italic">ordinare.</hi></note>
-    		<note type="footnote"> 7 Plerique Mss. omittunt, <hi rend="italic">aut</hi> beatitatem. </note>
-    		<note type="footnote"> a Mss., <hi rend="italic">devincti sunt, ct
-								si sæpe;</hi> omisso. <hi rend="italic">sed.</hi></note>
-    		<note type="footnote"> (a) n Retract. cap. t4. </note>
-    		
-						<lb/> societatem. Et tamen Dcus misericordissimus, et su<lb/>per impios homines
-						paticns est, et præbet eis pœni<lb/>tentiæatque correctionis locum.</p>
-					<p>32. Nam et quod omnes diluvio delevit, exceptu <lb/> uno justo cum suis, quos in arca
-						servari voluit, nove<lb/>rat quidem quod non se correcturi essent: verumta<lb/>men
-						cum per centum annos arca fabricata est, præ- <lb/> dicabatur utique eis ira Dei ventura
-						super eos <lb/>
-						<hi rend="italic">(Gen.</hi> vi, VII); ct si converterentur 1 ad Deum, par<lb/>cerct
-						cis, sicut pepercit postea Ninive civitati agenti <lb/> pœnitentiam, cum ei per
-						prophetam futurum inter<lb/>itum prænuntiasset <hi rend="italic">(Jonæ</hi> III). Hoc
-						autem facit Deus, <lb/> eliam illis quos novit in malitia-perseveraturos dans <lb/>
-						pœnitendi spatium, ut nostram paticntiam exerceat et <lb/> informet exemplo suo; quo
-						noverimus quantum nos <lb/> oporteat tolerabiliter malos sustinere, cum ignoremus <lb/>
-						quales postea futuri sunt, quando ille parcit ct sinil <lb/> cos vivcre, quem nihil
-						futurorum latet. Prænuntia<lb/>batur tamen etiam diluvii sacramento quo per Ii­ <lb/>
-						gnum justi liberati sunt, futura Ecclesia quam rex <lb/> ejus et Deus Christus mysterio
-						suae crucis ab hujus <lb/> sæculi submersione suspendit. Neque enim Deus <lb/> ignorabat
-						quod etiam ex illis qui fuerant in arca ser<lb/>vati, nascituri crant mali, qui
-						faciem terræ iniqnita<lb/>tibus iterum implerent : sed tamen et cxemplum fu­ <lb/>
-						turi judicii dedit, et sanctorum liberationem ligni <lb/> mysterio prænuntiavit. Nam ct
-						post hæc non cassa<lb/>vit rcpullularc malilia per superbiam ct libidines ct <lb/>
-						illicitas impielatcs, cum homines deserto Creatore <lb/> suo, non solum ad creaturam
-						quam Deus condidit <lb/> lapsi sunt, ut pro Dco colerent quod fecit Deus.; sed <lb/>
-						etiam ad opera manuum hominum et ad fabrorum <lb/> artificia curvaverunt animas suas,
-						ubi de illis turpius <lb/> diabolus et dæmonia triumpharent ; quæ se in talibus <lb/>
-						figmentis adorari venerarique letantur, dum errores <lb/> suos humanis crroribus pascunt
-						2.</p>
-					<p>33. Nequc tunc sane dcfucrunt justi qui Deum pie <lb/> quærerent, et superbiam diaboli
-						vincerent, cives it<lb/>lius sanctæ civitatis, quos rcgis sui Christi ventura <lb/>
-						humilitas per Spiritum revelata sanavit. Ex quibus <lb/> Abraham pius et fidelis Dei
-						servus electus est <hi rend="italic">(Gen.</hi> XII). <lb/> cui demonstraretur
-						sacramentum Filii Dei, ut propter <lb/> imitationem fidei omnes fideles omnium gentium
-						filii <lb/> cjus futuri dicerentur. Ex illo natus est populus a <lb/> quo unus Deus
-						vcrus coleretur qui fecit coelum ct <lb/> terram, cum cæteræ gentes simulacris et
-						dnemoniis <lb/> servirent. In eo plane populo multo evidentius futura <lb/> Ecclesia
-						figurata est. Erat enim ibi multitudo carna<lb/>lis, quæ propter visibilia beneficia
-						colebat Deum. <lb/> Erant ibi autem pauci futuram requiem cogitantes et <lb/> cælestem
-						patriam requirentes, quibus prophetando <lb/> revelabatur futura humilitas Dei, regis et
-						Domini <lb/> nostri Jesu Christi, ut per eam fidem ab omni fu<lb/>perbia et tumore
-						sanarentur. Horum sanctorum, qui <lb/> præcesserunt tempore nativitatem Domini, non so­
-						<lb/> lum sermo, sed etiam vita, et conjugia, et filii, et fa<lb/>cta, prophetia fuit
-						hujus temporis, quo per fidem
-						
-				<note type="footnote"> I Er. et Lov., <hi rend="italic">tU si converterentur.</hi> Am. et Mss., 
-					<hi rend="italic">et Ii CQIU<lb/> verterentur</hi>.</note>
-				<note type="footnote"> a Floriacensis oijidam Ms., <hi rend="italic">irriscent.</hi></note><lb/>
-						
-
-		<pb n="335"/> passionis Christi ex gentibus congregatur Ecclesia. <lb/> Per illos
-						sanctos Patriarchas et Prophetas carnali <lb/> populo Israel, qui postea eliam Judaei
-						appellati sunt, <lb/> et visibilia beneficia ministrabantur quæ carnaliter a <lb/>
-						Domico desiderabant, et coercitiones poenarum cor<lb/>poralium quibus pro tempore
-						terrerentur, sicut eo<lb/>rum duritiæ congruebat. Et in his tamen omnibus <lb/>
-						mysteria spiritualia significabantur, quæ ad Christum <lb/> et Ecclesiam pertinerent :
-						cujus Ecclesiae membra <lb/> etant etiam illi sancti, quamvis in hac vita fuerint <lb/>
-						antequam secundum carnem Christus Dominus na<lb/>sceretur. Ipse enim unigenitus Dei
-						Filius, Verbum <lb/> Patris, æquale et coæternum Patri, per quod facta <lb/> sunt omnia,
-						bomo propter nos factus est, ut totius <lb/> Ecclesiae tanquam totius corporis caput
-						esset. Sed <lb/> vclut totus homo dum nascitur, etiamsi manum in <lb/> nascendo
-						præmittat, tamen universo corpori sub ca<lb/>phe conjuncta atque compacta cst,
-						quemadmodum <lb/> etiam nonnulli in ipsis Patriarchis ad hujus ipsius rei <lb/> signum
-						mann præmissa nati suut <hi rend="italic">(Gen. XXV,</hi> 23) : ita <lb/> omnes sanct!
-						qui ante Domini nostri Jesu Christi na<lb/>livitatcm in terris fuerunt, quamvis ante
-						nati sunt, <lb/> tamen universo corpori, cujus ille caput cst1, sub <lb/> capite
-						cohæserunt.</p></div>
-    	<div type="textpart" subtype="chapter" n="20"><p>34. Israelitarum <hi rend="italic">servitus in Ægypto,<lb/> et liberatio
-							viaque per mare Rubrum.</hi> Baptismus <hi rend="italic">figura<lb/>tus.</hi> Ovis
-							<hi rend="italic">immolatio</hi> passionis Christi <hi rend="italic">figura. Lex
-							scripla <lb/> digito Dei. Jerusalem typus civitatis cœlesits.</hi> Populus <lb/> ergo
-						ille delatus in iEgyplum, servivit regi durissimo; <lb/> et gravissimis laboribus
-						eruditus, quæsivit libcrato<lb/>i em Deum : et missus est eis unus de ipso populo ,
-						<lb/> sanctus Dei servus Moyses, qui in virtute Dei magnis <lb/> miraculis terrens tunc
-						impiam gentem Ægyptiorum, <lb/> eduxit inde populum Dei per marc Rubrum ; ubi <lb/>
-						discedens aqua viam præbuit transeuntibus : Ægy<lb/>ptii autem cum eos
-						persequerentur, redeuntibus in <lb/> se fluctibus demersi exstincti sunt. Ita quemadmo­
-						<lb/> dum per diluvium aquis terra purgata est a nequitia. <lb/> peccatorum, qui tunc in
-						illa inundatione deleti sunt, <lb/> et juti evaserunt per lignum : sic ex Ægypto exiens
-						<lb/> populus Dei, per aquas iter invenit, quibus ipsorum <lb/> hostes consumpti sunt.
-						Nee ibi defuit ligni sacra. <lb/> mentum. Nam virga percussit Moyses, ut illud mira­
-						<lb/> culum fieret. Utrumque signum est sancti Baptismi, <lb/> pcr quod fideles in novam
-						vitam transeunt, peccata <lb/> vero eorum tanquam inimici delentur atque morim­ <lb/>
-						ur. Apertius autem Christi passio in illo populo figu<lb/>raia est, cum jussi sunt
-						ovem occidere et manducare, <lb/> et de sanguine ejus postes suos signare, et hoc ccle­
-						<lb/> brare omni anno, et appellare Pascha Domini. Mani<lb/>festissime quippe
-						prophetia I do Domino Jesu Christo <lb/> dicit, quia <hi rend="italic">tanquam ovis ad
-							immolandum ductus</hi> eat <lb/>
-						<hi rend="italic">(Isai.</hi> LIII, 7). Cujus passionis et crucis signo in fronte <lb/>
-						hodie tanquam in poste signandus es, omnesque <lb/> Christiani signantur.</p>
-					<p>55. Inde per desertum populus ille ductus est, per <lb/> q'iadraginta annos accepit
-						etiam legom digito Dci
-						
-				<note type="footnote"> ♦ 'm. et Mss., <hi rend="italic">cujusque ille caput est.</hi></note>
-				<note type="footnote">« ::vH editi, <hi rend="italic">proplwtu.</hi></note>
-						
-						<lb/> scriptam <hi rend="italic">(Exod.</hi> i-xx, XXXII , xxxiv; Num. XIV, 33, <hi rend="italic">et<lb/> Deut.</hi> xxix, 5), quo nomine significatur Spiritus san­ <lb/>
-						ctus, sicut in Evangelio manifestissiine declaratur . <lb/>
-						<hi rend="italic">(Luc.</hi> XI, 20). Neque enim Deus forma corporis defl<lb/>nitus
-						est, nec sic in illo membra et digiti cogitandi <lb/> sunt, quemadmodum videmus in nobis
-						: sed quia pcr <lb/> Spiritum sancium dona Dei sanctis dividuntur, ut cum <lb/> diversa
-						possunt, non tamen discedant a concordia <lb/> charitatis, in digitis autem maxime
-						apparct quædam <lb/> divisio, nec tamen ab unitate præcisio; sive propterea, <lb/> sivc
-						propter aliam quamcumque causam Spiritus <lb/> sanctus appellatus est digitus Dei, non
-						tamcn , cum <lb/> hoc audimus, humani corporis forma cogitanda est. <lb/> Accepit ergo
-						ille populus legem digito Dei scriptam <lb/> in tabulis sane lapideis, ad significandam
-						duritiam <lb/> cordis illorum, quod legem non erant impleturi. Cor<lb/>poralia quippe
-						dona desiderantes a Domino, magis car<lb/>nali timore quam spirituali charitate
-						tenebantur : te- . <lb/> gem autem non implet nisi charitas. Ideo multis <lb/>
-						sacramentis visibilibus onerati sunt, quo servili jugo <lb/> premerentur, in
-						observationibus ciborum et in sacri<lb/>ficiis animaliqm, ct in aliis innumerabilibus
-						: quæ ta<lb/>men signa erant rerum spiritualium ad Dominum<lb/> Jesum Christum et ad
-						Ecclesiam perlinentium; quæ <lb/> tunc a paucis sanctis et intelligebantur ad fructum
-						<lb/> salutis, et observabantur ad congruentiam temporis , <lb/> a multitudine vero
-						carnalium tantummodo observa<lb/>bantur, non intelligebantur.</p>
-					<p>36. Per multa itaque et varia signa rerum futura<lb/>rum, quas longum est omnes
-						commemorare, et eas <lb/> nunc in Ecclesia videmus impleri, perductus est ille <lb/>
-						populus ad terram promissionis, ubi temporaliter <lb/> I carnaliterque regnaret pro modo
-						desidcrii sul : quod <lb/> taman regnum terrenum regni spiritualis imaginem <lb/>
-						gessitJbi Jerusalem condita est famosissima civilasDei, <lb/> serviens in signo liberæ
-						civitatis,quæ cœelestis Jerusa<lb/>lem dicitur <hi rend="italic">(Galat.</hi> IV. 25,
-						26), quod verbum est lac.. <lb/> bræum, et interpretatur Vibio pacis. Cujus cives sunt
-						<lb/> omnes sanctificati homines qui fuerunt, ctqui sunt, et <lb/> qui futuri sunt; et
-						omnes sanctificati spiritus, ctiam <lb/> quicumque in excelsis coelorum partibus pia
-						devotione <lb/> obtemperant Deo, nec imitantur impiam diaboli su<lb/>perbiam et
-						angelorum ejus. Ilujus civitatis rex est <lb/> Dominus Jesus Christus, Verbum Dei quo
-						rcgunlur <lb/> summi Angeli, et Verbum hominem assumens ut eo <lb/> regerentur et
-						homines, qui simul omnes cum illo iu <lb/> æterna pace regnabunt. Ad hujus regis
-						praefiguratio<lb/>nem in illo terreno regno populi Israel maxime emi<lb/>nuit rex
-						David, de cujus semine secundum carnem <lb/> veniret verissimus rex noster Dominus Jesus
-						Christus, <lb/>
-						<hi rend="italic">qui est super omnia Deus benedictus</hi> in sæcula <hi rend="italic">(Rom.</hi>
-						<lb/> ix, 5). Multa in illa terra promissionis gesta sunt in <lb/> figuram venturi
-						Christi ct Ecclesiæ, quæ in sanctis <lb/> Libris paulatim discere poteris.</p></div>
-    	<div type="textpart" subtype="chapter" n="21"><p>37. <hi rend="italic">Captivitas</hi> Babylonica <hi rend="italic">et in
-							ea<lb/> gesta quid significent. Post captivitatem</hi> Babylonicam <lb/> libertas <hi rend="italic">qualis reddita.</hi> Post aliquot tamen generationes <lb/> ostendit
-						aliam typum ad rum maxime pertinentem- <lb/> Nam cap fiviia est illa civitas, ct multa
-						pars ejus edu- <lb/>
-						
-
-		<pb n="337"/> cta in Babyloniam. Sicut autem Jerusalem significat <lb/> ei vitatem
-						societatemque sanctorum; sic Babylonia <lb/> sigraificat civitatem socictatemqne
-						iniquorum, quoniam <lb/> dicitur interpretari Confusio. De quibus duabus civi­ <lb/>
-						tatibus, ab exordio generis humani usque in finem <lb/> sæculi permixte 1 temporum
-						varietate currentibus, et <lb/> ultimo judicio separandis, paulo ante jam diximus <lb/>
-						<hi rend="italic">(Cap.</hi> 19). Illa ergo captivitas Jerusalem civitatis, et <lb/> ;
-						lle populus in Babyloniam ductus ad servitutem ire <lb/> jubetur a Domino per Jcremiam
-						illius temporis pro<lb/>phetam. Et exstiterunt reges Babyloniae, sub quibus <lb/>
-						illi serviebant, qui ex eorum occasione commoti qui<lb/>busdam miraculis cognoscerent
-						et colerent et coli ju<lb/>berent unum verum Deum, qui condidit universam <lb/>
-						creaturam <hi rend="italic">(-Dan.</hi> II-VI, xiv). Jussi sunt autem et ora<lb/>te
-						pro eis a quibus capiivi tenebantur, et in eorum <lb/> pace pacem sperare, ad gignendos
-						filios, et domns <lb/> aedilicandas, et plantandos hortos et vineas. Post se­ <lb/>
-						ptuaginta autem annos promittitur eis ab illa captivi<lb/>tate liberatio <hi rend="italic">( Jerem.</hi> xxv, XXIX). Hoc autem totum <lb/> figurate significabat
-						Ecclesiam Christi in omnibus san<lb/>ctis ejus, qui sunt cives Jerusalem coelestis,
-						servitu<lb/>ram fuisse sub regibus hujus sæculi. Dicit enim et <lb/> apostolica
-						doctrina, ut <hi rend="italic">omnis anima sublimioribus po<lb/>testatibus subdita
-							sit ;</hi> et ut reddantur <hi rend="italic">omnibus omnia;</hi>
-						<lb/> cui <hi rend="italic">tributum, tributum; cui vectigal, vectigal (Rom.</hi>
-						<lb/> XIII, i , 7); et caetera quæ salvo Dei nostri cultu, <lb/> constitutionis humanae
-						principibus reddimus; quando <lb/> ct ipse Dominus, ut nobis hujus sanæ doctrinae præ­
-						<lb/> beret exemplum, pro capite hominis quo erat indutus, <lb/> tributum solvere non
-						dedignatus est <hi rend="italic">(Matth.</hi> XVII, 26). <lb/> Jubentur autem etiam
-						servi christiani et boni fideles <lb/> dormis suis temporalibus æquanimiter fideliterque
-						<lb/> servire <hi rend="italic">(Ephes.</hi> vi, 5) : quos judicaturi sunt, si usque
-						<lb/> in finem iniquos invenerint; aut cnm quibus :.quali<lb/>ter regnaturi sunt, si
-						et illi ad vcrum Deum conversi <lb/> fuerint. Omnibus tamen præcipitur servire humanis
-						<lb/> potestatibus atque terrenis, quousque post tempus <lb/> præfinitum, quod
-						significant septuaginta anni, ab <lb/> istius sæculi confusione tanquam de captivitate
-						Baby<lb/>loniæ, sicut Jerusalem liberetur Ecclesia. Ex cujus <lb/> captivitatis
-						occasione ipsi etiam terreni reges desertis <lb/> idolis, pro quibus persequebantur
-						Christianos, unum <lb/> vernm Deum et Christum Dominum cognoverunt et <lb/> colunt, pro
-						quibus apostolus Paulus jubet orari, etiam <lb/> cin persequerentur Ecclesiam. Sic enim
-						dicit: Ob<lb/>secro <hi rend="italic">itaque</hi> primum <hi rend="italic">fieri
-							deprecationes, adorationes</hi> I, <lb/>
-						<hi rend="italic">interpellationes, graliarum actiones, pro regibus, pro <lb/> omnibus
-							hominibus, et</hi> omnibus <hi rend="italic">qui in sublimitate sunt,</hi>
-						<lb/> ut securam <hi rend="italic">et tranquillam vitam agamus cum omni pie<lb/>tete
-							et charitate</hi> a (I <hi rend="italic">Tim.</hi> II, 1, 2). Itaque per ipsos <lb/>
-						data pax est Ecclesiæ, quamvis temporalis, tranquil<lb/>litis temporalis 4 ad
-						ædificandas spiritualiter domos <lb/> et plantandos hortos et vineas. Nam ct ecce te
-						modo <lb/> per istum sermuncm ædificamus atque pluitamus. Et
-    		
-    		<note type="footnote"> I cic Mss. At cditi, <hi rend="italic">permixta.</hi></note>
-    		<note type="footnote"> * Lov., oraliones. KdtU aulein alii ct Mis., adorationes.
-							<lb/> cra*c&lt;&gt; est, <hi rend="italic">proseuclws.</hi></note>
-    		<note type="footnote"> J vulpata, <hi rend="italic">castitate</hi> : juxta græcum,
-							<hi rend="italic">wmoleH.</hi></note>
-    		<note type="footnote"> ' sic .abs. Rliti vero, <hi rend="italic">tan?o;i&gt;.</hi></note>
-    		
-						<lb/> hoc fit per totum orbem terrarum cum pace regum <lb/> christianorum , sicut idem
-						dicit apostolus : <hi rend="italic">Dei agri - <lb/> cultura, Dei œdificatio estis</hi>
-						(I Cor. III, 9).</p>
-					<p>58. Et post annos quidem septuaginta, quos my<lb/>stice prophetaverat Jeremias, ut
-						finem temporum <lb/> præfiguraret, tamen ut ipsa figura integraretur, facia <lb/> est in
-						Jerusalem restitutio ædificationis templi Dei : <lb/> sed quia lotum figurate agebatur,
-						non erat firma pax <lb/> ac libertas reddita Judæis. Itaque postea a Romanis <lb/> victi
-						sunt, et tributarii facti. Ex illo sane tempore ex <lb/> quo terram promissionis
-						acceperunt, et reges habere <lb/> eœperunt, ne in aliquo regum suorum completum <lb/>
-						esse arbitrarentur quod eis liberator Christus pro<lb/>mittebatur, apertius per
-						multas prophetias propheta<lb/>tus est Christus; non solum ah ipso David in libro
-						<lb/> Psalmorum, sed etiam a cæteris et magnis et sanctis <lb/> propbelis, usque ad
-						tempus eaptivitatis in Babylo<lb/>niam : et in ipsa captivitate fuerunt prophetæ, qui
-						<lb/> venturum Dominum Jesum Christum liberatorem <lb/> omnium prophetarent. Et
-						posteaquam templum trans<lb/>actis septuaginta annis restitutum cst, tantas pres­
-						<lb/> suras et calamitates a regibus Gentium Judæi perpessi <lb/> sunt, ut intelligerent
-						nondum venisse liheraiorem , <lb/> quem non spiritualiter liberaturum intelligebant, sed
-						<lb/> pro lihcralione carnali desiderabant.</p></div>
-    	<div type="textpart" subtype="chapter" n="22"><p>39. <hi rend="italic">Ætates</hi> mundi <hi rend="italic">sex. Sexta<lb/>
-							œtas ex adventu Christi. Christus</hi> Novum <hi rend="italic">Testamentum <lb/>
-							sempiternœ hœreditatis</hi> manifestans, <hi rend="italic">terrena contemnere <lb/>
-							exemplo docet. Nalivitas ejus. vita et mors.</hi> Peractis <lb/> crgo quinque
-						aetatibus sacculi, quarum prima est ab <lb/> initio generis humani, id est, ab Adam, qui
-						primus <lb/> homo factus est, usque ad Noe, qui fecit arcam in di<lb/>luvio <hi rend="italic">(Gen.</hi> VI) ; inde secunda est usque ad Abraham, <lb/> qui pater
-						dictus est 1 omnium quidem gentium <hi rend="italic">( Id.</hi>
-						<lb/> XVII, 4), quæ fidem ipsius imitarentur ; sed tamen ex <lb/> propagine carnis suae
-						* futuri populi Judæorum : qui <lb/> ante fidem christianam gentium, unus inter omnes
-						<lb/> omnium terrarum populus unum verum Deum coluit, <lb/> ex quo populo Salvator
-						Christus secundum carnem <lb/> vcniret. isti enim articuli duarum ætatum eminent In-
-						<lb/> veteribus Libris, : reliquarum autem trium in Evan<lb/>gclio etiam declarantur,
-						cum carnalis origo Domini <lb/> Jesu Christi commemoratur <hi rend="italic">(Matth.</hi>
-						1, 17). N.un ter<lb/>tia est ab Abraham usque ad David regem : quarta a <lb/> David
-						usque ad, illam captivitatem qua populus Dci in <lb/> Babyloniam transmigravit : quinta
-						ab illa transmigra<lb/>tione usque ad adventum Domini nostri Jesu Christi i <lb/> ex
-						cujus adventu sexta ætas agitur : ut jam spiritua<lb/>lis gratia, qiue paucis tunc
-						Patriarchis et Prophetis <lb/> nota erat, manifestaretur omnibus gentibus : no quis­
-						<lb/> quam Deum nisi gratis coleret, non visibilia præmia <lb/> servitutis suæ et
-						præsentis vitas felitatem, sed solam <lb/> vitam æternam, in qua ipso Dea frueretur, ab
-						illo <lb/> desiderans ; ut hac sexta ætate mens humana rcno<lb/>vetur ad imaginem
-						Dei, sicut sella dic homo factus <lb/> est ad imaginem Dei (Gen. 1, 27). Tunc enim et
-						lex <lb/> impletur, dum non cupiditate rerum temporalium
-    		
-    		<note type="footnote"> ' Mss., <hi rend="italic">electus est.</hi></note>
-    		<note type="footnote"> ' Mss., e.r <hi rend="italic">progenie carmt</hi> sua.</note><lb/>
-						
-
-		<pb n="339"/> sed charitate illius qui præcepit, fiunt quxcumquc <lb/> præcepit. Quis
-						autem non redamare affectet justissi<lb/>inum et misericordissimum Deum, qui prior
-						sic ama- <lb/> vit injustissimos et superbissimos homines, ut pro<lb/>pter eus
-						mitteret unicum Filium, per quem fecit <lb/> omnia ; qui non sui mutatione, sed bominis
-						assum<lb/>ptione homo factus, non solum cum eis vivcre, sed <lb/> etiam pro eis et ab
-						eis posset occidi?</p>
-					<p>40. Itaque novum testamentum hæredilatis sempi<lb/>ternæ manifestans, in quo
-						renovatus homo per gra<lb/>tiam Dei ageret novam vitam, hoc est vitam spiritua­ <lb/>
-						iem ; ut vetus ostenderet primum , in quo carnalis <lb/> populus agens veterem hominem ,
-						exceptis paucis in<lb/>telligentibus Patriarchis et Prophetis et nonnullis la­ <lb/>
-						tentibus sanctis, carnaliter vivens carnalia præmia <lb/> desiderabat a Domino Deo, et
-						in figura spiritualium <lb/> bonorum accipiebat: omnia ergo bona terrena con­ <lb/>
-						tempsit bomo factus Dominus Christus, ut contc<lb/>mnenda monstraret ; et omnia
-						terrena sustinuit mala , <lb/> quæ sustinenda præcipiebat : ut neque in illis quæ­ <lb/>
-						rcretur felicitas, neque in istis infelicitas timcretur. <lb/> Natus enim de matre quæ
-						quamvis a viro intacta <lb/> conceperit, semperque intacta permanserit , virgo <lb/>
-						concipiens, virgo pariens, virgo moriens, tamen fa<lb/>bro desponsata erat, omnem
-						typhum carnalis nobi!!<lb/>tatis exstinxit. Natus cHam in civitate Bethlehem, <lb/>
-						quæ inter omnes Judææ civitates ita erat exigua , ut <lb/> hodieque villa appelletur,
-						noluit qucmquam de cujus<lb/>quam terrenæ civitatis sublimitate gloriari. Pauper
-						<lb/> ctiam factus est, cujus sunt omnia, et per quem <lb/> creata suut omnia ; IIC
-						quisquam cum in cum credo<lb/>vet, de terrenis divitiis auderet extolli. Noluit rex
-						<lb/> ab hominibus fieri ; quia humilitatis ostendebat viam <lb/> tniscris, quos ab co I
-						superbia separaverat: quamvis <lb/> sempiternum ejus regnum universa cre tUra testetur.
-						<lb/> Esurivit, qui omnes pascit; sitivit, per quem creatur <lb/> omnis potus, et qui
-						spiritualiter panis est csuricnlium <lb/> fonsque sitientium : ab itinere terrestri
-						fatigatus cst, <lb/> qui se ipsum nobis viam fccit in cainum : velut obmu<lb/>tuit ct
-						cbsurduit coram conviciantibus, per quem <lb/> mutus locutus est et surdus audivit :
-						vinctus est, qui <lb/> dc infirmitatum vinculis solvit : flagellatus est, qui <lb/>
-						omnium dolorum flagella de hominum corporibus cx<lb/>pulit : crucifixus est, qui
-						cruciafus nostros finivit : <lb/> mortuus cst, qui mortuos suscita vit. Scd ct resur­
-						<lb/> rexit nunquam moriturus, ne ab illo quisquam sic <lb/> disceret mortem contemuere,
-						quasi nunquam vi<lb/>eturus '.</p></div>
-    	<div type="textpart" subtype="chapter" n="23"><p>41. Spiritus <hi rend="italic">sanctus die quinqua-<lb/> gcsima post
-							resurrectionem Christi missus. Judœi prœ<lb/>dicutione Apostolorum conversi, vitœ
-							evangelicœ sindio<lb/> flagrantes. Ecclesiœ apud Gentes per Paulum constitutre-</hi>
-						<lb/> Inde confirmatis discipulis, couversatus cum eis qua<lb/>draginta diebus ,
-						eisdem spectantibus ascendit in cœ<lb/>lum ; et completis a resurrectione
-						quiuquaginta dic<lb/>bus misit eis Spiritum sanctum (promiserat enim),
-    		
-    		<note type="footnote"> 1 sic Mss. At clJiti, <hi rend="italic">fib ea.</hi></note>
-    		<note type="footnote"> 2AM. ".r. RL !c!'C mnucs p. ,....,<hi rend="italic">fiJr.rwi.</hi> I uus Yaii'*a;ris <lb/> U* , nniinectu; ia.</note>
-    		
-						<lb/> per quem diffusa charitate in cordibus eorum, non <lb/> solum sinc onere, sed cHam
-						cum jucunditate legem <lb/> possent implere. Quae data est Judæis in decem præ­ <lb/>
-						ceptis, quod appellant decalogum. Quæ rursus ad <lb/> duo rcdiguntur, ut diligamus Deum
-						ex toto corde, ex <lb/> tota anima, ex tota mente ; et diligamus proximum <lb/> sicut
-						nos ipsos. Nam in his duobus præceptis totam <lb/> Legem Prophetasque pendere, ipse
-						Dominus et dixit <lb/> in Evangelio <hi rend="italic">(Matth.</hi> XXII, 37-40), et suo
-						manifesta- <lb/> vit exemplo. Namf et populus Israel ex die quo pri<lb/>mum pascha in
-						imagine celebrarunt, ovcm occidentes <lb/> et manducantes, cujus sanguine postes corum
-						ad sa<lb/>lutis tutelam signati sunt <hi rend="italic">(Exod.</hi> XII); ex ipso ergo
-						<lb/> dic quinquagesimus dies impletus est , et legem acce<lb/>peruut scriptam digito
-						Dei <hi rend="italic">(Id.</hi> xix, xx), quo no<lb/>niine jam diximus significari
-						Spiritum sanctum (Su­ <lb/>
-						<hi rend="italic">pra, cap.</hi> xx, n. 55) : sicut post Domini passionem ei <lb/>
-						resurrectionem , quod est verum pascha , quinquage<lb/>simo die ipse Spiritus sanctus
-						discipulis missus est : <lb/> non jam lapidcis tabulis corda dura significans ; sed,
-						<lb/> cnm cssent unum in locum, congregati in ipsa Jerusa<lb/>lem , factus est subito
-						de coelo sonus, quasi ferretur <lb/> flatus vehenens, ct visae sunt illis linguæ divisæ
-						quasi <lb/> ignis, et cœpcrunt linguis loqui, ita ut omnes qui ad <lb/> illos venerant,
-						suam linguam quisque cognoscerct (ad <lb/> illam enim civitatem ex omni terra
-						conveniebant Ju<lb/>daei, quacumque dispersi crant, et diversas lingu. s <lb/>
-						gentium diversarum didicerant <hi rend="italic">[Act.</hi> II, 1-1 1]): deinde <lb/> cum
-						tota fiducia Christum prædicantes, in ejus no<lb/>mine multa signa faciebant, ita ut
-						quemdam mor<lb/>tuum transennte Petro umbra ejus tetigerit, et resur<lb/>rexerit
-							<hi rend="italic">(Id.</hi> v, 15).</p>
-					<p>42. Sed cum viderent Judxi tan!a signa fieri in ejus <lb/> nomine , quem partim per
-						invidiam , partim per er<lb/>rorem crucifixerunt, alii irritati sunt ad persequendos
-						<lb/> prædicatores ejus Apostolos, alii vero idipsum am<lb/>plius admirantes, quod in
-						ejus nomine, quem veluti <lb/> a se oppressum et victum riserant, tanta miracula <lb/>
-						fit'rent , poenitendo conversi crediderunt in eum mil<lb/>lia 1 Judœorum. Non erant
-						jam illi temporalii benefi<lb/>cia terrenumque regnum desiderantes a Ico, nec <lb/>
-						promissum regem Christum carnaliter exspectantes : <lb/> sed immertaliter intelligentes
-						ei diligentes eum qui <lb/> pro ipsis ab ipsis tanta mortaliter pertulit, et cis <lb/>
-						usque ad sui sanguinis ' peccata donavit , et immor<lb/>talitatem a se sperandam et
-						desiderandam exemplo <lb/> suæ resurrectionis ostendit. ltaque jam veteris homi­ <lb/>
-						nis terrena desideria mortificantes, et spiritualis vitæ <lb/> novitate flagrantes ,
-						sicut præceperat in Evangelio <lb/> Dominus, vendebant omnia quæ habebant, et pretia
-						<lb/> rerum suarum ante pedes Apostolorum poncbant, ut <lb/> ipsi distribuerent
-						unicuique , sicut cuique opus erat <lb/>
-						<hi rend="italic">(Id.</hi> II , 44, <hi rend="italic">ct</hi> IV , 34) : viventesque in
-						christiana di<lb/>lectione concorditer , non dicebant aliquid suum, scd <lb/> crant
-						illis omnia communia , et anima et cor unum in <lb/> Deum <hi rend="italic">(Id.</hi> IV
-						, 32 35). Deiade etiam ipsi a Judæis car
-						
-				<note type="footnote">1 Lov., post, <hi rend="italic">crediderunt in eum millia</hi>, addiderunt,<lb/>
-							<hi rend="italic">multa</hi>, ex uno codice Ms.</note>
-				<note type="footnote"> 2 Hic in editione Lov. additum fuerat,<hi rend="italic">effusionem</hi> : minus<lb/> bene.</note><lb/>
-						
-
-		<pb n="341"/>nalibus civibus carnis suae persecutionem passi atque <lb/> dispersi sunt,
-						ut tatius Christus eorum dispersione <lb/> prædicaretur, et imitarentur etiam ipsi
-						patientiam <lb/> Domini sui : quia qui eos 1 mansuetus passus fuerat , <lb/>
-						mansuefactos pro se pati jubebat.</p>
-					<p>43. Ex ipsis sanctorum persecutoribus fuerat etiam <lb/> apostolus Paulus, et in
-						Christianos maxime soevio<lb/>bat : sed postea credens et apostolus factus, missus
-						<lb/> cst ut Gentibus Evangelium prædicaret, graviora per<lb/>pessus pro nomine
-						Christi, quam fecerat contra no<lb/>men Christi. Ecclesias autem constituens per
-						omnes <lb/> gentes qua Evangelium seminabat, impense præcipie<lb/>bat, ut quoniam
-						ipsi ex idolorum cultu venientes, et <lb/> ad unum Deum colendum rudes , non facile
-						potcrant <lb/> rehus suis venditis et distributis servire Deo , obla<lb/>tiones
-						facerent in pauperes sanctorum qui erant in <lb/> Ecclesiis Judrrae, quæ Christo
-						crediderant : ita illos <lb/> tanquam milites, illos autem tanquam stipendiarios <lb/>
-						provinciales apostolica doctrina constituit; inserens <lb/> cis Christum velut lapidem
-						angularem , sicut per pro<lb/>phetam prænuntiatus crat, in quo ambo quasi parietes
-						<lb/> dc diverso venientes, de Judæis videlicet atque Gen<lb/>tibus, germana
-						charitate copularentur <hi rend="italic">(Psal.</hi> CXVII, <lb/> 22, <hi rend="italic">et Isai.</hi> XXVIII, 16). Sed postea graviores et cre<lb/>briores persecutiones
-						ex incredulis gontibus adversus <lb/> Christi Ecclesiam surrexerunt, et implebatur in
-						dies <lb/> singulos verbum Domini prædicentis, <hi rend="italic">Ecce ego mitto</hi>
-						<lb/> vos <hi rend="italic">velut oves in medio luporum (Math.</hi> x, 16).</p></div>
-    	<div type="textpart" subtype="chapter" n="24"><p>44. <hi rend="italic">Ecclesia quasi vitis pullulat, <lb/> et putatur. Ex
-							iis quæ videntur impleta, credantur præ<lb/>dicta qum restant implenda, præsertim
-							judicium</hi> futu<lb/>rum. Sed illa vitis quæ per orbem terrarum, sicut de <lb/>
-						illa prophetatum, ct ab ip o Domino prænuntiatum <lb/> crat, fructuosos palmites
-						diffundebat, tanto pullula<lb/>lat amplius, quanto uberiore' martyrum sanguinc <lb/>
-						rigabatur. Qnibus per omnes terras innumerabiliter <lb/> pro fidei vcritatc morientibus,
-						etiam ipsa persequentia <lb/> regna cesserunt, et ad Christum cognoscendum atque <lb/>
-						venerandum fracta superbiæ cervice conversa sunt. <lb/> Oportebat antemi ut cadem vitis,
-						sicut a Domino <lb/> identidem prædictum erat, putaretur , ct ex ea proc­ <lb/>
-						ciderentur infructuosa sarmenta <hi rend="italic">(Joan.</hi> xv, 2) , qui<lb/>bus
-						hæreses ct schismata per loca facta sunt, sub <lb/> Christi nomine, non ipsius gloriam ,
-						sed suain quæ<lb/>rentium, pur quorum adversitates magis magisque <lb/> exerceretur
-						Ecclesia. et probaretur alqucillustrarclur <lb/> il doctrina ejus et patientia.</p>
-					<p>45. Omnia ergo hæc, sicut tanto antc prædicta le<lb/>gimus, sic ct facta cognoscimus
-						: et quemadmodum <lb/> primi christiani, quia nondum ista provenisse vidc<lb/>bant,
-						miraculis movchantur ut crederent; sic nos <lb/> quia omnia ista ita completa sunt,
-						sicut ea inLibris <lb/> legimus, qui longe antequam hæc implerentur con<lb/>scripti
-						sunt, uhi omnia futura dicebantur, ct præsen<lb/>tia jam videntur, ædificamur ad
-						fidcm, ut etiam illa
-						
-				<note type="footnote"> 1 Am. ct Er., <hi rend="italic">qui anle COSo</hi> Lov., <hi rend="italic">qui pro</hi>
-					* is, Aliquot Mss. <lb/> qui <hi rend="italic">prr</hi> cos; et quidam, <hi rend="italic">qui propter</hi> c- s; I
-							leriqiichahenl <lb/> <hi rend="italic">ql!i cos.</hi></note>
-				<note type="footnote"> 1 Am. et Er., <hi rend="italic">teneriore.</hi></note>
-						
-						<lb/> quæ restant, sustinentes et perseverantes in Domino, <lb/> sine dubitatione
-						ventura credamus. Siquidem adhuc <lb/> tribulationes futurae in eisdem Scripturis
-						leguntur, et <lb/> ipse ultimus judicii dies, ubi omnes cives ambarum <lb/> illarum
-						civitatum receptis corporibus surrecturi sunt, <lb/> et rationem vitae suæ ante tribunal
-						Christi judicis red<lb/>dituri. Veniet enim in claritate potestatis, qui prius <lb/>
-						in humilitate humanitatis venire dignatus est; et <lb/> omnes pios ab impiis segregabit
-						: non tautum eis qui <lb/> in eum credere omnino noluerunt, sed etiam eis qui <lb/>
-						frustra et infructuose crediderunt in eum ; illis datu<lb/>rus regnum secum æternum,
-						illis autem poenam <lb/> aeternam cum diabolo. Sed sicut nullum gaudium re<lb/>rum
-						temporalium ex aliqua parte simile potest inve<lb/>uiri gaudio vitae æternæ , quam
-						sancti accepturi <lb/> sunt ; ita nullus cruciatus poenarum temporalium po<lb/>test
-						sempiternis iniquorum cruciatibus comparari.</p></div>
-    	<div type="textpart" subtype="chapter" n="25"><p>46. Fides <hi rend="italic">resurrectionis suadetur.<lb/> Mors
-							perpetua</hi> in <hi rend="italic">tormentis. Vita æterna sanctornm. <lb/> Cavendum
-							non tantum</hi> a <hi rend="italic">Paganis,</hi> Judæis, <hi rend="italic">et hære­
-							<lb/> ticis, sed etiam a malis Christianis. Societas</hi> sit <hi rend="italic">cum
-							bonis;</hi>
-						<lb/> non <hi rend="italic">tamen</hi> spes in <hi rend="italic">ipsis ponatur.</hi>
-						Itaque, frater, confir<lb/>ma te ipsum in ejus nomine atque adjutorio cui cre­ <lb/>
-						dis, adversus linguas eorum qui fidem nostram irrident, <lb/> de quibus diabolus
-						seductoria verba loquitur, maxime <lb/> volens irridere fidem resurrectionis. Sad cx te
-						ipso <lb/> erede futurum te esse cum fueris , quando cum aute <lb/> non fueris, nunc
-						esse te vides. Ubi enim erat ista mo<lb/>les corporis lui et ista forma membrorumque
-						compa - <lb/> go ante paucos annos, priusquam natus, vel etiam <lb/> priusquam in matris
-						utero conceptus esses ? ubi erat <lb/> hæc moles et hæc statura corporis tui? Nonne de
-						oc-. <lb/> cultis hujus creaturae secretis, Domino Deo invisibili . <lb/> ter formante ,
-						processit in lucem, certisque ætatum <lb/> incrementis in istam magnitudinem formamque
-						surre<lb/>xit? Numquid ergo difficile est Deo, qui etiam aggeres <lb/> nubium ex
-						occulto in momento contrahit, et contegit <lb/> cælum in ictu temporis, reddere istam
-						quantitatem <lb/> corporis tui sicut crat, qui eam facere potuit sicut non <lb/> crat 1?
-						Crede ergo fortiter et inconcusse quia omnia <lb/> quæ videntur quasi pcreundo humanis
-						oculis subtra. <lb/> hi, salva et integra sunt omnipotentiae Dei; qui ea <lb/> cum
-						voluerit, sine ulla mora et difficultate reparabit, <lb/> ea duntaxat quæ justitia ejus
-						reparanda esse judicat : <lb/> ut in his corporibus reddant homines factorum suorum
-						<lb/> rationem, in quibus ea fecerunt; et in his mereantur <lb/> aut commutationem
-						cœlestis incorruptionis pro me<lb/>ritis pietatis, aut corruptibilem I corporis
-						conditioneui <lb/> pro meritis iniquitatis, non quae morte solvatur, sed <lb/> quae
-						materiam sempiternis doloribus præbeat.</p>
-					<p>47. Fuge ergo per immobilem fidem et mores bo - <lb/> nos', fuge, frater, illatormenta,
-						ubi nec tortores de<lb/>ficiant, nec torti moriuntur; quibus sinc fine mors <lb/>
-						est, non posse in cruciatibus mori. Et exardesce <lb/> amore atque desiderio sempiternæ
-						vitæ sanctorum,
-						
-				<note type="footnote"> 1 Sic Am. Er. et plures Mss. At Lov., <hi rend="italic">potuit cum non erat,</hi>
-							<lb/> Corbeiensis codex a secunda manu, <hi rend="italic">sic cum non erat.</hi></note>
-				<note type="footnote"> 2 Aliquot Mss., <hi rend="italic">corruptibilis.</hi></note>
-				<note type="footnote"> 3 Sic Mss. Editi vero, <hi rend="italic">ad mores bonos.</hi></note><lb/>
-						
-
-		<pb n="343"/> ubi nec operosa erit actio, nec requies desidiosa; <lb/> laus erit Dei
-						sine fastidio, sine defectu : nullum in <lb/> animo tædium , nullus labor in corpore;
-						nulla indi<lb/>gentia, nec tua cui subveniri desideres, nec proximi <lb/> rui
-						subvenire festines. Omnes deliciæ Deus erit et sa<lb/>tictas1 sanctæ civitatis in
-						illo et de illo sapienter bea<lb/>teque viventis. Efficiemur enim, sicut ab illo
-						promis<lb/>sum speramus ct exspectamus , aequales Angelis Dei <lb/>
-						<hi rend="italic">(Luc.</hi> xx, 36), et cum cis pariter illa Trinitate per... <lb/>
-						fruemur jam per speciem, in qua nunc per fidem <lb/> ambulamus ( II <hi rend="italic">Cor.</hi> v, 7). Credimus cnim quod non <lb/> videmus, ut ipsis meritis fidei etiam
-						videre quod cre<lb/>dimus et inhaerere mereamur; ut aequalitatem Patris <lb/> et
-						Filii et Spiritus sancti, et ipsius Trinitatis unitatem, <lb/> quomodo sint hxc tria
-						unus Deus, non jam verbis fi<lb/>dci et strepentibus syllabis personemus, sed contem­
-						<lb/> platione purissima et ardentissima in illo silentio sor<lb/>beamus1.</p>
-					<p>48. Hæc tene fixa in corde tuo, et invoca Deum <lb/> cui credis, ut tucatur te adversus
-						tentationes diaboli: <lb/> et esto cautus, ne tibi aliunde hostis ille subrepat, <lb/>
-						qui ad solatium malevolentissimum damnationis suæ, <lb/> cum quibus damnetur inquirit.
-						Non enim per eos so<lb/>los qui christianum nomen oderunt, et dolent eo no­ <lb/>
-						mine occupatum esse orbem terrarum, et adhuc si<lb/>mulacris et daemoniorum
-						curiositatibus servire desi<lb/>derant, audet ille tentare christianos : sed etiam
-						per <lb/> eos quos paulo ante commemoravimus, de unitate <lb/> Ecclesiæ, velut putata
-						vite, præcisos, qui hæretici vel <lb/> schismatici dicuntur, conatur etiam id quidem
-						inter<lb/>dum, Sed tamen id etiam aliquando conatur et per <lb/> Judaeos tentare,
-						atque seduccre. Sed maxime caven<lb/>dum est ne per homines qui sunt in ipsa
-						catholica <lb/> Ecclesia, quos velut paleam usque ad tempus ventila<lb/>tionis suæ
-						sustinet, unusquisque tentetur et decipia<lb/>tur. Propterea enim Deus patiens est in
-						illus, ut et <lb/> suorum electorum fidem atque prudentiam per illo<lb/>rum
-						perversitatem exercendo confirmet; et quia de <lb/> numero eorum multi proficiunt, et ad
-						placendum Dee <lb/> miserati I animas suas, magno impetu convertuntur. <lb/> Non enim
-						omnes sibi per patientiam Dei thesaurizant <lb/> iram in die iræ justi judicii ejus :
-						sed multos eadem Om<lb/>nipotentis patientia perducit ad saluberrimum poeni­ <lb/>
-						tentiæ dolorem (Rom. II, 5, 4). Quod donec fiat, <lb/> exercetur per eos illorum qni jam
-						rectam viam tenent, <lb/> non solum tolerantia , sed etiam misericordia. Multos <lb/>
-						ergo visurus es ebriosos, avaros, frandatores, aleato<lb/>res, adulteros,
-						fornicatores, remedia sacrilega sibi al<lb/>ligantes, præcantatoribus et mathematicis
-						vel quarum<lb/>libet impiarum artium diviuatoribus dcditos. Animad<lb/>versurus
-						etiam qnod illac turbæ impleant ecclesias per <lb/> dies festos Christianorum, quæ
-						implent et theatra <lb/> per dies solemnes Paganorum; et haec videndo ad <lb/> imitandum
-						tentaberis. Et quid dicam , vidcbis , quod <lb/> etiam nunc jam utique nosti ? non enim
-						nescis nullos
-						
-				<note type="footnote"> * Editi, <hi rend="italic">soactas.</hi> Aptius forte quinque Mss., satietas. </note>
-				<note type="footnote"> 'sic duoMss. At editi <hi rend="italic">sorbeamur.</hi></note>
-				<note type="footnote">toY., <hi rend="italic">mifcranti.</hi> Metius Am. Er. et
-							aliquot Mss., <hi rend="italic">irrije<lb/>rut;.</hi> Alludit ad illud
-							Ecclesiastici, ca rw), v. : vis-mr <lb/>
-							<hi rend="italic">WtirtW 'lilt! placeus nco.</hi></note>
-						
-						<lb/> qui appellantur christiani, hæc omnia mala operari. <lb/> quae breviter
-						commemoravi. Et aliquando1 fortasse <lb/> graviora facere homines non ignoras, quos
-						nosti ap<lb/>pellari christianos. Sed si hoc animo venisti, ut quasi <lb/> securus
-						talia facias, multum erras : nec tibi proderit <lb/> nomen Christi, cum coeperit ille
-						severissime judicare, <lb/> qni prius dignatus est misericordissime subvenire. <lb/>
-						Praedixit enim ista , et ait in Evan gelio : <hi rend="italic">Non omnis<lb/> qui dicit
-							mihi, Domine, Domine , intrabit in regnum <lb/> cœlorum; sed</hi> is <hi rend="italic">qui facit voluntatem Patris mei. Multi<lb/> dicent mihi</hi> in <hi rend="italic">illa die, Domine, Domine,</hi> in <hi rend="italic">nomine<lb/> tuo manducavimus et
-							bibimus (Matth.</hi> VII, 21,22). <lb/> Omnibus ergo qui in talibus opcrihus
-						perseverant, <lb/> damnatio finis est. Cum ergo videris multos non so. <lb/> lum hæc
-						facere, sed etiam defendere atque suadere, <lb/> tene te ad legem Dei, et non seqnaris
-						prævaricatores <lb/> ejus. Non enim secundum illorum sensum. sed secun<lb/>dum
-						illitis veritatem judicabci is.</p>
-					<p>49. Conjungere bonis, quos vidcsamnre tecum re<lb/>gem tuum. Multos enim inventurus
-						es, si et tu talis <lb/> esse coeperis. Nam si in spectaculis cum illis esse cu­ <lb/>
-						picbas et eis inhærere 2, qui tecum vel aurigam, vcl <lb/> venatorem, vel aliquem
-						histrionem simul amabant; <lb/> quanto magis te delectare debet eorum conjunctio, <lb/>
-						qui tecum amant Deum , de quo nunquam erubescet <lb/> amator ejus, quia non solum ipse
-						non potest vinci, <lb/> sed eliam dilectores suos reddet invictos? Nec tamen <lb/> etiam
-						in ipsis bonis, qui te vel praecedunt vel tibi co<lb/>mitanturad Deum2, spem tuam
-						collocare debes, quia <lb/> nee in te ipso debes quantumcumque profeceris, sed <lb/> in
-						illo qui eos et te justificando tales facit. Securus es <lb/> enim de Deo, quia non
-						mutatur : de homine autem <lb/> nemo prudenter securus est. Sed si illos qni nondum
-						<lb/> justi sunt, amare debemus ut sint ; quanto ardentius <lb/> qui jain sunt, amandi
-						sunt? Sed aliud est diligere h<lb/> minem, aliud spem ponere in homine; tantumque in •
-						<lb/> terest, ut illud Deus jubeat, hoc prohibeat. Si autem <lb/> aliquas vel
-						insultationes vcl tribulationes pro nomine <lb/> Christi passus non defeceris a fide,
-						nec a bona via 4 <lb/> deviaveris, majorem mercedem acceplurus es : qni <lb/> autem in
-						his diabolo cesserint, etiam minorem perdunt. <lb/> Sed humilis esto Dco, ut non te
-						permittat tentari ut<lb/>tra vires tuas.</p></div>
-    	<div type="textpart" subtype="chapter" n="26"><p>50. <hi rend="italic">Initiatio catechumeni, cum<lb/> expositione
-							signorum. Sermo quandoque</hi> brevior adhi<lb/>bendus. <hi rend="italic">Incipit
-							sermo alius brevior. Filius Dei</hi> immissus, <lb/>
-						<hi rend="italic">ut a morte qnce per Adamum intravit,</hi> liberaremur. Ilis <lb/>
-						dictis, interrogandus cst an hæc credat atque obser<lb/>vare desideret Quod cum
-						responderit, solemniter uti<lb/>quesignandus est et Ecclesiæ more tractandus. De sa­
-						<lb/> cramento sane <hi rend="italic">(a)</hi> quod accipit5, cum ei bene commen­ <lb/>
-						datum fuerit, signacula quidem rerum divinarum es, a <lb/> visibilia, sed res ipsas
-						invisibiles in eis honorari; nec <lb/> sic habendam esse illam speciem benedictione
-						sancti
-    		
-    		<note type="footnote"> I Mss., <hi rend="italic">aUquanto.</hi></note>
-    		<note type="footnote"> ' sic Am. Er. et Mss. At Lor.: .Vanl si ill <hi rend="italic">spectaculis ei</hi> vty <lb/>
-							<hi rend="italic">nUalibu insanorum certaminum iltis cupiebas</hi> inhaereri.</note>
-    		<note type="footnote"> 1 ir. Lugd. Ven. lov. OIniUnnt, <hi rend="italic">tibi.</hi> W </note>
-    		<note type="footnote"> 4 'me Kr. et plures Mss., <hi rend="italic">rtin.</hi></note>
-    		<note type="footnote"> 5 Sic Mss. At editi, <hi rend="italic">accepit.</hi></note>
-			<note type="footnote"> (&gt;i) roite. <hi rend="italic">wtis.</hi></note><lb/>
-						
-
-		<pb n="345"/> ficalnm , quemadmodum habetur in usu quolibet : <lb/> dicendum eliam quid
-						significet et sermo ille qucm au<lb/>divit, quid in illo condiat1, cujus illa res
-						siinilitudi<lb/>nem gerit. Deinde monendus est cx hac occasione, <lb/> ut si quid
-						etiam in Scripturis audiat quod carnaliter <lb/> sonet, etiamsi non intelligit, credat
-						tamen spirituale <lb/> aliquid significari, quod ad sanctos morcs futuramque <lb/> vitam
-						pertineat. Hoc autem ita breviter discit 2, ut <lb/> quidquid audierit ex Libris
-						canonicis quod ad dilectio<lb/>nem æternitatis et veritatis et sanctitatis, et ad
-						dile<lb/>ctionem proximi referre non possit, figurale dictum <lb/> vel gestum esse
-						credat; atque ita conetur intelligere, <lb/> ut ad illam gcminam referat dilectionem.
-						Ita sane ut <lb/> proximum non carnaliter intelligat, sed omnem quicum <lb/> eo in illa
-						sancta civitate potest esse, sive jam, sive non<lb/>dum appareat : ct ut de nullius
-						hominis correcliono <lb/> desperet, quem patientia Dci videt vivere, non ob <lb/> aliud,
-						sicut Apostolus ait, nisi ut adducatur ad pœni<lb/>tentiam <hi rend="italic">(Rom.</hi> 11, 4).</p>
-					<p>51. Si longus tibi videtur iste sermo, quo tanquam <lb/> præsentem rudcm hominem
-						instruxi, licet ea tibi di<lb/>cere brevius, longiorem tamen esse debere non puto :
-						<lb/> quanquam mullum interest quid res ipsa, cum agitur, <lb/> moneat, ei quid
-						audiiorum præsentia non solum fer<lb/>re, sed etiam desiderare se ostendat. Cum autem
-						ce<lb/>leritate opus est, vide quam facile explicari tota res <lb/> possit. Fac
-						rursas adesse aliqucm, qui velit esse chri<lb/>stianus: ergo et interrogatum, illud
-						quod superior re<lb/>spondissc; quia et si non hoc respondet, huc eum re­ <lb/>
-						spondere debuisse dicendum est. Dcinde hoc modo ct <lb/> cætera contexenda.</p>
-					<p>52. Vere, frater, illa magna et vera beatitudo est, <lb/> quæ in futuro saeculo sanctis
-						promittitur. Omnia vero <lb/> visibilia transeunt, et omnis hujus sacculi pompa et <lb/>
-						deliciæ et curiositas interibunt, et secum ad inter<lb/>itum trahunt amatores suos. A
-						quo interitu, hoc est, <lb/> poenis sempiternis Deus misericors volens homines <lb/>
-						liberare , si sibi ipsi non sint inimici, et non resi<lb/>stant misericordiæ
-						Creatoris sui, misit unigcnilumFi<lb/>lium suum, hoc est, Verbum suum aequale sibi,
-						per <lb/> quod condidit omnia. Et manens quidem in divinitate <lb/> sua, et non recedens
-						a Patre, nec in aliquo mutatus, <lb/> assumendo tamen hominem, et in carne mortali' ho­
-						<lb/> minibus apparendo venit ad homines : ut quemad<lb/>modum per unum hominem qui
-						primus factus est, id <lb/> cst Adam, mors intravit in genus humanum, quia <lb/>
-						consensit mulieri suae seductae a diabolo, ut præce<lb/>ptum Dei transgrederentur;
-						sic per unum homi<lb/>nen qui eUam Deus est Dei Filius, Jesum Chri<lb/>stum,
-						deletis omnibus peccatis præteritis, creden<lb/>tes in cum omnes in æternam vitam
-						ingrederentur <lb/>
-						<hi rend="italic">(Id.</hi> v, 12-19).
-						
-				<note type="footnote"> I Fr. <hi rend="italic">et Lov., condatur.</hi> verius MSS. et Am., <hi rend="italic">condiat.</hi> Nam <lb/>
-							z;.dlur lviu de sacTanicsUo salis, quo catechumenus initiatur. <lb/> I :uc periinct
-							illud Augustini lib. i confess., cap. 11 : ..:t <lb/> « signabar jam signo cruci;
-							ejus, et comlicbar cjus sah', <lb/> « jam inde ab utero matris meie. » Ipsa est quam
-							Inc dixit <lb/> speciem <hi rend="italic">beneditione sanctificatam :</hi> adeoquc
-							laulosupra <lb/> I vo, <hi rend="italic">sane;</hi> legendum videtur, <hi rend="italic">salis.</hi></note>
-				<note type="footnote"> Sit- Mss. Editi vcro, <hi rend="italic">discet,</hi></note>
-				<note type="footnote"> * Aliquot MSS., <hi rend="italic">mortalis.</hi></note></p></div>
-    	
-    	<div type="textpart" subtype="chapter" n="27"><p>53. <hi rend="italic">Prophetias Veleris Testa</hi>
-						<lb/>menti <hi rend="italic">impletas cerni in Ecclesia. Hinc firmata fides eo. <lb/>
-							rum quæ ventura restant, judicii</hi> ultimi <hi rend="italic">et resurrectio<lb/>
-								nis. Cavendæ</hi> tentationes <hi rend="italic">a</hi> malis <hi rend="italic">etiam
-							in Ecclesia re-</hi>
-						<lb/> perlis. <hi rend="italic">Societas cum bonis. Spes</hi> omnis in <hi rend="italic">Deo.</hi> Omnia <lb/> enim 1 qu v nunc vides in Ecclesia Dei, et sub Chri<lb/>sti
-						nominc p er totum orbem terrarum geri2, ante sæ<lb/>cula jam prædicta sunt, et sicut
-						ca legimus, ita ct <lb/> vidcmus; et inde ædificamur in fidem. Factum cst ali­ <lb/>
-						quando diluvium per totam terram, ut peccatores de<lb/>lerentur : et tamen illi qui
-						evaserunt in arca : sacra<lb/>mentum futuræ Ecclesiæ demonstrabant, quæ nunc <lb/> in
-						fluctibus sæculi natat, et per lignum crucis Chri<lb/>sli a submersione liberatur.
-						Prædictum est Abrahæ <lb/> fidcli Servo Dei, uni homini, quod de illo esset po­ <lb/>
-						pulus nasciturus, qui coleret unum Deum inter cæ<lb/>teras gentes quæ idola colebant
-						: et omnia quæ illi <lb/> populo ventura prædicta sunt, sic evenerunt ut præ­ <lb/>
-						dicta sunt. Prophetatus est in illo populo etiam Chri<lb/>stus rex omnium sanctorum
-						et Deus venturus ex se<lb/>mine ipsius Abraham secundum carnem, quam as­ <lb/>
-						sumpsit, ut omnes etiam filii essent Abrahæ, qui fidem <lb/> ejus imitarentur; et sic
-						est factum : natus est Chri<lb/>stus de Maria virgine, quæ ex illo genere fuit. Præ­
-						<lb/> dictum est per Prophetas quod in cruce passurus es. <lb/> set ab eodem populo
-						Judæorum , de cujus genere se<lb/>cundum carnem veniebat; et sic est factum. Prædi­
-						<lb/> ctum est quod resurrecturus esset; resurrexit: et se<lb/>cundum ipsa prædicta
-						Prophetarum ascendit in coelum, <lb/> et discipulis suis Spiritum sanctum misit.
-						Prædictum <lb/> est non solum a Prophetis, sed eliam ab ipso Domino <lb/> Jesu Christo,
-						quod Ecclesia ejus pcr universum or<lb/>bem terrarum esset futura, pcr*sanctorum
-						martyria <lb/> passionesque disseminata; et tunc praedictum, quando <lb/> adhuc nomen
-						ejus et latebat gentes, et ubi notum erat <lb/> irridebatur: et tamen in virtutibus
-						miraculorum cjus, <lb/> sive quæ per se ipse, sive quæ per servos suos fecit, <lb/> dum
-						annuntiantur hoec et creduntur, jam videmus <lb/> quod prædictum est esse completum,
-						regesque ipsos <lb/> terræ, qui antea persequebantur Christianos, jam <lb/> Christi
-						nomini subjugatos. Prædictum est etiam quod <lb/> schismata et hæreses ex ejus Ecclesia
-						essent exitu<lb/>ræ, et sub ejus nominc per loca ubi possent, suam, <lb/> non
-						Christi, gloriam quæsituræ; et ista completa <lb/> sunt.</p>
-					<p>54. Numquid ergo illa qunc restant n n sunt ven<lb/>tura ? Manifestum est quia sicut
-						ista pr:rdicta vene<lb/>runt, sic etiam illa ventura sunt: quæcumque tri­ <lb/>
-						bulationes juslormn adhuc restant; el judicii dies, <lb/> qui separabit omnes impius a
-						justis in resurrectione <lb/> mortuorum; et non solum cos qui sunt extra Eccle­ <lb/>
-						siarn , sed etiam ipsius Ecclesiæ palcas, quas opor<lb/>tet us iae ad novissimam
-						ventilatienem patientissime <lb/> sufferat, ad ignem debitum segregabit. Qui autem ir­
-						<lb/> rident resurrectionem , putantes quod caro ista quia <lb/> putrescit, resurgere
-						non potest, ad pœnas in ca re<lb/>surrecturi sunt : et ostendet eis Deus quia qui
-						potuit
-						
-				<note type="footnote"> t rorbciensisMs., <hi rend="italic">omnia ergo.</hi></note>
-				<note type="footnote"> I Abest, geri, a HSS. </note><lb/>
-						
-
-		<pb n="347"/> hæc corpora facere antequam essent, potest ca in mo<lb/>mento
-						restiluerc sicut erant. Omnes autem fideles re<lb/>gnaturi cum Christo, iia resurgent
-						in eodem corpore, <lb/> ut etiam commutari mereantur ad incorruptionem <lb/> angelicam :
-						ut fiant æquales Angelis Dei, sicut Do<lb/>minus &lt;psc promisit <hi rend="italic">(Luc.</hi> xx, 36) ; ct Llaudent eum <lb/> sine aliquo defectu et sine aliquo
-						fastidio, semper <lb/> viventes in illo et de illo, cum tali gaudio et bca­ <lb/>
-						titudine, quali nee dici' nec cogitari ab homine <lb/> potest.</p>
-					<p>55. Tu itaque credens ista, cave tentationes (quia <lb/> diabolus quærit qui secum
-						pereant): ut non solum per <lb/> eus qui extra Ecclesiam sunt, sive Pagani, sive Ju­
-						<lb/> dæi,sive hæretici , non te hostis ille seducat ; sed <lb/> ctiam quos in ipsa
-						Ecclesia catholica vidcris malc vi<lb/>ventes, aut immoderatos 2voluptatibus veptris
-						et gut<lb/>turis, aut impudicos, aut vanis curiositatibus vel i!<lb/>licitis
-						deditos sive spectaculorum, sive remediorum a <lb/> aut divinationum diabolicarum , sive
-						in pompa et ty<lb/>pho avaritiæ atque superbiæ, sive in aliqua vila quam <lb/> lex 4
-						damnat et punit, non eos irnitcris : sed potius <lb/> conjungaris honis, quos inventurus
-						es facile, si ct tu <lb/> talis fucris; ut simul colatis et diligatis Dcum gratis :
-						<lb/> quia lotum præmium nostrum ipse erit, ut in illa vita I <lb/> honilate ejus et
-						pulchritudine perfruamur. Sed aman<lb/>dus est, non sicut aliquid quod videtur
-						oculis; sed <lb/> bicut amatur sapientia , et veritas, et sanctitas, et
-						
-				<note type="footnote"> 1 sic Mss. At editi, <hi rend="italic">gualis nec dici.</hi></note>
-				<note type="footnote">s Ms.;., <hi rend="italic">immoderatis</hi> : fortasse pro,
-								<hi rend="italic">in immoderatis.</hi></note>
-				<note type="footnote">a Editi, <hi rend="italic">sive remediorum
-								sacrilegorum.</hi>Abest, <hi rend="italic">sacrileqo<lb/>rvm,</hi> a Mss , ut
-							illa quai post adhibetur,vox, <hi rend="italic">diabolicurwll,</hi>
-							<lb/> ct aJ <hi rend="italic">divinationum</hi> referatur, et ad remcdwrum.</note>
-				<note type="footnote"> 4 corbeiensis Ms., <hi rend="italic">lex Dei:</hi> sed
-							atlJilulll, <hi rend="italic">Dci,</hi> a secun<lb/>da manu. </note>
-				<note type="footnote"> Ii Editi, <hi rend="italic">ill illa (vlerna vita.</hi> Abest, <hi rend="italic">ælerlla,</hi> a Mss. </note>
-						
-						<lb/> justitia, et charitas I , et si quid aliud talc dicitur : <lb/> non qucmadmodunf
-						sant ista in hominibus; sed quem - <lb/> admodum sunt in ipso fonte incorruptibilis et
-						in<lb/>commutabilis sapientiae. Quoscumque ergo videris hæc <lb/> amare, illis
-						conjungere, ut per Christum qui homo <lb/> factus est, ut esset Mediator Dei et hominum,
-						re- <lb/> coucilieris Deo. Homines autem perversos, etiamsi <lb/> intrent parietes
-						ecclesiæ,non cos arbitreris intratu<lb/>ros in regnum coelorum; quia suo tempore
-						separa<lb/>buntur, si se in melius non commutaverint. Homines <lb/> ergo bonos
-						imitare, malos tolera, omnes ama; quo<lb/>niam nescis quid cras futurus sit qui hodie
-						malus est. <lb/> Nec corum ames injustitiam; sed ipsos ideo ama, ut <lb/> apprehendant
-						justitiam : quia non solum dilectio Dei <lb/> nobis præcepta est, sed cHam dilectio
-						proximi, in <lb/> quibus duobus præceptis tota Lex pendet ei Prophe<lb/>tæ <hi rend="italic">(Matth.</hi> XXII, 37-40). Quam non imp'et nisi qui <lb/> donum'
-						acceperit Spiritum sanctum, Patri ct Filio <lb/> uliqne aequalem; quia ipsa Trinitas
-						Deus est : in quo <lb/> Dco spes omnis ponenda cst. In hominc non est po<lb/>nenda,
-						qualiscumque ille fuerit. Aliud est enim ille a <lb/> quo justificamur, aliud illi cum
-						quibus justificamur. <lb/> Non autcm solum per cupiditates diabolus tentat, sed <lb/>
-						etiam pcr terrores insultationum et dolorum et. ipsius <lb/> mortis. Quidquid autem homo
-						passus fuerit pro no<lb/>mine Christi, et pro spe vitæ æternæ,et permaners <lb/>
-						toleravcrit, major ei merces dabitur : quod si cesse<lb/>rit diabolo, cum illo
-						damnabitur. Sed opera miseri<lb/>cordiæ cum pia humilitate impetrant a Domino, ut
-						<lb/> non permittat servos suos tentari plus quam possunt <lb/> sustinere (I <hi rend="italic">Cor.</hi> x, 13).
-						
-				<note type="footnote"> I Mss. omittiuit, <hi rend="italic">et sanctitas, etjusdtii, ct ch&gt;</hi> rit is. </note>
-				<note type="footnote"> * sola editio Lov. pro, <hi rend="italic">donum,</hi> iiabet, <hi rend="italic">Lominum.</hi></note></p></div>
-    	
+				<div type="textpart" subtype="chapter" n="1">
+					<p>1. <hi rend="italic">Rogatus a diacono Cartha<lb/>ginensi scribit de
+							catechizandis rudibus.</hi> Petisti me, fra<lb/>ter Deogralias <hi
+							rend="italic">(b),</hi> ut aliquid ad te de catechizandis <lb/> rudibus,
+						quod tibi usui esset, scriberem. Dixisti <lb/> euim quod sæpe apud
+						Carthaginem, ubi diaconus es, <lb/> ad te adducuntur, qui fide christiana
+						primitus im<lb/>buendi sunt , eo quod existimeris habere cale<lb/>chizandi
+						uberem facultatem, ct doctrina fidei et sua<lb/>vitate sermenis i : te autem
+						pene semper angustias <lb/> pati, idipsum quod credendo christiani sumus,
+						quo <note type="footnote"> ADMONIO PP. BENEDICTINORUM. </note>
+						<note type="footnote"> Libri de Catechizandis Rudibus contulimus codices
+							manuscriptos quatuordecim : Corbeiensem perquam egregium anno<lb/>rum
+							800, alium Ecclesiæ taudunensis annorum 700, Divionensem abbatiæ S.
+							Benigni, Pratellensem, Fiscannensem, <lb/> Michaelinum, Cisterciensem,
+							Floriacenses duos, totidem victorinos, sorbonicum et duos valicanos;
+							lectiones variantes ex <lb/> tribus Belgicis cura Lovaniensium
+							decerptas; et postremo editiones primarias Amerbachii, Erasmi ac
+							Lovaniensium.</note>
+						<note type="footnote"><hi rend="italic">Comparavimus prœterea eas omnes
+								editiones initio</hi> Retr. <hi rend="italic">et</hi> Confess. <hi
+								rend="italic">t.</hi> 1, <hi rend="italic">memoratas.</hi> M. </note>
+						<note type="footnote"><hi rend="italic">(a)</hi> Scriptus circiter anuum
+							400.</note>
+						<note type="footnote"><hi rend="italic">(b)</hi> Idem ille forsitan est
+							Deogratias, cui presibytero Au <lb/>gustinus, post annum Chiristi
+							circiter 406, ad quæstiones Pa<lb/> ganorum ab eo sibi Carthasine missas
+							respondet epistula <lb/> nunu ordine 102.</note>
+						<note type="footnote">1 Lov,<hi rend="italic">et doctrinam fidei et
+								survitatem sermonis.</hi></note><lb/>
+						<pb n="311"/> pacto commode intimandum sit ; unde exordienda, <lb/> quousque
+						sit perducenda narratio; utrum exhortatio<lb/>nem aliquam terminata
+						narraliouc adhibere debea<lb/>mus, an præcepta sola, quihus observandis cui
+						lo<lb/>quimur noverit christianam vitam professionemque <lb/> retineri l.
+						Sæpe autem libi accidisse confessus atque <lb/> conquestus cs, ut in sermone
+						logo et tepido tibi ipse <lb/> vil scercs essesque fastidio, nedum illi quem
+						lo<lb/>quedo imbuebas, ct cæicris qui audientes aderant : <lb/> caque te
+						necessitate fuisse compulsum , ul ea me <lb/> quam tibi debco charitate
+						compelleres, ne gravarer in<lb/>ter occupationes meas tibi dc hac re aliquid
+						scribere.</p>
+					<p>2. Ego vero non ca tantum quam familiariter tilii, <lb/> sed clam quam matri
+						Ecclesiæ universaliter de- <lb/> beo charitate ac servitute compellor, si
+						quid per <lb/> operam meam quam Donnini nostri largitate possum <lb/>
+						exhibere, idem cos Dominus quos mihi fratres fecit, <lb/> adjuvari jubet,
+						nullo modo recusare, scd potus <lb/> prompta et devota voluntate suscipere.
+						Quanto enim <lb/> cupio latius crogari I pecuniam dominicam, tanto <lb/>
+						magis me oportet, si quani dispensatores conservos <lb/> meos difficultatem
+						in erogando scutire cognosco , <lb/> agere quantum in me est, ut facile
+						atque expedite <lb/> possint, quod impigre ac studiose volunt.</p>
 				</div>
-				</body>
-  </text>
+				
+				<div type="textpart" subtype="chapter" n="2">
+					<p>3. <hi rend="italic">Sermo sæpe qui audienti placet, <lb/> displicet dlcenti
+							: unde id contingat. Qui sermonem na<lb/>bet, curet ut sine fastidio et
+							hilariter dicat.</hi> Sed quod <lb/> ad tuam pn pric considerationem
+						pertinet, nolim te <lb/> moveri ex eo quod sa'pc tibi abjectum sermonem
+						fa<lb/>stidiosumque hahere visus cs. Fieri enim potest ut ci <lb/> quem
+						instrucbas non ita sit visum , sed quia lu ali<lb/>quid melius audiri
+						desiderabas, eo libi quod dicebas <lb/> videretur indignum auribus aliorum.
+						Nam et mihi <lb/> prope semper sermo meus displicet. Melioris enim <lb/>
+						avidus sum, quo sæpe fruor interius, antequam eum <lb/> explicare verbis
+						sonantibus cœpero : quod ubi minus <lb/> quam mihi notus est evaluero,
+						contristor linguam <lb/> meam cordi meo non potuisse 2 suflicere. Totum enim
+						<lb/> quod intelligo, volo ut qui me audit intelligat; et sen<lb/>lio nic
+						non ita loqui, ut hoc efficiam : maxime quia <lb/> ille intellectus quasi
+						rapida coruscatione perfundit <lb/> animum ; illa autem locutio tarda et
+						longa est, lon<lb/>geque dissimilis : et dnm ista volvitur, jam se ille in
+						<lb/> secreta sua condidit: tamen quia vestigia quædem <lb/> miro nodo
+						impressit memoriæ, perdurant illa cun) <lb/> syllabarum morulis; atque ex
+						eisdem vestigiis sonan<lb/>lia signa peragimus, quæ lingua dicitur vel
+						latina, <lb/> vel græca, vel hebræa, vel alia quælibet ; sive
+						cogi<lb/>lentur hec signa, sive cliam voce proferantur ; cum <lb/> illa
+						vestigia nec latina, nec græca, vel hebræa, <lb/> nec cujusque alterius
+						gentis sint propria, sed ita <lb/> efficiantur in animo, ut vultus in
+						corpore. Aliter <lb/> enim latine ira dicitur, alilcr græce, aliter atque
+						ali<lb/>ter aliarum diversitate linguarum : non autem lati<lb/>nus ant
+						gra'cus est vultus irati. Non itaque omnes <lb/> gentes intelligunt, cum
+						quisque dicit, Iratus sum, sed <note type="footnote"> 1 Sic in Mss. At in
+							editis, <hi rend="italic">retinere.</hi></note>
+						<note type="footnote"> 2 Editi, <hi rend="italic">erogare</hi>. At Mss., <hi
+								rend="italic">erogari</hi>.</note>
+						<note type="footnote"> 3 Editi, <hi rend="italic">non posse</hi>. Mss., <hi
+								rend="italic">non potuisse</hi>.</note>
+						<lb/> Latin! tantum: at si affectus excandescentis animi exeat <lb/> in
+						faciem, vultumque faciat (a). omnes sentiunt qui <lb/> intuentur iratum. Sed
+						neque ita licet educere et quasi <lb/> exporrigere in sensum audientium per
+						sonum vocis <lb/> illa vestigia, quæ imprimit intellectus memoriæ, sicut
+						<lb/> apertus et manifestus est vultus : illa enim sunt iutus <lb/> in
+						animo, iste foris in corpore. Quapropter conjicien­ <lb/> dum est quantum
+						distet sonus oris nostri ab illo ictu <lb/> intelligentiæ, quando ne ipsi
+						quidem impressioni me<lb/>moriæ similis est. Nos autem plerumque in
+						auditoris <lb/> utilit item vehementer ardentes, ita loqui volumus, <lb/>
+						quemadmodum tunc intelligimus, cum per ipsam in<lb/>tentionem loqui non
+						possuntus : et quia non succe­ <lb/> dit, angimur, et velut frustra operam
+						insumamus, <lb/> tædio marcescimus: atque ex ipso tadio languidior <lb/> tit
+						idem sermo, et hebetior quam erat, unde perduxit <lb/> ad tædium.</p>
+					<p>4. Sed mihi sæpe indicat eorum studium, qui me <lb/> audire cupiunt, non ita
+						esse frigidum eloquium <lb/> meum, ut videtur mihi : et cos inde aliquid
+						utile <lb/> capere, ex eorum delectatione cognosco; mecum<lb/>que ago
+						sedulo, ut huic exhibendo ministerio non <lb/> dcsim , in quo illos video
+						bene accipere quod exhi<lb/>betur. Sic et tu, eo ipso quod ad te sxpius
+						addu<lb/>cuntur qui fide imbuendi sunt, debes intelligere non <lb/> ita
+						displicere aliis sermonem tuum ut displicet tibi : <lb/> nec infructuosum te
+						debes putaro, quod ea quae <lb/> cernis non explicas ita ut cupis; quando
+						forte ut <lb/> cupis nec cernere valeas. Quis enim in hac vita nisi <lb/> in
+						anigmate et per speculum videt (1 <hi rend="italic">Cor.</hi> XIII, 12) ?
+						<lb/> Nec ipse amor tantus est , ut carnis disrupta caligine <lb/> penetret
+						in æternum serenum, unde utcumque ful<lb/>gcut etiam ista quæ transcunt. Sed
+						quia boni pro<lb/>ficiunt de dic in diem ad videndum dicin sine
+						volu<lb/>mine caTi et sine noctis incursu, quem oculus uon <lb/> vidit, nec
+						auris audivit, nec in cor hominis ascendit <lb/> (Jd. II. 9); nulla major
+						causa cst cur nohis in imbuen<lb/>dis rudibus noster sermo vilescat, nisi
+						quia libet in<lb/>usitate cernere, et tædet usitate proloqui. Et re qui­
+						<lb/> dem vera multo gratius audimur, cuti et nos eodem <lb/> opere
+						delectamur : afficitur enim filum locutionis <lb/> nostr;e ipso nostro
+						gaudio , et exit f cilius atquc ac­ <lb/> ceptius. Quapropter non arduutn
+						est negotium, ea <lb/> quæ credenda insinuantur, præcipere unde et
+						quo<lb/>usque narranda sint; nec quomodo sit varianda nar. <lb/> ratio, ut
+						aliquando brevior, aliquando longior. sem<lb/>per tamen plena atque perfecta
+						sit ; et quando bre<lb/>viorc, et quando longiore sit utendum : sed quibus
+						<lb/> modis faciendum sit, ut gaudens qni que catechim <lb/> (lanlo enim
+						suavior crit, quanto magis id potuerit), ea <lb/> cura maxima est Et
+						preceptum quidem rei hujus in <lb/> promptu est. Si enim in pet unia
+						corporali, quanto <lb/> magis in spirituali hilarem datorem diligit Deus (II
+						<lb/> Cor. IX, 7) ? Sed hæc hilaritas ad horam ut adsit, ejus <lb/> est
+						misericordiæ qui ista præcepit. Itaque prius de <lb/> modo narrationis quod
+						te velle cognovi, tum de præ<lb/>cipiendo atque cohortando, postea de hac
+						hilaritate <lb/> comparanda, quæ Deus suggesserit, disseremus. <note
+							type="footnote">
+							<hi rend="italic">(a)</hi> Forte, <hi rend="italic"
+							>afficiat</hi>.</note></p>
+				</div>
+
+				<pb n="313"/>
+				
+				<div type="textpart" subtype="chapter" n="3">
+					<p>5. <hi rend="italic">Narratio plena quai fieri debeat <lb/> catechizando. Ad
+							charitatis finem dirigenda narratio. <lb/> Scripturæ veteres propter
+							commendandum</hi> Christi <hi rend="italic">ad.<lb/> ventum, cujus finis
+							charitas.</hi> Narratio plena est, cnm <lb/> quisque primo catechizatur
+						ab eo quod scriptum est, <lb/> In <hi rend="italic">principio fecit
+							Deus</hi> coelum <hi rend="italic">et terram (Gen.</hi> I. 1), <lb/>
+						usque ad præsentia tempora Ecclesiæ. Non tamen <lb/> propterea ilcbemus
+						totum Pentateuchum, totosque <lb/> Judicum et Regnormn et Esdræ 1 libros,
+						totumque <lb/> Evangelium et Actus Apostolorum, vol, si ad verbum <lb/>
+						edidicimus, memoriter reddere, vel nostris verbis <lb/> onniia quæ his
+						continentur voluminibus narrando <lb/> evolvere et explicare; quod ncc
+						tempus capit, nee <lb/> ulla necessitas postulat : sed cuncta summatim
+						gene<lb/>ratimque complecti, ita ut eligantur quxdam mirabi<lb/>liora quæ
+						suavius audiuntur, atque in ipsis articulis <lb/> constituta sunt <hi
+							rend="italic">(a),</hi> ut ea 2 tanquam in involucris os­ <lb/> tendere,
+						statimque a conspectu abripere non opor<lb/>teat, sed aliquantum immorando
+						quasi resolvere atque <lb/> expandere , et inspicienda atque miranda offerre
+						ani<lb/>mis auditorum ; cætera vero celeri percursione inse<lb/>rendo
+						contexere. Ita et illa quæ maxime commendari <lb/> volumus , aliorum
+						submissione magis eminent; nec <lb/> ad ea fatigatus pervenit, quem narrando
+						volumus ex<lb/>citare; nec illius memoria confunditur, quem do<lb/>cendo
+						debemus instrucre.</p>
+					<p>6. In omnibus sanc non tantum nos oportet intueri <lb/> præcepti finem , quod
+						est cbaritas de corde puro et <lb/> conscientia bona et fide uon ficta (I
+						Tim. I, 5), quo ea <lb/> quæ loquimur cuncta referamus; sed eliam illius
+						<lb/> quem loquendo instruimus, ad id movendus 3 atque <lb/> iiluc
+						dirigendus aspectus est. Necque enim ob aliud <lb/> ante adventum Domini
+						scripta sunt omnia quæ in <lb/> sanctis Scripturis legimus, nisi ut illius
+						commenda<lb/>retur adventus, et futura præsignaretur Ecclesia , id <lb/>
+						est, populus Dei per omnes gentes, quod est corpus <lb/> ejus; adjunctis
+						atque annumeratis omnibus sanctis , <lb/> qui etiam ante adventum ejus in
+						boc s:rculo vixeruul, <lb/> ita eum credentes venturum esse, sicut nos
+						vcnisse. <lb/> Sicut cnim Jacob manum prius, dum nasceretur, <lb/> emisit ex
+						utero, qua eliam pedem prænascentis fratris <lb/> tenebat, deinde utique
+						secutum est caput, tum de<lb/>mum necessario membra cætera <hi rend="italic"
+							>(Gen.</hi> xxv, 25); sed <lb/> tamen caput non tantum ea membra quæ
+						secuta sunt, <lb/> sed etiam ipsam manum quæ in nascendo præcessit , <lb/>
+						dignitate ac potestate præcedit; et quamvis non tem<lb/>pore apparendi,
+						tamen naturæ ordine prius est: ita <lb/> et Dominus Jesus Christus ctsi
+						antequam appareret <lb/> in carne, et quodam modo ex utero secreti sui ad
+						<lb/> hominum oculus Mediator Dci et hominum homo pro<lb/>cederet, qui est
+						super omnes Deus benedictus in sæ<lb/>cula <hi rend="italic">(Rom.</hi> ix,
+						5), præmisit in sanctis Patriarchis et <lb/> Prophetis quamdam partem
+						corporis sui, qua velut <note type="footnote"> 1 In Mss., <hi rend="italic"
+								>Ezræ</hi>.</note>
+						<note type="footnote"> 2 Er. et Lov., <hi rend="italic">et ea</hi> At Am.,
+								<hi rend="italic">utea</hi>. Et sic potiores Mss. <lb/> ex quibus
+							postea corrigimus, <hi rend="italic">non oporteat</hi> ; ubi editi
+							fere<lb/>bant, <hi rend="italic">non oportet</hi>.</note>
+						<note type="footnote"> 3 Ita Mss., Editi vero, <hi rend="italic"
+								>monendus</hi>.</note>
+						<note type="footnote">
+							<hi rend="italic">(a)</hi> Articuli temporum quinque notantur infra, n 6
+							et <lb/> n. 30.</note>
+						<lb/> manu se nasciturum esse prænuntians, etiam popu<lb/>lum præcedentem
+						superbe, vinculis Legis tanquam di<lb/>gitis quinque supplantavit1 (quia et
+						per quinque tem­ <lb/> porum articulos prænuntiari venturus prophetarique
+						<lb/> non destitit; et huic rei consonans per quem Lex data <lb/> est,
+						quinque libros conscripsit : et superbi carnaliter <lb/> sentientes, et suam
+						justitiam volentes constituere <lb/>
+						<hi rend="italic">[Rom.</hi> x, 5], non aperta manu Christi repleti sunt be­
+						<lb/> nedictione, sed constricta atque conclusa retenti <lb/> sunt : itaque
+						illis obligati sunt pedes , et ceciderunt; <lb/> nos autem surreximus et
+						erecti sumus [Psal xix, 9]): <lb/> quamvis ergo, ut dixi, præmiserit Dominus
+						Christus <lb/> quamdam partem corporis sui in sanctis, qui enim <lb/>
+						nascendi tempore prxierunt; tamen ipse est caput <lb/> corporis Ecclesiæ <hi
+							rend="italic">(Coloaa.</hi> i, 18); illique omnes eidem <lb/> corpori
+						cujus ille caput es!. cohxserunt, credendo in <lb/> cum quem prænuntiabant.
+						Non enim præcurrendo <lb/> divulsi sunt, sed adjuncti potius obsequendo. Nam
+						<lb/> etsi manus a capite præmitti potest, connexio tamen <lb/> cjus sub
+						capite cst. Quapropter omnia quæ ante <lb/> scripta sunt, ut nos doceremur
+						scripta sunt (Hom. <lb/> xv, 4), ct figura nostræ fuerunt, et <hi
+							rend="italic">in figura contin<lb/>gebant in eis1</hi> I ; <hi
+							rend="italic">scripta sunt autem propter nos, in quos<lb/> finis</hi>
+						sæculorum <hi rend="italic">obvenit</hi> (I <hi rend="italic">Cor.</hi> x,
+						11).</p>
+				</div>
+				
+				<div type="textpart" subtype="chapter" n="4">
+					<p>7. Præcipua <hi rend="italic">causa adventus Christi,<lb/> charitatis
+							commendatio. Ad dilectionem</hi> referenda <hi rend="italic">esse<lb/>
+							quæ de Christo ex Scripturis narrantur</hi> in <hi rend="italic"
+							>catechismo.</hi>
+						<lb/> Quæ autem major causa est adventus Domini, nisi ut <lb/> ostenderet
+						Deus dilectionem suam in nobis, commen<lb/>dans eam vehementer i quia cum
+						adhuc inimici esse<lb/>mus, Christus pro nobis mortuus est <hi rend="italic"
+							>(Rom.</hi> v, 6-9). <lb/> Iloc autem ideo, quia finis præcepti et
+						plenitudo le<lb/>gis, charitas est (I <hi rend="italic">Tim.</hi> I, 5, <hi
+							rend="italic">et Rom.</hi> XIII, 10) : ut ut <lb/> nos invicem
+						diligamus, et quemadmodum ille pro <lb/> nobis animam suam posuit, sic et
+						nos pro fratribus <lb/> animam ponamus (I Joan. III, 16); et ipsum Dcum ,
+						<lb/> quoniam prior dilexit nos (Id. IV, 10), et Filio suo <lb/> unico non
+						pepercit, sed pro nobis omnibus tradidit <lb/> cum (Rom. vin, 32), si amare
+						pigebat, saltem nunc <lb/> redamare non pigeat'. Nulla est enim major ad
+						amo<lb/>rcm invitatio, quam prævenire amando; et nimis du<lb/>rus est animus
+						qui dilectionem si nolebat impendere, <lb/> nolit rependere. Quod si in
+						ipsis flagitiosis et sordidis <lb/> amoribus videmus, nihil aliud eos agere
+						qui amari vi<lb/>cissirn volunt, nisi ut documentis quibus valent
+						ape<lb/>riant et ostendant quantum ament; eamque imaginem <lb/> justitie
+						prætendere affectant, ut vicem sibi reddi quo<lb/>dam modo flagitent ab cis
+						animis quos illecebrare <lb/> moliuntur; ipsique ardentius æstuant, cum jam
+						mo<lb/>veri eodem igne etiam illos mentes quas appetunt <lb/> sentiunt : si
+						ergo et animus qui torpebat, cum se <lb/> amari senserit excitatur, et qui
+						jam ferveba!, cum se <lb/> rcdamari didicerit magis accenditur; manifestum
+						cst <lb/> nullam esse majorem causam qua vel inchnetur vel <lb/> augcatur
+						amor, quam cum amari se cognoscit qui <note type="footnote"> 1 Aliquot Mss.,
+								<hi rend="italic">supplantaret</hi>.</note>
+						<note type="footnote"> 2 Editi, <hi rend="italic">contingebant</hi> eis ;
+							omissa particula, in, quæ ta<lb/>men hic reperitur in Mss. et in græco
+							textu Apostoli.</note>
+						<note type="footnote"> 3 Am. Er. et Mss., <hi rend="italic">saltem redamare
+								non pigeat</hi> ; omisso, <lb/> nunc</note>.<lb/>
+						<pb n="315"/> nondum amat, aut redamari se vel posse sperat, vel <lb/> jam
+						probat qui prior amat Et si boc etiam in turpi<lb/>bus amoribus, quanto plus
+						1 in amicitia? Quid euim <lb/> aliud cavemus in offensione amicitiæ, nisi ne
+						amicus <lb/> arbitretur quod euin vel non diligimus, vel minus
+						di<lb/>ligimus quam ipse nos diligit? Quod si crediderit, <lb/> frigidior
+						crit in eo amore quo invicem homines mu<lb/>tua familiaritate perfruuntur :
+						et si non ita est infir<lb/>mus , ut hæc illum offensio faciat ab omni
+						dilectione <lb/> frigescere; in ca se tenet, qua non ut fruatur, sed ut
+						<lb/> consulat diligit. Operae pretium est autem animad<lb/>vertere,
+						quomodo, quanquam ct superiores velint se <lb/> ab inferioribus diligi ,
+						eorumque in se studioso I de<lb/>lectentur obsequio, et quanto magis id
+						senserint, <lb/> tanto magis cos diligant, tamen quanto amore
+						exar<lb/>descat inferior, cum a superiore se diligi senserit. Ibi <lb/> enim
+						gratior amor est, ubi non æstuat indigentiæ sic<lb/>citate, sed ubertate
+						beneficentiæ 3 profluit. Ille nam<lb/>que amor ex miseria est, iste ex
+						misericordia. Jam <lb/> vero si etiam se amari posse a superiore desperabat
+						<lb/> inferior, ineffabiliter commovebitur in amorem, si ut<lb/>tro ille
+						fuerit dignatus ostendere quantum diligat eum <lb/> qui nequaquam sibi
+						tantum bonum promittere aude­ <lb/> ret. Quid autem superius Deu judicante,
+						et quid de<lb/>speratius homine peccante? qui se tanto magis tuen- <lb/> dum
+						et subjugandum superbis potestatibus addixerat, <lb/> quæ beatificare non
+						possunt, quanto magis despera. <lb/> vcrat posse sui curam geri ab ea
+						potestate quæ non <lb/> malitia sublimis esse vult, sed bonitate sublimis
+						cst.</p>
+					<p>8. Si ergo maxime propterea Christus advenit, ut <lb/> cognosceret horno
+						quantum eum diligat Deus; et ideo <lb/> cognosceret, ut in ejus dilectionem
+						a quo prior dile­ <lb/> ctus est, inardesceret, proximumque illo jubente et
+						<lb/> demonstrante diligeret, qui non proximum, scd longe <lb/>
+						pcregrinantem diligendo factus est proximus; omnis­ <lb/> que Scriptura
+						divina quæ ante scripta est, ad prænun<lb/>tiandum adventum Domini scripta
+						est; et quidquid <lb/> postea mandatum est litteris et divina auctoritate
+						fir­ <lb/> matum, Christum narrat, et dilectionem monet: ma<lb/>nifestum est
+						non tantum totam Legem et Prophe<lb/>tas in illis duobus pendere præceptis
+						dilectionis Dei <lb/> ct <hi rend="italic">proximi (Matth.</hi> XXII, 40),
+						quæ adhuc sola Scriptura <lb/> sancta erat cum hoc Dominus diceret, sed
+						etiam qaae<lb/>cumquc posterius salubriter conscripta 4 suut memo<lb/>riæque
+						mandata divinarum volumina Litterarum. <lb/> Quapropter in Veteri Testamento
+						est occultatio Novi, <lb/> ill Novo Testamento est manifestatio Veteris.
+						Secun<lb/>dum iilam occultationem carnaliter intelligentes car­ <lb/> nales,
+						et tunc et nunc poenali timore subjugati sunt. <lb/> Secundum hanc autem
+						manifestationem spirituales, et <lb/> tunc quibus pie pulsantibus ctiam
+						occulta patuerunt, <lb/> et nunc qui non superbe quærunt, ne etiam aperta
+						<lb/> claudantur, spiritualiter intelligentes donata charitate <lb/>
+						liberali sunt. Quia ergo charitati nihil adversius quam <lb/> invidentia;
+						mater autem invidentiæ superbia est : <note type="footnote"> 1 Pleriquee
+							Mss., <hi rend="italic">purius?</hi> Am. et Mss. vaticani, <hi
+								rend="italic">plurius?</hi></note>
+						<note type="footnote"> 2 Sic Mss. At edili, <hi rend="italic"
+							>studiose</hi>.</note>
+						<note type="footnote"> 3 Veteres libri, <hi rend="italic"
+							>beneficentiæ.</hi></note>
+						<note type="footnote"> 4 Am. Er et plures Mss., <hi rend="italic"
+								>consecrata</hi>. Alii duo Mss., <hi rend="italic"
+								>con<lb/>secuta</hi>.</note>
+						<lb/> idem Dominus Jesus Christus, Deus homo, et divinæ <lb/> in nos
+						dilectionis indicium est , et humanæ apud no; <lb/> humilitatis exemplum ,
+						ut magnus tumor noster ma<lb/>jnre contraria medicina sanaretur. Magna est
+						enim <lb/> miseria, superbus homo; sed major misericordia, hu<lb/>milis
+						Deus. Hac ergo dilectione tibi tanquam line <lb/> proposito, quo rcferas
+						omnia quæ dicis, quidquid <lb/> narras ita narra, ut ille cui loqueris
+						audiendo cre<lb/>dat, credendo speret, sperando amet.</p>
+				</div>
+				
+				<div type="textpart" subtype="chapter" n="5">
+					<p>9. <hi rend="italic">Accedens ad catechismum</hi> scrutan­ <lb/>
+						<hi rend="italic">dua quo fine velit fieri christianus.</hi> De ipsa etiam
+						sevc­ <lb/> rilate Dei, qua corda mortalium saluberrimo terrore <lb/>
+						quatiuntur, charitas ædificanda est; ut ab.co quem <lb/> timet, amari se
+						gaudens, eum rcdamare audeat, cjus­ <lb/> que in se dilectioni, etiamsi
+						impune posset, tamen <lb/> displicere vereatur. Rarissime quippe accidit,
+						imo <lb/> vero nunquam, ut quisquam veniat volens fieri chri­ <lb/> stianus,
+						qui non sit aliquo Dci timore perculsus. Si <lb/> enim aliquod commodum
+						exspectando ab hominibus, <lb/> quibus se aliter placiturum non putat, aut
+						aliquod <lb/> ab hominibus incommodum devitando, quorum offen<lb/>sionem aut
+						inimicitias reformidat, vult fieri christia<lb/>nus; non fieri vult potius
+						qunm fingere. Fides enim <lb/> non res est salutantis 1 corporis, sed
+						credentis animi. <lb/> Scd plane sæpe adest misericordia Dei pcr
+						ministe<lb/>rium catechizantis, ut sermone commotus jam fleri <lb/> velit
+						quod decreverat fingere : quod cum velle cœpe- <lb/> rit, tunc cum venisse
+						dcputcmus. Et occultum qui<lb/>dem nobis est quando 2 veniat animo, quem
+						jain <lb/> corpore præsentem videmus : sed tamen sic cnm co <lb/> debemus
+						agere, ut fiat in illo hæc voluntas, etiamsi <lb/> non est. Nihil enim
+						dcperit, quando si cst, utique <lb/> tali nostra actione firmatur, quamvis
+						quo tempore. <lb/> vcl qua hora cæperit, ignoremus. Utile est sane ut <lb/>
+						praemoncamur antea, si fieri potest, ab iis qui eum <lb/> norunt, in quo
+						statu animi sit, vel quibus causis <lb/> commotus ad suscipicndam religionem
+						venerit. Quod <lb/> si defuerit alius a quo id noverimus, etiam ipse in­
+						<lb/> terrogandus est, ut ex eo quod responderit ducamns <lb/> sermonis
+						exordium. Sed si ficto pectore accessit, <lb/> humana commoda cupicns , vel
+						incommoda fugiens, <lb/> utique mentiturus est : tamen es eo ipso quod
+						men<lb/>titur, capiendum est principium ; non ut refellatur <lb/> ejus
+						mendacium, quasi tibi certum sit, sed ut si <lb/> dixerit eo proposito se
+						venisse quod vere approban<lb/>dum est, sive ille verum sive falsum dicai,
+						tale ta<lb/>men propositum quali se vcnisse respondit, appro<lb/>bantes
+						atque laudantes, faciamus cum delectari esse <lb/> se talem, qualem videri
+						cupit. Si autem aliud dixerit, <lb/> quam oportet esse in animo ejus qui
+						christiana fide <lb/> imbuendus cst; blandius et lenius reprchendendo <lb/>
+						tanquam rudem et ignarum, et christianæ doctrinæ <lb/> finem vcrissimum
+						demonstrando atqne laudando <lb/> breviter et graviter, ne aut tempera
+						futuræ narratio<lb/>nis occupes, aut cam non prius collocato animo <lb/>
+						audeas imponere, facias eum velle quod ant per <note type="footnote"> 1
+							Editi Er. et Lov., <hi rend="italic">salvandi</hi>. Nonnulle codices,
+								<hi rend="italic">salutis</hi>. <lb/> Quidam, <hi rend="italic"
+								>saltantis</hi>. Sed plerique ac melioris notœ Mss. cunt <lb/>
+							editione. Am., <hi rend="italic">salutantis</hi> : id est, salutera sive
+							assensum <lb/> gestu significantis.</note>
+						<note type="footnote"> 2 Sic Am. Er. et Mss. At Lov., <hi rend="italic"
+								>quo</hi>.</note><lb/>
+						<pb n="317"/> errorem aut per simulationem nondum volebat.</p>
+				</div>
+				
+				<div type="textpart" subtype="chapter" n="6">
+					<p>10. <hi rend="italic">Exordium</hi> catechismi, <hi rend="italic">et
+							narratio</hi>
+						<lb/> ab <hi rend="italic">historia creationis mundi usque ad præsens tempus
+							<lb/> Ecclesia.</hi> Quod si forte se divinius admonitum vel <lb/>
+						territum esse responderit, ut fieret christianus, laetis<lb/>simum nobis
+						exordiendi aditum præbet, quanta Deo <lb/> sit cura pro nobis. Sane ab
+						bujusmodi miraculorum <lb/> sive somniorum, ad Scripturarum solidiorem viam
+						<lb/> et oracula certiora transferenda est ejus intentio; ut <lb/> et illa
+						admonitio quam misericorditer ei prærogata <lb/> sit, noverit antequam
+						Scripturis sanctis inhæreret. <lb/> Et utique demonstrandum est ei quod ipse
+						Dominus <lb/> non eum admoneret aut compelleret fieri christianum <lb/> et
+						incorporari Ecclesiae, seu talibus signis aut reve- <lb/> lationibus
+						erudiret, nisi jam preparatum iter in <lb/> Scripturis sanctis, ubi non
+						quæreret visibilia mira<lb/>cula, sed invisibilia sperare consuesceret,
+						neque <lb/> dormiens, sed vigilans moneretur, eum securius et <lb/> tutius
+						carpere voluisset. Inde jam exordienda narra<lb/>tio est, ab eo quod fecit
+						Deus omnia bona valde <lb/>
+						<hi rend="italic">(Gen.</hi> I), et perducenda, ut diximus, usque ad
+						præ<lb/>sentia tempora Ecclesiae : ita ut singularum rerum <lb/> atque
+						gestorum quæ narramus, causæ rationesque <lb/> reddantur, quibus ea
+						referamus ad illum finem dHe<lb/>ctionis, unde neque agentis aliquid neque
+						loquentis <lb/> oculus avertendus est. Si enim fictas poctarum fabu<lb/>las,
+						et ad voluptatcm I excogitatas animorum quo<lb/>rum cibus nugæ sunt, tamen
+						boni qui habentur <lb/> atquc appellantur grammatici, ad aliquam utilitatem
+						<lb/> referre conantur, quanquam et ipsam vanam et <lb/> avidam saginæ
+						saecularis; quanto nos decet esse <lb/> cautiores, ne illa quae vera
+						narramus, sine snarum <lb/> . causarum redditione digesta, aut inani
+						suavitate, <lb/> aut etiam perniciosa cupiditate credantur ? Non <lb/> tamen
+						sic asseramus has causas, ut relicto narratio<lb/>nis tractu, cor nostrum et
+						lingua in nodos diffici<lb/>liuris disputationis excurrat; sed ipsa veritas
+						adhi<lb/>bitæ rationis 2, quasi aurum sit gemmarum ordinem <lb/> ligans, non
+						tamen ornamenti sericin ulla immodera<lb/>tione perturbans.</p>
+				</div>
+				
+				<div type="textpart" subtype="chapter" n="7">
+					<p>11. <hi rend="italic">Resurrectio, judicium et alia <lb/> quædam post
+							narrationem intimanda.</hi> Narrtatione tini<lb/>t a, spes
+						resurrectionis intimanda est, et pro capaci<lb/>late ac viribus audientis,
+						proque ipsius temporis <lb/> modulo, adversus vanas irrisiones infidelium de
+						<lb/> corporis resurrectione tractandum, et futuri ultimi <lb/> judicii
+						bonitate in bonos, severitate in malos, veri<lb/>tate in omnes;
+						commemoratisque cum detestatione <lb/> et horrore poenis impiorum, regnum
+						justorum atque <lb/> fidelium et superna illa civitas ejusque gaudium <lb/>
+						cnm desiderio prædicandum est. Tum vero instrucn<lb/>da et animanda est
+						infirmitas hominis adversus <lb/> tentationes et scandala, sive foris sive
+						in ipsa intus <lb/> Ecclesia : foris adversus Gentiles vel Judaeos vel <lb/>
+						hæreticos; intus autem adversus areae dominicæ <note type="footnote"> 1 Am.
+							et plerique Mss., <hi rend="italic">voluntatem</hi>.</note>
+						<note type="footnote"> 2 Sic vetus codex Corheiensis. At Victorinus, <hi
+								rend="italic">adhibitæ</hi>
+							<lb/> narrationis. Editiones Am. et Er., <hi rend="italic">adhibita
+								rationi</hi>. Denique <lb/> Lov., <hi rend="italic">adhibita
+								rationis</hi>.</note>
+						<lb/> paleam. Nun ut contra singula perversorum genera <lb/> disputetur,
+						omnesque illorum pravæ opiniones pro<lb/>positis quæstionibus refellantur ;
+						sed pro tempore <lb/> brevi demonstrandum est ila esse prædictum, ct <lb/>
+						quæ sit utilitas tentationum erudiendis fidclibus, et <lb/> quae medicina in
+						exemplo patientiæ Dei, qai stamit <lb/> usque in tinem ista perinittere. Cum
+						veru adversus <lb/> . eos instruitur, quorum perversæ turbe corporaliter
+						<lb/> implent ecclesias, simul etiam præcepta breviter et <lb/> decenter
+						commemorentur christianæ atque honestæ <lb/> conversationis, ne ab ebriosis,
+						avaris, fraudatoribus <lb/> aleatoribus, adulteris, fornicatoribus,
+						spectaculorum <lb/> amatoribus, remcdiorum sacrilegurum alligatoribus, <lb/>
+						præcantatoribus, mathematicis, vel quarumlibet ar<lb/>tium vanarum et
+						malarum divinatoribus, atque hujus<lb/>modi cæteris ita facile seducatur, et
+						impunitum sibi <lb/> fore arbitretur, qnia videt multos qui christiani <lb/>
+						appellantur, hrec amare, et agere, ct defendere , et <lb/> suadere, et
+						persuadere. Quis enim finis præstitutus <lb/> sit in tali vita
+						perseverantibus, et quam sint in ipsa <lb/> Ecclesia tolerandi, ex qua in
+						finc separandi sunt, <lb/> divinorum Librorum testimoniis edocendum est.
+						<lb/> Prænuntiandum est etiam inventurum eum in Eccle<lb/>sia multos
+						christianos bonos , verissimos cives cæle<lb/>stis Jerusalem, si esse ipse
+						coeperit. Ad extremum <lb/> ne spes ejus in homine ponalur, sedulo monendus
+						<lb/> est : quia neque facile ab homine judicari potest <lb/> quis homo sil
+						justus; et si facile posset, non ideo <lb/> nobis proponi exempla justorum,
+						ut ab eis justifice<lb/>mur, sed ut eos imitantes ab eorum justificatore nos
+						<lb/> quoque justificari sciamus. Hinc enim fiet, quod ma<lb/>xime
+						commendandum est, ut cum ille qui nos audit, <lb/> imo per nos audit Deum,
+						moribus et scientia profi<lb/>cere coeperit, et viam Christi alacriter
+						ingredi, nee <lb/> nobis id audeat assignare, nee sibi; sed ct se ipsum,
+						<lb/> et no;, et quoscumque alios diligit amicos, in illu ct <lb/> propter
+						illum diligat, qui eum dilexit inimicum, ut <lb/> justificans faceret
+						amicum, Hic jam non te puto præ<lb/>ceptore indigere, ut cum occupata sant
+						tempora, vel <lb/> tua, vel eorum qui te audiunt, breviter agas; cum <lb/>
+						autem largiora, argius eloqualis : hoc euim nullo <lb/> admonente ipsa
+						necessitas præcipit.</p>
+				</div>
+				
+				<div type="textpart" subtype="chapter" n="8">
+					<p>12. <hi rend="italic">Eruditi quomodo catechizandi.</hi>
+						<lb/> Sed illud plane non prætereundum est, ut si ad te <lb/> quisquam
+						catechizandus venerit liberalibus doctrinis <lb/> excultus, qui jam
+						decreverit esse christianus, et ideo <lb/> venerit ut fiat, difficillimum
+						omnino cst ut hon multa <lb/> nostrarun, scripturarum litterarumque
+						cognoverit, <lb/> quibus jam instructus ad Sacramentorum
+						participa<lb/>tionem tantuminodo venerii. Tales enim non eadem <lb/> hora
+						qua christiani fiunt, sed ante solent omnia dili<lb/>genter inquircre, et
+						motus animi sui, cum quibus <lb/> possunt, communicare atque discutere. Cum
+						his ita<lb/>que breviter agendum est, et non odiose 1 inculcando <lb/> quæ
+						norunt. sed modeste perstringendo; ita ut dica<lb/>mus nos credere quod jam
+						noverint illud, atque <lb/> illud ; atque hoc modo cursim enumerare omnia
+						quæ <note type="footnote"> 1 Aliquot Mss., <hi rend="italic"
+							>otiose</hi>.</note><lb/>
+						<pb n="319"/> rudibus indoctisque inculcanda sunt : ut etsi quid <lb/> novit
+						eruditus iste, non tanquam a doctore audiat ; <lb/> ct si quid adhuc ignorat
+						1. dum ea commemoramus <lb/> quæ illum nosse jam credimus, discat. Noc ipse
+						sane <lb/> inutilter interrogatur, quibus rcbus motus sit ut <lb/> v lit sse
+						christianus : ut si libris ei persuasum I esse <lb/> videris, sive
+						canonicis. sive utilium tractatorum, de <lb/> bis :liquid in principio
+						loquaris, collaudans eos pro <lb/> diversitate meritorum canonicæ
+						auctoritatis et expo<lb/>nentium a solertissimæ diligentiæ ; maximeque com­
+						<lb/> mendans in Scripturis canonicis admirandæ altitudi<lb/>nis
+						saluberrimam humilitatem, in illis autempro <lb/> sua cujusque facultate
+						aptum superbioribus, et per <lb/> hoc infirmioribus animis, stilum
+						sonanlioris et quasi <lb/> tornatioris eloquii 4.Sane cHam exprimendum de
+						<lb/> ilio est ut iudicet quem maxime legerit, et quibus <lb/> libris
+						familiarius innæserit, undc illi persuasum est <lb/> ut sociari vellet
+						Ecclesiæ Quod cum dixerit, tum si <lb/> nobis noti sunl illi libri, aut
+						ecclesiastica fama saltem <lb/> accepimus a catholico aliquo memorabili viro
+						esse <lb/> conscriptos, læti approbemus. Si autem in alicujus <lb/> hæretici
+						volumina incurrit, et nesciens forte quod <lb/> vera fides improbat, tenuit
+						animo, et catholicum <lb/> esse arhitralur; sedulo edocendus est,
+						prælataaucto<lb/>ritate universalis Ecclesiæ aliorumque doctissimorum <lb/>
+						hominum el disputationibus ct scriptionibus in ejus <lb/> veriiale
+						florentium. Quanquam et illi qui catholici <lb/> ex bac vita migrarunt, et
+						aliquid litterarum christia<lb/>narum posteris reliquerunt, ill quibusdam
+						locis opu<lb/>seniorum suorum, vel non intellecti, vel sicuti est <lb/>
+						humana infirmitas, minus valentes acie mentis abdi­ <lb/> liora penetrare,
+						et veri similitudine aberrantes a <lb/> veritate, præsumptoribus et
+						audacibus fuerunt occa<lb/>sioni ad aliquam hæresim moliendam atque gignen­
+						<lb/> dam. Quod mirum non est, cum de ip is canonicis <lb/> Litteris, ubi
+						omnia sanissime dicta sunt, noH quidem <lb/> aliter accipiendo quædam, quam
+						vel scriptor sensit, <lb/> vul se ipsa veritas habet ; (nam si hoc solum
+						esset, <lb/> quis non humanae infirmitati ad corrigendum paratæ <lb/>
+						libenter ignosceret?) sed id quod perverse ac prave <lb/> op nati sunt,
+						animositate acerrima et pervicaci arro<lb/>gantia defensitantes, multi multa
+						pcruiciosa dogmata, <lb/> concisa communionis unitate pepererunt. Hæc omnia
+						<lb/> cum illo qui ad societatem populi christiani, non <lb/> idiota, ut
+						aiunt, sed doctorum libris expolitus atque <lb/> excultus accedit, modesta
+						collatione tractanda sunt: <lb/> tantum assumpta præcipiendi auctoritate, ut
+						caveat <lb/> præsumptionis errores ; quantum ejus humilitas quæ <lb/> illum
+						adduxit, jam sentitur admittere. Cætera vero <lb/> secundum regulas doctrinæ
+						salutaris, sive de fide, <lb/> quæcumque narranda vel disserenda sunt, sive
+						de <lb/> moribus, sive de tentationibus, eo modo percurrendo <lb/> quo dixi,
+						ad illati supereminentiorem viam omnia <lb/> rererenda sunt.</p>
+				</div>
+				
+				<div type="textpart" subtype="chapter" n="9">
+					<p>13. <hi rend="italic">Grammatici</hi> et <hi rend="italic">oratores quo</hi>
+						<note type="footnote"> 1 Editi, <hi rend="italic">et si quid forte adhuc
+								ignorat</hi>. Abest, <hi rend="italic">forte,</hi><lb/> a
+							Mss.</note>
+						<note type="footnote"> 2 Mss., <hi rend="italic">ut si libris eum
+								persuasum</hi>.</note>
+						<note type="footnote"> 3 Plures codices, <hi rend="italic">et ad
+								exponendum</hi>.</note>
+						<note type="footnote"> 4 Lov., <hi rend="italic">ornatioris</hi>
+							cloquii</note>.<lb/>
+						<hi rend="italic">modo tractandi. Vox ad aures Da. animi</hi> affectus. Sunt
+						<lb/> item quidam de scholis usitatissimis grammaticorum <lb/> oratorumque
+						venientes, quos neque inter idiotas nu<lb/>merare audeas, ncque inter illos
+						doctissimos, quorum <lb/> mens magnarum rerum cst exercitata quæstionibus.
+						<lb/> His ergo qui loquendi arte cæteris hominibus excel<lb/>lere videntur,
+						cum veniunt ut christiani fiant, hoc <lb/> amplius quam illis illitteratis
+						impertire dcbemus, quod <lb/> ' scdulo monendi sunt ut humilitate induti
+						christiana, <lb/> discant non conteminere quos cognoverint morum vi­ <lb/>
+						tia quam verborum amplius devitare; et cordi casto <lb/> linguam exercitatam
+						nec conferre 1 audeantv quam <lb/> etiam præferre consueverant. Maxime autem
+						isti do­ <lb/> cendi sunt Scripturas audire divinas, nc sordeat cis <lb/>
+						solidum eloquium, quia uon est inflatum ; neque ar<lb/>bitrentur carnalibus
+						integumentis involuta atque <lb/> operta dicta vel facta hominum, quæ
+						iniliis libris le<lb/>guntur, non evolvenda atque aperienda ut
+						intelligan<lb/>tur, sed sic accipienda ut litteræ sonant; deque ipsa <lb/>
+						utilitate secreti, unde etiam mysteria vocantur, quid <lb/> valeant
+						aenigmatum latebræ ad amorem veritatis <lb/> acuendum, decutiendumque 2
+						fastidii torporem, ipsa <lb/> experientia probandum est talibus, cum aliquid
+						eis <lb/> quod in promptu positum non ita movebat, enoda<lb/>tione allegoriæ
+						alicujus eruitur. Ilis enim maxime <lb/> utile cst nosse, ita esse
+						præponendas verbis senten<lb/>tias, ut præponituranimus corpori. Ex quo fit
+						ut ita <lb/> malle debeant veriores quam disertiores audire ser­ <lb/>
+						mones, sicut malle debeut prudentiores, quant for<lb/>mosiores habere
+						amicos. Noverint etiam non esse vo<lb/>cem ad aures Dei, nisi animi affectum
+						: ita enim non <lb/> irridebunt, si aliquos antistites et ministres Ecclesiæ
+						<lb/> forte animadverterint, vel cum barbarismis et solœ<lb/>cismis Dcum
+						invocare, vel cadem verba quæ pronun- <lb/> tiant non intelligere,
+						perturbateque distinguere. Non <lb/> quia ista minime corrigenda sunt, ut
+						populus ad id <lb/> quod plane intelligit, dicat Amen; sed tamen pie
+						to<lb/>leranda sunt ab eis qui didicerint, ut sono in foro, sic <lb/> volo
+						in Ecclesia benedici. Itaque forensis illa nonnum. <lb/> quam forte bona
+						dictio, nunquam tamen Ienedictio <lb/> dici potest. De Sacramento autem quod
+						accepturi <lb/> suni, sufficit prudentioribus audirc quid res illa
+						si<lb/>gnificet : cum tardioribus autem aliquanto pluribus <lb/> verbis et
+						similitudinibus agendum est, ne conteninant <lb/> quod vident.</p>
+				</div>
+				
+				<div type="textpart" subtype="chapter" n="10">
+					<p>14. <hi rend="italic">Jam de hilaritate comparanda.<lb/> Causæ</hi> sex <hi
+							rend="italic">lædium afferentes catechizanti. Remedium <lb/> contra
+							primam causam tædii.</hi> Hic tu fortasse exem­ <lb/>
+						<lb/> plum aliquod sermonis desideras, ut ipso tibi opere <lb/> ostendam
+						quomodo facienda sint ista quæ monni. <lb/> Quod quidem faciam, quantum
+						Domino adjuvante po­ <lb/> tuero : sed prius de iila hilaritate comparanda,
+						quod <lb/> pollicitus sum, dicere dehco. Jam euim de ipsis prae. <lb/>
+						ceptis explicandi sermonis, in catechizando eo qui <lb/> sic verit ut
+						christianus fiat, quantum satis visum cst, <lb/> quod promiseram exsolvi.
+						Indebitum quippe eat, ut <note type="footnote"> 1 Præcipui Mss., <hi
+								rend="italic">linguam exercitam nec conferre</hi>.</note>
+						<note type="footnote"> 2 Sic plures Mss. At editi, <hi rend="italic"
+								>discutiendumque</hi>.</note><lb/>
+						<pb n="321"/> etiam ipse faciam in hoc volumine, quod fieri oportere <lb/>
+						praecipio. Si ergo fecero, ad cumulum valebit : cu<lb/>mulus autem quo pacto
+						a me superfundi potest, an<lb/>tequam mensuram debiti explevero ? Neque enim
+						te <lb/> maxime conqueri audivi, nisi qnod tibi sermo tuus <lb/> vilis
+						abjectusquc videretur, cum aliqucm christiano <lb/> nomine imbuercs. Hoc
+						autem scio, non tam rerum <lb/> quae dicendæ sunt, quibus te satis novi
+						paratum et <lb/> instructum, neque ipsius locutionis inopia, sed animi <lb/>
+						tædio fieri; vel illa causa quam dixi, quia magis nos <lb/> delectat ct
+						tenet, quud in silentio mente cernimus, <lb/> nec inde volumus avocari ad
+						verborum longe dispa<lb/>rem strepitum; vel quia etiam cum sermo jucundus
+						<lb/> est, magis nos libet audire aut legere quæ melius di<lb/>cia sunt, et
+						quae sine nostra cura et sollicitudine pro<lb/>muntur, quam ad alienum
+						sensum repentina verba <lb/> coaptare incerto exitu, sive utrum occurrant
+						pro sen<lb/>tentia, sive ulrum accipiantur utiliter; vel quia illa <lb/> quæ
+						rudibus insinuantur, eo quod nohis notissima <lb/> sunt, et provectui nostro
+						jam non necessaria, piget <lb/> ad ea sæpissime redire, nec in eis tam
+						usitatis et tan<lb/>quam infantilibus cum aliqua voluptate jam gran­ <lb/>
+						disculus anianus graditur. Facit etiam loquenti tae<lb/>dium auditor
+						[immobilis vel quia non movetur affe<lb/>ctn, vel quia nullo motu corporis
+						iudicat se intelligere <lb/> vel sibi placere quæ dicuntur1 ] : non quia
+						humanæ <lb/> laudis nos esse avidos decet, sed quia ea quæ mini<lb/>stramus
+						Dei sunt; et quanto magis diligimus eos qui­ <lb/> bus loquimur, tanto magis
+						eis cupimus ut placeant <lb/> quæ ad corum porriguntur salutem : quod si non
+						suc<lb/>cedit, contristamur, et in ipso cursu debilitamur et <lb/>
+						frangimur, quasi frustra operam conteramus. Nun<lb/>nunquam etiam cum
+						avertimur ab aliqua re quam <lb/> desideramus agere, et cujus actio aut
+						delectabat nos, <lb/> aut magis nobis necessaria videbatur, et cogimur aut
+						<lb/> jussu ejus quem offendere nolumus, aut aliquorum <lb/> inevitabili
+						instantia catechizare aliquem jam contur­ <lb/> bati accedimus ad negotium,
+						cui magna tranquillitate <lb/> opus est, dolentes qnod ncque ordinem
+						actionum no<lb/>bis conceditur tenere quem volumus, nee sufficere <lb/>
+						omnibus possumus : atque ita ex ipsa tristitia sermo <lb/> procedens minus
+						gratus est, quia de ariditate mœsti<lb/>tiae minus exuberat. Aliquando item
+						ex aliquo scan­ <lb/> dalo mœror pectus obsedit2, et tunc nobis dicitur,
+						<lb/> Venit loquere huic; christianus vult fieri. Dicitur 2 <lb/> enim ab
+						ignorantibus quid nos clausumintus exurat: <lb/> quibus si affectum nostrum
+						aperire non oportet, <lb/> suscipimus ingratius quod volunt '; et
+						profectolan<lb/>guidus et insuavis ille sermo erit pcr venam cordis <lb/>
+						aestuantem fumantemque trajectus. Tot igitur ex cau<lb/>sis, quælibet earum
+						serenitatem nostra; mentis obnu<lb/>bilet, secundum Deum sunt quxrenda
+						remedia, qui­ <lb/> bus relaxetur illa contractio, et fervore spiritus
+						ex<lb/>suitemus et jucundemur in tranquillitate botri operis. <note
+							type="footnote"> 1 Verba hic uncis inclusa absunt a plerisque Mss. et ab
+							<lb/> Am. Er.</note>
+						<note type="footnote"> 2 Editi, <hi rend="italic">obsidet</hi>. At Mss., <hi
+								rend="italic">obsedit</hi>.</note>
+						<note type="footnote"> 3 Sola editio Lov., <hi rend="italic"
+							>nescitur</hi>.</note>
+						<note type="footnote"> 4 Plures Mss., <hi rend="italic">suscripimus ingrati
+								quod volunt</hi>.</note><lb/>
+						<hi rend="italic">Hilarem enim datorem diligit Deus</hi> (Il Cor. ix,
+						7).</p>
+					<p>15. Si enim causa illa contristat, quod intellectum <lb/> nostrum auditor non
+						capit, a cujus cacumine quodam <lb/> modo descendentes cogimur in syllabarum
+						longe in<lb/>fra distantium tarditate demorari, et curam gerimus <lb/>
+						quemadmodum longis et per plexis anfractibus proce<lb/>dat ex ore carnis,
+						quod celerrimo haustu mentis im­ <lb/> bibitur, et quia multum dissimiliter
+						exit, tædet loqui, <lb/> et libet tacere; cogitemus quid nobis prærogatum
+						sit <lb/> ab illo qui demonstravit nobis exemplum, ut sequa­ <lb/> mur
+						vestigia'ejus ( I <hi rend="italic">Petr.</hi> II, 21). Quantumvis enim
+						<lb/> difierat articulata vox nostra aC intelligentiæ nostræ <lb/>
+						vivacitate, longe differentior est mortalitas carnis "b <lb/> æqualitate
+						Dei. Et tamen cum in eadem <hi rend="italic">forma esset,<lb/> temetipsum
+							exinanivit formam servi accipiens,</hi> etc., us<lb/>que ad <hi
+							rend="italic">(a)</hi> mortem <hi rend="italic">crucis</hi> ( <hi
+							rend="italic">Philipp.</hi> II, 6-8). Quam ob <lb/> causam, nisi quia
+						factus est infirmis infirmis,;ut in<lb/>firmos lucrificaret ( I <hi
+							rend="italic">Cor.</hi> IX, 22 ) ? Audi ejus imita<lb/>torem alibi etiam
+						dicentem : <hi rend="italic">Sive</hi> enim <hi rend="italic">mente
+							excessi­</hi>
+						<lb/> mus, <hi rend="italic">Deo; sive temperantes</hi> sumus, <hi
+							rend="italic">vobis. Charitas enim<lb/> Christi compellit nos,
+							judicantes hoc, quia unus pro</hi> om­ <lb/>
+						<hi rend="italic">nibus mortuus eat</hi> (II <hi rend="italic">Cor.</hi> v,
+						13 <hi rend="italic">et</hi> 14). Quomodo enim <lb/> paratus esset impendi
+						pro animabus eorum <hi rend="italic">( Id. XII,</hi>
+						<lb/> 15), si eum pigeret inclinari ad aures eorum? Hinc <lb/> ergo factus
+						est parvulus in medio nostrum, tanquam <lb/> nutrix fovens filios suos (I
+							<hi rend="italic">Thess.</hi> II, 7). Num enim <lb/> delectat, nisi amor
+						invitet, decurtata et multilata ver<lb/>ba immurmurare? Et tamen optant
+						homines babere <lb/> infantes, quibus id exhibeant : et suavius est matri
+						<lb/> minuta mansa inspuere parvulo filio, quam ipsam <lb/> mandere ac
+						devorare grandiora. Non ergo recedat de <lb/> pectore etiam cogitatio
+						gallinae illius, quæ languidu<lb/>lis plumis teneros fetus operit, et
+						susurrantes pullos <lb/> confracta voce advocat; cujus blandas alas
+						refugien<lb/>tcs superbi, præda fiunt alitibus ( Matth. XXIII, 37). <lb/> Si
+						enim intellectus delectat in penetralibus sinceris<lb/>simis, hoc cHam
+						intelligere delci tat, quomodo chari­ <lb/> tas, quanto officiosius
+						descendit in infima, tanto ro<lb/>bustius recurrit in intima per bonam
+						conscientiam <lb/> nihil quærendi1 ab eis ad quos descendit, præter eo­
+						<lb/> rum sempiternam salutem.</p>
+				</div>
+				
+				<div type="textpart" subtype="chapter" n="11">
+					<p>16. <hi rend="italic">Remedium contra secundumtœdii<lb/> causam.</hi> Si
+						autem niagis appetimus, ea quæ jam parata <lb/> sunt et melius dicta legere
+						vel audire, et ideo piget <lb/> inecrto exitu ad tempus coaptare quae
+						loquimur : tan<lb/>tum a veritnte rerum non aberret animus, facile est <lb/>
+						ut si in verbis auditorem aliquid offenderit, ex ipsa <lb/> occasione discat
+						quam sit re intellectacontemnen<lb/>dum, si minus integre, aut si minus
+						propric sonare <lb/> potuit, quod ideo sonabat ut res intelligeretur Quod
+						<lb/> si humanæ infirmitatis intentio enam ab ipsa reruni <lb/> veritate
+						aberraverit; quanquam in catechizandis ru<lb/>dibus, ubi via tritissima
+						tenenda est, difficile potest <lb/> accidere : tamen ne forte accidat ut
+						ctiam hinc offen<lb/>datur auditor, non aliunde nohis debet vidcri
+						acci<lb/>disse, nisi quia Deus experi ..os voluit, utrum cum <note
+							type="footnote"> 1 Sic Mss. Editi vero, <hi rend="italic">nihil
+								quærendo</hi>.</note>
+						<note type="footnote"> (a) Istæ voces, etc., <hi rend="italic">usque
+							ad</hi>, librarii sunt prætereuntis, <lb/> ut solet, verba intermedia
+							citati loci.</note><lb/>
+						<pb n="323"/> mentis placiditate corrigamur, ne in defensionem IIO<lb/>stri
+						erroris majore præcipitemur errore. Quod si ne<lb/>mo nobis dixerit, nosque
+						et illos qui audierunt omni- <lb/> IIO latuerit, nullus dolor est, si non
+						fiat iterum. Ple­ <lb/> rumque antem nos ipsi recolentes quae
+						dixeri<lb/>mus, reprehendimus aliquid, et ignoramus quo<lb/>modo cum
+						diceretur acceptum sit; magisque do<lb/>lemus, quando in nobis fervet
+						charitas , si cum <lb/> falsum esset, libenter acceptum est. Ideoque op­
+						<lb/> portunitate reperta , sicut nos ipsos in silentio re<lb/>prehendimus,
+						ita curandum est ut etiam illi sensim <lb/> corrigantur, qui non Dei verbis,
+						sed plane nostris in <lb/> aliquam lapsi sunt falsitatem. Si vero aliqui
+						livore ve<lb/>sano cæci errasse nos gaudent, susurrones, detracto<lb/>res,
+						Deo odibiles <hi rend="italic">( Rom.</hi> i, 50); præbcant nobis
+						ma<lb/>teriam exercendæ patientiæ cum misericordia, quia <lb/> et patientia
+						Dei ad poenitentiam eos adducit. Quid <lb/> enim est detestabilius, et quod
+						magis thesaurizet <lb/> iram in die iræ et revelationis justi judicii Dei <lb/>
+						<hi rend="italic">(Id.</hi> n, 4 <hi rend="italic">et</hi> 5), qnam de malo
+						alterius mala1 diaboli si<lb/>militudine atque imitatione laetari?
+						Nonnunquam <lb/> etiam, cum rectc omnia vereque dicantur, aut non <lb/>
+						intellectum aliquid, aut contra opinionem et consue<lb/>tudinem vetcris
+						erroris ipsa novitate asperum, of<lb/>fendit et perturbat audientem. Quod si
+						apparuerit, <lb/> sanabilemque se præbet, auctoritatum rationumque <lb/>
+						copia sine ulla dilatione sanandus est. Si autem tacita <lb/> et occulta
+						offensio est, Dei medicina opitulari potest. <lb/> At si resiluerit2, et
+						curari recusaverit, consoletur <lb/> nos dominicum illud exemplum, qui
+						offensis homi­ <lb/> nibus ex verbo suo, et tanquam durum refugientibus,
+						<lb/> etiam iis qui remanserant ait, <hi rend="italic">Numquid et vos
+							vultis<lb/> ire (Joan.</hi> vi, 68)? Salis enim fixum atque
+						immo<lb/>bile debet corde retineri, Jerusalem captivam ab hu<lb/>jus saeculi
+						Babylonia decursis temporibus liberari, <lb/> nullumque ex illa esse
+						periturum; quia qui perierit, <lb/> non ex illa erat. <hi rend="italic"
+							>Firmum</hi> enim <hi rend="italic">fundamentum Dei stat, <lb/> habens
+							signaculum hoc</hi> : novit <hi rend="italic">Dominus</hi> qui <hi
+							rend="italic">sunt ejus ; <lb/> et recedat ab iniquitate, omnis</hi> qui
+							<hi rend="italic">nominat</hi> nomen <hi rend="italic">Do­</hi>
+						<lb/> mini ( II Tim. II, 19). Ista cogitantes , ct invocantes <lb/> Dominum
+						in cor nostrum, minus timebimus incertos <lb/> exitus sermonis nostri
+						propter incertos motus audito<lb/>rum; delectabitque nos etiam ipsa
+						perpessio mole<lb/>stiarum pro misericordi opere, si non in eo nostram <lb/>
+						gloriam rcquirainus. Tunc enim est vere opus bo<lb/>num, cum a charitate
+						jaculatur agentis intentio, et <lb/> tanquam ad locum suum rediens, rursus
+						in charitate <lb/> requiescit. Lectio vero quæ nos delectat, aut aliqua
+						<lb/> . auditio melioris eloquii, ut eam promendo, sermoni <lb/> nostro
+						præponere volentes, cum pigritia vel tædio lo<lb/>quamur, alacriores nos
+						suscipiet; jucundiorqne prae. <lb/> stabitur post laborem; et majore fiducia
+						deprecabimur <lb/> ut loquatur nobis Deus quomodo volumus , si
+						susci<lb/>piamus hilariter ut loquatur per nos quomodo possu<lb/>mus : ita
+						lit ut diligentibus Deum omnia concurrant <lb/> in bonum (Rom. VIII,
+						28).</p>
+				</div>
+				
+				<div type="textpart" subtype="chapter" n="12">
+					<p>17. <hi rend="italic">Remedium contra tertiam</hi> causam <note
+							type="footnote"> 1 Ita in Mss. At in editis, <hi rend="italic"
+							>mera</hi>.</note>
+						<note type="footnote"> 2 Editi, <hi rend="italic">resilierit</hi>.
+							Præstantiores Mss. <hi rend="italic">resiluerit</hi>.</note><lb/>
+						<hi rend="italic">tædii.</hi> Jam vcro si usitata et parvulis congruentia
+						<lb/> sæpe rcpetere faslidimus; congruamus eis per fra<lb/>ternum, paternum,
+						maternumque amorem, et copu<lb/>latis cordi eorum etiam nobis nova
+						videbuntur. Tan<lb/>tum enim valet animi compatientis affectus, ut cum <lb/>
+						illi afficiuntur nohis loquentibus, et nos illis discenti<lb/>bus, habitemus
+						in invicem; atque ita et illi quæ au. <lb/> diunt quasi loquantur in nobis,
+						et nos in illis disca - <lb/> mus quodam modo quæ docemus. Nonne accidere
+						hoc <lb/> solet, cum loca quaedam ampla et pulchra, vel urbium <lb/> vel quæ
+						jam nos sæpe videndo sinealiquavo<lb/>luptate præteribamus, ostendimus eis
+						qui antea nun<lb/>quam viderant, ut nostra delectatio in eorum
+						novita<lb/>tatis delectatione rcnovetur? Et tanto magis, quanto <lb/> suut
+						amiciores; quia per amoris vinculum in quan<lb/>tum in illis sumus, in
+						tantum et nobis nova Dunt quae <lb/> vetera fuerunt. Sed si in rebus
+						contemplandis ali<lb/>quantum profccimus, non volumus cos quos diligimus
+						<lb/> lætari et stupere, cum intuentur opera manuum ho- <lb/> minum; sed
+						volumus eos in ipsam artem 1 consilium<lb/>ve institutoris attollere, atque
+						inde exsurgere in ad<lb/>miralionem laudemque omnicreantis Dei, ubi amoris
+						<lb/> fructuosissimus finis est: quanto ergo magis delectari <lb/> nos
+						oportet, cunt ipsum Deum jam discere homines <lb/> accedunt, propter quem
+						discenda sunt quæcumque <lb/> discenda sunt; et in eorum novitate innovari,
+						ut si <lb/> frigidior est solita I nostra praedicatio, insolita eo<lb/>rum
+						auditione fervescat? Huc accedit ad comparan­ <lb/> dam laetitiam, quod
+						cogitamus et consideramus, de <lb/> qua erroris morte in vitam fidei
+						transeat homo. Et si <lb/> vicos usitatissimos cum benefica hilaritate
+						transimus , <lb/> quando alicui forte qui errando laboraverat,
+						demon<lb/>stramus viam : quanto alacrius et cum gaudio majo<lb/>re in
+						doctrina salutari, etiam illa quæ propter nos re­ <lb/> texere nou opus est,
+						perambulare debemus; cum <lb/> animam miserandam et crroribus sacculi
+						fatigatam <lb/> per itinera pacis, ipso qui nobis eam I praestitit ju­ <lb/>
+						bente3, deducimus?</p>
+				</div>
+				
+				<div type="textpart" subtype="chapter" n="13">
+					<p>18. <hi rend="italic">Remedium contra</hi> quartam <hi rend="italic"
+							>causam<lb/> fastidii. Auditor veI audiendo vel stando</hi> fatigatus,
+							<hi rend="italic">quo<lb/>modo recreandus. Usus audiendi verbum Dei
+							sedendo,<lb/> in quibusdam</hi> Ecclesiis <hi rend="italic"
+							>receptus.</hi> Sed revera multum <lb/> est perdurare in loquendo usque
+						ad terminum præ. <lb/> stitutum, cum moveri non videmus audientem; quod
+						<lb/> sive nou audeat, religionis timore constrictus , voce <lb/> aut aliquo
+						motu corporis significare approbationem <lb/> suam, sive humana verecundia
+						reprimatur; sive di<lb/>cta nou intelligat, sive contemnat: quandoquidem
+						<lb/> nobis non cernentibus auimum ejus incertum est, <lb/> omnia sermone
+						tentanda sunt, quae ad eum excitan<lb/>dum et tanquam de latebris eruendum
+						possint valere. <lb/> Nam et timor nimius atque impediens declarationem
+						<lb/> judicii ejus, blanda exhortatione pellendus est, et <lb/> insinuando
+						fraternam societatem verecundia tempe<lb/>randa, et interrogatione quærendum
+						utrum intelligat, <lb/> et danda fiducia, ut si quid ei contradiccudum vide
+							<note type="footnote"> 1 Editi, <hi rend="italic">arcem</hi>. Aptius
+							Mss., <hi rend="italic">artem</hi>.</note>
+						<note type="footnote"> 2 Sic Am. et plerique Mss. At Er. et Lov., <hi
+								rend="italic">solito</hi>.</note>
+						<note type="footnote"> 3 Codex Corbeiensis, ea,</note><lb/>
+						<pb n="325"/>tur, libere proferat. Quaerendam etiam de illo utrum <lb/> hæc
+						aliquando jam audierit, et fortassis eum tanquam <lb/> nota et pervulgata
+						non moveant; et agendum pro ejus <lb/> responsione, ut aut planius et
+						enodatius loquamur, <lb/> aut opinionem contrariam refellamus, aut ea quæ
+						illi <lb/> nota sunt uon explicemus latius, sed breviter com<lb/>plicemus,
+						eligamusque aliqua ex bis quæ mystice <lb/> dicta sunt in sanctis Libris, et
+						maxime in ipsa nar<lb/>ratione, quae aperiendo et revelando noster sermo
+						<lb/> dulcescat. Quod si nimis tardus est, et ab omni tali <lb/> suavitate
+						absurdus et aversus, misericorditer suffe<lb/>rendus est, breviterque
+						decursis cæteris, ea quæ ma<lb/>sime necessaria sunt, de unitate Catholicæ
+						de ten­ <lb/> tationibns, de christiana conversatione propter futu<lb/>rum
+						judicium terribiliter inculcanda sunt, magisque <lb/> pro illo ad Deum, quam
+						illi de Deo multa dicenda.</p>
+					<p>49. Saepe etiam fit ut qui primo libenter audiebat, <lb/> vel audiendo vel
+						stando fatigatus, non jam laudans, sed <lb/> oscitans labia diducat, et se
+						abire velle etiam invitus <lb/> ostendat. Quod ubi senserimus, aut renovare
+						oportet <lb/> ejus animum, dicendo aliquid honesta hilaritate con<lb/>ditum
+						et aptum rei quæ agitur, vel aliquid valde mi<lb/>randum et stupendum, vel
+						etiam dolendum atque <lb/> plangendum; et magis de ipso, ut propria cura
+						pun<lb/>cius evigilet; quod tamen non offendat ejus verecun­ <lb/> diam
+						asperitate aliqua, sed potius familiaritate con<lb/>ciliet ; aut oblata
+						sessione I succurrere ; quanquam <lb/> sine dubitatione melius fiat, ubi
+						decenter fieri potest, <lb/> ut a principio sedens audiat; longeque
+						consultius in <lb/> quibusdam Ecclesiis transmarinis non solum
+						antisti<lb/>tes sedentes loquuntur ad populum, sed ipsi eliam <lb/> populo
+						sedilia subjacent, ne quisquam infirmior stan<lb/>do lassatus a saluberrima
+						intentione avertatur, aut <lb/> etiam cogatur abscedere. Et tamen multum
+						interest, <lb/> si se quisquam de magna multitudine subtrahat ad <lb/>
+						reparandas vires, qui jam sacramentorum societate <lb/> devinctus est; et si
+						ille discedat (quod plerumque in<lb/>evitabiliter urgetur, ne interiore
+						defectu victus etiam <lb/> cadat) qui primis sacramentis imbuendus est: et
+						pu<lb/>dore enim non dicit cur eat, et imbecillitate stare nou <lb/>
+						sinitur. Expertus hæc dico: nam fecit hoc quidam , <lb/> cum eum
+						catechizarem, homo rusticanus , unde ma<lb/>gnopere praecavendum esse
+						didici. Quis enim ferat <lb/> arrogantiam nostram, cum viros' fralres
+						nostros, <lb/> vel eliam quod majore solliciludine curandum est, ut <lb/>
+						sint fratres nostri, coram nobis sedere non facimus ; <lb/> et ipsum Dominum
+						nostrum, cui assistunt Angeli, <lb/> sedens mulier audiebat <hi
+							rend="italic">(Luc.</hi> x, 59)? Sane si aut <lb/> brevis sermo futurus
+						est, aut consessui locus non est <lb/> aptus, stantesaudiant; sed cum multi
+						audiunt, et <lb/> non tunc initiandi \ Nam cum unus , aut duo, aui <lb/>
+						pauci, qui propterea venerunt ut christiani fiant, pe<lb/>riculose loquimur
+						stantibus. Tamen si jam sic cœpi- <lb/> mos. saltem animadverso auditoris
+						tædio, et offe<lb/>renda sessio est, iuto vero prorsus urgendus ut sedeat,
+							<note type="footnote"> 1 Lov., <hi rend="italic">Catholicæ fidei</hi>
+							Editi vero alii et plerique Mss. <lb/> non habent, <hi rend="italic"
+								>fidei :</hi> pro quo subaudiri debet, Ecclesiæ.</note>
+						<note type="footnote"> 2 Apud Lov. additur, <hi rend="italic">studeat</hi>.
+							Sed subaudiendum, <hi rend="italic">oportet</hi>.</note>
+						<note type="footnote"> 3 Nonnulli Mss., <hi rend="italic">veros</hi>.</note>
+						<note type="footnote"> 4 Sola editio Lov., pro, tunc, habet, <hi
+								rend="italic">sunt</hi>.</note>
+						<lb/> et dicendum aliquid quo renovetur, quo etiam curas, <lb/> si qua forte
+						irruens eum avocare coeperat, fugiat ex <lb/> animo. Cum enim causæ incertæ
+						sint cur jam tacitus <lb/> recuset audire, jam sedenti aliquid adversus
+						inciden<lb/>tes cogitationes sæcularium negotiorum dicatur, aut <lb/>
+						hilari, ut dixi, aut tristi modo : ut si ipsae sunt quae <lb/> mentem
+						occupaverunt, cedant quasi nominatim ac<lb/>cusatæ; si autem ipsæ non sunt,
+						et audicndo fatiga<lb/>tus cst, cum de illis tanquam ipsæ sint
+						(quandoqui<lb/>dem ignoramus), inopinatum aliquid et extraordiua<lb/>rium,
+						eo modo quo dixi, loquimur, a tædio renovatur <lb/> intentio. Sed et breve
+						sit, maxime quia extra ordinem <lb/> inseritur, ne morbum fastidii cui
+						subvenire volumus <lb/> eliam augeat ipsa medicina: et acceleranda sunt
+						cætera, <lb/> et promittendus atque exhibendus finis propinquior.</p>
+				</div>
+				
+				<div type="textpart" subtype="chapter" n="14">
+					<p>20. <hi rend="italic">Remedium adversus quintam <lb/> causam lædii. Remedium
+							contra</hi> sextam <hi rend="italic">causam tædii. <lb/> ltem adversus
+							causam sextam.</hi> Si autem confregit ani<lb/>mum tuum alterius
+						actionis, cui tanquam magis ne<lb/>cessariae jam suspensus eras, omissio, et
+						propterea <lb/> tristis insuaviter catechizas; cogitare debes, excepto <lb/>
+						quod scimus misericorditer nobis agendum esse quid<lb/>quid cum hominibus
+						agimus, et ex officio sinceris<lb/>simae charitatis; hoc ergo excepto,
+						incertum esse <lb/> quid utilius agamus, et quid opportuniys aut
+						inter<lb/>mittamus, aut omnino omittamus. Quia enim merita <lb/> hominum pro
+						quibus agimus, qualia sint apud Deum <lb/> non novimus, quid eis ad tempus
+						expediat aut nulla <lb/> aut tenuissima aut incertissima conjectura
+						suspicamur <lb/> potius , quam comprehendimus. Quapropter res qui<lb/>dem
+						agendas pro nostro captu ordinare debemus: <lb/> quas eo modo quo statuimus,
+						si peragere potuerimus, <lb/> non ideo gaudeamus quia nobis, sed quia Deo
+						sic eas <lb/> agi placuit : si autem aliqua inciderit necessitas, qua <lb/>
+						noster ille ordo turbetur; flectamur facile, ne fran- <lb/> gamur; ut quem
+						Deus nostro (a) praeposuit, ipse sit no<lb/>ster. Æquius est enim ut nos
+						ejus, quam ut ille no<lb/>stram voluntatem sequatur. Quia et ordo agendarum
+						<lb/> rerum, quem nostro arbitrio tenere volumus, ille uti<lb/>que
+						approbandus est, ubi jotiora præcedunt. Cur <lb/> ergo nos dolemus homines a
+						Domino Deo tanto po<lb/>tiore præcedi, ut eo ipso quo nostrum amamus
+						ordi<lb/>nem, inordinati esse cupiamus? Nemo enim melius or<lb/>dinat quid
+						agat, nisi qui paratior est non agere quod <lb/> divina potestate
+						prohibetur, quam cupidior agere <lb/> quod humana cogitatione meditatur.
+						Quia <hi rend="italic">multæ</hi> co<lb/>gitationes sunt <hi rend="italic"
+							>in corde viri,</hi> consilium <hi rend="italic">autem Domim <lb/> manet
+							in æternum (Prov.</hi> xix, 21).</p>
+					<p>21. Si vero ex aliquo scandalo perturbatus animus <lb/> non valet edere
+						serenum jucundumque sermonem, <lb/> tantam esse charitatem oportet in cos
+						pro quibus <lb/> Christus mortuus est, volens eos pretio sanguinis sai <lb/>
+						ab errorum saecularium niorte redimere; at hoc ipsum <lb/> quod nobis
+						tristibus nuntiatur, præsto esse aliquem <lb/> quidesiderct fieri
+						christianus, ad consolationem illius <lb/> resolutionemque tristitiae valere
+						debeat, sicut solent <lb/> lucrorum gaudia dolorem lenire damnorum. Non
+						<lb/> cnitn scandalum nos contristat alicujus, nisi quem <note
+							type="footnote"> (a) Subaudiendum, <hi rend="italic">ordini</hi>.</note><lb/>
+						<pb n="327"/> perire aut pcr quem perire infirmam vel credimus <lb/> vel
+						videmus. Ille igitur qni initiandus advenit, dum <lb/> speratur po se
+						proficere, dolorem deficientis abster<lb/>gat. Quia «t si timor ille
+						suggeritur, lie fiat proselytus <lb/> filius gehennæ <hi rend="italic"
+							>(Matth.</hi> XXIII, 15), dum mulli tales <lb/> versantur ante oculos,
+						ex quibus oriuntur ca quibus <lb/> urimur .caudata, non ad retardandos nos
+						pertincre <lb/> debet, sed magis ad excitandos et acuendos : quale<lb/>nns
+						quem imbuimus moneamus, ut caveat imitatio<lb/>nem eorum qui non ipsa
+						veritate, sed solo nomine <lb/> christiani sunt; nec eorum turba commotus,
+						aut <lb/> sectari velit eos, aut Cbristum nolit sectari propter <lb/> eos;
+						et aut nolit esse in Ecclesia Dei uhi illi sunt, <lb/> aut talis ibi velit
+						esse quales illi sunt. Et nescio quo<lb/>modo in hujusmodi monitis 1
+						ardentior sermo est, <lb/> cui fomitem subministrat præsens dolor : ut non
+						so<lb/>lum pigriorcs non simus, sed co ipso dicamus accen<lb/>sitis atque
+						vehementius, quod securiores frigidius et <lb/> lentius diceremus;
+						gaudeamusque nobis occasionem <lb/> dari, ubi motus animi nostri sinc
+						fructificatione non <lb/> transeat.</p>
+					<p>22. Si autem de aliquo errato nostro vel peccato <lb/> nos moestitudo
+						comprehendit, non tantum memine<lb/>rimus sacrificium Deu spiritum esse
+						contribulatum <lb/>
+						<hi rend="italic">(Ptal.</hi> L, 19), sed etiam illud, <hi rend="italic"
+							>Quia sicut aqua ignem,<lb/> sic eleemosyna exstinguit peccatum
+							(Eccli.</hi> III, 33); et, <lb/>
+						<hi rend="italic">Quia misericordiam</hi>, inquit, <hi rend="italic">volo
+							quam sacrificium</hi> 2 <lb/>
+						<hi rend="italic">(Osee</hi> vi, 6). Sicut ergo si periclitaremUr incendio,
+						ad <lb/> aquam uti'tue curreremus, quo posset exstingui, et <lb/>
+						gratularemur si quis eam de proximo offerret; ita si <lb/> de nostro feno
+						aliqua peccati flamma surrexitJ, et <lb/> propterea conturbamur, data
+						occasione misericordis<lb/>simi operis, tanquam de oblato fonte gaudeamus,
+						ut <lb/> inde illud quod exarserat opprimatur. Nisi forte tam <lb/> Stulti
+						sumus, ut alacrius arbitremur cum pane cur<lb/>rendum, quo ventrem
+						esurientis impleamus, quam <lb/> cum verbo Dei, quo mentem istud edentis '
+						instrua<lb/>mus. lluc accedit , quia si tantummodo prodesset <lb/> hoc
+						facere, non facere autem nibil obesset; infeliciter <lb/> in periculo
+						salutis, non jam proximi, sed nostræ, <lb/> oblatum remedium sperneremus.
+						Cum vero ex ore <lb/> Domini tam minaciter sonet, <hi rend="italic">Serve
+							nequam et piger,<lb/> dares pecuniam meam nummulariis (Matth.</hi> xxv,
+						26, <lb/> 27); quæ tandem dementia est, quoniam peccatum <lb/> nostrum nos
+						angit, ideo rursus velle peccare, non <lb/> dando pecuniam dominicam volenti
+						et petenti? lIis <lb/> atque hujusmodi cogitationibus et considerationibus
+						<lb/> depulsa caligine tædiorum, ad catechizandum aptatur <lb/> intentio, ut
+						suaviter imbibatur, quod impigre atque <lb/> hilariter de charitatis
+						ubertate prorumpit. Haec enim <lb/> non tam ego tibi, quam omnibus nobis
+						dicit 3 ipsa di. <lb/> lectio, quae diffusa est in cordibus nostris per Spi
+							<note type="footnote"> 1 Editi, <hi rend="italic">motu</hi> : quam vocem
+							prætereunt Mss.; plures alii <lb/> autem ejus loco habent, <hi
+								rend="italic">monitis </hi>. Paulo post, ex verbo, <lb/>
+							subministrat, sive uti scribi solet in antiquis codicibus, <lb/>
+							<hi rend="italic">sumministrat</hi>, factum erat in editis, <hi
+								rend="italic">summ munistrat</hi>.</note>
+						<note type="footnote"> 2 Editi, <hi rend="italic">solo magis quam
+								sacrificium</hi>. At Mss., constanter <lb/> præterenat, <hi
+								rend="italic">magis</hi>.</note>
+						<note type="footnote"> 3 Apud Ex. Lugd. Ven. Lov., <hi rend="italic"
+								>surrexerit</hi>. M.</note>
+						<note type="footnote"> 4 Sic Mss. Editi vero, <hi rend="italic">mentem
+								studentis</hi>.</note>
+						<note type="footnote"> 5 Editi fere soli, <hi rend="italic"
+							>dictat</hi>.</note>
+						<lb/>ritum sanctum qui datus est nobis <hi rend="italic">(Rom.</hi> v,
+						5).</p>
+				</div>
+				
+				<div type="textpart" subtype="chapter" n="15">
+					<p>23. <hi rend="italic">Pro personarum diversitate tem­</hi>
+						<lb/> peranda <hi rend="italic">oratio.</hi> Sed nunc etiam illud quod
+						priusquam <lb/> promitterem non debebam, jam fortasse debitum fla<lb/>gitas,
+						ut aliquod sermonis exemplum, tanquam si ego <lb/> aliquem catechizem, non
+						me pigeat explicare, et in­ <lb/> tuendum tibi proponere Quod priusquam
+						faciam, volo <lb/> cogites aliam esse intentionem dictantis, cum lector
+						<lb/> futurus cogitatur; et aliam loquentis, cuti præsens <lb/> auditor
+						attenditur : et in eo ipso aliam in secreto mo<lb/>nentis, dum nullus alius
+						qui de nobis judicet pra sto <lb/> est; aliam palam docentis aliquid, cum
+						dissimiliter <lb/> opinantium circumstat auditus : et in huc genere <lb/>
+						aliam, cum ducetur unus, cæteri autem tanq alii ju<lb/>dicantes aut
+						attestantes quæ sibi nota sunt audiunt; <lb/> aliam cum omnes communiter
+						quid ad eos profera<lb/>mus exspectant: et rursus in hoc ipso aliam, cum
+						<lb/> quasi privatim consedetur, ut sermocinatio consera<lb/>tur; aliam, cum
+						populus tacens unum de loco supe<lb/>riore dicturum suspensus intuetur:
+						multumque in<lb/>terest, et cum ila dicimus, utrum pauci adsint an <lb/>
+						multi; docti an indocti, an ex utroque gcnere mixti; <lb/> urbani an
+						rustici, an hi et illi simul; an populus ex <lb/> omni hominum gcnere
+						temperatus sit. Fieri enim non <lb/> potest, nisi aliter atque aliter afik
+						iant locuturum at<lb/>que dicturum, et ut sermo qui profertur, affectionis
+						<lb/> animi a quo profertur, qucmdam quasi vultum Hera.., <lb/> et pro eadem
+						diversitate diversc afficiat auditores, <lb/> cum et ipsi se ipsos diverse
+						afficiant invicem prae<lb/>sentia sua. Sed quia de rudibus imbuendis nunc
+						agi­ <lb/> mus, de me ipso tibi testis sum, aliter atque aliter <lb/> me
+						moveri, cum ante ine catechizandum video erudi<lb/>lum, inertem, civem,
+						peregrinum, divitem, paupe- <lb/> rem, privatum, honoratum, in potestate
+						aliqua consti<lb/>tutum, illius aut illius gentis hominem, illius aut <lb/>
+						illius ætatis aut sexus, ex illa aut illa serta, ex illo <lb/> aut illo
+						vulgari errore venientem : ac pro diversitate <lb/> mutus mei sermo ipse et
+						procedit, et progreatur, <lb/> et linitur. Et quia cum eadem omnibus
+						debeatur cha<lb/>ritas, non eadem est omnibus adhibenda medicina : <lb/>
+						ipsa item charitas alios parturit, cum aliis infirmatur; <lb/> alios curat
+						aedilicarc, alios contremiscit offendere; <lb/> ad alios se inciinat, ad
+						alios se erigit; aliis blanda, <lb/> aliis severa, nulli inimica , omnibus
+						mater. Et qui <lb/> non expertus est eadem charitate quod dico, cum <lb/>
+						videt nos, quia facultas aliqua nobis donata delectat <lb/> laudabiliter
+						innotescere in ore multitudinis, inde nos <lb/> beatos putat : Deus autem,
+						in cujtis conspecturn in<lb/>trat gemitus compeditorum <hi rend="italic"
+							>(Psal.</hi> LXXVIII, 11), vi<lb/>deat humilitatem nostram et laborem
+						nostrum, et di<lb/>mittat omnia peCcata nostra <hi rend="italic">(Pul.</hi>
+						XXIV, 18). Quam<lb/>obrem si quid tibi in nobis placuit, ut aliquam <lb/>
+						observationem sermonis tui a nobis audire quæretes, <lb/> melius videndo et
+						audiendo nos cum hæc agimus, <lb/> quam legendo cum hæc dictamus.
+						edisceres.</p>
+				</div>
+				
+				<div type="textpart" subtype="chapter" n="16">
+					<p>24. <hi rend="italic">Formula orationis catechistæ. <lb/> Exordium ductum a
+							laudabili proposito suscipiendæ <lb/> christianæ</hi> religionis, <hi
+							rend="italic">propter futuram requiem. Requies</hi>
+						<lb/> in <hi rend="italic">rebus inquietis non quærenda. Non in
+							divitiis,</hi> noc in <lb/>
+						<pb n="329"/> honoribus. <hi rend="italic">Requiem quærentes</hi> in <hi
+							rend="italic">oblectamentis earnis</hi>
+						<lb/> et in <hi rend="italic">spectaculis.</hi> Sed tamen faciamus aliquem
+						venisse <lb/> ad nos, qui vult esse christianus, et de genere qui<lb/>dem
+						idiotarum, non tamen rusticanorum, sed urba<lb/>norum, quales apud
+						Carthaginem plures experiri te <lb/> necesse est : interrogatum etiam utrum
+						propter vitæ <lb/> præsentis aliquod commodum, an propter requiem <lb/> quae
+						post hanc vitam speratur, christianus esse de<lb/>sidcrat, propter futuram
+						reqpiem respondisse: tali <lb/> fortasse a nobis instrueretur alloquio. Deo
+						gratias, <lb/> frater : valde tibi gratulor, et gaudeo de te, quod in <lb/>
+						tantis ac tam periculosis hujus sæculi tempestatibus <lb/> de aliqua vera et
+						certa securitate cogitasti. Nam et in <lb/> hac vita homines magnis
+						laboribus requiem quaerunt <lb/> et securitatem, sed pravis cupiditatibus
+						non inve<lb/>niunt. Volunt enim requiescere in rebus inquietis et <lb/> uon
+						permanentibus : et quia illae tempore subtra<lb/>huntur et transeunt,
+						timoribus et doloribus eos agi<lb/>tant, nee quietos esse permiuunt. Sive
+						enim in di<lb/>viliis velit homo requiescere, magis superbus <lb/>
+						efficitur, quam securus. Annon videmus quam multi <lb/> eas subito
+						perdiderint, multi etiam propter illas <lb/> perierint, aut cum eas habere
+						cupiunt, aut cum eis <lb/> oppressis a cupidioribus auferuntur 1? Quæ si
+						etiam <lb/> per totam vitam cum homine permanerent, et non <lb/> desererent
+						dilectorem suum, ipse illas sua morte de<lb/>sereret. Quanta est enim vita
+						hominis, etiamsi sene<lb/>scat? Aut cum sibi homines optant senectutem, quid
+						<lb/> aliud optant nisi longam infirmitatem? Sic et hono<lb/>res hujus
+						sacculi, quid sunt nisi typhus, et inanitas2, <lb/> et ruinx periculum? Quia
+						sic Scriptura sancta dicit: <lb/>
+						<hi rend="italic">Omnis</hi> earo fenum, et claritas <hi rend="italic"
+							>hominis ut</hi> flos feni. Fe<lb/>num <hi rend="italic">aruit, flos
+							decidit; verbum</hi> autem <hi rend="italic">Domini</hi> manet <lb/> in
+						æternum <hi rend="italic">[Isa. XL,</hi> 6-8). Ideo qui veram requiem et
+						<lb/> veram felicitatem desiderat, debet tollere spem suam <lb/> de rebus
+						mortalibus et praetereuntibus, et eam col<lb/>locare in verbo Domini; ut
+						haerens ei quod manet in <lb/> æternum, etiam ipse cum illo maneat in
+						æternum.</p>
+					<p>25. Sunt etiam homines qui nee divites quaerunt <lb/> esse, nee ad vanas
+						honorum pompas ambiunt per<lb/>venire : sed gaudere et requiescere volunt in
+						pop!<lb/>nis et in fornicationibus, et in theatris atque specta<lb/>culis
+						nugacitatis quæ in magnis civitatibus gratis <lb/> habent. Sed sic ctiam
+						ipsi aut consumunt per <lb/> luxuriam paupertatem suam, et ab egestate
+						postea in <lb/> furta et effracturas, et aliquando eLiam in latrocinia <lb/>
+						prosiliunt, et subito multis et magnis timoribus iut­ <lb/> pUnitur; et qui
+						in popina paulo ante cantabant, jam <lb/> planctus carceris somniant.
+						Studiis autem spectacu<lb/>lorum fiunt dæmonibus similes, clamoribus suis
+						in­ <lb/> citando homines ut se invicem caedant, secumque ha<lb/>beant
+						contentiosa certamina qui se non laeserunt, <lb/> dnm placere insano populo
+						cupiunt: quos si animad­ <lb/> verterint esse concordes, tunc eos oderunt et
+						per<lb/>sequuntur, et tanquam collusores ut fustibus verbe <note
+							type="footnote"> 1 Plerique Mss., <hi rend="italic">aut ut eis oppressis
+								a cupidioribus au<lb/> ferrentur.</hi>.</note>
+						<note type="footnote"> 2 Sic plerique Mss. At editi omittunt, <hi
+								rend="italic">et inanitas</hi> : cujus <lb/> loco nonnulli Mss., et
+								<hi rend="italic">vanitas</hi>.</note>
+						<lb/> rentur exclamant, et hanc iniquitatem facere etiam <lb/> vindicem
+						iniquitatum judicem cogunt; si autem hor. <lb/> rendas adversus invicem
+						inimicitias eos exercere <lb/> cognoverint, sive sintae qui appellantur 1,
+						sive sce<lb/>nici et thymelici, sive aurigæ, sive venatores, quos <lb/>
+						miseros non solum homines cum hominibus, sed etiam <lb/> homines cum bestiis
+						in certamen pugnamque com<lb/>mittunt ; quo majore adversus invicem
+						discordia fu<lb/>rere senserint, eo magis amant et delectantur, et
+						in<lb/>citatis 2 favent, et faventes incitant, plus adversus se <lb/> ipsos
+						insanicntes ipsi spectatores alter pro altero, <lb/> quam illi quorum
+						insaniam insani provocant, sed in - <lb/> saniendo 8 spectare desiderant.
+						Quomodo ergo sani<lb/>tatem pacis tenere animus potest, qui discordiis et
+						<lb/> certaminibus pascitur? Qualis enim cibus sumitur, <lb/> talis valetudo
+						consequitur. Postremo, quamvis in<lb/>sana gaudia non sint gaudia, tamen
+						qualiacumque <lb/> sint, et quantumlibet delectet jactantia divitiarum,
+						<lb/> i i tumor honorum, vorago popinarum, et bella thea<lb/>trorum I, et
+						immunditia fornicationum, et prurigo <lb/> thermarum; aufert omnia ista una
+						febricula, et <lb/> adhuc viventibus totam rabam beatitudinem
+						sublra<lb/>hit: remanet inanis et saucia conscientia, Deum sen<lb/>sura
+						judicem, quem noluit habere custodem; et in <lb/>Tentura asperum Dominum,
+						quem dulcem patrem <lb/> quærere et amare contempsit. Tu autem quia veram
+						<lb/> requiem quae post hanc vitam Christianis promitti<lb/>tur qu;eris,
+						etiam hic eam inter amarissimas vito <lb/> hujus molestias suavem
+						jucundamque gustabis, si ejus <lb/> qui eam promisit præcepta dilexeris.
+						Cito enim sen<lb/>ties dulciores esse justitiæ fructus quam iniquitatis,
+						<lb/> et verius atque jucundius gaudere homiuem de bona <lb/> conscientia
+						inter molestias, quam de mala inter de. <lb/> licias; quia non sic venisti
+						conjungi Ecclesiae Dei, ut <lb/> ex ea temporalem aliquam utilitatem
+						requiras.</p>
+				</div>
+				
+				<div type="textpart" subtype="chapter" n="17">
+					<p>26. <hi rend="italic">Reprehenditur</hi> qui <hi rend="italic">velit
+							esseChri<lb/>stianus propter commodum</hi> temporale. <hi rend="italic"
+							>Christianus</hi> vere <lb/>
+						<hi rend="italic">est, qui religionem profitetur propter futuram</hi>
+						requiem. <lb/>
+						<hi rend="italic">Transit ad narrationem eorum quæ credenda sunt. <lb/>
+							Filius</hi> Dei <hi rend="italic">cur homo factus.</hi> Sunt enim qui
+						propterea <lb/> volunt esse cbristiani, ut aut promereantur homines <lb/> a
+						quibus temporalia commoda exspectant, aut quia <lb/> offendere nolunt quos
+						timent. Sed isti reprobi sunt : <lb/> et si ad tempus eos portat Ecclesia,
+						sicut area usque <lb/> ad tempus ventilationis paleam sustinet; si non se
+						<lb/> correxerint, et propter futuram sempiternam re<lb/>quiem christiani
+						esse coeperint, in fine separabuntur. <lb/> Nec sibi blandiantur quod in
+						area possunt esse cam <lb/> frumento Dei : quia in horreo cum illo non
+						erunt, sed <lb/> igni debito destinantur' (<hi rend="italic">Matth.</hi>
+						III, 12). Sunt etiam <note type="footnote"> 1 Lov., <hi rend="italic">sint
+								athletæ</hi> qui <hi rend="italic">appellantur.</hi> At plerique ac
+							me<lb/> lioris notæ Mss., <hi rend="italic">sintæ qui appellantur</hi>.
+							Vox erat forsitan <lb/> apud Afros tunc vulgaris. In Corbeiensi codice
+							scribitur, <lb/>
+							<hi rend="italic">sinthæ</hi>. In Mss. quibusdam et apud Am. legitur,
+								<hi rend="italic">sint æqui <lb/> appellantur</hi>. Apud Er., <hi
+								rend="italic">sint qui appellantur</hi>.</note>
+						<note type="footnote"> 2 Am Er. et aliquot Mss., <hi rend="italic">et
+								incitati</hi>. Alii plures Mss., <hi rend="italic">et <lb/>
+								incitanies</hi>.</note>
+						<note type="footnote"> 3 Sic Mss. At editi, <hi rend="italic">provocant, et
+								insaniendo</hi>.</note>
+						<note type="footnote"> 4 Er. et Lov., <hi rend="italic">delectent</hi>. At
+							Am. et Mss., <hi rend="italic">delectet</hi>.</note>
+						<note type="footnote"> 5 Sic Am. Er. et plerique Mss. At Lov., <hi
+								rend="italic">theatracorum</hi>.</note>
+						<note type="footnote"> 6 Lov., <hi rend="italic">destinabuntur</hi>. At Am.
+							Er. et Mss. habent præ<lb/>senti tempore, <hi rend="italic"
+								>destinantur</hi>.</note>
+						<note type="footnote"> (Onze.) </note><lb/>
+						<pb n="331"/> atii meliore quidem spc, scil lamcn non minore pe<lb/>riculo,
+						qui jam Deum timent, ct non irrident chri<lb/>stianum nomcn, nee simulalo
+						cordc intrant Eccle<lb/>siam Dei, sed in ista vita exspectant felicitatem,
+						ut fe<lb/>liciores sint in rchus terrenis, quam illi qui non colunt <lb/>
+						Deum : ideoque cum viderint quosdam sceleratos et <lb/> impios ista sæculi 1
+						prosperitate pollere ct excellere, <lb/> . se autem vel minus habere ista
+						vel amittere, pertur<lb/>bantur tanquam sine causa Deum colant , el facile a
+						<lb/> fide deficiunt.</p>
+					<p>27. Qui autem propter beatitudinem sempiternam <lb/> ct perpetuam requiem,
+						quæ post hanc vitam sanctis <lb/> futura promittitur, vult fieri
+						christianus, ut non eat <lb/> in ignem aeternum cum diabolo, sod in regnum
+						<lb/> æternum intret cum <hi rend="italic">Christo (Matth.</hi> xxv, 54, 41,
+						46), <lb/> vere ipse christianus est, cautus in omni tentatione, <lb/> ne
+						prosperis rebus corrumpatur, et ne frangatur ad<lb/>versis, et in abundantia
+						bonorum terrenorum mo<lb/>destus et temperans, et in tribulationibus fortis
+						et <lb/> patiens. Qui etiam proficiendo pervenict ad talem <lb/> animum, ut
+						plus amet Deum, quam timeat gehen<lb/>nam : ut ctiamsi dicat illi Dens,
+						Ulcre dcliciis car<lb/>nalibus sempiternis, et quantum potes pecca, nec
+						<lb/> morieris, nee ia gehennam mitteris, sed mecum tan<lb/>tummodo non
+						cris; exhorrescat, et omnino non pec<lb/>cet, non jam ut in illud quod
+						timebat non incidat, <lb/> sed ne illum quem sic amat offendat: in quo uno
+						est <lb/> rcquics t, quam oculus non vidit, nec auris audivit, <lb/> me in
+						cor hominis ascendit, quam præparavit Dcus <lb/> diligentibus cum (I <hi
+							rend="italic">Cor.</hi> II, 9).</p>
+					<p>28. De qua requie significat 8 Scriptura, et non <lb/> tacet, quod ab mitio
+						mundi ex quo fecit Deus cœlum <lb/> et terram ct omnia quae in eis sunt, sex
+						dicbus ope­ <lb/> ratus est, ct septimo dic requievit <hi rend="italic"
+							>(Gen,</hi> i, <hi rend="italic">et</hi> II, 1-3). <lb/> Poterat cnim
+						omnipotens et uno momento temporis <lb/> omnia faccre. Non autem
+						laboraverat, ut requiesce<lb/>rel, quando, <hi rend="italic">Dixit, et facta
+							sunt ; mandavit,</hi> et <hi rend="italic">creata<lb/> sunt (Psal.</hi>
+						CXLVIII, 5) : sed ut significaret, quia post <lb/> sex ætates mundi hujus,
+						septima actate tanquam se<lb/>ptimo die requicturus est in sanctis suis;
+						quia ipsi <lb/> in illo requiescent post omnia bona opera, in quibus <lb/>
+						ei servierunt, quae ipse in illis operatur, qui vocat, <lb/> et præcipit, et
+						delicta praetrita dimittit, et justificat <lb/> cum qui prius erat impius.
+						Sicut autem cum illi ex <lb/> duno ejus bene opcrantur, recte dicitur ipse
+						operari ; <lb/> sic cum in illo requiescunt *, recto dicitur ipse
+						re<lb/>quicscere. Nam quod ad ipsum attinet, pausationem <lb/> non quærit,
+						quia laborem non sentit. Fecit autcm <lb/> omnia per Verbum suum; et Verbum
+						ejus ipse Chri<lb/>stus, in quo requiescunt Angeli et omnes cœlestes <lb/>
+						mundissimi spiritus in sancto silentio. Homo autem <lb/> peecato lapsus
+						perdidit requiem quam habebat in cjus <lb/> divinitate, pt recipit eam 1 in
+						ejus humanitate : ideo<lb/>que opportuno tempore, quo ipse sciebat oportere
+						<lb/> fieri, homo factus et de feniina natus est. A carne <note
+							type="footnote"> 1 Am. Er. et tres Mss., <hi rend="italic"
+							>sæculari</hi>.</note>
+						<note type="footnote"> 2 Sic Mss. Editi vero, <hi rend="italic">in quo una
+								est requies</hi>.</note>
+						<note type="footnote"> 3 Am. Er. et fere omnes Mss., <hi rend="italic">De
+								qua re significat</hi>.</note>
+						<note type="footnote"> 4 Ita Mss. At editi, <hi rend="italic">si cum illi
+								requiescunt</hi>.</note>
+						<note type="footnote"> 5 Sic Mss. At editi, <hi rend="italic">et recepit
+								eam</hi>.</note>
+						<lb/> quippe contaminari nun poterat, ipse cariem potius <lb/> mundaturus.
+						Ipsum antiqui sancti venturum in rcte" <lb/> latione Spiritus cognoverunt,
+						et prophetaverunt, et <lb/> sic salvi facti sunt credendo quia veniet, sicut
+						nos <lb/> salvi efficimur credendo quia venit : ut diligeremus <lb/> Deum,
+						qui sic nos dilexit, ut unicum Filium suma <lb/> mitteret, qui humililale1
+						nostræ mortalitatis indultis , <lb/> et a peccatoribus et pro peccatoribus
+						moreretur. Jam <lb/> enim olim ab incuniibus sæculis mysterii hujus alti­
+						<lb/> tudo præfigurari prænuntiarique non cessat.</p>
+				</div>
+				
+				<div type="textpart" subtype="chapter" n="18">
+					<p>29. <hi rend="italic">De hominis et rerum aliarum<lb/> creatione quid
+							credendum. Homo</hi> in <hi rend="italic">paradiso</hi> constitu­ <lb/>
+						<hi rend="italic">tus. Cur creatus qui præsciebatur peccaturus. Lapsus <lb/>
+							hominis et angeli nihil Deo nocuit.</hi> Quoniam Deus <lb/> omnipotens,
+						et bonus et justus et misericors, qui fc<lb/>cit omnia bona, sive. magna
+						sive parva, sive summa <lb/> sive infima ; sive quæ videntur, sicuti sunt
+						cœlum et <lb/> terra ct mare, et in coelo sol et luna, et cætera
+						si<lb/>der:., in terra autem et mari arbores et frutices et <lb/> animalia
+						suæ cujusque naturæ, et omnia corpora vel <lb/> coelestia vel terrestria ;
+						sive quæ non videntur, sicuti <lb/> sunt spiritus quibus corpora vegetantur
+						et vivifican­ <lb/> tur : fecit et hominem ad imaginem suam ; ut
+						quem<lb/>admodum ipse per omnipotentiam suam præest uni<lb/>versæ creaturæ,
+						sic homo per intelligentiam suam, <lb/> qua etiam Crcatorem suum cognoscit
+						et colit, præes<lb/>set omnibus terrenis animalibus. Fecit iili etiam ad.
+						<lb/> jutorium feminam : non ad carnalem concupiscen­ <lb/> tiam,
+						quandoquidem nec corruptibilia corpora tunc <lb/> hahenant, antequam eos
+						mortalitas invaderet poena <lb/> peccati; sed ut habcret et vir gloriam de
+						femina, <lb/> cum ei præiret ad Deum 2, seque i!li præberet imi<lb/>tandum
+						in sanctitate atque pietate; sicut ipse esset <lb/> gloria Dei, cum ejus
+						sapientiam sequcretur.</p>
+					<p>. 50. Itaque constituit cos in quodam loco perpetuæ <lb/> beatitudinis, quem
+						appellat Scriptura paradisum ; <lb/> præceptumque illis dedit, quod si non
+						transgrede­ <lb/> rentur, in illa semper immoratlitatis beatitudine
+						per<lb/>manerent: si autem transgrederentur, supplicia mor<lb/>talitatis
+						expenderent. Praesciebat autem Deus eos <lb/> transgressuros : sed tamen
+						quia conditor est et effe<lb/>ctor omnis boni, magis eos fecit, quando fecit
+						et be<lb/>stias, ut impleret terram bonis terrenis. Et utique <lb/> mclior
+						est homo etiam peccator, quam bestia. Et <lb/> præceptum quod non erant
+						servaturi, magis dedit, ut <lb/> essent inexcusabiles, cum in eos vindicare
+						coepisset. <lb/> Quidquid enim homo fecerit, laudabilem in suis fa<lb/>ctis
+						invenit Deum : si recte egerit, laudabilem inve<lb/>nit per justitiam
+						præmiorum ; si peccaverit, lauda­ <lb/> bilem invenit per justitiam
+						suppliciorum ; si peccata <lb/> confessus ad recte vivendum redierit,
+						laudabilem in<lb/>venit pur misericordiam indulgentiarum. Cur ergo <lb/> non
+						faceret Deus hominem, quamvis eum peccaturum <lb/> praenosceret, cum et
+						stantem coronaret, et caden<lb/>tem ordinaret, et surgentem adjuvaret,
+						semper et <lb/> ubique ipse gloriosus bonitate, justitia, clementia? <lb/>
+						maxime quia et illud præsciebat, de propagine mor <note type="footnote"> 1
+							Am. et Er., <hi rend="italic">humanitate</hi>.</note>
+						<note type="footnote"> 2 Er., <hi rend="italic">dominium</hi>. Editi alii,
+								<hi rend="italic">Dominum</hi>.</note><lb/>
+						<pb n="333"/>talitatis ejus futuro! sanctos, qui non ili qua-re<lb/>rent,
+						sed Creatori suo gloriam darent, et cum co<lb/>lendo ab omni corruptione
+						liberati, cum Angelis <lb/> sanctis semper vivere et beate vivere
+						mererentur? <lb/> Qui enim hominibus dedit liberum arbitrium, ut non <lb/>
+						servili necessitate, sed ingenua voluntate Dcum co<lb/>lerent, dedit ctiam
+						Angelis. Et idco ncc angelus, qui <lb/> cum spiritibus aliis satellitibus
+						suis superbiendo de<lb/>seruit obedientiam Dei, et diabolus factus est,
+						aliquid <lb/> nocuit Dco, sed sibi : novit enim Deus ordinare
+						de<lb/>serentes se animas (a), et ex earum justa miscria in<lb/>feriores
+						partes creaturæ suæconvenientissimis et <lb/> congruentissimis Icgibus
+						admirandæ dispensationis <lb/> ornure1. ltaque nec diabol us aliquid Deo
+						nocuit, quia <lb/> vcl ipse lapsus est, vel hominem seduxit ad mortem :
+						<lb/> nec ipse bomo in aliquo minuit veritatem aut pole­ <lb/> statom aut
+						beatitatem 2Conditoris sui, quia conjugi <lb/> suæ seductæ a diabolo, ad id
+						quod Deus prohibuerat, <lb/> propria voluntate consensit. Justissimis enim
+						Dei <lb/> legibus omnes damnati sunt, Dco glorioso per æqui<lb/>tatem
+						vindictæ, ipsi ignominiosi per turpitudinem <lb/> pœnæ <hi rend="italic"
+							>(Gen.</hi> II, III) : ut et homo a suo Creatore aver<lb/>sas victus
+						diabolo subderetur, et diabolus homini ad <lb/> Creatorem suum converso
+						vincendus proponeretur; <lb/> lit quicumque diabolo usque in finem
+						consentirent, <lb/> cum illo irent in æterna supplicia ; quicumque autem
+						<lb/> humiliarent se Deo, et per ejus gratiam diabolum <lb/> vincerent,
+						æterna præmia mererentur.</p>
+				</div>
+				
+				<div type="textpart" subtype="chapter" n="19">
+					<p>31. In Ecclesia <hi rend="italic">boni et mali,</hi> in <lb/>
+						<hi rend="italic">fine separandi. Civitates duæ ab initio generis
+							humani.<lb/> Diluvium et arca sacramentum. De Abrahamo et
+							Israe<lb/>litico populo. Horum dicta et facta, prophetia fuit.</hi>
+						<lb/> Neque hoc nos movere debet; quia multi diabolo <lb/> con entiunt, et
+						pauci Deum sequuntur : quia et fru<lb/>mentum in comparatione palearum valde
+						pauciorem <lb/> habet numerum. Sed sicut agricola novit quid faciat <lb/>
+						cie ingenti acervo paleas, sic nihil est Dco multitudo <lb/> peccatorum, qui
+						novit quid de illis agat, ut admi­ <lb/> nistatio regni ejus ex nulla parte
+						turbetur atqu tur<lb/>petur. Nec idCo putandus. cst vicissc diabolus, quia
+						<lb/> secum plurcs, cum quibus a paucis vinceretur, at­ <lb/> traxit. Duæ
+						itaque civitates, una iniquorum, altera <lb/> sanctorum, ab initio generis
+						humani usque in finem <lb/> sæculi perducuntur, nunc permivtæcorporibus, sed
+						<lb/> voluntatibus separatæ, in die vero judicii etiam cor<lb/>pure
+						separandae. Omnes enim homincs amantes su<lb/>perbiam et temporalem
+						dominationem cum vano ty<lb/>pho ct pompa arrogantiæ, omnesque spiritus qui
+						talia <lb/> diligunt, et gloriam suam subjectione hominum quae<lb/>runt.
+						simul una societate devincti sunt; sed et si <lb/> sæpe 3 adversum se pro
+						his rebus dimicant, pari ta<lb/>men pondere cupiditatis in eamdem
+						profunditatem <lb/> præcipitantur, et sibi morum et meritorum similitu­
+						<lb/> dine conjunguntur. Et rursus omnes homines et <lb/> omnes spiritus
+						humiliter Dei gloriam quærentes, non <lb/> suam, et cum pictate sectantes,
+						ad unam pertinent <note type="footnote"> 1 Sola editio Lov., <hi
+								rend="italic">ordinare</hi>.</note>
+						<note type="footnote"> 2 Plerique Mss. omittunt, <hi rend="italic">aut
+								beatitatem</hi>.</note>
+						<note type="footnote"> 3 Mss., <hi rend="italic">devincti sunt, et si
+								sæpe</hi> ; omisso. <hi rend="italic">sed.</hi></note>
+						<note type="footnote"> (a) Il Retract. cap. 11. </note>
+						<lb/> societatem. Et tamen Dcus misericordissimus, et su<lb/>per impios
+						homines paticns est, et præbet eis pœni<lb/>tentiæatque correctionis
+						locum.</p>
+					<p>32. Nam et quod omnes diluvio delevit, exceptu <lb/> uno justo cum suis, quos
+						in arca servari voluit, nove<lb/>rat quidem quod non se correcturi essent:
+						verumta<lb/>men cum per centum annos arca fabricata est, præ- <lb/>
+						dicabatur utique eis ira Dei ventura super eos <lb/>
+						<hi rend="italic">(Gen.</hi> vi, VII); ct si converterentur 1 ad Deum,
+						par<lb/>cerct cis, sicut pepercit postea Ninive civitati agenti <lb/>
+						pœnitentiam, cum ei per prophetam futurum inter<lb/>itum prænuntiasset <hi
+							rend="italic">(Jonæ</hi> III). Hoc autem facit Deus, <lb/> eliam illis
+						quos novit in malitia-perseveraturos dans <lb/> pœnitendi spatium, ut
+						nostram paticntiam exerceat et <lb/> informet exemplo suo; quo noverimus
+						quantum nos <lb/> oporteat tolerabiliter malos sustinere, cum ignoremus
+						<lb/> quales postea futuri sunt, quando ille parcit ct sinil <lb/> cos
+						vivcre, quem nihil futurorum latet. Prænuntia<lb/>batur tamen etiam diluvii
+						sacramento quo per Ii­ <lb/> gnum justi liberati sunt, futura Ecclesia quam
+						rex <lb/> ejus et Deus Christus mysterio suae crucis ab hujus <lb/> sæculi
+						submersione suspendit. Neque enim Deus <lb/> ignorabat quod etiam ex illis
+						qui fuerant in arca ser<lb/>vati, nascituri crant mali, qui faciem terræ
+						iniqnita<lb/>tibus iterum implerent : sed tamen et cxemplum fu­ <lb/> turi
+						judicii dedit, et sanctorum liberationem ligni <lb/> mysterio prænuntiavit.
+						Nam ct post hæc non cassa<lb/>vit rcpullularc malilia per superbiam ct
+						libidines ct <lb/> illicitas impielatcs, cum homines deserto Creatore <lb/>
+						suo, non solum ad creaturam quam Deus condidit <lb/> lapsi sunt, ut pro Dco
+						colerent quod fecit Deus.; sed <lb/> etiam ad opera manuum hominum et ad
+						fabrorum <lb/> artificia curvaverunt animas suas, ubi de illis turpius <lb/>
+						diabolus et dæmonia triumpharent ; quæ se in talibus <lb/> figmentis adorari
+						venerarique letantur, dum errores <lb/> suos humanis crroribus pascunt
+						2.</p>
+					<p>33. Nequc tunc sane dcfucrunt justi qui Deum pie <lb/> quærerent, et
+						superbiam diaboli vincerent, cives it<lb/>lius sanctæ civitatis, quos rcgis
+						sui Christi ventura <lb/> humilitas per Spiritum revelata sanavit. Ex quibus
+						<lb/> Abraham pius et fidelis Dei servus electus est <hi rend="italic"
+							>(Gen.</hi> XII). <lb/> cui demonstraretur sacramentum Filii Dei, ut
+						propter <lb/> imitationem fidei omnes fideles omnium gentium filii <lb/>
+						cjus futuri dicerentur. Ex illo natus est populus a <lb/> quo unus Deus
+						vcrus coleretur qui fecit coelum ct <lb/> terram, cum cæteræ gentes
+						simulacris et dnemoniis <lb/> servirent. In eo plane populo multo evidentius
+						futura <lb/> Ecclesia figurata est. Erat enim ibi multitudo carna<lb/>lis,
+						quæ propter visibilia beneficia colebat Deum. <lb/> Erant ibi autem pauci
+						futuram requiem cogitantes et <lb/> cælestem patriam requirentes, quibus
+						prophetando <lb/> revelabatur futura humilitas Dei, regis et Domini <lb/>
+						nostri Jesu Christi, ut per eam fidem ab omni fu<lb/>perbia et tumore
+						sanarentur. Horum sanctorum, qui <lb/> præcesserunt tempore nativitatem
+						Domini, non so­ <lb/> lum sermo, sed etiam vita, et conjugia, et filii, et
+						fa<lb/>cta, prophetia fuit hujus temporis, quo per fidem <note
+							type="footnote"> 1 Er. et Lov., <hi rend="italic">ut si
+								converterentur</hi>. Am. et Mss., <hi rend="italic">et si
+								cen<lb/>verterentur</hi>.</note>
+						<note type="footnote"> 2 Floriacensis quidam Ms., <hi rend="italic"
+								>miscent</hi>.</note><lb/>
+						<pb n="335"/> passionis Christi ex gentibus congregatur Ecclesia. <lb/> Per
+						illos sanctos Patriarchas et Prophetas carnali <lb/> populo Israel, qui
+						postea eliam Judaei appellati sunt, <lb/> et visibilia beneficia
+						ministrabantur quæ carnaliter a <lb/> Domico desiderabant, et coercitiones
+						poenarum cor<lb/>poralium quibus pro tempore terrerentur, sicut eo<lb/>rum
+						duritiæ congruebat. Et in his tamen omnibus <lb/> mysteria spiritualia
+						significabantur, quæ ad Christum <lb/> et Ecclesiam pertinerent : cujus
+						Ecclesiae membra <lb/> etant etiam illi sancti, quamvis in hac vita fuerint
+						<lb/> antequam secundum carnem Christus Dominus na<lb/>sceretur. Ipse enim
+						unigenitus Dei Filius, Verbum <lb/> Patris, æquale et coæternum Patri, per
+						quod facta <lb/> sunt omnia, bomo propter nos factus est, ut totius <lb/>
+						Ecclesiae tanquam totius corporis caput esset. Sed <lb/> vclut totus homo
+						dum nascitur, etiamsi manum in <lb/> nascendo præmittat, tamen universo
+						corpori sub ca<lb/>phe conjuncta atque compacta cst, quemadmodum <lb/> etiam
+						nonnulli in ipsis Patriarchis ad hujus ipsius rei <lb/> signum mann præmissa
+						nati suut <hi rend="italic">(Gen. XXV,</hi> 23) : ita <lb/> omnes sanct! qui
+						ante Domini nostri Jesu Christi na<lb/>livitatcm in terris fuerunt, quamvis
+						ante nati sunt, <lb/> tamen universo corpori, cujus ille caput cst1, sub
+						<lb/> capite cohæserunt.</p>
+				</div>
+				
+				<div type="textpart" subtype="chapter" n="20">
+					<p>34. Israelitarum <hi rend="italic">servitus in Ægypto,<lb/> et liberatio
+							viaque per mare Rubrum.</hi> Baptismus <hi rend="italic"
+							>figura<lb/>tus.</hi> Ovis <hi rend="italic">immolatio</hi> passionis
+						Christi <hi rend="italic">figura. Lex scripla <lb/> digito Dei. Jerusalem
+							typus civitatis cœlesits.</hi> Populus <lb/> ergo ille delatus in
+						iEgyplum, servivit regi durissimo; <lb/> et gravissimis laboribus eruditus,
+						quæsivit libcrato<lb/>i em Deum : et missus est eis unus de ipso populo ,
+						<lb/> sanctus Dei servus Moyses, qui in virtute Dei magnis <lb/> miraculis
+						terrens tunc impiam gentem Ægyptiorum, <lb/> eduxit inde populum Dei per
+						marc Rubrum ; ubi <lb/> discedens aqua viam præbuit transeuntibus :
+						Ægy<lb/>ptii autem cum eos persequerentur, redeuntibus in <lb/> se fluctibus
+						demersi exstincti sunt. Ita quemadmo­ <lb/> dum per diluvium aquis terra
+						purgata est a nequitia. <lb/> peccatorum, qui tunc in illa inundatione
+						deleti sunt, <lb/> et juti evaserunt per lignum : sic ex Ægypto exiens <lb/>
+						populus Dei, per aquas iter invenit, quibus ipsorum <lb/> hostes consumpti
+						sunt. Nee ibi defuit ligni sacra. <lb/> mentum. Nam virga percussit Moyses,
+						ut illud mira­ <lb/> culum fieret. Utrumque signum est sancti Baptismi,
+						<lb/> pcr quod fideles in novam vitam transeunt, peccata <lb/> vero eorum
+						tanquam inimici delentur atque morim­ <lb/> ur. Apertius autem Christi
+						passio in illo populo figu<lb/>raia est, cum jussi sunt ovem occidere et
+						manducare, <lb/> et de sanguine ejus postes suos signare, et hoc ccle­ <lb/>
+						brare omni anno, et appellare Pascha Domini. Mani<lb/>festissime quippe
+						prophetia I do Domino Jesu Christo <lb/> dicit, quia <hi rend="italic"
+							>tanquam ovis ad immolandum ductus</hi> eat <lb/>
+						<hi rend="italic">(Isai.</hi> LIII, 7). Cujus passionis et crucis signo in
+						fronte <lb/> hodie tanquam in poste signandus es, omnesque <lb/> Christiani
+						signantur.</p>
+					<p>55. Inde per desertum populus ille ductus est, per <lb/> q'iadraginta annos
+						accepit etiam legom digito Dci <note type="footnote"> 1 Am. et Mss., <hi
+								rend="italic">cujusque ille caput est</hi>.</note>
+						<note type="footnote"> 2 Soli editi, <hi rend="italic">propheta</hi>.</note>
+						<lb/> scriptam <hi rend="italic">(Exod.</hi> i-xx, XXXII , xxxiv; Num. XIV,
+						33, <hi rend="italic">et<lb/> Deut.</hi> xxix, 5), quo nomine significatur
+						Spiritus san­ <lb/> ctus, sicut in Evangelio manifestissiine declaratur . <lb/>
+						<hi rend="italic">(Luc.</hi> XI, 20). Neque enim Deus forma corporis
+						defl<lb/>nitus est, nec sic in illo membra et digiti cogitandi <lb/> sunt,
+						quemadmodum videmus in nobis : sed quia pcr <lb/> Spiritum sancium dona Dei
+						sanctis dividuntur, ut cum <lb/> diversa possunt, non tamen discedant a
+						concordia <lb/> charitatis, in digitis autem maxime apparct quædam <lb/>
+						divisio, nec tamen ab unitate præcisio; sive propterea, <lb/> sivc propter
+						aliam quamcumque causam Spiritus <lb/> sanctus appellatus est digitus Dei,
+						non tamcn , cum <lb/> hoc audimus, humani corporis forma cogitanda est.
+						<lb/> Accepit ergo ille populus legem digito Dei scriptam <lb/> in tabulis
+						sane lapideis, ad significandam duritiam <lb/> cordis illorum, quod legem
+						non erant impleturi. Cor<lb/>poralia quippe dona desiderantes a Domino,
+						magis car<lb/>nali timore quam spirituali charitate tenebantur : te- . <lb/>
+						gem autem non implet nisi charitas. Ideo multis <lb/> sacramentis
+						visibilibus onerati sunt, quo servili jugo <lb/> premerentur, in
+						observationibus ciborum et in sacri<lb/>ficiis animaliqm, ct in aliis
+						innumerabilibus : quæ ta<lb/>men signa erant rerum spiritualium ad
+						Dominum<lb/> Jesum Christum et ad Ecclesiam perlinentium; quæ <lb/> tunc a
+						paucis sanctis et intelligebantur ad fructum <lb/> salutis, et observabantur
+						ad congruentiam temporis , <lb/> a multitudine vero carnalium tantummodo
+						observa<lb/>bantur, non intelligebantur.</p>
+					<p>36. Per multa itaque et varia signa rerum futura<lb/>rum, quas longum est
+						omnes commemorare, et eas <lb/> nunc in Ecclesia videmus impleri, perductus
+						est ille <lb/> populus ad terram promissionis, ubi temporaliter <lb/> I
+						carnaliterque regnaret pro modo desidcrii sul : quod <lb/> taman regnum
+						terrenum regni spiritualis imaginem <lb/> gessitJbi Jerusalem condita est
+						famosissima civilasDei, <lb/> serviens in signo liberæ civitatis,quæ
+						cœelestis Jerusa<lb/>lem dicitur <hi rend="italic">(Galat.</hi> IV. 25, 26),
+						quod verbum est lac.. <lb/> bræum, et interpretatur Vibio pacis. Cujus cives
+						sunt <lb/> omnes sanctificati homines qui fuerunt, ctqui sunt, et <lb/> qui
+						futuri sunt; et omnes sanctificati spiritus, ctiam <lb/> quicumque in
+						excelsis coelorum partibus pia devotione <lb/> obtemperant Deo, nec
+						imitantur impiam diaboli su<lb/>perbiam et angelorum ejus. Ilujus civitatis
+						rex est <lb/> Dominus Jesus Christus, Verbum Dei quo rcgunlur <lb/> summi
+						Angeli, et Verbum hominem assumens ut eo <lb/> regerentur et homines, qui
+						simul omnes cum illo iu <lb/> æterna pace regnabunt. Ad hujus regis
+						praefiguratio<lb/>nem in illo terreno regno populi Israel maxime
+						emi<lb/>nuit rex David, de cujus semine secundum carnem <lb/> veniret
+						verissimus rex noster Dominus Jesus Christus, <lb/>
+						<hi rend="italic">qui est super omnia Deus benedictus</hi> in sæcula <hi
+							rend="italic">(Rom.</hi>
+						<lb/> ix, 5). Multa in illa terra promissionis gesta sunt in <lb/> figuram
+						venturi Christi ct Ecclesiæ, quæ in sanctis <lb/> Libris paulatim discere
+						poteris.</p>
+				</div>
+				
+				<div type="textpart" subtype="chapter" n="21">
+					<p>37. <hi rend="italic">Captivitas</hi> Babylonica <hi rend="italic">et in
+							ea<lb/> gesta quid significent. Post captivitatem</hi> Babylonicam <lb/>
+						libertas <hi rend="italic">qualis reddita.</hi> Post aliquot tamen
+						generationes <lb/> ostendit aliam typum ad rum maxime pertinentem- <lb/> Nam
+						cap fiviia est illa civitas, ct multa pars ejus edu- <lb/>
+						<pb n="337"/> cta in Babyloniam. Sicut autem Jerusalem significat <lb/> ei
+						vitatem societatemque sanctorum; sic Babylonia <lb/> sigraificat civitatem
+						socictatemqne iniquorum, quoniam <lb/> dicitur interpretari Confusio. De
+						quibus duabus civi­ <lb/> tatibus, ab exordio generis humani usque in finem
+						<lb/> sæculi permixte 1 temporum varietate currentibus, et <lb/> ultimo
+						judicio separandis, paulo ante jam diximus <lb/>
+						<hi rend="italic">(Cap.</hi> 19). Illa ergo captivitas Jerusalem civitatis,
+						et <lb/> ; lle populus in Babyloniam ductus ad servitutem ire <lb/> jubetur
+						a Domino per Jcremiam illius temporis pro<lb/>phetam. Et exstiterunt reges
+						Babyloniae, sub quibus <lb/> illi serviebant, qui ex eorum occasione commoti
+						qui<lb/>busdam miraculis cognoscerent et colerent et coli ju<lb/>berent unum
+						verum Deum, qui condidit universam <lb/> creaturam <hi rend="italic"
+							>(-Dan.</hi> II-VI, xiv). Jussi sunt autem et ora<lb/>te pro eis a
+						quibus capiivi tenebantur, et in eorum <lb/> pace pacem sperare, ad
+						gignendos filios, et domns <lb/> aedilicandas, et plantandos hortos et
+						vineas. Post se­ <lb/> ptuaginta autem annos promittitur eis ab illa
+						captivi<lb/>tate liberatio <hi rend="italic">( Jerem.</hi> xxv, XXIX). Hoc
+						autem totum <lb/> figurate significabat Ecclesiam Christi in omnibus
+						san<lb/>ctis ejus, qui sunt cives Jerusalem coelestis, servitu<lb/>ram
+						fuisse sub regibus hujus sæculi. Dicit enim et <lb/> apostolica doctrina, ut
+							<hi rend="italic">omnis anima sublimioribus po<lb/>testatibus subdita
+							sit ;</hi> et ut reddantur <hi rend="italic">omnibus omnia;</hi>
+						<lb/> cui <hi rend="italic">tributum, tributum; cui vectigal, vectigal
+							(Rom.</hi>
+						<lb/> XIII, i , 7); et caetera quæ salvo Dei nostri cultu, <lb/>
+						constitutionis humanae principibus reddimus; quando <lb/> ct ipse Dominus,
+						ut nobis hujus sanæ doctrinae præ­ <lb/> beret exemplum, pro capite hominis
+						quo erat indutus, <lb/> tributum solvere non dedignatus est <hi
+							rend="italic">(Matth.</hi> XVII, 26). <lb/> Jubentur autem etiam servi
+						christiani et boni fideles <lb/> dormis suis temporalibus æquanimiter
+						fideliterque <lb/> servire <hi rend="italic">(Ephes.</hi> vi, 5) : quos
+						judicaturi sunt, si usque <lb/> in finem iniquos invenerint; aut cnm quibus
+						:.quali<lb/>ter regnaturi sunt, si et illi ad vcrum Deum conversi <lb/>
+						fuerint. Omnibus tamen præcipitur servire humanis <lb/> potestatibus atque
+						terrenis, quousque post tempus <lb/> præfinitum, quod significant
+						septuaginta anni, ab <lb/> istius sæculi confusione tanquam de captivitate
+						Baby<lb/>loniæ, sicut Jerusalem liberetur Ecclesia. Ex cujus <lb/>
+						captivitatis occasione ipsi etiam terreni reges desertis <lb/> idolis, pro
+						quibus persequebantur Christianos, unum <lb/> vernm Deum et Christum Dominum
+						cognoverunt et <lb/> colunt, pro quibus apostolus Paulus jubet orari, etiam
+						<lb/> cin persequerentur Ecclesiam. Sic enim dicit: Ob<lb/>secro <hi
+							rend="italic">itaque</hi> primum <hi rend="italic">fieri deprecationes,
+							adorationes</hi> I, <lb/>
+						<hi rend="italic">interpellationes, graliarum actiones, pro regibus, pro
+							<lb/> omnibus hominibus, et</hi> omnibus <hi rend="italic">qui in
+							sublimitate sunt,</hi>
+						<lb/> ut securam <hi rend="italic">et tranquillam vitam agamus cum omni
+							pie<lb/>tete et charitate</hi> a (I <hi rend="italic">Tim.</hi> II, 1,
+						2). Itaque per ipsos <lb/> data pax est Ecclesiæ, quamvis temporalis,
+						tranquil<lb/>litis temporalis 4 ad ædificandas spiritualiter domos <lb/> et
+						plantandos hortos et vineas. Nam ct ecce te modo <lb/> per istum sermuncm
+						ædificamus atque pluitamus. Et <note type="footnote"> 1 sic Mss. At editi,
+								<hi rend="italic">permixta</hi>.</note>
+						<note type="footnote"> 2 Lov., <hi rend="italic">orationes</hi>. Editi autem
+							alii et Mss., <hi rend="italic">adorationes</hi>. <lb/> Græce est, <hi
+								rend="italic">proseuchas</hi>.</note>
+						<note type="footnote"> 3 Vulgata, <hi rend="italic">castitate</hi> : juxta
+							græcum, <hi rend="italic">semnoleti</hi>.</note>
+						<note type="footnote"> 4 Sic Mss. Editi vero, <hi rend="italic"
+								>temporis</hi>.</note>
+						<lb/> hoc fit per totum orbem terrarum cum pace regum <lb/> christianorum ,
+						sicut idem dicit apostolus : <hi rend="italic">Dei agri - <lb/> cultura, Dei
+							œdificatio estis</hi> (I Cor. III, 9).</p>
+					<p>58. Et post annos quidem septuaginta, quos my<lb/>stice prophetaverat
+						Jeremias, ut finem temporum <lb/> præfiguraret, tamen ut ipsa figura
+						integraretur, facia <lb/> est in Jerusalem restitutio ædificationis templi
+						Dei : <lb/> sed quia lotum figurate agebatur, non erat firma pax <lb/> ac
+						libertas reddita Judæis. Itaque postea a Romanis <lb/> victi sunt, et
+						tributarii facti. Ex illo sane tempore ex <lb/> quo terram promissionis
+						acceperunt, et reges habere <lb/> eœperunt, ne in aliquo regum suorum
+						completum <lb/> esse arbitrarentur quod eis liberator Christus
+						pro<lb/>mittebatur, apertius per multas prophetias propheta<lb/>tus est
+						Christus; non solum ah ipso David in libro <lb/> Psalmorum, sed etiam a
+						cæteris et magnis et sanctis <lb/> propbelis, usque ad tempus eaptivitatis
+						in Babylo<lb/>niam : et in ipsa captivitate fuerunt prophetæ, qui <lb/>
+						venturum Dominum Jesum Christum liberatorem <lb/> omnium prophetarent. Et
+						posteaquam templum trans<lb/>actis septuaginta annis restitutum cst, tantas
+						pres­ <lb/> suras et calamitates a regibus Gentium Judæi perpessi <lb/>
+						sunt, ut intelligerent nondum venisse liheraiorem , <lb/> quem non
+						spiritualiter liberaturum intelligebant, sed <lb/> pro lihcralione carnali
+						desiderabant.</p>
+				</div>
+				
+				<div type="textpart" subtype="chapter" n="22">
+					<p>39. <hi rend="italic">Ætates</hi> mundi <hi rend="italic">sex. Sexta<lb/>
+							œtas ex adventu Christi. Christus</hi> Novum <hi rend="italic"
+							>Testamentum <lb/> sempiternœ hœreditatis</hi> manifestans, <hi
+							rend="italic">terrena contemnere <lb/> exemplo docet. Nalivitas ejus.
+							vita et mors.</hi> Peractis <lb/> crgo quinque aetatibus sacculi, quarum
+						prima est ab <lb/> initio generis humani, id est, ab Adam, qui primus <lb/>
+						homo factus est, usque ad Noe, qui fecit arcam in di<lb/>luvio <hi
+							rend="italic">(Gen.</hi> VI) ; inde secunda est usque ad Abraham, <lb/>
+						qui pater dictus est 1 omnium quidem gentium <hi rend="italic">( Id.</hi>
+						<lb/> XVII, 4), quæ fidem ipsius imitarentur ; sed tamen ex <lb/> propagine
+						carnis suae * futuri populi Judæorum : qui <lb/> ante fidem christianam
+						gentium, unus inter omnes <lb/> omnium terrarum populus unum verum Deum
+						coluit, <lb/> ex quo populo Salvator Christus secundum carnem <lb/> vcniret.
+						isti enim articuli duarum ætatum eminent In- <lb/> veteribus Libris, :
+						reliquarum autem trium in Evan<lb/>gclio etiam declarantur, cum carnalis
+						origo Domini <lb/> Jesu Christi commemoratur <hi rend="italic">(Matth.</hi>
+						1, 17). N.un ter<lb/>tia est ab Abraham usque ad David regem : quarta a
+						<lb/> David usque ad, illam captivitatem qua populus Dci in <lb/> Babyloniam
+						transmigravit : quinta ab illa transmigra<lb/>tione usque ad adventum Domini
+						nostri Jesu Christi i <lb/> ex cujus adventu sexta ætas agitur : ut jam
+						spiritua<lb/>lis gratia, qiue paucis tunc Patriarchis et Prophetis <lb/>
+						nota erat, manifestaretur omnibus gentibus : no quis­ <lb/> quam Deum nisi
+						gratis coleret, non visibilia præmia <lb/> servitutis suæ et præsentis vitas
+						felitatem, sed solam <lb/> vitam æternam, in qua ipso Dea frueretur, ab illo
+						<lb/> desiderans ; ut hac sexta ætate mens humana rcno<lb/>vetur ad imaginem
+						Dei, sicut sella dic homo factus <lb/> est ad imaginem Dei (Gen. 1, 27).
+						Tunc enim et lex <lb/> impletur, dum non cupiditate rerum temporalium <note
+							type="footnote"> 1 Mss., <hi rend="italic">electus est</hi>.</note>
+						<note type="footnote"> 2 Mss., <hi rend="italic">ex progenie carmis
+							suæ</hi>.</note><lb/>
+						<pb n="339"/> sed charitate illius qui præcepit, fiunt quxcumquc <lb/>
+						præcepit. Quis autem non redamare affectet justissi<lb/>inum et
+						misericordissimum Deum, qui prior sic ama- <lb/> vit injustissimos et
+						superbissimos homines, ut pro<lb/>pter eus mitteret unicum Filium, per quem
+						fecit <lb/> omnia ; qui non sui mutatione, sed bominis assum<lb/>ptione homo
+						factus, non solum cum eis vivcre, sed <lb/> etiam pro eis et ab eis posset
+						occidi?</p>
+					<p>40. Itaque novum testamentum hæredilatis sempi<lb/>ternæ manifestans, in quo
+						renovatus homo per gra<lb/>tiam Dei ageret novam vitam, hoc est vitam
+						spiritua­ <lb/> iem ; ut vetus ostenderet primum , in quo carnalis <lb/>
+						populus agens veterem hominem , exceptis paucis in<lb/>telligentibus
+						Patriarchis et Prophetis et nonnullis la­ <lb/> tentibus sanctis, carnaliter
+						vivens carnalia præmia <lb/> desiderabat a Domino Deo, et in figura
+						spiritualium <lb/> bonorum accipiebat: omnia ergo bona terrena con­ <lb/>
+						tempsit bomo factus Dominus Christus, ut contc<lb/>mnenda monstraret ; et
+						omnia terrena sustinuit mala , <lb/> quæ sustinenda præcipiebat : ut neque
+						in illis quæ­ <lb/> rcretur felicitas, neque in istis infelicitas timcretur.
+						<lb/> Natus enim de matre quæ quamvis a viro intacta <lb/> conceperit,
+						semperque intacta permanserit , virgo <lb/> concipiens, virgo pariens, virgo
+						moriens, tamen fa<lb/>bro desponsata erat, omnem typhum carnalis
+						nobi!!<lb/>tatis exstinxit. Natus cHam in civitate Bethlehem, <lb/> quæ
+						inter omnes Judææ civitates ita erat exigua , ut <lb/> hodieque villa
+						appelletur, noluit qucmquam de cujus<lb/>quam terrenæ civitatis sublimitate
+						gloriari. Pauper <lb/> ctiam factus est, cujus sunt omnia, et per quem <lb/>
+						creata suut omnia ; IIC quisquam cum in cum credo<lb/>vet, de terrenis
+						divitiis auderet extolli. Noluit rex <lb/> ab hominibus fieri ; quia
+						humilitatis ostendebat viam <lb/> tniscris, quos ab co I superbia
+						separaverat: quamvis <lb/> sempiternum ejus regnum universa cre tUra
+						testetur. <lb/> Esurivit, qui omnes pascit; sitivit, per quem creatur <lb/>
+						omnis potus, et qui spiritualiter panis est csuricnlium <lb/> fonsque
+						sitientium : ab itinere terrestri fatigatus cst, <lb/> qui se ipsum nobis
+						viam fccit in cainum : velut obmu<lb/>tuit ct cbsurduit coram
+						conviciantibus, per quem <lb/> mutus locutus est et surdus audivit : vinctus
+						est, qui <lb/> dc infirmitatum vinculis solvit : flagellatus est, qui <lb/>
+						omnium dolorum flagella de hominum corporibus cx<lb/>pulit : crucifixus est,
+						qui cruciafus nostros finivit : <lb/> mortuus cst, qui mortuos suscita vit.
+						Scd ct resur­ <lb/> rexit nunquam moriturus, ne ab illo quisquam sic <lb/>
+						disceret mortem contemuere, quasi nunquam vi<lb/>eturus '.</p>
+				</div>
+				
+				<div type="textpart" subtype="chapter" n="23">
+					<p>41. Spiritus <hi rend="italic">sanctus die quinqua-<lb/> gcsima post
+							resurrectionem Christi missus. Judœi prœ<lb/>dicutione Apostolorum
+							conversi, vitœ evangelicœ sindio<lb/> flagrantes. Ecclesiœ apud Gentes
+							per Paulum constitutre-</hi>
+						<lb/> Inde confirmatis discipulis, couversatus cum eis qua<lb/>draginta
+						diebus , eisdem spectantibus ascendit in cœ<lb/>lum ; et completis a
+						resurrectione quiuquaginta dic<lb/>bus misit eis Spiritum sanctum
+						(promiserat enim), <note type="footnote"> 1 Sic Mss. At editi, <hi
+								rend="italic">ab ea</hi>.</note>
+						<note type="footnote"> 2 Am. Er. et fere omnes Mss., <hi rend="italic"
+								>futurus</hi>. Unus Vaticanus <lb/> Ms., <hi rend="italic"
+								>resurrecturus</hi>.</note>
+						<lb/> per quem diffusa charitate in cordibus eorum, non <lb/> solum sinc
+						onere, sed cHam cum jucunditate legem <lb/> possent implere. Quae data est
+						Judæis in decem præ­ <lb/> ceptis, quod appellant decalogum. Quæ rursus ad
+						<lb/> duo rcdiguntur, ut diligamus Deum ex toto corde, ex <lb/> tota anima,
+						ex tota mente ; et diligamus proximum <lb/> sicut nos ipsos. Nam in his
+						duobus præceptis totam <lb/> Legem Prophetasque pendere, ipse Dominus et
+						dixit <lb/> in Evangelio <hi rend="italic">(Matth.</hi> XXII, 37-40), et suo
+						manifesta- <lb/> vit exemplo. Namf et populus Israel ex die quo pri<lb/>mum
+						pascha in imagine celebrarunt, ovcm occidentes <lb/> et manducantes, cujus
+						sanguine postes corum ad sa<lb/>lutis tutelam signati sunt <hi rend="italic"
+							>(Exod.</hi> XII); ex ipso ergo <lb/> dic quinquagesimus dies impletus
+						est , et legem acce<lb/>peruut scriptam digito Dei <hi rend="italic"
+							>(Id.</hi> xix, xx), quo no<lb/>niine jam diximus significari Spiritum
+						sanctum (Su­ <lb/>
+						<hi rend="italic">pra, cap.</hi> xx, n. 55) : sicut post Domini passionem ei
+						<lb/> resurrectionem , quod est verum pascha , quinquage<lb/>simo die ipse
+						Spiritus sanctus discipulis missus est : <lb/> non jam lapidcis tabulis
+						corda dura significans ; sed, <lb/> cnm cssent unum in locum, congregati in
+						ipsa Jerusa<lb/>lem , factus est subito de coelo sonus, quasi ferretur <lb/>
+						flatus vehenens, ct visae sunt illis linguæ divisæ quasi <lb/> ignis, et
+						cœpcrunt linguis loqui, ita ut omnes qui ad <lb/> illos venerant, suam
+						linguam quisque cognoscerct (ad <lb/> illam enim civitatem ex omni terra
+						conveniebant Ju<lb/>daei, quacumque dispersi crant, et diversas lingu. s
+						<lb/> gentium diversarum didicerant <hi rend="italic">[Act.</hi> II, 1-1
+						1]): deinde <lb/> cum tota fiducia Christum prædicantes, in ejus no<lb/>mine
+						multa signa faciebant, ita ut quemdam mor<lb/>tuum transennte Petro umbra
+						ejus tetigerit, et resur<lb/>rexerit <hi rend="italic">(Id.</hi> v, 15).</p>
+					<p>42. Sed cum viderent Judxi tan!a signa fieri in ejus <lb/> nomine , quem
+						partim per invidiam , partim per er<lb/>rorem crucifixerunt, alii irritati
+						sunt ad persequendos <lb/> prædicatores ejus Apostolos, alii vero idipsum
+						am<lb/>plius admirantes, quod in ejus nomine, quem veluti <lb/> a se
+						oppressum et victum riserant, tanta miracula <lb/> fit'rent , poenitendo
+						conversi crediderunt in eum mil<lb/>lia 1 Judœorum. Non erant jam illi
+						temporalii benefi<lb/>cia terrenumque regnum desiderantes a Ico, nec <lb/>
+						promissum regem Christum carnaliter exspectantes : <lb/> sed immertaliter
+						intelligentes ei diligentes eum qui <lb/> pro ipsis ab ipsis tanta
+						mortaliter pertulit, et cis <lb/> usque ad sui sanguinis ' peccata donavit ,
+						et immor<lb/>talitatem a se sperandam et desiderandam exemplo <lb/> suæ
+						resurrectionis ostendit. ltaque jam veteris homi­ <lb/> nis terrena
+						desideria mortificantes, et spiritualis vitæ <lb/> novitate flagrantes ,
+						sicut præceperat in Evangelio <lb/> Dominus, vendebant omnia quæ habebant,
+						et pretia <lb/> rerum suarum ante pedes Apostolorum poncbant, ut <lb/> ipsi
+						distribuerent unicuique , sicut cuique opus erat <lb/>
+						<hi rend="italic">(Id.</hi> II , 44, <hi rend="italic">ct</hi> IV , 34) :
+						viventesque in christiana di<lb/>lectione concorditer , non dicebant aliquid
+						suum, scd <lb/> crant illis omnia communia , et anima et cor unum in <lb/>
+						Deum <hi rend="italic">(Id.</hi> IV , 32 35). Deiade etiam ipsi a Judæis car
+							<note type="footnote"> 1 Lov., post, <hi rend="italic">crediderunt in
+								eum millia</hi>, addiderunt,<lb/>
+							<hi rend="italic">multa</hi>, ex uno codice Ms.</note>
+						<note type="footnote"> 2 Hic in editione Lov. additum fuerat,<hi
+								rend="italic">effusionem</hi> : minus<lb/> bene.</note><lb/>
+						<pb n="341"/>nalibus civibus carnis suae persecutionem passi atque <lb/>
+						dispersi sunt, ut tatius Christus eorum dispersione <lb/> prædicaretur, et
+						imitarentur etiam ipsi patientiam <lb/> Domini sui : quia qui eos 1
+						mansuetus passus fuerat , <lb/> mansuefactos pro se pati jubebat.</p>
+					<p>43. Ex ipsis sanctorum persecutoribus fuerat etiam <lb/> apostolus Paulus, et
+						in Christianos maxime soevio<lb/>bat : sed postea credens et apostolus
+						factus, missus <lb/> cst ut Gentibus Evangelium prædicaret, graviora
+						per<lb/>pessus pro nomine Christi, quam fecerat contra no<lb/>men Christi.
+						Ecclesias autem constituens per omnes <lb/> gentes qua Evangelium seminabat,
+						impense præcipie<lb/>bat, ut quoniam ipsi ex idolorum cultu venientes, et
+						<lb/> ad unum Deum colendum rudes , non facile potcrant <lb/> rehus suis
+						venditis et distributis servire Deo , obla<lb/>tiones facerent in pauperes
+						sanctorum qui erant in <lb/> Ecclesiis Judrrae, quæ Christo crediderant :
+						ita illos <lb/> tanquam milites, illos autem tanquam stipendiarios <lb/>
+						provinciales apostolica doctrina constituit; inserens <lb/> cis Christum
+						velut lapidem angularem , sicut per pro<lb/>phetam prænuntiatus crat, in quo
+						ambo quasi parietes <lb/> dc diverso venientes, de Judæis videlicet atque
+						Gen<lb/>tibus, germana charitate copularentur <hi rend="italic">(Psal.</hi>
+						CXVII, <lb/> 22, <hi rend="italic">et Isai.</hi> XXVIII, 16). Sed postea
+						graviores et cre<lb/>briores persecutiones ex incredulis gontibus adversus
+						<lb/> Christi Ecclesiam surrexerunt, et implebatur in dies <lb/> singulos
+						verbum Domini prædicentis, <hi rend="italic">Ecce ego mitto</hi>
+						<lb/> vos <hi rend="italic">velut oves in medio luporum (Math.</hi> x,
+						16).</p>
+				</div>
+				
+				<div type="textpart" subtype="chapter" n="24">
+					<p>44. <hi rend="italic">Ecclesia quasi vitis pullulat, <lb/> et putatur. Ex iis
+							quæ videntur impleta, credantur præ<lb/>dicta qum restant implenda,
+							præsertim judicium</hi> futu<lb/>rum. Sed illa vitis quæ per orbem
+						terrarum, sicut de <lb/> illa prophetatum, ct ab ip o Domino prænuntiatum
+						<lb/> crat, fructuosos palmites diffundebat, tanto pullula<lb/>lat amplius,
+						quanto uberiore' martyrum sanguinc <lb/> rigabatur. Qnibus per omnes terras
+						innumerabiliter <lb/> pro fidei vcritatc morientibus, etiam ipsa
+						persequentia <lb/> regna cesserunt, et ad Christum cognoscendum atque <lb/>
+						venerandum fracta superbiæ cervice conversa sunt. <lb/> Oportebat antemi ut
+						cadem vitis, sicut a Domino <lb/> identidem prædictum erat, putaretur , ct
+						ex ea proc­ <lb/> ciderentur infructuosa sarmenta <hi rend="italic"
+							>(Joan.</hi> xv, 2) , qui<lb/>bus hæreses ct schismata per loca facta
+						sunt, sub <lb/> Christi nomine, non ipsius gloriam , sed suain
+						quæ<lb/>rentium, pur quorum adversitates magis magisque <lb/> exerceretur
+						Ecclesia. et probaretur alqucillustrarclur <lb/> il doctrina ejus et
+						patientia.</p>
+					<p>45. Omnia ergo hæc, sicut tanto antc prædicta le<lb/>gimus, sic ct facta
+						cognoscimus : et quemadmodum <lb/> primi christiani, quia nondum ista
+						provenisse vidc<lb/>bant, miraculis movchantur ut crederent; sic nos <lb/>
+						quia omnia ista ita completa sunt, sicut ea inLibris <lb/> legimus, qui
+						longe antequam hæc implerentur con<lb/>scripti sunt, uhi omnia futura
+						dicebantur, ct præsen<lb/>tia jam videntur, ædificamur ad fidcm, ut etiam
+						illa <note type="footnote"> 1 Am. et Er., <hi rend="italic">qui ante
+								cos</hi> Lov., <hi rend="italic">qui pro eis</hi> , Aliquot Mss. <lb/>
+							<hi rend="italic">qui per cos</hi> ; et quidam, <hi rend="italic">qui
+								propter cos</hi> ; plerique ??? <lb/>
+							<hi rend="italic">qui cos</hi>.</note>
+						<note type="footnote"> 2 Am. et Er., <hi rend="italic"
+							>teneriore.</hi></note>
+						<lb/> quæ restant, sustinentes et perseverantes in Domino, <lb/> sine
+						dubitatione ventura credamus. Siquidem adhuc <lb/> tribulationes futurae in
+						eisdem Scripturis leguntur, et <lb/> ipse ultimus judicii dies, ubi omnes
+						cives ambarum <lb/> illarum civitatum receptis corporibus surrecturi sunt,
+						<lb/> et rationem vitae suæ ante tribunal Christi judicis red<lb/>dituri.
+						Veniet enim in claritate potestatis, qui prius <lb/> in humilitate
+						humanitatis venire dignatus est; et <lb/> omnes pios ab impiis segregabit :
+						non tautum eis qui <lb/> in eum credere omnino noluerunt, sed etiam eis qui
+						<lb/> frustra et infructuose crediderunt in eum ; illis datu<lb/>rus regnum
+						secum æternum, illis autem poenam <lb/> aeternam cum diabolo. Sed sicut
+						nullum gaudium re<lb/>rum temporalium ex aliqua parte simile potest
+						inve<lb/>uiri gaudio vitae æternæ , quam sancti accepturi <lb/> sunt ; ita
+						nullus cruciatus poenarum temporalium po<lb/>test sempiternis iniquorum
+						cruciatibus comparari.</p>
+				</div>
+				
+				<div type="textpart" subtype="chapter" n="25">
+					<p>46. Fides <hi rend="italic">resurrectionis suadetur.<lb/> Mors perpetua</hi>
+						in <hi rend="italic">tormentis. Vita æterna sanctornm. <lb/> Cavendum non
+							tantum</hi> a <hi rend="italic">Paganis,</hi> Judæis, <hi rend="italic"
+							>et hære­ <lb/> ticis, sed etiam a malis Christianis. Societas</hi> sit
+							<hi rend="italic">cum bonis;</hi>
+						<lb/> non <hi rend="italic">tamen</hi> spes in <hi rend="italic">ipsis
+							ponatur.</hi> Itaque, frater, confir<lb/>ma te ipsum in ejus nomine
+						atque adjutorio cui cre­ <lb/> dis, adversus linguas eorum qui fidem nostram
+						irrident, <lb/> de quibus diabolus seductoria verba loquitur, maxime <lb/>
+						volens irridere fidem resurrectionis. Sad cx te ipso <lb/> erede futurum te
+						esse cum fueris , quando cum aute <lb/> non fueris, nunc esse te vides. Ubi
+						enim erat ista mo<lb/>les corporis lui et ista forma membrorumque compa -
+						<lb/> go ante paucos annos, priusquam natus, vel etiam <lb/> priusquam in
+						matris utero conceptus esses ? ubi erat <lb/> hæc moles et hæc statura
+						corporis tui? Nonne de oc-. <lb/> cultis hujus creaturae secretis, Domino
+						Deo invisibili . <lb/> ter formante , processit in lucem, certisque ætatum
+						<lb/> incrementis in istam magnitudinem formamque surre<lb/>xit? Numquid
+						ergo difficile est Deo, qui etiam aggeres <lb/> nubium ex occulto in momento
+						contrahit, et contegit <lb/> cælum in ictu temporis, reddere istam
+						quantitatem <lb/> corporis tui sicut crat, qui eam facere potuit sicut non
+						<lb/> crat 1? Crede ergo fortiter et inconcusse quia omnia <lb/> quæ
+						videntur quasi pcreundo humanis oculis subtra. <lb/> hi, salva et integra
+						sunt omnipotentiae Dei; qui ea <lb/> cum voluerit, sine ulla mora et
+						difficultate reparabit, <lb/> ea duntaxat quæ justitia ejus reparanda esse
+						judicat : <lb/> ut in his corporibus reddant homines factorum suorum <lb/>
+						rationem, in quibus ea fecerunt; et in his mereantur <lb/> aut commutationem
+						cœlestis incorruptionis pro me<lb/>ritis pietatis, aut corruptibilem I
+						corporis conditioneui <lb/> pro meritis iniquitatis, non quae morte
+						solvatur, sed <lb/> quae materiam sempiternis doloribus præbeat.</p>
+					<p>47. Fuge ergo per immobilem fidem et mores bo - <lb/> nos', fuge, frater,
+						illatormenta, ubi nec tortores de<lb/>ficiant, nec torti moriuntur; quibus
+						sinc fine mors <lb/> est, non posse in cruciatibus mori. Et exardesce <lb/>
+						amore atque desiderio sempiternæ vitæ sanctorum, <note type="footnote"> 1
+							Sic Am. Er. et plures Mss. At Lov., <hi rend="italic">potuit cum non
+								erat,</hi>
+							<lb/> Corbeiensis codex a secunda manu, <hi rend="italic">sic cum non
+								erat</hi>.</note>
+						<note type="footnote"> 2 Aliquot Mss., <hi rend="italic"
+							>corruptibilis</hi>.</note>
+						<note type="footnote"> 3 Sic Mss. Editi vero, <hi rend="italic">ad mores
+								bonos</hi>.</note><lb/>
+						<pb n="343"/> ubi nec operosa erit actio, nec requies desidiosa; <lb/> laus
+						erit Dei sine fastidio, sine defectu : nullum in <lb/> animo tædium , nullus
+						labor in corpore; nulla indi<lb/>gentia, nec tua cui subveniri desideres,
+						nec proximi <lb/> rui subvenire festines. Omnes deliciæ Deus erit et
+						sa<lb/>tictas1 sanctæ civitatis in illo et de illo sapienter bea<lb/>teque
+						viventis. Efficiemur enim, sicut ab illo promis<lb/>sum speramus ct
+						exspectamus , aequales Angelis Dei <lb/>
+						<hi rend="italic">(Luc.</hi> xx, 36), et cum cis pariter illa Trinitate
+						per... <lb/> fruemur jam per speciem, in qua nunc per fidem <lb/> ambulamus
+						( II <hi rend="italic">Cor.</hi> v, 7). Credimus cnim quod non <lb/>
+						videmus, ut ipsis meritis fidei etiam videre quod cre<lb/>dimus et inhaerere
+						mereamur; ut aequalitatem Patris <lb/> et Filii et Spiritus sancti, et
+						ipsius Trinitatis unitatem, <lb/> quomodo sint hxc tria unus Deus, non jam
+						verbis fi<lb/>dci et strepentibus syllabis personemus, sed contem­ <lb/>
+						platione purissima et ardentissima in illo silentio sor<lb/>beamus1.</p>
+					<p>48. Hæc tene fixa in corde tuo, et invoca Deum <lb/> cui credis, ut tucatur
+						te adversus tentationes diaboli: <lb/> et esto cautus, ne tibi aliunde
+						hostis ille subrepat, <lb/> qui ad solatium malevolentissimum damnationis
+						suæ, <lb/> cum quibus damnetur inquirit. Non enim per eos so<lb/>los qui
+						christianum nomen oderunt, et dolent eo no­ <lb/> mine occupatum esse orbem
+						terrarum, et adhuc si<lb/>mulacris et daemoniorum curiositatibus servire
+						desi<lb/>derant, audet ille tentare christianos : sed etiam per <lb/> eos
+						quos paulo ante commemoravimus, de unitate <lb/> Ecclesiæ, velut putata
+						vite, præcisos, qui hæretici vel <lb/> schismatici dicuntur, conatur etiam
+						id quidem inter<lb/>dum, Sed tamen id etiam aliquando conatur et per <lb/>
+						Judaeos tentare, atque seduccre. Sed maxime caven<lb/>dum est ne per homines
+						qui sunt in ipsa catholica <lb/> Ecclesia, quos velut paleam usque ad tempus
+						ventila<lb/>tionis suæ sustinet, unusquisque tentetur et decipia<lb/>tur.
+						Propterea enim Deus patiens est in illus, ut et <lb/> suorum electorum fidem
+						atque prudentiam per illo<lb/>rum perversitatem exercendo confirmet; et quia
+						de <lb/> numero eorum multi proficiunt, et ad placendum Dee <lb/> miserati I
+						animas suas, magno impetu convertuntur. <lb/> Non enim omnes sibi per
+						patientiam Dei thesaurizant <lb/> iram in die iræ justi judicii ejus : sed
+						multos eadem Om<lb/>nipotentis patientia perducit ad saluberrimum poeni­
+						<lb/> tentiæ dolorem (Rom. II, 5, 4). Quod donec fiat, <lb/> exercetur per
+						eos illorum qni jam rectam viam tenent, <lb/> non solum tolerantia , sed
+						etiam misericordia. Multos <lb/> ergo visurus es ebriosos, avaros,
+						frandatores, aleato<lb/>res, adulteros, fornicatores, remedia sacrilega sibi
+						al<lb/>ligantes, præcantatoribus et mathematicis vel quarum<lb/>libet
+						impiarum artium diviuatoribus dcditos. Animad<lb/>versurus etiam qnod illac
+						turbæ impleant ecclesias per <lb/> dies festos Christianorum, quæ implent et
+						theatra <lb/> per dies solemnes Paganorum; et haec videndo ad <lb/>
+						imitandum tentaberis. Et quid dicam , vidcbis , quod <lb/> etiam nunc jam
+						utique nosti ? non enim nescis nullos <note type="footnote"> 1 Editi, <hi
+								rend="italic">societas</hi>. Aptius forte quinque Mss., <hi
+								rend="italic">satietas</hi>.</note>
+						<note type="footnote"> 2 Sic duo Mss. At editi <hi rend="italic"
+								>sorbeamur</hi>.</note>
+						<note type="footnote"> 3 Lov., <hi rend="italic">miseranti</hi>. Melius Am.
+							Er. et aliquot Mss., <hi rend="italic">mise<lb/>rati</hi>. Alludit ad
+							illud Ecclesiastici, cap. 30, 21. : <hi rend="italic">Miserere <lb/>
+								animæ tuæ placens Deo</hi>.</note>
+						<lb/> qui appellantur christiani, hæc omnia mala operari. <lb/> quae
+						breviter commemoravi. Et aliquando1 fortasse <lb/> graviora facere homines
+						non ignoras, quos nosti ap<lb/>pellari christianos. Sed si hoc animo
+						venisti, ut quasi <lb/> securus talia facias, multum erras : nec tibi
+						proderit <lb/> nomen Christi, cum coeperit ille severissime judicare, <lb/>
+						qni prius dignatus est misericordissime subvenire. <lb/> Praedixit enim ista
+						, et ait in Evan gelio : <hi rend="italic">Non omnis<lb/> qui dicit mihi,
+							Domine, Domine , intrabit in regnum <lb/> cœlorum; sed</hi> is <hi
+							rend="italic">qui facit voluntatem Patris mei. Multi<lb/> dicent
+							mihi</hi> in <hi rend="italic">illa die, Domine, Domine,</hi> in <hi
+							rend="italic">nomine<lb/> tuo manducavimus et bibimus (Matth.</hi> VII,
+						21,22). <lb/> Omnibus ergo qui in talibus opcrihus perseverant, <lb/>
+						damnatio finis est. Cum ergo videris multos non so. <lb/> lum hæc facere,
+						sed etiam defendere atque suadere, <lb/> tene te ad legem Dei, et non
+						seqnaris prævaricatores <lb/> ejus. Non enim secundum illorum sensum. sed
+						secun<lb/>dum illitis veritatem judicabci is.</p>
+					<p>49. Conjungere bonis, quos vidcsamnre tecum re<lb/>gem tuum. Multos enim
+						inventurus es, si et tu talis <lb/> esse coeperis. Nam si in spectaculis cum
+						illis esse cu­ <lb/> picbas et eis inhærere 2, qui tecum vel aurigam, vcl
+						<lb/> venatorem, vel aliquem histrionem simul amabant; <lb/> quanto magis te
+						delectare debet eorum conjunctio, <lb/> qui tecum amant Deum , de quo
+						nunquam erubescet <lb/> amator ejus, quia non solum ipse non potest vinci,
+						<lb/> sed eliam dilectores suos reddet invictos? Nec tamen <lb/> etiam in
+						ipsis bonis, qui te vel praecedunt vel tibi co<lb/>mitanturad Deum2, spem
+						tuam collocare debes, quia <lb/> nee in te ipso debes quantumcumque
+						profeceris, sed <lb/> in illo qui eos et te justificando tales facit.
+						Securus es <lb/> enim de Deo, quia non mutatur : de homine autem <lb/> nemo
+						prudenter securus est. Sed si illos qni nondum <lb/> justi sunt, amare
+						debemus ut sint ; quanto ardentius <lb/> qui jain sunt, amandi sunt? Sed
+						aliud est diligere h<lb/> minem, aliud spem ponere in homine; tantumque in •
+						<lb/> terest, ut illud Deus jubeat, hoc prohibeat. Si autem <lb/> aliquas
+						vel insultationes vcl tribulationes pro nomine <lb/> Christi passus non
+						defeceris a fide, nec a bona via 4 <lb/> deviaveris, majorem mercedem
+						acceplurus es : qni <lb/> autem in his diabolo cesserint, etiam minorem
+						perdunt. <lb/> Sed humilis esto Dco, ut non te permittat tentari ut<lb/>tra
+						vires tuas.</p>
+				</div>
+				
+				<div type="textpart" subtype="chapter" n="26">
+					<p>50. <hi rend="italic">Initiatio catechumeni, cum<lb/> expositione signorum.
+							Sermo quandoque</hi> brevior adhi<lb/>bendus. <hi rend="italic">Incipit
+							sermo alius brevior. Filius Dei</hi> immissus, <lb/>
+						<hi rend="italic">ut a morte qnce per Adamum intravit,</hi> liberaremur.
+						Ilis <lb/> dictis, interrogandus cst an hæc credat atque obser<lb/>vare
+						desideret Quod cum responderit, solemniter uti<lb/>quesignandus est et
+						Ecclesiæ more tractandus. De sa­ <lb/> cramento sane <hi rend="italic"
+							>(a)</hi> quod accipit5, cum ei bene commen­ <lb/> datum fuerit,
+						signacula quidem rerum divinarum es, a <lb/> visibilia, sed res ipsas
+						invisibiles in eis honorari; nec <lb/> sic habendam esse illam speciem
+						benedictione sancti <note type="footnote"> 1 Mss., <hi rend="italic"
+								>aliquanto</hi>.</note>
+						<note type="footnote"> 2 Sic Am. Er. et Mss. At Lov.: <hi rend="italic">Nam
+								si in spectaculis et va<lb/> nitalibus insanorum certaminum illis
+								cupiebas inhærere</hi>.</note>
+						<note type="footnote"> 3 Er. Lugd. Ven. Lov. omittunt, <hi rend="italic"
+								>tibi</hi>. M.</note>
+						<note type="footnote"> 4 Am. Er. et plures Mss., <hi rend="italic"
+							>vita</hi>.</note>
+						<note type="footnote"> 5 Sic Mss. At editi, <hi rend="italic"
+							>accepit</hi>.</note>
+						<note type="footnote"> (a) Forte. <hi rend="italic">salis</hi>.</note><lb/>
+						<pb n="345"/> ficalnm , quemadmodum habetur in usu quolibet : <lb/> dicendum
+						eliam quid significet et sermo ille qucm au<lb/>divit, quid in illo
+						condiat1, cujus illa res siinilitudi<lb/>nem gerit. Deinde monendus est cx
+						hac occasione, <lb/> ut si quid etiam in Scripturis audiat quod carnaliter
+						<lb/> sonet, etiamsi non intelligit, credat tamen spirituale <lb/> aliquid
+						significari, quod ad sanctos morcs futuramque <lb/> vitam pertineat. Hoc
+						autem ita breviter discit 2, ut <lb/> quidquid audierit ex Libris canonicis
+						quod ad dilectio<lb/>nem æternitatis et veritatis et sanctitatis, et ad
+						dile<lb/>ctionem proximi referre non possit, figurale dictum <lb/> vel
+						gestum esse credat; atque ita conetur intelligere, <lb/> ut ad illam gcminam
+						referat dilectionem. Ita sane ut <lb/> proximum non carnaliter intelligat,
+						sed omnem quicum <lb/> eo in illa sancta civitate potest esse, sive jam,
+						sive non<lb/>dum appareat : ct ut de nullius hominis correcliono <lb/>
+						desperet, quem patientia Dci videt vivere, non ob <lb/> aliud, sicut
+						Apostolus ait, nisi ut adducatur ad pœni<lb/>tentiam <hi rend="italic"
+							>(Rom.</hi> 11, 4).</p>
+					<p>51. Si longus tibi videtur iste sermo, quo tanquam <lb/> præsentem rudcm
+						hominem instruxi, licet ea tibi di<lb/>cere brevius, longiorem tamen esse
+						debere non puto : <lb/> quanquam mullum interest quid res ipsa, cum agitur,
+						<lb/> moneat, ei quid audiiorum præsentia non solum fer<lb/>re, sed etiam
+						desiderare se ostendat. Cum autem ce<lb/>leritate opus est, vide quam facile
+						explicari tota res <lb/> possit. Fac rursas adesse aliqucm, qui velit esse
+						chri<lb/>stianus: ergo et interrogatum, illud quod superior
+						re<lb/>spondissc; quia et si non hoc respondet, huc eum re­ <lb/> spondere
+						debuisse dicendum est. Dcinde hoc modo ct <lb/> cætera contexenda.</p>
+					<p>52. Vere, frater, illa magna et vera beatitudo est, <lb/> quæ in futuro
+						saeculo sanctis promittitur. Omnia vero <lb/> visibilia transeunt, et omnis
+						hujus sacculi pompa et <lb/> deliciæ et curiositas interibunt, et secum ad
+						inter<lb/>itum trahunt amatores suos. A quo interitu, hoc est, <lb/> poenis
+						sempiternis Deus misericors volens homines <lb/> liberare , si sibi ipsi non
+						sint inimici, et non resi<lb/>stant misericordiæ Creatoris sui, misit
+						unigcnilumFi<lb/>lium suum, hoc est, Verbum suum aequale sibi, per <lb/>
+						quod condidit omnia. Et manens quidem in divinitate <lb/> sua, et non
+						recedens a Patre, nec in aliquo mutatus, <lb/> assumendo tamen hominem, et
+						in carne mortali' ho­ <lb/> minibus apparendo venit ad homines : ut
+						quemad<lb/>modum per unum hominem qui primus factus est, id <lb/> cst Adam,
+						mors intravit in genus humanum, quia <lb/> consensit mulieri suae seductae a
+						diabolo, ut præce<lb/>ptum Dei transgrederentur; sic per unum homi<lb/>nen
+						qui eUam Deus est Dei Filius, Jesum Chri<lb/>stum, deletis omnibus peccatis
+						præteritis, creden<lb/>tes in cum omnes in æternam vitam ingrederentur <lb/>
+							(<hi rend="italic">Id.</hi> v, 12-19). <note type="footnote"> 1 Er. et
+							Lov., <hi rend="italic">condatur</hi>. Verius Mss. et Am., <hi
+								rend="italic">condiat</hi>. Nam <lb/> agitur hic de sacramento
+							salis, quo catechumenus initiatur. <lb/> Huc pertinet illud Augustini
+							lib. 1 Confess., cap. 11 : « Et<lb/> a signabar jam signo crucis ejus,
+							et condiebar ejus sale, <lb/> « jam inde ab utero matris meæ. » Ipsa est
+							quam hic dixit <lb/> speciem <hi rend="italic">beneditione
+								sanctificatam</hi> : adeoque paulo supra <lb/> loco, <hi
+								rend="italic">sane;</hi> legendum videtur, <hi rend="italic"
+								>salis.</hi></note>
+						<note type="footnote"> 2 Sic Mss. Editi vero, <hi rend="italic"
+							>discet</hi>.</note>
+						<note type="footnote"> 3 Aliquot Mss., <hi rend="italic"
+							>mortalis</hi>.</note></p>
+				</div>
+
+				<div type="textpart" subtype="chapter" n="27">
+					<p>53. <hi rend="italic">Prophetias Veleris Testa</hi>
+						<lb/>menti <hi rend="italic">impletas cerni in Ecclesia. Hinc firmata fides
+							eo. <lb/> rum quæ ventura restant, judicii</hi> ultimi <hi rend="italic"
+							>et resurrectio<lb/> nis. Cavendæ</hi> tentationes <hi rend="italic"
+							>a</hi> malis <hi rend="italic">etiam in Ecclesia re-</hi>
+						<lb/> perlis. <hi rend="italic">Societas cum bonis. Spes</hi> omnis in <hi
+							rend="italic">Deo.</hi> Omnia <lb/> enim 1 qu v nunc vides in Ecclesia
+						Dei, et sub Chri<lb/>sti nominc p er totum orbem terrarum geri2, ante
+						sæ<lb/>cula jam prædicta sunt, et sicut ca legimus, ita ct <lb/> vidcmus; et
+						inde ædificamur in fidem. Factum cst ali­ <lb/> quando diluvium per totam
+						terram, ut peccatores de<lb/>lerentur : et tamen illi qui evaserunt in arca
+						: sacra<lb/>mentum futuræ Ecclesiæ demonstrabant, quæ nunc <lb/> in
+						fluctibus sæculi natat, et per lignum crucis Chri<lb/>sli a submersione
+						liberatur. Prædictum est Abrahæ <lb/> fidcli Servo Dei, uni homini, quod de
+						illo esset po­ <lb/> pulus nasciturus, qui coleret unum Deum inter
+						cæ<lb/>teras gentes quæ idola colebant : et omnia quæ illi <lb/> populo
+						ventura prædicta sunt, sic evenerunt ut præ­ <lb/> dicta sunt. Prophetatus
+						est in illo populo etiam Chri<lb/>stus rex omnium sanctorum et Deus venturus
+						ex se<lb/>mine ipsius Abraham secundum carnem, quam as­ <lb/> sumpsit, ut
+						omnes etiam filii essent Abrahæ, qui fidem <lb/> ejus imitarentur; et sic
+						est factum : natus est Chri<lb/>stus de Maria virgine, quæ ex illo genere
+						fuit. Præ­ <lb/> dictum est per Prophetas quod in cruce passurus es. <lb/>
+						set ab eodem populo Judæorum , de cujus genere se<lb/>cundum carnem
+						veniebat; et sic est factum. Prædi­ <lb/> ctum est quod resurrecturus esset;
+						resurrexit: et se<lb/>cundum ipsa prædicta Prophetarum ascendit in coelum,
+						<lb/> et discipulis suis Spiritum sanctum misit. Prædictum <lb/> est non
+						solum a Prophetis, sed eliam ab ipso Domino <lb/> Jesu Christo, quod
+						Ecclesia ejus pcr universum or<lb/>bem terrarum esset futura, pcr*sanctorum
+						martyria <lb/> passionesque disseminata; et tunc praedictum, quando <lb/>
+						adhuc nomen ejus et latebat gentes, et ubi notum erat <lb/> irridebatur: et
+						tamen in virtutibus miraculorum cjus, <lb/> sive quæ per se ipse, sive quæ
+						per servos suos fecit, <lb/> dum annuntiantur hoec et creduntur, jam videmus
+						<lb/> quod prædictum est esse completum, regesque ipsos <lb/> terræ, qui
+						antea persequebantur Christianos, jam <lb/> Christi nomini subjugatos.
+						Prædictum est etiam quod <lb/> schismata et hæreses ex ejus Ecclesia essent
+						exitu<lb/>ræ, et sub ejus nominc per loca ubi possent, suam, <lb/> non
+						Christi, gloriam quæsituræ; et ista completa <lb/> sunt.</p>
+					<p>54. Numquid ergo illa qunc restant n n sunt ven<lb/>tura ? Manifestum est
+						quia sicut ista pr:rdicta vene<lb/>runt, sic etiam illa ventura sunt:
+						quæcumque tri­ <lb/> bulationes juslormn adhuc restant; el judicii dies,
+						<lb/> qui separabit omnes impius a justis in resurrectione <lb/> mortuorum;
+						et non solum cos qui sunt extra Eccle­ <lb/> siarn , sed etiam ipsius
+						Ecclesiæ palcas, quas opor<lb/>tet us iae ad novissimam ventilatienem
+						patientissime <lb/> sufferat, ad ignem debitum segregabit. Qui autem ir­
+						<lb/> rident resurrectionem , putantes quod caro ista quia <lb/> putrescit,
+						resurgere non potest, ad pœnas in ca re<lb/>surrecturi sunt : et ostendet
+						eis Deus quia qui potuit <note type="footnote"> 1 Corbeiensis Ms., <hi
+								rend="italic">Omnia ergo</hi>.</note>
+						<note type="footnote"> 2 Abest, <hi rend="italic">geri</hi>, a Mss.</note><lb/>
+						<pb n="347"/> hæc corpora facere antequam essent, potest ca in mo<lb/>mento
+						restiluerc sicut erant. Omnes autem fideles re<lb/>gnaturi cum Christo, iia
+						resurgent in eodem corpore, <lb/> ut etiam commutari mereantur ad
+						incorruptionem <lb/> angelicam : ut fiant æquales Angelis Dei, sicut
+						Do<lb/>minus &lt;psc promisit <hi rend="italic">(Luc.</hi> xx, 36) ; ct
+						Llaudent eum <lb/> sine aliquo defectu et sine aliquo fastidio, semper <lb/>
+						viventes in illo et de illo, cum tali gaudio et bca­ <lb/> titudine, quali
+						nee dici' nec cogitari ab homine <lb/> potest.</p>
+					<p>55. Tu itaque credens ista, cave tentationes (quia <lb/> diabolus quærit qui
+						secum pereant): ut non solum per <lb/> eus qui extra Ecclesiam sunt, sive
+						Pagani, sive Ju­ <lb/> dæi,sive hæretici , non te hostis ille seducat ; sed
+						<lb/> ctiam quos in ipsa Ecclesia catholica vidcris malc vi<lb/>ventes, aut
+						immoderatos 2voluptatibus veptris et gut<lb/>turis, aut impudicos, aut vanis
+						curiositatibus vel i!<lb/>licitis deditos sive spectaculorum, sive
+						remediorum a <lb/> aut divinationum diabolicarum , sive in pompa et
+						ty<lb/>pho avaritiæ atque superbiæ, sive in aliqua vila quam <lb/> lex 4
+						damnat et punit, non eos irnitcris : sed potius <lb/> conjungaris honis,
+						quos inventurus es facile, si ct tu <lb/> talis fucris; ut simul colatis et
+						diligatis Dcum gratis : <lb/> quia lotum præmium nostrum ipse erit, ut in
+						illa vita I <lb/> honilate ejus et pulchritudine perfruamur. Sed
+						aman<lb/>dus est, non sicut aliquid quod videtur oculis; sed <lb/> bicut
+						amatur sapientia , et veritas, et sanctitas, et <note type="footnote"> 1 Sic
+							Mss. At editi, <hi rend="italic">gualis nec dici</hi>.</note>
+						<note type="footnote"> 2 Mss., <hi rend="italic">immoderatis</hi> : fortasse
+							pro, <hi rend="italic">in immoderatis</hi>.</note>
+						<note type="footnote"> 3 Editi, <hi rend="italic">sive remediorum
+								sacrilegorum</hi>. Abest, <hi rend="italic">sacrilego<lb/>rum,</hi>
+							a Mss., ut illa quæ post adhibetur, vox, <hi rend="italic"
+								>diabolicarum</hi>, <lb/> et ad <hi rend="italic">divinationum</hi>
+							referatur, et ad <hi rend="italic">remediorum</hi>.</note>
+						<note type="footnote"> 4 Corbeiensis Ms., <hi rend="italic">lex Dei</hi> :
+							sed additum, <hi rend="italic">Dei</hi>, a secun<lb/>da manu.</note>
+						<note type="footnote"> 5 Editi, <hi rend="italic">in illa æterna vita</hi>.
+							Abest, <hi rend="italic">æterna</hi>, a Mss.</note>
+						<lb/> justitia, et charitas I , et si quid aliud talc dicitur : <lb/> non
+						qucmadmodunf sant ista in hominibus; sed quem - <lb/> admodum sunt in ipso
+						fonte incorruptibilis et in<lb/>commutabilis sapientiae. Quoscumque ergo
+						videris hæc <lb/> amare, illis conjungere, ut per Christum qui homo <lb/>
+						factus est, ut esset Mediator Dei et hominum, re- <lb/> coucilieris Deo.
+						Homines autem perversos, etiamsi <lb/> intrent parietes ecclesiæ,non cos
+						arbitreris intratu<lb/>ros in regnum coelorum; quia suo tempore
+						separa<lb/>buntur, si se in melius non commutaverint. Homines <lb/> ergo
+						bonos imitare, malos tolera, omnes ama; quo<lb/>niam nescis quid cras
+						futurus sit qui hodie malus est. <lb/> Nec corum ames injustitiam; sed ipsos
+						ideo ama, ut <lb/> apprehendant justitiam : quia non solum dilectio Dei
+						<lb/> nobis præcepta est, sed cHam dilectio proximi, in <lb/> quibus duobus
+						præceptis tota Lex pendet ei Prophe<lb/>tæ <hi rend="italic">(Matth.</hi>
+						XXII, 37-40). Quam non imp'et nisi qui <lb/> donum' acceperit Spiritum
+						sanctum, Patri ct Filio <lb/> uliqne aequalem; quia ipsa Trinitas Deus est :
+						in quo <lb/> Dco spes omnis ponenda cst. In hominc non est po<lb/>nenda,
+						qualiscumque ille fuerit. Aliud est enim ille a <lb/> quo justificamur,
+						aliud illi cum quibus justificamur. <lb/> Non autcm solum per cupiditates
+						diabolus tentat, sed <lb/> etiam pcr terrores insultationum et dolorum et.
+						ipsius <lb/> mortis. Quidquid autem homo passus fuerit pro no<lb/>mine
+						Christi, et pro spe vitæ æternæ,et permaners <lb/> toleravcrit, major ei
+						merces dabitur : quod si cesse<lb/>rit diabolo, cum illo damnabitur. Sed
+						opera miseri<lb/>cordiæ cum pia humilitate impetrant a Domino, ut <lb/> non
+						permittat servos suos tentari plus quam possunt <lb/> sustinere (I <hi
+							rend="italic">Cor.</hi> x, 13). <note type="footnote"> 1 Mss. omittunt,
+								<hi rend="italic">et sanctitas, et justitia, et
+							charitas</hi>.</note>
+						<note type="footnote"> 2 Sola editio Lov. pro, <hi rend="italic">donum</hi>,
+							habet, <hi rend="italic">Dominum</hi>.</note></p>
+				</div>
+
+			</div>
+		</body>
+	</text>
 </TEI>

--- a/data/stoa0040/stoa002/stoa0040.stoa002.opp-lat1.xml
+++ b/data/stoa0040/stoa002/stoa0040.stoa002.opp-lat1.xml
@@ -150,29 +150,31 @@
 						ratione, sed eliam sine taedio et cum hilaritate impleatur. Postea revocatisad <lb/>
 						usum præceptis, profert ipse in exemplum sermones, ad cum erudiendum qui christianus
 						esse velit, comparatos duaM, <lb/> longiorem num, alterum brevissimu.u.</p>
+    	
     	<div type="textpart" subtype="chapter" n="1"><p>1. <hi rend="italic">Rogatus a diacono Cartha<lb/>ginensi scribit de
 							catechizandis rudibus.</hi> Petisti me, fra<lb/>ter Deogralias <hi rend="italic">(b),</hi> ut aliquid ad te de catechizandis <lb/> rudibus, quod tibi usui esset,
 						scriberem. Dixisti <lb/> euim quod sæpe apud Carthaginem, ubi diaconus es, <lb/> ad te
 						adducuntur, qui fide christiana primitus im<lb/>buendi sunt , eo quod existimeris
 						habere cale<lb/>chizandi uberem facultatem, ct doctrina fidei et sua<lb/>vitate
 						sermenis i : te autem pene semper angustias <lb/> pati, idipsum quod credendo christiani
-						sumus, quo <note type="footnote"> ADMONIO PP. BENEDICTINORUM. </note><note type="footnote"> Uiri de Catechizandis Rudibus contulimus colices manuscriptos
-							quatuordecim : Corbeiensem perquam egregium anno<lb/>rum 800, alium Ecclesiae
-							taudunensis annorum 700, Divionensem abbatiæ S. Benigni, Pratellensem, Fiscannensem,
-							<lb/> Michaelinum, Cisterciensem, Floriacenses duos, totidem victorinos, sorbonicum et
-							duos valicanos; lectiones variantes ex <lb/> tribus Belgicis cura Lovaniensium
-							decerptas; et postremo editiones primarias Amerbachii, Erasmi ac Lovaniensium.
-							</note><note type="footnote">
-							<hi rend="italic">Comparavimus prœterea eas omnes editiones initio</hi> Retr. <hi rend="italic">et</hi> Confess. <hi rend="italic">t.</hi> 1, <hi rend="italic">memoratas.</hi> M. </note><note type="footnote">
-							<hi rend="italic">(u)</hi> Scriptus circiter anuum 400. </note><note type="footnote">
-							<hi rend="italic">( Į,)</hi> Mem Hie lorsilan est Dcogratias, cui presi&gt;ytero Au­
-							<lb/> gustinus, iost aanum Cliristi circUler .wu, ad qu:pst)(j!tcs i'a- <lb/>
-							p:mot't!m ab eo sil.i Carthasine missas respondet epistula <lb/> nunu ordine 102. </note>
-						<note type="footnote"> I Lov , ri (iortii.ium <hi rend="italic">[idei et suavitatem
-								MHMIU.</hi>
-						</note>
-						<lb/>
-						<pb n="311"/> pacto commoIc intimandum sit ; unde exordienda , <lb/> quousque sit
+						sumus, quo
+						
+	    		<note type="footnote"> ADMONIO PP. BENEDICTINORUM. </note>
+	    		<note type="footnote"> Uiri de Catechizandis Rudibus contulimus colices manuscriptos
+								quatuordecim : Corbeiensem perquam egregium anno<lb/>rum 800, alium Ecclesiae
+								taudunensis annorum 700, Divionensem abbatiæ S. Benigni, Pratellensem, Fiscannensem,
+								<lb/> Michaelinum, Cisterciensem, Floriacenses duos, totidem victorinos, sorbonicum et
+								duos valicanos; lectiones variantes ex <lb/> tribus Belgicis cura Lovaniensium
+								decerptas; et postremo editiones primarias Amerbachii, Erasmi ac Lovaniensium.</note>
+	    		<note type="footnote"><hi rend="italic">Comparavimus prœterea eas omnes editiones initio</hi> Retr. <hi rend="italic">et</hi> Confess. <hi rend="italic">t.</hi> 1, <hi rend="italic">memoratas.</hi> M. </note>
+    			<note type="footnote"><hi rend="italic">(u)</hi> Scriptus circiter anuum 400.</note>
+    			<note type="footnote"><hi rend="italic">( Į,)</hi> Mem Hie lorsilan est Dcogratias, cui presi&gt;ytero Au­
+								<lb/> gustinus, iost aanum Cliristi circUler .wu, ad qu:pst)(j!tcs i'a- <lb/>
+								p:mot't!m ab eo sil.i Carthasine missas respondet epistula <lb/> nunu ordine 102.</note>
+	    		<note type="footnote"> I Lov , ri (iortii.ium <hi rend="italic">[idei et suavitatem MHMIU.</hi></note><lb/>
+						
+
+		<pb n="311"/> pacto commoIc intimandum sit ; unde exordienda , <lb/> quousque sit
 						perducenda narratio; utrum exhortatio<lb/>nem aliquam terminata narraliouc adhibere
 						debea<lb/>mus, an præcepta sola, quihus observandis cui lo<lb/>quimur noverit
 						christianam vitam professionemque <lb/> retineri l. Sæpe autem libi accidisse confessus
@@ -210,11 +212,12 @@
 						cujusque alterius gentis sint propria, sed ita <lb/> efficiantur in animo, ut vultus in
 						corpore. Aliter <lb/> enim latine ira dicitur, alilcr græce, aliter atque ali<lb/>ter
 						aliarum diversitate linguarum : non autem lati<lb/>nus ant gra'cus est vultus irati.
-						Non itaque omnes <lb/> gentes intelligunt, cum quisque dicit, Iratus sum, sed <note type="footnote"> I sic in vss. At In erhtis, <hi rend="italic">retinere.</hi>
-						</note><note type="footnote"> t rdiU, <hi rend="italic">eroqare.</hi> At Mss., eioqiti.
-							</note><note type="footnote"> 1 fcditi, non fto <hi rend="italic">rr.</hi> "SS., non
-								<hi rend="italic">ZrW. iw.</hi>
-						</note>
+						Non itaque omnes <lb/> gentes intelligunt, cum quisque dicit, Iratus sum, sed
+    		
+	    		<note type="footnote"> I sic in vss. At In erhtis, <hi rend="italic">retinere.</hi></note>
+	    		<note type="footnote"> t rdiU, <hi rend="italic">eroqare.</hi> At Mss., eioqiti.</note>
+	    		<note type="footnote"> 1 fcditi, non fto <hi rend="italic">rr.</hi> "SS., non <hi rend="italic">ZrW. iw.</hi></note>
+    		
 						<lb/> Latin! tantum: at si affectus excandescentis animi exeat <lb/> in faciem,
 						vultumque faciat (a). omnes sentiunt qui <lb/> intuentur iratum. Sed neque ita licet
 						educere et quasi <lb/> exporrigere in sensum audientium per sonum vocis <lb/> illa
@@ -254,11 +257,12 @@
 						hilarem datorem diligit Deus (II <lb/> Cur. ix, 7 ) ? Sed hæc hilaritas ad horam ut
 						adsit, ejus <lb/> est misericordiæ qui ista præcepit. Itaque prius de <lb/> modo
 						narrationis quod te velle cognovi, tum de præ<lb/>cipiendo atque cohortando, postea
-						de hac hilaritate <lb/> comparanda, quæ Deus suggesserit, disseremus. <note type="footnote">
-							<hi rend="italic">(/0</hi> Furto, <hi rend="italic">afficiat.</hi>
-						</note></p></div>
-					<pb n="313"/>
+						de hac hilaritate <lb/> comparanda, quæ Deus suggesserit, disseremus.
+						
+				<note type="footnote"><hi rend="italic">(/0</hi> Furto, <hi rend="italic">afficiat.</hi></note></p></div>
+					
 
+		<pb n="313"/>
     	<div type="textpart" subtype="chapter" n="3"><p>5. <hi rend="italic">Narratio plena quai fieri debeat <lb/> catechizando.
 							Ad charitatis finem dirigenda narratio. <lb/> Scripturæ veteres propter
 							commendandum</hi> Christi <hi rend="italic">ad.<lb/> ventum, cujus finis
@@ -293,14 +297,15 @@
 						est: ita <lb/> et Dominus Jesus Christus ctsi antequam appareret <lb/> in carne, et
 						quodam modo ex utero secreti sui ad <lb/> hominum oculus Mediator Dci et hominum homo
 						pro<lb/>cederet, qui est super omnes Deus benedictus in sæ<lb/>cula <hi rend="italic">(Rom.</hi> ix, 5), præmisit in sanctis Patriarchis et <lb/> Prophetis
-						quamdam partem corporis sui, qua velut <note type="footnote"> I In Mss., <hi rend="italic">Ezw.</hi>
-						</note><note type="footnote"> • YJT. et Lov., et <hi rend="italic">ea</hi> AtAm., <hi rend="italic">uten.</hi> Et sic potiores uss. <lb/> rx quitms posiea corrigimus, <hi rend="italic">non oporteat;</hi> ubi editi lerc<lb/>hant, <hi rend="italic">noM
-								oporM.</hi>
-						</note><note type="footnote"> » tu Mat., Editi vero, <hi rend="italic">monendus.</hi>
-						</note>
-						<note type="footnote">
-							<hi rend="italic">(a)</hi> Articuli temporum quinqiie nota iltir infra, u G et <lb/>
+						quamdam partem corporis sui, qua velut
+						
+				<note type="footnote"> I In Mss., <hi rend="italic">Ezw.</hi></note>
+				<note type="footnote"> • YJT. et Lov., et <hi rend="italic">ea</hi> AtAm., <hi rend="italic">uten.</hi> Et sic potiores uss. <lb/> rx quitms posiea corrigimus, <hi rend="italic">non oporteat;</hi> ubi editi lerc<lb/>hant, <hi rend="italic">noM
+								oporM.</hi></note>
+				<note type="footnote"> » tu Mat., Editi vero, <hi rend="italic">monendus.</hi></note>
+				<note type="footnote"><hi rend="italic">(a)</hi> Articuli temporum quinqiie nota iltir infra, u G et <lb/>
 							n. 3U. </note>
+						
 						<lb/> manu se nasciturum esse prænuntians, etiam popu<lb/>lum præcedentem superbe,
 						vinculis Legis tanquam di<lb/>gitis quinque supplantavit1 (quia et per quinque tem­
 						<lb/> porum articulos prænuntiari venturus prophetarique <lb/> non destitit; et huic rei
@@ -341,13 +346,16 @@
 						igne etiam illos mentes quas appetunt <lb/> sentiunt : si ergo et animus qui torpebat,
 						cum se <lb/> amari senserit excitatur, et qui jam ferveba!, cum se <lb/> rcdamari
 						didicerit magis accenditur; manifestum cst <lb/> nullam esse majorem causam qua vel
-						inchnetur vel <lb/> augcatur amor, quam cum amari se cognoscit qui <note type="footnote"> I Aliquot Mss., <hi rend="italic">supplantaret.</hi>
-						</note><note type="footnote"> I hd!ti, <hi rend="italic">contvigebant</hi> ela ; omissa
-							particula, .w, quae ta<lb/>men hie reperitur in Mss. et in græco textu Apostoli.
-							</note><note type="footnote"> a Aui. fl'. et vss., <hi rend="italic">saltem redtmiare
-								non pigeal;</hi> omisso, <lb/> nwtc. </note>
-						<lb/>
-						<pb n="315"/> nondum amat, aut redamari se vel posse sperat, vel <lb/> jam probat qui
+						inchnetur vel <lb/> augcatur amor, quam cum amari se cognoscit qui
+    		
+	    		<note type="footnote"> I Aliquot Mss., <hi rend="italic">supplantaret.</hi></note>
+	    		<note type="footnote"> I hd!ti, <hi rend="italic">contvigebant</hi> ela ; omissa
+								particula, .w, quae ta<lb/>men hie reperitur in Mss. et in græco textu Apostoli.</note>
+	    		<note type="footnote"> a Aui. fl'. et vss., <hi rend="italic">saltem redtmiare
+									non pigeal;</hi> omisso, <lb/> nwtc.</note><lb/>
+						
+
+		<pb n="315"/> nondum amat, aut redamari se vel posse sperat, vel <lb/> jam probat qui
 						prior amat Et si boc etiam in turpi<lb/>bus amoribus, quanto plus 1 in amicitia? Quid
 						euim <lb/> aliud cavemus in offensione amicitiæ, nisi ne amicus <lb/> arbitretur quod
 						euin vel non diligimus, vel minus di<lb/>ligimus quam ipse nos diligit? Quod si
@@ -385,11 +393,14 @@
 						manifestationem spirituales, et <lb/> tunc quibus pie pulsantibus ctiam occulta
 						patuerunt, <lb/> et nunc qui non superbe quærunt, ne etiam aperta <lb/> claudantur,
 						spiritualiter intelligentes donata charitate <lb/> liberali sunt. Quia ergo charitati
-						nihil adversius quam <lb/> invidentia; mater autem invidentiæ superbia est : <note type="footnote"> ' ilerkpie Mss., ""rim? Am. et Mss. vatfcani, plurius? </note><note type="footnote"> ' NC Mss. At edili, <hi rend="italic">studiose.</hi>
-						</note><note type="footnote"> 9 Veteres libri, <hi rend="italic">bcnefieenliæ.</hi>
-						</note><note type="footnote"> * Am. Er et iluro Mss., <hi rend="italic">consecrata.</hi>
-							Alii duoMss.. <hi rend="italic">corr­</hi>
-							<lb/> ucula. </note>
+						nihil adversius quam <lb/> invidentia; mater autem invidentiæ superbia est :
+						
+				<note type="footnote"> ' ilerkpie Mss., ""rim? Am. et Mss. vatfcani, plurius? </note>
+				<note type="footnote"> ' NC Mss. At edili, <hi rend="italic">studiose.</hi></note>
+				<note type="footnote"> 9 Veteres libri, <hi rend="italic">bcnefieenliæ.</hi></note>
+				<note type="footnote"> * Am. Er et iluro Mss., <hi rend="italic">consecrata.</hi>
+							Alii duoMss.. <hi rend="italic">corr­</hi><lb/> ucula.</note>
+						
 						<lb/> idem Dominus Jesus Christus, Deus homo, et divinæ <lb/> in nos dilectionis
 						indicium est , et humanæ apud no; <lb/> humilitatis exemplum , ut magnus tumor noster
 						ma<lb/>jnre contraria medicina sanaretur. Magna est enim <lb/> miseria, superbus
@@ -427,15 +438,16 @@
 						imbuendus cst; blandius et lenius reprchendendo <lb/> tanquam rudem et ignarum, et
 						christianæ doctrinæ <lb/> finem vcrissimum demonstrando atqne laudando <lb/> breviter et
 						graviter, ne aut tempera futuræ narratio<lb/>nis occupes, aut cam non prius collocato
-						animo <lb/> audeas imponere, facias eum velle quod ant per <note type="footnote"> 1
-							Edili Er. et Lpv.. <hi rend="italic">salvandi.</hi> Kounu!!! ccdices, <hi rend="italic">salutis.</hi>
-							<lb/> Quidam, <hi rend="italic">sattantis.</hi> sed plerique ac melioris notae Mss.
-							cnin <lb/> editione. AIH., <hi rend="italic">satultmiis</hi> : id est, saiutctu sivc
-							asaeu..n <lb/> gestu significant is. </note>
-						<note type="footnote"> 1 hie Mrn. Kr. cl Mss. At !jov., <hi rend="italic">quo.</hi>
-						</note>
-						<lb/>
-						<pb n="317"/> errorem aut per simulationem nondum volebat.</p></div>
+						animo <lb/> audeas imponere, facias eum velle quod ant per
+    		
+	    		<note type="footnote"> 1 Edili Er. et Lpv.. <hi rend="italic">salvandi.</hi> Kounu!!! ccdices, <hi rend="italic">salutis.</hi>
+								<lb/> Quidam, <hi rend="italic">sattantis.</hi> sed plerique ac melioris notae Mss.
+								cnin <lb/> editione. AIH., <hi rend="italic">satultmiis</hi> : id est, saiutctu sivc
+								asaeu..n <lb/> gestu significant is.</note>
+				<note type="footnote"> 1 hie Mrn. Kr. cl Mss. At !jov., <hi rend="italic">quo.</hi></note><lb/>
+						
+
+		<pb n="317"/> errorem aut per simulationem nondum volebat.</p></div>
     	<div type="textpart" subtype="chapter" n="6"><p>10. <hi rend="italic">Exordium</hi> catechismi, <hi rend="italic">et
 							narratio</hi>
 						<lb/> ab <hi rend="italic">historia creationis mundi usque ad præsens tempus <lb/>
@@ -475,10 +487,13 @@
 						desiderio prædicandum est. Tum vero instrucn<lb/>da et animanda est infirmitas
 						hominis adversus <lb/> tentationes et scandala, sive foris sive in ipsa intus <lb/>
 						Ecclesia : foris adversus Gentiles vel Judaeos vel <lb/> hæreticos; intus autem adversus
-						areae dominicæ <note type="footnote"> I An. et 1.1erlque Mss., voluntatem. </note><note type="footnote"> • Sic vetus codex Corhciensis. At victorinus, <hi rend="italic">Qdhibitcz</hi>
-							<lb/> narrationis. Editiones Ain. et Kr., <hi rend="italic">ndnihita rniiom.</hi>
-							Denique <lb/> LoV'f <hi rend="italic">adhibita ratiofiis.</hi>
-						</note>
+						areae dominicæ
+    		
+	    		<note type="footnote"> I An. et 1.1erlque Mss., voluntatem. </note>
+	    		<note type="footnote"> • Sic vetus codex Corhciensis. At victorinus, <hi rend="italic">Qdhibitcz</hi>
+								<lb/> narrationis. Editiones Ain. et Kr., <hi rend="italic">ndnihita rniiom.</hi>
+								Denique <lb/> LoV'f <hi rend="italic">adhibita ratiofiis.</hi></note>
+    		
 						<lb/> paleam. Nun ut contra singula perversorum genera <lb/> disputetur, omnesque
 						illorum pravæ opiniones pro<lb/>positis quæstionibus refellantur ; sed pro tempore
 						<lb/> brevi demonstrandum est ila esse prædictum, ct <lb/> quæ sit utilitas tentationum
@@ -518,11 +533,12 @@
 						sui, cum quibus <lb/> possunt, communicare atque discutere. Cum his ita<lb/>que
 						breviter agendum est, et non odiose 1 inculcando <lb/> quæ norunt. sed modeste
 						perstringendo; ita ut dica<lb/>mus nos credere quod jam noverint illud, atque <lb/>
-						iJ nd ; atque hoc modo cursim enumerare omnia qua <note type="footnote"> 1 Aliquot Mss.,
-								<hi rend="italic">otiose­</hi>
-						</note>
-						<lb/>
-						<pb n="319"/> rudibus indoctisque inculcanda sunt : ut etsi quid <lb/> novit eruditus
+						iJ nd ; atque hoc modo cursim enumerare omnia qua
+    		
+    			<note type="footnote"> 1 Aliquot Mss., <hi rend="italic">otiose­</hi></note><lb/>
+						
+
+		<pb n="319"/> rudibus indoctisque inculcanda sunt : ut etsi quid <lb/> novit eruditus
 						iste, non tanquam a doctore audiat ; <lb/> ct si quid adhuc ignorat 1. dum ea
 						commemoramus <lb/> quæ illum nosse jam credimus, discat. Noc ipse sane <lb/> inutilter
 						interrogatur, quibus rcbus motus sit ut <lb/> v lit sse christianus : ut si libris ei
@@ -560,13 +576,14 @@
 						quo dixi, ad illati supereminentiorem viam omnia <lb/> rererenda sunt.</p></div>
     	<div type="textpart" subtype="chapter" n="9"><p>13. <hi rend="italic">Grammatici</hi> et <hi rend="italic">oratores
 							quo­</hi>
-						<note type="footnote"> s Editi, <hi rend="italic">et</hi> si <hi rend="italic">quid
-								forts adhuc ignorai.</hi> Abest, <hi rend="italic">forte,</hi>
-							<lb/> a MV. </note><note type="footnote"> * a;,s., 'I' <hi rend="italic">:-i libr"
-								ettm persuasum.</hi>
-						</note><note type="footnote"> * Pim es codiccs, <hi rend="italic">ci ad exponendum.</hi>
-						</note><note type="footnote"> * L-iV., <hi rend="italic">ornationis</hi> eloquii. </note>
-						<lb/>
+						
+	    		<note type="footnote"> s Editi, <hi rend="italic">et</hi> si <hi rend="italic">quid
+									forts adhuc ignorai.</hi> Abest, <hi rend="italic">forte,</hi>
+								<lb/> a MV.</note>
+	    		<note type="footnote"> * a;,s., 'I' <hi rend="italic">:-i libr" ettm persuasum.</hi></note>
+	    		<note type="footnote"> * Pim es codiccs, <hi rend="italic">ci ad exponendum.</hi></note>
+	    		<note type="footnote"> * L-iV., <hi rend="italic">ornationis</hi> eloquii.</note><lb/>
+    		
 						<hi rend="italic">modo tractandi. Vox ad aures Da. animi</hi> affectus. Sunt <lb/> item
 						quidam de scholis usitatissimis grammaticorum <lb/> oratorumque venientes, quos neque
 						inter idiotas nu<lb/>merare audeas, ncque inter illos doctissimos, quorum <lb/> mens
@@ -605,11 +622,13 @@
 						<lb/> tuero : sed prius de iila hilaritate comparanda, quod <lb/> pollicitus sum, dicere
 						dehco. Jam euim de ipsis prae. <lb/> ceptis explicandi sermonis, in catechizando eo qui
 						<lb/> sic verit ut christianus fiat, quantum satis visum cst, <lb/> quod promiseram
-						exsolvi. Indebitum quippe eat, ut <note type="footnote"> I Praecipui Mss., <hi rend="italic">linguam exerntam nec</hi> conferrc. </note><note type="footnote"> '
-							bic plures v.gs. At eiliti, <hi rend="italic">discutiendumque</hi>
-						</note>
-						<lb/>
-						<pb n="321"/> etiam ipse faciam in hoc volumine, quod fieri oportere <lb/> praecipio. Si
+						exsolvi. Indebitum quippe eat, ut
+    		
+	    		<note type="footnote"> I Praecipui Mss., <hi rend="italic">linguam exerntam nec</hi> conferrc.</note>
+	    		<note type="footnote"> 'bic plures v.gs. At eiliti, <hi rend="italic">discutiendumque</hi></note><lb/>
+						
+
+		<pb n="321"/> etiam ipse faciam in hoc volumine, quod fieri oportere <lb/> praecipio. Si
 						ergo fecero, ad cumulum valebit : cu<lb/>mulus autem quo pacto a me superfundi
 						potest, an<lb/>tequam mensuram debiti explevero ? Neque enim te <lb/> maxime conqueri
 						audivi, nisi qnod tibi sermo tuus <lb/> vilis abjectusquc videretur, cum aliqucm
@@ -645,13 +664,13 @@
 						aestuantem fumantemque trajectus. Tot igitur ex cau<lb/>sis, quælibet earum
 						serenitatem nostra; mentis obnu<lb/>bilet, secundum Deum sunt quxrenda remedia, qui­
 						<lb/> bus relaxetur illa contractio, et fervore spiritus ex<lb/>suitemus et
-						jucundemur in tranquillitate botri operis. <note type="footnote"> ' verba hic unds
-							indusa 4bsont a plerisque Mss. et ab <lb/> Atto. Ir. </note><note type="footnote"> '
-							Editi, obsidet. At Mss., <hi rend="italic">obsedit.</hi>
-						</note><note type="footnote"> 3 Sola editio LOT., <hi rend="italic">nescitur.</hi>
-						</note><note type="footnote"> k rhiroa Mss., <hi rend="italic">sust-ipimu? ingrati</hi>
-							",..oJ volent </note>
-						<lb/>
+						jucundemur in tranquillitate botri operis.
+    		
+	    		<note type="footnote"> ' verba hic unds indusa 4bsont a plerisque Mss. et ab <lb/> Atto. Ir. </note>
+	    		<note type="footnote"> ' Editi, obsidet. At Mss., <hi rend="italic">obsedit.</hi></note>
+	    		<note type="footnote"> 3 Sola editio LOT., <hi rend="italic">nescitur.</hi></note>
+	    		<note type="footnote"> k rhiroa Mss., <hi rend="italic">sust-ipimu? ingrati</hi>",..oJ volent </note><lb/>
+    		
 						<hi rend="italic">Hilarem enim datorem diligit Deus</hi> (Il Cor. ix, 7).</p>
 					<p>15. Si enim causa illa contristat, quod intellectum <lb/> nostrum auditor non capit, a
 						cujus cacumine quodam <lb/> modo descendentes cogimur in syllabarum longe in<lb/>fra
@@ -693,12 +712,14 @@
 						veritate aberraverit; quanquam in catechizandis ru<lb/>dibus, ubi via tritissima
 						tenenda est, difficile potest <lb/> accidere : tamen ne forte accidat ut ctiam hinc
 						offen<lb/>datur auditor, non aliunde nohis debet vidcri acci<lb/>disse, nisi quia
-						Deus experi ..os voluit, utrum cum <note type="footnote"> 1 sic Mss. Editi vero, <hi rend="italic">nihil n</hi> i:<hi rend="italic">ccrenda.</hi>
-						</note>
-						<note type="footnote"> (a) Istai voces, c!.c., unrue ed, librarii sunt prætereuntis,
-							<lb/> tit s.J..'!. vc:!a intermedi i I,...v </note>
-						<lb/>
-						<pb n="323"/> mentis placiditate corrigamur, ne in defensionem IIO<lb/>stri erroris
+						Deus experi ..os voluit, utrum cum
+    		
+	    		<note type="footnote"> 1 sic Mss. Editi vero, <hi rend="italic">nihil n</hi> i:<hi rend="italic">ccrenda.</hi></note>
+				<note type="footnote"> (a) Istai voces, c!.c., unrue ed, librarii sunt prætereuntis,
+								<lb/> tit s.J..'!. vc:!a intermedi i I,...v </note><lb/>
+						
+						
+		<pb n="323"/> mentis placiditate corrigamur, ne in defensionem IIO<lb/>stri erroris
 						majore præcipitemur errore. Quod si ne<lb/>mo nobis dixerit, nosque et illos qui
 						audierunt omni- <lb/> IIO latuerit, nullus dolor est, si non fiat iterum. Ple­ <lb/>
 						rumque antem nos ipsi recolentes quae dixeri<lb/>mus, reprehendimus aliquid, et
@@ -737,11 +758,11 @@
 						loquatur nobis Deus quomodo volumus , si susci<lb/>piamus hilariter ut loquatur per
 						nos quomodo possu<lb/>mus : ita lit ut diligentibus Deum omnia concurrant <lb/> in
 						bonum (Rom. VIII, 28).</p></div>
-    	<div type="textpart" subtype="chapter" n="12"><p>17. <hi rend="italic">Remedium contra tertiam</hi> causam <note type="footnote"> I Ita in Mss. At in editis, <hi rend="italic">mera.</hi>
-						</note><note type="footnote"> 2 Editi, <hi rend="italic">rctilierit.</hi> Præstantieres
-							ua . <hi rend="italic">resiluerit.</hi>
-						</note>
-						<lb/>
+    	<div type="textpart" subtype="chapter" n="12"><p>17. <hi rend="italic">Remedium contra tertiam</hi> causam
+    		
+	    		<note type="footnote"> I Ita in Mss. At in editis, <hi rend="italic">mera.</hi></note>
+	    		<note type="footnote"> 2 Editi, <hi rend="italic">rctilierit.</hi> Præstantieres ua . <hi rend="italic">resiluerit.</hi></note><lb/>
+    		
 						<hi rend="italic">tædii.</hi> Jam vcro si usitata et parvulis congruentia <lb/> sæpe
 						rcpetere faslidimus; congruamus eis per fra<lb/>ternum, paternum, maternumque amorem,
 						et copu<lb/>latis cordi eorum etiam nobis nova videbuntur. Tan<lb/>tum enim valet
@@ -779,12 +800,14 @@
 						nimius atque impediens declarationem <lb/> judicii ejus, blanda exhortatione pellendus
 						est, et <lb/> insinuando fraternam societatem verecundia tempe<lb/>randa, et
 						interrogatione quærendum utrum intelligat, <lb/> et danda fiducia, ut si quid ei
-						contradiccudum vide­ <note type="footnote"> * Edi! i, <hi rend="italic">arcem.</hi>
-							Aptius Mss., aitem. </note><note type="footnote"> * SiC Am. ei plerique MSS. At t:r.
-							et tov., <hi rend="italic">solito.</hi>
-						</note><note type="footnote"> I Codex Corbeiensis, ea &gt; </note>
-						<lb/>
-						<pb n="325"/> tur, libere proferat. Quaerendam etiam de illo utrum <lb/> hæc aliquando
+						contradiccudum vide
+    		
+	    		<note type="footnote"> * Edi! i, <hi rend="italic">arcem.</hi> Aptius Mss., aitem. </note>
+	    		<note type="footnote"> * SiC Am. ei plerique MSS. At t:r. et tov., <hi rend="italic">solito.</hi></note>
+	    		<note type="footnote"> I Codex Corbeiensis, ea &gt; </note><lb/>
+						
+
+		<pb n="325"/>tur, libere proferat. Quaerendam etiam de illo utrum <lb/> hæc aliquando
 						jam audierit, et fortassis eum tanquam <lb/> nota et pervulgata non moveant; et agendum
 						pro ejus <lb/> responsione, ut aut planius et enodatius loquamur, <lb/> aut opinionem
 						contrariam refellamus, aut ea quæ illi <lb/> nota sunt uon explicemus latius, sed
@@ -821,10 +844,15 @@
 						<lb/> non tunc initiandi \ Nam cum unus , aut duo, aui <lb/> pauci, qui propterea
 						venerunt ut christiani fiant, pe<lb/>riculose loquimur stantibus. Tamen si jam sic
 						cœpi- <lb/> mos. saltem animadverso auditoris tædio, et offe<lb/>renda sessio est,
-						iuto vero prorsus urgendus ut sedeat, <note type="footnote">1 toY., <hi rend="italic">eathoHcai pdeL</hi> EdM vero alII et plerique Mss. <lb/> MB ... babeat, <hi rend="italic">fidei:</hi> pro quo subauliiri debet, Ecclesiae. </note><note type="footnote"> Apud Lov. additur, <hi rend="italic">studeat.</hi> Sed subaudiendum,
-								<hi rend="italic">oporlel.</hi>
-						</note><note type="footnote"> I Nonuulti MM., <hi rend="italic">vero*.</hi>
-						</note><note type="footnote"> fc SOIa editio ijov., pro, tmc9 babet, sunt. </note>
+						iuto vero prorsus urgendus ut sedeat,
+						
+				<note type="footnote">1 toY., <hi rend="italic">eathoHcai pdeL</hi> EdM vero alII et plerique Mss. <lb/>
+							MB ... babeat, <hi rend="italic">fidei:</hi> pro quo subauliiri debet, Ecclesiae.</note>
+				<note type="footnote"> Apud Lov. additur, <hi rend="italic">studeat.</hi> Sed subaudiendum,
+								<hi rend="italic">oporlel.</hi></note>
+				<note type="footnote"> I Nonuulti MM., <hi rend="italic">vero*.</hi></note>
+				<note type="footnote"> fc SOIa editio ijov., pro, tmc9 babet, sunt.</note>
+						
 						<lb/> et dicendum aliquid quo renovetur, quo etiam curas, <lb/> si qua forte irruens eum
 						avocare coeperat, fugiat ex <lb/> animo. Cum enim causæ incertæ sint cur jam tacitus
 						<lb/> recuset audire, jam sedenti aliquid adversus inciden<lb/>tes cogitationes
@@ -865,11 +893,12 @@
 						niorte redimere; at hoc ipsum <lb/> quod nobis tristibus nuntiatur, præsto esse aliquem
 						<lb/> quidesiderct fieri christianus, ad consolationem illius <lb/> resolutionemque
 						tristitiae valere debeat, sicut solent <lb/> lucrorum gaudia dolorem lenire damnorum.
-						Non <lb/> cnitn scandalum nos contristat alicujus, nisi quem <note type="footnote"> (a)
-							Subaudiciulum, <hi rend="italic">ortliJli.</hi>
-						</note>
-						<lb/>
-						<pb n="327"/> perire aut pcr quem perire infirmam vel credimus <lb/> vel videmus. Ille
+						Non <lb/> cnitn scandalum nos contristat alicujus, nisi quem
+						
+				<note type="footnote"> (a) Subaudiciulum, <hi rend="italic">ortliJli.</hi></note><lb/>
+						
+
+		<pb n="327"/> perire aut pcr quem perire infirmam vel credimus <lb/> vel videmus. Ille
 						igitur qni initiandus advenit, dum <lb/> speratur po se proficere, dolorem deficientis
 						abster<lb/>gat. Quia «t si timor ille suggeritur, lie fiat proselytus <lb/> filius
 						gehennæ <hi rend="italic">(Matth.</hi> XXIII, 15), dum mulli tales <lb/> versantur ante
@@ -906,16 +935,19 @@
 						tædiorum, ad catechizandum aptatur <lb/> intentio, ut suaviter imbibatur, quod impigre
 						atque <lb/> hilariter de charitatis ubertate prorumpit. Haec enim <lb/> non tam ego
 						tibi, quam omnibus nobis dicit 3 ipsa di. <lb/> lectio, quae diffusa est in cordibus
-						nostris per Spi- <note type="footnote">1 Rditi, <hi rend="italic">motu:</hi> quam vocem
-							prætereunt Mss.; plures alii <lb/> ,Mem ejus loco babeni, <hi rend="italic">monitis.</hi> Paulo past, ex verbb, <lb/> suunwiul at, sive uti scribi solet in
-							antiquis codicibus, <lb/>
-							<hi rend="italic">swimuwstrat,</hi> factum erat in eJitis, suum <hi rend="italic">muristrat.</hi>
-						</note><note type="footnote"> I Ediii, <hi rend="italic">volo magis quam</hi>
-							satrifictum. At Mss., constantEr <lb/> practereimt, <hi rend="italic">magis.</hi>
-						</note><note type="footnote"> • Apud Ex. Lugd. ven. Lov., <hi rend="italic">surrexerit.</hi> M. </note><note type="footnote"> • sic Mas. Editi vero, <hi rend="italic">mentem studentis.</hi>
-						</note><note type="footnote"> • Edui fcre soli, <hi rend="italic">dictat.</hi>
-						</note>
-						<lb/> ritum sanctum qui datus est nobis <hi rend="italic">(Rom.</hi> v, 5).</p></div>
+						nostris per Spi
+						
+				<note type="footnote">1 Rditi, <hi rend="italic">motu:</hi> quam vocem
+							prætereunt Mss.; plures alii <lb/> ,Mem ejus loco babeni, <hi rend="italic">monitis.
+							</hi> Paulo past, ex verbb, <lb/> suunwiul at, sive uti scribi solet in antiquis codicibus, <lb/>
+							<hi rend="italic">swimuwstrat,</hi> factum erat in eJitis, suum <hi rend="italic">muristrat.</hi></note>
+				<note type="footnote"> I Ediii, <hi rend="italic">volo magis quam</hi>
+							satrifictum. At Mss., constantEr <lb/> practereimt, <hi rend="italic">magis.</hi></note>
+				<note type="footnote"> • Apud Ex. Lugd. ven. Lov., <hi rend="italic">surrexerit.</hi> M. </note>
+				<note type="footnote"> • sic Mas. Editi vero, <hi rend="italic">mentem studentis.</hi></note>
+				<note type="footnote"> • Edui fcre soli, <hi rend="italic">dictat.</hi></note>
+						
+						<lb/>ritum sanctum qui datus est nobis <hi rend="italic">(Rom.</hi> v, 5).</p></div>
     	<div type="textpart" subtype="chapter" n="15"><p>23. <hi rend="italic">Pro personarum diversitate tem­</hi>
 						<lb/> peranda <hi rend="italic">oratio.</hi> Sed nunc etiam illud quod priusquam <lb/>
 						promitterem non debebam, jam fortasse debitum fla<lb/>gitas, ut aliquod sermonis
@@ -954,10 +986,12 @@
 						tibi in nobis placuit, ut aliquam <lb/> observationem sermonis tui a nobis audire
 						quæretes, <lb/> melius videndo et audiendo nos cum hæc agimus, <lb/> quam legendo cum
 						hæc dictamus. edisceres.</p></div>
-    	<div type="textpart" subtype="chapter" n="16"><p>CAPUT XVI. — 24. <hi rend="italic">Formula orationis catechistæ. <lb/> Exordium ductum
+    	<div type="textpart" subtype="chapter" n="16"><p>24. <hi rend="italic">Formula orationis catechistæ. <lb/> Exordium ductum
 							a laudabili proposito suscipiendæ <lb/> christianæ</hi> religionis, <hi rend="italic">propter futuram requiem. Requies</hi>
 						<lb/> in <hi rend="italic">rebus inquietis non quærenda. Non in divitiis,</hi> noc in <lb/>
-						<pb n="329"/> honoribus. <hi rend="italic">Requiem quærentes</hi> in <hi rend="italic">oblectamentis earnis</hi>
+						
+
+		<pb n="329"/> honoribus. <hi rend="italic">Requiem quærentes</hi> in <hi rend="italic">oblectamentis earnis</hi>
 						<lb/> et in <hi rend="italic">spectaculis.</hi> Sed tamen faciamus aliquem venisse <lb/>
 						ad nos, qui vult esse christianus, et de genere qui<lb/>dem idiotarum, non tamen
 						rusticanorum, sed urba<lb/>norum, quales apud Carthaginem plures experiri te <lb/>
@@ -996,9 +1030,13 @@
 						citando homines ut se invicem caedant, secumque ha<lb/>beant contentiosa certamina
 						qui se non laeserunt, <lb/> dnm placere insano populo cupiunt: quos si animad­ <lb/>
 						verterint esse concordes, tunc eos oderunt et per<lb/>sequuntur, et tanquam
-						collusores ut fustibus verbe- <note type="footnote">1 Plerique diss., <hi rend="italic">aut ui eia oppressh</hi> a cupidioribus au­ <lb/>
-							<hi rend="italic">krrentur.</hi>
-						</note><note type="footnote"> s sic pierique Mss. At editi omittunt, <hi rend="italic">et viawta*</hi> : cujus <lb/> loco nonnulli Mss., et vomtas. </note>
+						collusores ut fustibus verbe
+						
+				<note type="footnote">1 Plerique diss., <hi rend="italic">aut ui eia oppressh</hi> a cupidioribus au<lb/>
+							<hi rend="italic">krrentur.</hi></note>
+				<note type="footnote"> s sic pierique Mss. At editi omittunt, <hi rend="italic">et viawta*</hi>
+							: cujus <lb/> loco nonnulli Mss., et vomtas. </note>
+						
 						<lb/> rentur exclamant, et hanc iniquitatem facere etiam <lb/> vindicem iniquitatum
 						judicem cogunt; si autem hor. <lb/> rendas adversus invicem inimicitias eos exercere
 						<lb/> cognoverint, sive sintae qui appellantur 1, sive sce<lb/>nici et thymelici,
@@ -1034,22 +1072,24 @@
 						sustinet; si non se <lb/> correxerint, et propter futuram sempiternam re<lb/>quiem
 						christiani esse coeperint, in fine separabuntur. <lb/> Nec sibi blandiantur quod in area
 						possunt esse cam <lb/> frumento Dei : quia in horreo cum illo non erunt, sed <lb/> igni
-						debito destinantur' <hi rend="italic">(Matth.</hi> III, 12). Sunt etiam <note type="footnote"> 1 to,., <hi rend="italic">sint aihleUB</hi> qui <hi rend="italic">appeUmdur.</hi> At plerique ae me- <lb/> Doris notae Mss., <hi rend="italic">sintce</hi> qvi <hi rend="italic">appeUantur.</hi> vox erat forsitaa <lb/> apud
-							Afros tunc vulgaris. In corbeiensi codice scribitur, <lb/>
-							<hi rend="italic">sinthæ.</hi> In MSS. qulbusdam et apud Am. legitur, sb* mqki <lb/>
-							<hi rend="italic">appiilantur.</hi> Apud Er., <hi rend="italic">sint</hi> qui <hi rend="italic">appelUmtur.</hi>
-						</note><note type="footnote"> * Am Er. et aliquot Mss., <hi rend="italic">et
-								incitati.</hi> Alii plures ibs., <hi rend="italic">ei <lb/> incitanies.</hi>
-						</note><note type="footnote">a sic Mss. At editi, <hi rend="italic">provocani, et</hi>
-							insamendo. </note><note type="footnote"> * Er. et Lov., <hi rend="italic">delectent.</hi> At An. et Mss., <hi rend="italic">delectet.</hi>
-						</note><note type="footnote"> * sic Ain. Er. et plerique Mss. 'L Lov., theatncorum.
-							</note><note type="footnote">e IJOV., <hi rend="italic">desiinabuntur.</hi> At Am. Er.
-							et MSS. habent pr. <lb/> tenti tempore, <hi rend="italic">destinantur.</hi>
-						</note>
-						<note type="footnote"> PATIIOL. XL. </note>
-						<note type="footnote"> (Unze.J </note>
-						<lb/>
-						<pb n="331"/> atii meliore quidem spc, scil lamcn non minore pe<lb/>riculo, qui jam
+						debito destinantur' <hi rend="italic">(Matth.</hi> III, 12). Sunt etiam
+    		
+	    		<note type="footnote"> 1 to,., <hi rend="italic">sint aihleUB</hi> qui <hi rend="italic">appeUmdur.</hi> At plerique ae me<lb/>
+	    			Doris notae Mss., <hi rend="italic">sintce</hi> qvi <hi rend="italic">appeUantur.</hi> vox erat forsitaa <lb/> apud
+								Afros tunc vulgaris. In corbeiensi codice scribitur, <lb/>
+								<hi rend="italic">sinthæ.</hi> In MSS. qulbusdam et apud Am. legitur, sb* mqki <lb/>
+								<hi rend="italic">appiilantur.</hi> Apud Er., <hi rend="italic">sint</hi> qui <hi rend="italic">appelUmtur.</hi></note>
+	    		<note type="footnote"> * Am Er. et aliquot Mss., <hi rend="italic">et incitati.</hi> Alii plures ibs., <hi rend="italic">ei <lb/> incitanies.</hi>
+							</note><note type="footnote">a sic Mss. At editi, <hi rend="italic">provocani, et</hi> insamendo.</note>
+	    		<note type="footnote"> * Er. et Lov., <hi rend="italic">delectent.</hi> At An. et Mss., <hi rend="italic">delectet.</hi></note>
+	    		<note type="footnote"> * sic Ain. Er. et plerique Mss. 'L Lov., theatncorum.</note>
+	    		<note type="footnote">e IJOV., <hi rend="italic">desiinabuntur.</hi> At Am. Er.
+								et MSS. habent pr. <lb/> tenti tempore, <hi rend="italic">destinantur.</hi></note>
+				<note type="footnote"> PATIIOL. XL. </note>
+				<note type="footnote"> (Unze.J </note><lb/>
+
+
+		<pb n="331"/> atii meliore quidem spc, scil lamcn non minore pe<lb/>riculo, qui jam
 						Deum timent, ct non irrident chri<lb/>stianum nomcn, nee simulalo cordc intrant
 						Eccle<lb/>siam Dei, sed in ista vita exspectant felicitatem, ut fe<lb/>liciores
 						sint in rchus terrenis, quam illi qui non colunt <lb/> Deum : ideoque cum viderint
@@ -1086,15 +1126,17 @@
 						spiritus in sancto silentio. Homo autem <lb/> peecato lapsus perdidit requiem quam
 						habebat in cjus <lb/> divinitate, pt recipit eam 1 in ejus humanitate : ideo<lb/>que
 						opportuno tempore, quo ipse sciebat oportere <lb/> fieri, homo factus et de feniina
-						natus est. A carne <note type="footnote">1 Am. Er. et tres Mss., <hi rend="italic">tceculari.</hi>
-						</note><note type="footnote"> I sic Mss. Editi vero, <hi rend="italic">iri quo una</hi>
-							est <hi rend="italic">requies.</hi>
-						</note><note type="footnote"> a Am. Er. et fere omnes Has., Dequa <hi rend="italic">re
-								sigmficat.</hi>
-						</note><note type="footnote"> * Ita Mss. At editi, <hi rend="italic">si cimi iUi
-								reqniescwit.</hi>
-						</note><note type="footnote"> s sic M.M. At editi, <hi rend="italic">et rprepn eam.</hi>
-						</note>
+						natus est. A carne
+						
+				<note type="footnote">1 Am. Er. et tres Mss., <hi rend="italic">tceculari.</hi></note>
+				<note type="footnote"> I sic Mss. Editi vero, <hi rend="italic">iri quo una</hi>
+							est <hi rend="italic">requies.</hi></note>
+				<note type="footnote"> a Am. Er. et fere omnes Has., Dequa <hi rend="italic">re
+								sigmficat.</hi></note>
+				<note type="footnote"> * Ita Mss. At editi, <hi rend="italic">si cimi iUi
+								reqniescwit.</hi></note>
+				<note type="footnote"> s sic M.M. At editi, <hi rend="italic">et rprepn eam.</hi></note>
+						
 						<lb/> quippe contaminari nun poterat, ipse cariem potius <lb/> mundaturus. Ipsum antiqui
 						sancti venturum in rcte" <lb/> latione Spiritus cognoverunt, et prophetaverunt, et <lb/>
 						sic salvi facti sunt credendo quia veniet, sicut nos <lb/> salvi efficimur credendo quia
@@ -1134,11 +1176,13 @@
 						<lb/> non faceret Deus hominem, quamvis eum peccaturum <lb/> praenosceret, cum et
 						stantem coronaret, et caden<lb/>tem ordinaret, et surgentem adjuvaret, semper et
 						<lb/> ubique ipse gloriosus bonitate, justitia, clementia? <lb/> maxime quia et illud
-						præsciebat, de propagine mor- <note type="footnote"> 1 AM. et Er., <hi rend="italic">humanitate</hi>.
-						</note><note type="footnote"> 2 Er., <hi rend="italic">dominium</hi>. Editi alii, <hi rend="italic">Dominum</hi>.
-						</note>
-						<lb/>
-						<pb n="333"/> . talitatis ejus futuro! sanctos, qui non ili qua-re<lb/>rent, sed
+						præsciebat, de propagine mor
+						
+						<note type="footnote"> 1 AM. et Er., <hi rend="italic">humanitate</hi>.</note>
+						<note type="footnote"> 2 Er., <hi rend="italic">dominium</hi>. Editi alii, <hi rend="italic">Dominum</hi>.</note><lb/>
+						
+
+		<pb n="333"/>talitatis ejus futuro! sanctos, qui non ili qua-re<lb/>rent, sed
 						Creatori suo gloriam darent, et cum co<lb/>lendo ab omni corruptione liberati, cum
 						Angelis <lb/> sanctis semper vivere et beate vivere mererentur? <lb/> Qui enim hominibus
 						dedit liberum arbitrium, ut non <lb/> servili necessitate, sed ingenua voluntate Dcum
@@ -1177,12 +1221,14 @@
 						sæpe 3 adversum se pro his rebus dimicant, pari ta<lb/>men pondere cupiditatis in
 						eamdem profunditatem <lb/> præcipitantur, et sibi morum et meritorum similitu­ <lb/>
 						dine conjunguntur. Et rursus omnes homines et <lb/> omnes spiritus humiliter Dei gloriam
-						quærentes, non <lb/> suam, et cum pictate sectantes, ad unam pertinent <note type="footnote"> 1 sola cditio Lov., <hi rend="italic">ordinare.</hi>
-						</note><note type="footnote"> 7 Plerique Mss. omittunt, <hi rend="italic">aut</hi>
-							beatitatem. </note><note type="footnote"> a Mss., <hi rend="italic">devincti sunt, ct
-								si sæpe;</hi> omisso. <hi rend="italic">sed.</hi>
-						</note>
-						<note type="footnote"> (a) n Retract. cap. t4. </note>
+						quærentes, non <lb/> suam, et cum pictate sectantes, ad unam pertinent
+    		
+    		<note type="footnote"> 1 sola cditio Lov., <hi rend="italic">ordinare.</hi></note>
+    		<note type="footnote"> 7 Plerique Mss. omittunt, <hi rend="italic">aut</hi> beatitatem. </note>
+    		<note type="footnote"> a Mss., <hi rend="italic">devincti sunt, ct
+								si sæpe;</hi> omisso. <hi rend="italic">sed.</hi></note>
+    		<note type="footnote"> (a) n Retract. cap. t4. </note>
+    		
 						<lb/> societatem. Et tamen Dcus misericordissimus, et su<lb/>per impios homines
 						paticns est, et præbet eis pœni<lb/>tentiæatque correctionis locum.</p>
 					<p>32. Nam et quod omnes diluvio delevit, exceptu <lb/> uno justo cum suis, quos in arca
@@ -1223,12 +1269,14 @@
 						Domini <lb/> nostri Jesu Christi, ut per eam fidem ab omni fu<lb/>perbia et tumore
 						sanarentur. Horum sanctorum, qui <lb/> præcesserunt tempore nativitatem Domini, non so­
 						<lb/> lum sermo, sed etiam vita, et conjugia, et filii, et fa<lb/>cta, prophetia fuit
-						hujus temporis, quo per fidem <note type="footnote"> I Er. et Lov., <hi rend="italic">tU
-								si converterentur.</hi> Am. et Mss., <hi rend="italic">et Ii CQIU<lb/>
-								verterentur</hi> . </note><note type="footnote"> a Floriacensis oijidam Ms., <hi rend="italic">irriscent.</hi>
-						</note>
-						<lb/>
-						<pb n="335"/> passionis Christi ex gentibus congregatur Ecclesia. <lb/> Per illos
+						hujus temporis, quo per fidem
+						
+				<note type="footnote"> I Er. et Lov., <hi rend="italic">tU si converterentur.</hi> Am. et Mss., 
+					<hi rend="italic">et Ii CQIU<lb/> verterentur</hi>.</note>
+				<note type="footnote"> a Floriacensis oijidam Ms., <hi rend="italic">irriscent.</hi></note><lb/>
+						
+
+		<pb n="335"/> passionis Christi ex gentibus congregatur Ecclesia. <lb/> Per illos
 						sanctos Patriarchas et Prophetas carnali <lb/> populo Israel, qui postea eliam Judaei
 						appellati sunt, <lb/> et visibilia beneficia ministrabantur quæ carnaliter a <lb/>
 						Domico desiderabant, et coercitiones poenarum cor<lb/>poralium quibus pro tempore
@@ -1269,10 +1317,11 @@
 						<hi rend="italic">(Isai.</hi> LIII, 7). Cujus passionis et crucis signo in fronte <lb/>
 						hodie tanquam in poste signandus es, omnesque <lb/> Christiani signantur.</p>
 					<p>55. Inde per desertum populus ille ductus est, per <lb/> q'iadraginta annos accepit
-						etiam legom digito Dci <note type="footnote"> ♦ 'm. et Mss., <hi rend="italic">cujusque
-								ille caput est.</hi>
-						</note><note type="footnote">« ::vH editi, <hi rend="italic">proplwtu.</hi>
-						</note>
+						etiam legom digito Dci
+						
+				<note type="footnote"> ♦ 'm. et Mss., <hi rend="italic">cujusque ille caput est.</hi></note>
+				<note type="footnote">« ::vH editi, <hi rend="italic">proplwtu.</hi></note>
+						
 						<lb/> scriptam <hi rend="italic">(Exod.</hi> i-xx, XXXII , xxxiv; Num. XIV, 33, <hi rend="italic">et<lb/> Deut.</hi> xxix, 5), quo nomine significatur Spiritus san­ <lb/>
 						ctus, sicut in Evangelio manifestissiine declaratur . <lb/>
 						<hi rend="italic">(Luc.</hi> XI, 20). Neque enim Deus forma corporis defl<lb/>nitus
@@ -1315,7 +1364,9 @@
 							ea<lb/> gesta quid significent. Post captivitatem</hi> Babylonicam <lb/> libertas <hi rend="italic">qualis reddita.</hi> Post aliquot tamen generationes <lb/> ostendit
 						aliam typum ad rum maxime pertinentem- <lb/> Nam cap fiviia est illa civitas, ct multa
 						pars ejus edu- <lb/>
-						<pb n="337"/> cta in Babyloniam. Sicut autem Jerusalem significat <lb/> ei vitatem
+						
+
+		<pb n="337"/> cta in Babyloniam. Sicut autem Jerusalem significat <lb/> ei vitatem
 						societatemque sanctorum; sic Babylonia <lb/> sigraificat civitatem socictatemqne
 						iniquorum, quoniam <lb/> dicitur interpretari Confusio. De quibus duabus civi­ <lb/>
 						tatibus, ab exordio generis humani usque in finem <lb/> sæculi permixte 1 temporum
@@ -1356,14 +1407,15 @@
 							et charitate</hi> a (I <hi rend="italic">Tim.</hi> II, 1, 2). Itaque per ipsos <lb/>
 						data pax est Ecclesiæ, quamvis temporalis, tranquil<lb/>litis temporalis 4 ad
 						ædificandas spiritualiter domos <lb/> et plantandos hortos et vineas. Nam ct ecce te
-						modo <lb/> per istum sermuncm ædificamus atque pluitamus. Et <note type="footnote"> I
-							cic Mss. At cditi, <hi rend="italic">permixta.</hi>
-						</note><note type="footnote"> * Lov., oraliones. KdtU aulein alii ct Mis., adorationes.
-							<lb/> cra*c&lt;&gt; est, <hi rend="italic">proseuclws.</hi>
-						</note><note type="footnote"> J vulpata, <hi rend="italic">castitate</hi> : juxta græcum
-							, <hi rend="italic">wmoleH.</hi>
-						</note><note type="footnote"> ' sic .abs. Rliti vero, <hi rend="italic">tan?o;i&gt;.</hi>
-						</note>
+						modo <lb/> per istum sermuncm ædificamus atque pluitamus. Et
+    		
+    		<note type="footnote"> I cic Mss. At cditi, <hi rend="italic">permixta.</hi></note>
+    		<note type="footnote"> * Lov., oraliones. KdtU aulein alii ct Mis., adorationes.
+							<lb/> cra*c&lt;&gt; est, <hi rend="italic">proseuclws.</hi></note>
+    		<note type="footnote"> J vulpata, <hi rend="italic">castitate</hi> : juxta græcum,
+							<hi rend="italic">wmoleH.</hi></note>
+    		<note type="footnote"> ' sic .abs. Rliti vero, <hi rend="italic">tan?o;i&gt;.</hi></note>
+    		
 						<lb/> hoc fit per totum orbem terrarum cum pace regum <lb/> christianorum , sicut idem
 						dicit apostolus : <hi rend="italic">Dei agri - <lb/> cultura, Dei œdificatio estis</hi>
 						(I Cor. III, 9).</p>
@@ -1404,11 +1456,13 @@
 						præsentis vitas felitatem, sed solam <lb/> vitam æternam, in qua ipso Dea frueretur, ab
 						illo <lb/> desiderans ; ut hac sexta ætate mens humana rcno<lb/>vetur ad imaginem
 						Dei, sicut sella dic homo factus <lb/> est ad imaginem Dei (Gen. 1, 27). Tunc enim et
-						lex <lb/> impletur, dum non cupiditate rerum temporalium <note type="footnote"> ' Mss.,
-								<hi rend="italic">electus est.</hi>
-						</note><note type="footnote"> ' Mss., e.r <hi rend="italic">progenie carmt</hi> sua. </note>
-						<lb/>
-						<pb n="339"/> sed charitate illius qui præcepit, fiunt quxcumquc <lb/> præcepit. Quis
+						lex <lb/> impletur, dum non cupiditate rerum temporalium
+    		
+    		<note type="footnote"> ' Mss., <hi rend="italic">electus est.</hi></note>
+    		<note type="footnote"> ' Mss., e.r <hi rend="italic">progenie carmt</hi> sua.</note><lb/>
+						
+
+		<pb n="339"/> sed charitate illius qui præcepit, fiunt quxcumquc <lb/> præcepit. Quis
 						autem non redamare affectet justissi<lb/>inum et misericordissimum Deum, qui prior
 						sic ama- <lb/> vit injustissimos et superbissimos homines, ut pro<lb/>pter eus
 						mitteret unicum Filium, per quem fecit <lb/> omnia ; qui non sui mutatione, sed bominis
@@ -1446,8 +1500,11 @@
 							evangelicœ sindio<lb/> flagrantes. Ecclesiœ apud Gentes per Paulum constitutre-</hi>
 						<lb/> Inde confirmatis discipulis, couversatus cum eis qua<lb/>draginta diebus ,
 						eisdem spectantibus ascendit in cœ<lb/>lum ; et completis a resurrectione
-						quiuquaginta dic<lb/>bus misit eis Spiritum sanctum (promiserat enim) , <note type="footnote"> 1 sic Mss. At clJiti, <hi rend="italic">fib ea.</hi>
-						</note><note type="footnote"> 2AM. ".r. RL !c!'C mnucs p. ,....,<hi rend="italic">fiJr.rwi.</hi> I uus Yaii'*a;ris <lb/> U* , nniinectu; ia. </note>
+						quiuquaginta dic<lb/>bus misit eis Spiritum sanctum (promiserat enim),
+    		
+    		<note type="footnote"> 1 sic Mss. At clJiti, <hi rend="italic">fib ea.</hi></note>
+    		<note type="footnote"> 2AM. ".r. RL !c!'C mnucs p. ,....,<hi rend="italic">fiJr.rwi.</hi> I uus Yaii'*a;ris <lb/> U* , nniinectu; ia.</note>
+    		
 						<lb/> per quem diffusa charitate in cordibus eorum, non <lb/> solum sinc onere, sed cHam
 						cum jucunditate legem <lb/> possent implere. Quae data est Judæis in decem præ­ <lb/>
 						ceptis, quod appellant decalogum. Quæ rursus ad <lb/> duo rcdiguntur, ut diligamus Deum
@@ -1489,12 +1546,14 @@
 						<hi rend="italic">(Id.</hi> II , 44, <hi rend="italic">ct</hi> IV , 34) : viventesque in
 						christiana di<lb/>lectione concorditer , non dicebant aliquid suum, scd <lb/> crant
 						illis omnia communia , et anima et cor unum in <lb/> Deum <hi rend="italic">(Id.</hi> IV
-						, 32 35). Deiade etiam ipsi a Judæis car<note type="footnote">1 Lov., post, <hi rend="italic">crediderunt in eum millia</hi>, addiderunt,<lb/>
-							<hi rend="italic">multa</hi>, ex uno codice Ms.</note><note type="footnote"> 2
-							Hic in editione Lov. additum fuerat,<hi rend="italic">effusionem</hi> : minus<lb/>
-							bene.</note>
-						<lb/>
-						<pb n="341"/>nalibus civibus carnis suae persecutionem passi atque <lb/> dispersi sunt,
+						, 32 35). Deiade etiam ipsi a Judæis car
+						
+				<note type="footnote">1 Lov., post, <hi rend="italic">crediderunt in eum millia</hi>, addiderunt,<lb/>
+							<hi rend="italic">multa</hi>, ex uno codice Ms.</note>
+				<note type="footnote"> 2 Hic in editione Lov. additum fuerat,<hi rend="italic">effusionem</hi> : minus<lb/> bene.</note><lb/>
+						
+
+		<pb n="341"/>nalibus civibus carnis suae persecutionem passi atque <lb/> dispersi sunt,
 						ut tatius Christus eorum dispersione <lb/> prædicaretur, et imitarentur etiam ipsi
 						patientiam <lb/> Domini sui : quia qui eos 1 mansuetus passus fuerat , <lb/>
 						mansuefactos pro se pati jubebat.</p>
@@ -1532,12 +1591,13 @@
 						miraculis movchantur ut crederent; sic nos <lb/> quia omnia ista ita completa sunt,
 						sicut ea inLibris <lb/> legimus, qui longe antequam hæc implerentur con<lb/>scripti
 						sunt, uhi omnia futura dicebantur, ct præsen<lb/>tia jam videntur, ædificamur ad
-						fidcm, ut etiam illa <note type="footnote"> 1 Am. ct Er., <hi rend="italic">qui anle
-								COSo</hi> Lov., <hi rend="italic">qui pro</hi> * is, Aliquot Mss. <lb/> qui <hi rend="italic">prr</hi> cos; et quidam, <hi rend="italic">qui propter</hi> c- s; I
-							leriqiichahenl <lb/>
-							<hi rend="italic">ql!i cos.</hi>
-						</note><note type="footnote"> 1 Am. et Er., <hi rend="italic">teneriore.</hi>
-						</note>
+						fidcm, ut etiam illa
+						
+				<note type="footnote"> 1 Am. ct Er., <hi rend="italic">qui anle COSo</hi> Lov., <hi rend="italic">qui pro</hi>
+					* is, Aliquot Mss. <lb/> qui <hi rend="italic">prr</hi> cos; et quidam, <hi rend="italic">qui propter</hi> c- s; I
+							leriqiichahenl <lb/> <hi rend="italic">ql!i cos.</hi></note>
+				<note type="footnote"> 1 Am. et Er., <hi rend="italic">teneriore.</hi></note>
+						
 						<lb/> quæ restant, sustinentes et perseverantes in Domino, <lb/> sine dubitatione
 						ventura credamus. Siquidem adhuc <lb/> tribulationes futurae in eisdem Scripturis
 						leguntur, et <lb/> ipse ultimus judicii dies, ubi omnes cives ambarum <lb/> illarum
@@ -1579,13 +1639,15 @@
 					<p>47. Fuge ergo per immobilem fidem et mores bo - <lb/> nos', fuge, frater, illatormenta,
 						ubi nec tortores de<lb/>ficiant, nec torti moriuntur; quibus sinc fine mors <lb/>
 						est, non posse in cruciatibus mori. Et exardesce <lb/> amore atque desiderio sempiternæ
-						vitæ sanctorum, <note type="footnote"> 1 Sic Am. Er. et plures Mss. At Lov., <hi rend="italic">potuit cum non erat,</hi>
-							<lb/> Corbeiensis codex a secunda manu, <hi rend="italic">sic cum non erat.</hi>
-						</note><note type="footnote"> 2 Aliquot Mss., <hi rend="italic">corruptibilis.</hi>
-						</note><note type="footnote"> 3 Sic Mss. Editi vero, <hi rend="italic">ad mores bonos.</hi>
-						</note>
-						<lb/>
-						<pb n="343"/> ubi nec operosa erit actio, nec requies desidiosa; <lb/> laus erit Dei
+						vitæ sanctorum,
+						
+				<note type="footnote"> 1 Sic Am. Er. et plures Mss. At Lov., <hi rend="italic">potuit cum non erat,</hi>
+							<lb/> Corbeiensis codex a secunda manu, <hi rend="italic">sic cum non erat.</hi></note>
+				<note type="footnote"> 2 Aliquot Mss., <hi rend="italic">corruptibilis.</hi></note>
+				<note type="footnote"> 3 Sic Mss. Editi vero, <hi rend="italic">ad mores bonos.</hi></note><lb/>
+						
+
+		<pb n="343"/> ubi nec operosa erit actio, nec requies desidiosa; <lb/> laus erit Dei
 						sine fastidio, sine defectu : nullum in <lb/> animo tædium , nullus labor in corpore;
 						nulla indi<lb/>gentia, nec tua cui subveniri desideres, nec proximi <lb/> rui
 						subvenire festines. Omnes deliciæ Deus erit et sa<lb/>tictas1 sanctæ civitatis in
@@ -1622,13 +1684,15 @@
 						etiam qnod illac turbæ impleant ecclesias per <lb/> dies festos Christianorum, quæ
 						implent et theatra <lb/> per dies solemnes Paganorum; et haec videndo ad <lb/> imitandum
 						tentaberis. Et quid dicam , vidcbis , quod <lb/> etiam nunc jam utique nosti ? non enim
-						nescis nullos <note type="footnote"> * Editi, <hi rend="italic">soactas.</hi> Aptius
-							forte quinque Mss., satietas. </note><note type="footnote"> 'sic duoMss. At editi <hi rend="italic">sorbeamur.</hi>
-						</note><note type="footnote">toY., <hi rend="italic">mifcranti.</hi> Metius Am. Er. et
+						nescis nullos
+						
+				<note type="footnote"> * Editi, <hi rend="italic">soactas.</hi> Aptius forte quinque Mss., satietas. </note>
+				<note type="footnote"> 'sic duoMss. At editi <hi rend="italic">sorbeamur.</hi></note>
+				<note type="footnote">toY., <hi rend="italic">mifcranti.</hi> Metius Am. Er. et
 							aliquot Mss., <hi rend="italic">irrije<lb/>rut;.</hi> Alludit ad illud
 							Ecclesiastici, ca rw), v. : vis-mr <lb/>
-							<hi rend="italic">WtirtW 'lilt! placeus nco.</hi>
-						</note>
+							<hi rend="italic">WtirtW 'lilt! placeus nco.</hi></note>
+						
 						<lb/> qui appellantur christiani, hæc omnia mala operari. <lb/> quae breviter
 						commemoravi. Et aliquando1 fortasse <lb/> graviora facere homines non ignoras, quos
 						nosti ap<lb/>pellari christianos. Sed si hoc animo venisti, ut quasi <lb/> securus
@@ -1667,16 +1731,18 @@
 						<lb/> cramento sane <hi rend="italic">(a)</hi> quod accipit5, cum ei bene commen­ <lb/>
 						datum fuerit, signacula quidem rerum divinarum es, a <lb/> visibilia, sed res ipsas
 						invisibiles in eis honorari; nec <lb/> sic habendam esse illam speciem benedictione
-						sancti- <note type="footnote"> I Mss., <hi rend="italic">aUquanto.</hi>
-						</note><note type="footnote"> ' sic Am. Er. et Mss. At Lor.: .Vanl si ill <hi rend="italic">spectaculis ei</hi> vty <lb/>
-							<hi rend="italic">nUalibu insanorum certaminum iltis cupiebas</hi> inhaereri.
-							</note><note type="footnote"> 1 ir. Lugd. Ven. lov. OIniUnnt, <hi rend="italic">tibi.</hi> W </note><note type="footnote"> 4 'me Kr. et plures Mss., <hi rend="italic">rtin.</hi>
-						</note><note type="footnote"> 5 Sic Mss. At editi, <hi rend="italic">accepit.</hi>
-						</note>
-						<note type="footnote"> (&gt;i) roite. <hi rend="italic">wtis.</hi>
-						</note>
-						<lb/>
-						<pb n="345"/> ficalnm , quemadmodum habetur in usu quolibet : <lb/> dicendum eliam quid
+						sancti
+    		
+    		<note type="footnote"> I Mss., <hi rend="italic">aUquanto.</hi></note>
+    		<note type="footnote"> ' sic Am. Er. et Mss. At Lor.: .Vanl si ill <hi rend="italic">spectaculis ei</hi> vty <lb/>
+							<hi rend="italic">nUalibu insanorum certaminum iltis cupiebas</hi> inhaereri.</note>
+    		<note type="footnote"> 1 ir. Lugd. Ven. lov. OIniUnnt, <hi rend="italic">tibi.</hi> W </note>
+    		<note type="footnote"> 4 'me Kr. et plures Mss., <hi rend="italic">rtin.</hi></note>
+    		<note type="footnote"> 5 Sic Mss. At editi, <hi rend="italic">accepit.</hi></note>
+			<note type="footnote"> (&gt;i) roite. <hi rend="italic">wtis.</hi></note><lb/>
+						
+
+		<pb n="345"/> ficalnm , quemadmodum habetur in usu quolibet : <lb/> dicendum eliam quid
 						significet et sermo ille qucm au<lb/>divit, quid in illo condiat1, cujus illa res
 						siinilitudi<lb/>nem gerit. Deinde monendus est cx hac occasione, <lb/> ut si quid
 						etiam in Scripturis audiat quod carnaliter <lb/> sonet, etiamsi non intelligit, credat
@@ -1711,21 +1777,21 @@
 						sic per unum homi<lb/>nen qui eUam Deus est Dei Filius, Jesum Chri<lb/>stum,
 						deletis omnibus peccatis præteritis, creden<lb/>tes in cum omnes in æternam vitam
 						ingrederentur <lb/>
-						<hi rend="italic">(Id.</hi> v, 12-19). <note type="footnote"> I Fr. <hi rend="italic">et
-								Lov., condatur.</hi> verius MSS. et Am., <hi rend="italic">condiat.</hi> Nam <lb/>
+						<hi rend="italic">(Id.</hi> v, 12-19).
+						
+				<note type="footnote"> I Fr. <hi rend="italic">et Lov., condatur.</hi> verius MSS. et Am., <hi rend="italic">condiat.</hi> Nam <lb/>
 							z;.dlur lviu de sacTanicsUo salis, quo catechumenus initiatur. <lb/> I :uc periinct
 							illud Augustini lib. i confess., cap. 11 : ..:t <lb/> « signabar jam signo cruci;
 							ejus, et comlicbar cjus sah', <lb/> « jam inde ab utero matris meie. » Ipsa est quam
 							Inc dixit <lb/> speciem <hi rend="italic">beneditione sanctificatam :</hi> adeoquc
-							laulosupra <lb/> I vo, <hi rend="italic">sane;</hi> legendum videtur, <hi rend="italic">salis.</hi>
-						</note><note type="footnote"> Sit- Mss. Editi vcro, <hi rend="italic">discet,</hi>
-						</note><note type="footnote"> * Aliquot MSS., <hi rend="italic">mortalis.</hi>
-						</note>
-					</p></div>
-    	<div type="textpart" subtype="chapter" n="27"><p>53. <hi rend="italic">Prophetias Veleris Testa­</hi>
-						<lb/> menti <hi rend="italic">impletas cerni in Ecclesia. Hinc firmata fides eo. <lb/>
-							rum quæ ventura restant, judicii</hi> ultimi <hi rend="italic">et resurrectio­ <lb/>
-							nis. Cavendæ</hi> tentationes <hi rend="italic">a</hi> malis <hi rend="italic">etiam
+							laulosupra <lb/> I vo, <hi rend="italic">sane;</hi> legendum videtur, <hi rend="italic">salis.</hi></note>
+				<note type="footnote"> Sit- Mss. Editi vcro, <hi rend="italic">discet,</hi></note>
+				<note type="footnote"> * Aliquot MSS., <hi rend="italic">mortalis.</hi></note></p></div>
+    	
+    	<div type="textpart" subtype="chapter" n="27"><p>53. <hi rend="italic">Prophetias Veleris Testa</hi>
+						<lb/>menti <hi rend="italic">impletas cerni in Ecclesia. Hinc firmata fides eo. <lb/>
+							rum quæ ventura restant, judicii</hi> ultimi <hi rend="italic">et resurrectio<lb/>
+								nis. Cavendæ</hi> tentationes <hi rend="italic">a</hi> malis <hi rend="italic">etiam
 							in Ecclesia re-</hi>
 						<lb/> perlis. <hi rend="italic">Societas cum bonis. Spes</hi> omnis in <hi rend="italic">Deo.</hi> Omnia <lb/> enim 1 qu v nunc vides in Ecclesia Dei, et sub Chri<lb/>sti
 						nominc p er totum orbem terrarum geri2, ante sæ<lb/>cula jam prædicta sunt, et sicut
@@ -1762,10 +1828,13 @@
 						ventilatienem patientissime <lb/> sufferat, ad ignem debitum segregabit. Qui autem ir­
 						<lb/> rident resurrectionem , putantes quod caro ista quia <lb/> putrescit, resurgere
 						non potest, ad pœnas in ca re<lb/>surrecturi sunt : et ostendet eis Deus quia qui
-						potuit <note type="footnote"> t rorbciensisMs., <hi rend="italic">omnia ergo.</hi>
-						</note><note type="footnote"> I Abest, geri, a HSS. </note>
-						<lb/>
-						<pb n="347"/> hæc corpora facere antequam essent, potest ca in mo<lb/>mento
+						potuit
+						
+				<note type="footnote"> t rorbciensisMs., <hi rend="italic">omnia ergo.</hi></note>
+				<note type="footnote"> I Abest, geri, a HSS. </note><lb/>
+						
+
+		<pb n="347"/> hæc corpora facere antequam essent, potest ca in mo<lb/>mento
 						restiluerc sicut erant. Omnes autem fideles re<lb/>gnaturi cum Christo, iia resurgent
 						in eodem corpore, <lb/> ut etiam commutari mereantur ad incorruptionem <lb/> angelicam :
 						ut fiant æquales Angelis Dei, sicut Do<lb/>minus &lt;psc promisit <hi rend="italic">(Luc.</hi> xx, 36) ; ct Llaudent eum <lb/> sine aliquo defectu et sine aliquo
@@ -1782,15 +1851,19 @@
 						es facile, si ct tu <lb/> talis fucris; ut simul colatis et diligatis Dcum gratis :
 						<lb/> quia lotum præmium nostrum ipse erit, ut in illa vita I <lb/> honilate ejus et
 						pulchritudine perfruamur. Sed aman<lb/>dus est, non sicut aliquid quod videtur
-						oculis; sed <lb/> bicut amatur sapientia , et veritas, et sanctitas, et <note type="footnote"> 1 sic Mss. At editi, <hi rend="italic">gualis nec dici.</hi>
-						</note><note type="footnote">s Ms.;., <hi rend="italic">immoderatis</hi> : fortasse pro,
-								<hi rend="italic">in immoderatis.</hi>
-						</note><note type="footnote">a Editi, <hi rend="italic">sive remediorum
+						oculis; sed <lb/> bicut amatur sapientia , et veritas, et sanctitas, et
+						
+				<note type="footnote"> 1 sic Mss. At editi, <hi rend="italic">gualis nec dici.</hi></note>
+				<note type="footnote">s Ms.;., <hi rend="italic">immoderatis</hi> : fortasse pro,
+								<hi rend="italic">in immoderatis.</hi></note>
+				<note type="footnote">a Editi, <hi rend="italic">sive remediorum
 								sacrilegorum.</hi>Abest, <hi rend="italic">sacrileqo<lb/>rvm,</hi> a Mss , ut
 							illa quai post adhibetur,vox, <hi rend="italic">diabolicurwll,</hi>
-							<lb/> ct aJ <hi rend="italic">divinationum</hi> referatur, et ad remcdwrum.
-							</note><note type="footnote"> 4 corbeiensis Ms., <hi rend="italic">lex Dei:</hi> sed
-							atlJilulll, <hi rend="italic">Dci,</hi> a secun<lb/>da manu. </note><note type="footnote"> Ii Editi, <hi rend="italic">ill illa (vlerna vita.</hi> Abest, <hi rend="italic">ælerlla,</hi> a Mss. </note>
+							<lb/> ct aJ <hi rend="italic">divinationum</hi> referatur, et ad remcdwrum.</note>
+				<note type="footnote"> 4 corbeiensis Ms., <hi rend="italic">lex Dei:</hi> sed
+							atlJilulll, <hi rend="italic">Dci,</hi> a secun<lb/>da manu. </note>
+				<note type="footnote"> Ii Editi, <hi rend="italic">ill illa (vlerna vita.</hi> Abest, <hi rend="italic">ælerlla,</hi> a Mss. </note>
+						
 						<lb/> justitia, et charitas I , et si quid aliud talc dicitur : <lb/> non qucmadmodunf
 						sant ista in hominibus; sed quem - <lb/> admodum sunt in ipso fonte incorruptibilis et
 						in<lb/>commutabilis sapientiae. Quoscumque ergo videris hæc <lb/> amare, illis
@@ -1810,8 +1883,11 @@
 						passus fuerit pro no<lb/>mine Christi, et pro spe vitæ æternæ,et permaners <lb/>
 						toleravcrit, major ei merces dabitur : quod si cesse<lb/>rit diabolo, cum illo
 						damnabitur. Sed opera miseri<lb/>cordiæ cum pia humilitate impetrant a Domino, ut
-						<lb/> non permittat servos suos tentari plus quam possunt <lb/> sustinere (I <hi rend="italic">Cor.</hi> x, 13). <note type="footnote"> I Mss. omittiuit, <hi rend="italic">et sanctitas, etjusdtii, ct ch&gt;</hi> rit is. </note><note type="footnote"> * sola editio Lov. pro, <hi rend="italic">donum,</hi> iiabet, <hi rend="italic">Lominum.</hi>
-						</note></p></div>
+						<lb/> non permittat servos suos tentari plus quam possunt <lb/> sustinere (I <hi rend="italic">Cor.</hi> x, 13).
+						
+				<note type="footnote"> I Mss. omittiuit, <hi rend="italic">et sanctitas, etjusdtii, ct ch&gt;</hi> rit is. </note>
+				<note type="footnote"> * sola editio Lov. pro, <hi rend="italic">donum,</hi> iiabet, <hi rend="italic">Lominum.</hi></note></p></div>
+    	
 				</div>
 				</body>
   </text>

--- a/data/stoa0040/stoa002/stoa0040.stoa002.opp-lat1.xml
+++ b/data/stoa0040/stoa002/stoa0040.stoa002.opp-lat1.xml
@@ -128,7 +128,7 @@
 		<encodingDesc>
 			<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
 				Architecture.</p>
-		  <refsDecl n="CTS">
+	  <refsDecl n="CTS">
         <cRefPattern n="chapitre" matchPattern="(\w+)" 
         	replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
         	<p>Cette unité de citation correspond au niveau chapitre du texte</p>
@@ -149,7 +149,8 @@
   	</revisionDesc>
 	</teiHeader>
   <text>
-    <body><div type="edition" n="urn:cts:latinLit:stoa0040.stoa002.opp-lat1">
+    <body>
+    	<div type="edition" n="urn:cts:latinLit:stoa0040.stoa002.opp-lat1" xml:lang="la">
 					<head>
 						<title type="main">S. AURELII AUGUSTINI HIPPONENSIS EPISCOPI DE CATECHIZANDIS RUDIBUS
 								<hi rend="italic">LIBER UNUS (a) .</hi>

--- a/data/stoa0040/stoa002/stoa0040.stoa002.opp-lat1.xml
+++ b/data/stoa0040/stoa002/stoa0040.stoa002.opp-lat1.xml
@@ -128,15 +128,25 @@
 		<encodingDesc>
 			<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
 				Architecture.</p>
-		  <refsDecl n="CTS"> <!-- modifier ici le pattern -->
-        <cRefPattern n="no citable units founds" matchPattern="(.+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"/> 
+		  <refsDecl n="CTS">
+        <cRefPattern n="chapitre" matchPattern="(\w+)" 
+        	replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
+        	<p>Cette unité de citation correspond au niveau chapitre du texte</p>
+        </cRefPattern> 
       </refsDecl>
+			<refsDecl>
+				<refState unit="chapitre"/>
+			</refsDecl>
     </encodingDesc>
 		<profileDesc>
 			<langUsage>
 				<language ident="la">Latin</language>
 			</langUsage>
 		</profileDesc>
+  	<revisionDesc>
+  		<change who="Segolene-Albouy" when="2019-02-18">CapiTainS : Ajout du découpage au niveau chapitre du document</change>
+  		<change who="Segolene-Albouy" when="2019-02-18">OCR : Corrections des erreurs d'OCR</change>
+  	</revisionDesc>
 	</teiHeader>
   <text>
     <body><div type="edition" n="urn:cts:latinLit:stoa0040.stoa002.opp-lat1">

--- a/data/stoa0040/stoa002/stoa0040.stoa002.opp-lat1.xml
+++ b/data/stoa0040/stoa002/stoa0040.stoa002.opp-lat1.xml
@@ -128,8 +128,8 @@
 		<encodingDesc>
 			<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
 				Architecture.</p>
-		  <refsDecl n="CTS">
-        <cRefPattern n="no citable units founds" matchPattern="(.+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"/>
+		  <refsDecl n="CTS"> <!-- modifier ici le pattern -->
+        <cRefPattern n="no citable units founds" matchPattern="(.+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"/> 
       </refsDecl>
     </encodingDesc>
 		<profileDesc>
@@ -150,7 +150,7 @@
 						ratione, sed eliam sine taedio et cum hilaritate impleatur. Postea revocatisad <lb/>
 						usum præceptis, profert ipse in exemplum sermones, ad cum erudiendum qui christianus
 						esse velit, comparatos duaM, <lb/> longiorem num, alterum brevissimu.u.</p>
-					<p>CAPUT PRIMUM. — 1. <hi rend="italic">Rogatus a diacono Cartha<lb/>ginensi scribit de
+    	<div type="textpart" subtype="chapter" n="1"><p>1. <hi rend="italic">Rogatus a diacono Cartha<lb/>ginensi scribit de
 							catechizandis rudibus.</hi> Petisti me, fra<lb/>ter Deogralias <hi rend="italic">(b),</hi> ut aliquid ad te de catechizandis <lb/> rudibus, quod tibi usui esset,
 						scriberem. Dixisti <lb/> euim quod sæpe apud Carthaginem, ubi diaconus es, <lb/> ad te
 						adducuntur, qui fide christiana primitus im<lb/>buendi sunt , eo quod existimeris
@@ -188,8 +188,8 @@
 						devota voluntate suscipere. Quanto enim <lb/> cupio latius crogari I pecuniam dominicam,
 						tanto <lb/> magis me oportet, si quani dispensatores conservos <lb/> meos difficultatem
 						in erogando scutire cognosco , <lb/> agere quantum in me est, ut facile atque expedite
-						<lb/> possint, quod impigre ac studiose volunt.</p>
-					<p>CAPUT II. — 3. <hi rend="italic">Sermo sæpe qui audienti placet, <lb/> displicet
+						<lb/> possint, quod impigre ac studiose volunt.</p></div>
+    	<div type="textpart" subtype="chapter" n="2"><p>3. <hi rend="italic">Sermo sæpe qui audienti placet, <lb/> displicet
 							dlcenti : unde id contingat. Qui sermonem na<lb/>bet, curet ut sine fastidio et
 							hilariter dicat.</hi> Sed quod <lb/> ad tuam pn pric considerationem pertinet, nolim
 						te <lb/> moveri ex eo quod sa'pc tibi abjectum sermonem fa<lb/>stidiosumque hahere
@@ -256,10 +256,10 @@
 						narrationis quod te velle cognovi, tum de præ<lb/>cipiendo atque cohortando, postea
 						de hac hilaritate <lb/> comparanda, quæ Deus suggesserit, disseremus. <note type="footnote">
 							<hi rend="italic">(/0</hi> Furto, <hi rend="italic">afficiat.</hi>
-						</note></p>
+						</note></p></div>
 					<pb n="313"/>
 
-					<p>CAPIT III. — a. <hi rend="italic">Narratio plena quai fieri debeat <lb/> catechizando.
+    	<div type="textpart" subtype="chapter" n="3"><p>5. <hi rend="italic">Narratio plena quai fieri debeat <lb/> catechizando.
 							Ad charitatis finem dirigenda narratio. <lb/> Scripturæ veteres propter
 							commendandum</hi> Christi <hi rend="italic">ad.<lb/> ventum, cujus finis
 							charitas.</hi> Narratio plena est, cnm <lb/> quisque primo catechizatur ab eo quod
@@ -318,8 +318,8 @@
 						omnia quæ ante <lb/> scripta sunt, ut nos doceremur scripta sunt (Hom. <lb/> xv, 4), ct
 						figura nostræ fuerunt, et <hi rend="italic">in figura contin<lb/>gebant in eis1</hi>
 						I ; <hi rend="italic">scripta sunt autem propter nos, in quos<lb/> finis</hi> sæculorum
-							<hi rend="italic">obvenit</hi> (I <hi rend="italic">Cor.</hi> x, 11).</p>
-					<p>CAPUT IV.— 7. Præcipua <hi rend="italic">causa adventus Christi,<lb/> charitatis
+							<hi rend="italic">obvenit</hi> (I <hi rend="italic">Cor.</hi> x, 11).</p></div>
+    	<div type="textpart" subtype="chapter" n="4"><p>7. Præcipua <hi rend="italic">causa adventus Christi,<lb/> charitatis
 							commendatio. Ad dilectionem</hi> referenda <hi rend="italic">esse<lb/> quæ de Christo
 							ex Scripturis narrantur</hi> in <hi rend="italic">catechismo.</hi>
 						<lb/> Quæ autem major causa est adventus Domini, nisi ut <lb/> ostenderet Deus
@@ -395,8 +395,8 @@
 						ma<lb/>jnre contraria medicina sanaretur. Magna est enim <lb/> miseria, superbus
 						homo; sed major misericordia, hu<lb/>milis Deus. Hac ergo dilectione tibi tanquam
 						line <lb/> proposito, quo rcferas omnia quæ dicis, quidquid <lb/> narras ita narra, ut
-						ille cui loqueris audiendo cre<lb/>dat, credendo speret, sperando amet.</p>
-					<p>CAPUT V. — 9. <hi rend="italic">Accedens ad catechismum</hi> scrutan­ <lb/>
+						ille cui loqueris audiendo cre<lb/>dat, credendo speret, sperando amet.</p></div>
+    	<div type="textpart" subtype="chapter" n="5"><p>9. <hi rend="italic">Accedens ad catechismum</hi> scrutan­ <lb/>
 						<hi rend="italic">dua quo fine velit fieri christianus.</hi> De ipsa etiam sevc­ <lb/>
 						rilate Dei, qua corda mortalium saluberrimo terrore <lb/> quatiuntur, charitas
 						ædificanda est; ut ab.co quem <lb/> timet, amari se gaudens, eum rcdamare audeat, cjus­
@@ -435,8 +435,8 @@
 						<note type="footnote"> 1 hie Mrn. Kr. cl Mss. At !jov., <hi rend="italic">quo.</hi>
 						</note>
 						<lb/>
-						<pb n="317"/> errorem aut per simulationem nondum volebat.</p>
-					<p>CAPUT VI. —10. <hi rend="italic">Exordium</hi> catechismi, <hi rend="italic">et
+						<pb n="317"/> errorem aut per simulationem nondum volebat.</p></div>
+    	<div type="textpart" subtype="chapter" n="6"><p>10. <hi rend="italic">Exordium</hi> catechismi, <hi rend="italic">et
 							narratio</hi>
 						<lb/> ab <hi rend="italic">historia creationis mundi usque ad præsens tempus <lb/>
 							Ecclesia.</hi> Quod si forte se divinius admonitum vel <lb/> territum esse
@@ -464,8 +464,8 @@
 						narratio<lb/>nis tractu, cor nostrum et lingua in nodos diffici<lb/>liuris
 						disputationis excurrat; sed ipsa veritas adhi<lb/>bitæ rationis 2, quasi aurum sit
 						gemmarum ordinem <lb/> ligans, non tamen ornamenti sericin ulla immodera<lb/>tione
-						perturbans.</p>
-					<p>CAPUT VII. — 11. <hi rend="italic">Resurrectio, judicium et alia <lb/> quædam post
+						perturbans.</p></div>
+    	<div type="textpart" subtype="chapter" n="7"><p>11. <hi rend="italic">Resurrectio, judicium et alia <lb/> quædam post
 							narrationem intimanda.</hi> Narrtatione tini<lb/>t a, spes resurrectionis intimanda
 						est, et pro capaci<lb/>late ac viribus audientis, proque ipsius temporis <lb/>
 						modulo, adversus vanas irrisiones infidelium de <lb/> corporis resurrectione tractandum,
@@ -507,8 +507,8 @@
 						<lb/> justificans faceret amicum, Hic jam non te puto præ<lb/>ceptore indigere, ut
 						cum occupata sant tempora, vel <lb/> tua, vel eorum qui te audiunt, breviter agas; cum
 						<lb/> autem largiora, argius eloqualis : hoc euim nullo <lb/> admonente ipsa necessitas
-						præcipit.</p>
-					<p>CAPUT VIII. — 12. <hi rend="italic">Eruditi quomodo catechizandi.</hi>
+						præcipit.</p></div>
+    	<div type="textpart" subtype="chapter" n="8"><p>12. <hi rend="italic">Eruditi quomodo catechizandi.</hi>
 						<lb/> Sed illud plane non prætereundum est, ut si ad te <lb/> quisquam catechizandus
 						venerit liberalibus doctrinis <lb/> excultus, qui jam decreverit esse christianus, et
 						ideo <lb/> venerit ut fiat, difficillimum omnino cst ut hon multa <lb/> nostrarun,
@@ -557,8 +557,8 @@
 						ejus humilitas quæ <lb/> illum adduxit, jam sentitur admittere. Cætera vero <lb/>
 						secundum regulas doctrinæ salutaris, sive de fide, <lb/> quæcumque narranda vel
 						disserenda sunt, sive de <lb/> moribus, sive de tentationibus, eo modo percurrendo <lb/>
-						quo dixi, ad illati supereminentiorem viam omnia <lb/> rererenda sunt.</p>
-					<p>CAl'UT IX. — 13. <hi rend="italic">Grammatici</hi> et <hi rend="italic">oratores
+						quo dixi, ad illati supereminentiorem viam omnia <lb/> rererenda sunt.</p></div>
+    	<div type="textpart" subtype="chapter" n="9"><p>13. <hi rend="italic">Grammatici</hi> et <hi rend="italic">oratores
 							quo­</hi>
 						<note type="footnote"> s Editi, <hi rend="italic">et</hi> si <hi rend="italic">quid
 								forts adhuc ignorai.</hi> Abest, <hi rend="italic">forte,</hi>
@@ -597,8 +597,8 @@
 						nunquam tamen Ienedictio <lb/> dici potest. De Sacramento autem quod accepturi <lb/>
 						suni, sufficit prudentioribus audirc quid res illa si<lb/>gnificet : cum tardioribus
 						autem aliquanto pluribus <lb/> verbis et similitudinibus agendum est, ne conteninant
-						<lb/> quod vident.</p>
-					<p>CAPUT X. — 14. <hi rend="italic">Jam de hilaritate comparanda.<lb/> Causæ</hi> sex <hi rend="italic">lædium afferentes catechizanti. Remedium <lb/> contra primam causam
+						<lb/> quod vident.</p></div>
+    	<div type="textpart" subtype="chapter" n="10"><p>14. <hi rend="italic">Jam de hilaritate comparanda.<lb/> Causæ</hi> sex <hi rend="italic">lædium afferentes catechizanti. Remedium <lb/> contra primam causam
 							tædii.</hi> Hic tu fortasse exem­ <lb/>
 						<lb/> plum aliquod sermonis desideras, ut ipso tibi opere <lb/> ostendam quomodo
 						facienda sint ista quæ monni. <lb/> Quod quidem faciam, quantum Domino adjuvante po­
@@ -682,8 +682,8 @@
 						penetralibus sinceris<lb/>simis, hoc cHam intelligere delci tat, quomodo chari­ <lb/>
 						tas, quanto officiosius descendit in infima, tanto ro<lb/>bustius recurrit in intima
 						per bonam conscientiam <lb/> nihil quærendi1 ab eis ad quos descendit, præter eo­ <lb/>
-						rum sempiternam salutem.</p>
-					<p>CAPUT XI.- 16. <hi rend="italic">Remedium contra secundumtœdii<lb/> causam.</hi> Si
+						rum sempiternam salutem.</p></div>
+    	<div type="textpart" subtype="chapter" n="11"><p>16. <hi rend="italic">Remedium contra secundumtœdii<lb/> causam.</hi> Si
 						autem niagis appetimus, ea quæ jam parata <lb/> sunt et melius dicta legere vel audire,
 						et ideo piget <lb/> inecrto exitu ad tempus coaptare quae loquimur : tan<lb/>tum a
 						veritnte rerum non aberret animus, facile est <lb/> ut si in verbis auditorem aliquid
@@ -736,8 +736,8 @@
 						jucundiorqne prae. <lb/> stabitur post laborem; et majore fiducia deprecabimur <lb/> ut
 						loquatur nobis Deus quomodo volumus , si susci<lb/>piamus hilariter ut loquatur per
 						nos quomodo possu<lb/>mus : ita lit ut diligentibus Deum omnia concurrant <lb/> in
-						bonum (Rom. VIII, 28).</p>
-					<p>CAPUT XII.—17. <hi rend="italic">Remedium contra tertiam</hi> causam <note type="footnote"> I Ita in Mss. At in editis, <hi rend="italic">mera.</hi>
+						bonum (Rom. VIII, 28).</p></div>
+    	<div type="textpart" subtype="chapter" n="12"><p>17. <hi rend="italic">Remedium contra tertiam</hi> causam <note type="footnote"> I Ita in Mss. At in editis, <hi rend="italic">mera.</hi>
 						</note><note type="footnote"> 2 Editi, <hi rend="italic">rctilierit.</hi> Præstantieres
 							ua . <hi rend="italic">resiluerit.</hi>
 						</note>
@@ -767,8 +767,8 @@
 						et cum gaudio majo<lb/>re in doctrina salutari, etiam illa quæ propter nos re­ <lb/>
 						texere nou opus est, perambulare debemus; cum <lb/> animam miserandam et crroribus
 						sacculi fatigatam <lb/> per itinera pacis, ipso qui nobis eam I praestitit ju­ <lb/>
-						bente3, deducimus?</p>
-					<p>CAPUT XIII.—18. <hi rend="italic">Remedium contra</hi> quartam <hi rend="italic">causam<lb/> fastidii. Auditor veI audiendo vel stando</hi> fatigatus, <hi rend="italic">quo<lb/>modo recreandus. Usus audiendi verbum Dei sedendo,<lb/> in
+						bente3, deducimus?</p></div>
+    	<div type="textpart" subtype="chapter" n="13"><p>18. <hi rend="italic">Remedium contra</hi> quartam <hi rend="italic">causam<lb/> fastidii. Auditor veI audiendo vel stando</hi> fatigatus, <hi rend="italic">quo<lb/>modo recreandus. Usus audiendi verbum Dei sedendo,<lb/> in
 							quibusdam</hi> Ecclesiis <hi rend="italic">receptus.</hi> Sed revera multum <lb/> est
 						perdurare in loquendo usque ad terminum præ. <lb/> stitutum, cum moveri non videmus
 						audientem; quod <lb/> sive nou audeat, religionis timore constrictus , voce <lb/> aut
@@ -835,8 +835,8 @@
 						quo dixi, loquimur, a tædio renovatur <lb/> intentio. Sed et breve sit, maxime quia
 						extra ordinem <lb/> inseritur, ne morbum fastidii cui subvenire volumus <lb/> eliam
 						augeat ipsa medicina: et acceleranda sunt cætera, <lb/> et promittendus atque exhibendus
-						finis propinquior.</p>
-					<p>CAPUT XIV. — 20. <hi rend="italic">Remedium adversus quintam <lb/> causam lædii.
+						finis propinquior.</p></div>
+    	<div type="textpart" subtype="chapter" n="14"><p>20. <hi rend="italic">Remedium adversus quintam <lb/> causam lædii.
 							Remedium contra</hi> sextam <hi rend="italic">causam tædii. <lb/> ltem adversus causam
 							sextam.</hi> Si autem confregit ani<lb/>mum tuum alterius actionis, cui tanquam
 						magis ne<lb/>cessariae jam suspensus eras, omissio, et propterea <lb/> tristis
@@ -915,8 +915,8 @@
 						</note><note type="footnote"> • Apud Ex. Lugd. ven. Lov., <hi rend="italic">surrexerit.</hi> M. </note><note type="footnote"> • sic Mas. Editi vero, <hi rend="italic">mentem studentis.</hi>
 						</note><note type="footnote"> • Edui fcre soli, <hi rend="italic">dictat.</hi>
 						</note>
-						<lb/> ritum sanctum qui datus est nobis <hi rend="italic">(Rom.</hi> v, 5).</p>
-					<p>CAPUT X V. —23. <hi rend="italic">Pro personarum diversitate tem­</hi>
+						<lb/> ritum sanctum qui datus est nobis <hi rend="italic">(Rom.</hi> v, 5).</p></div>
+    	<div type="textpart" subtype="chapter" n="15"><p>23. <hi rend="italic">Pro personarum diversitate tem­</hi>
 						<lb/> peranda <hi rend="italic">oratio.</hi> Sed nunc etiam illud quod priusquam <lb/>
 						promitterem non debebam, jam fortasse debitum fla<lb/>gitas, ut aliquod sermonis
 						exemplum, tanquam si ego <lb/> aliquem catechizem, non me pigeat explicare, et in­ <lb/>
@@ -953,8 +953,8 @@
 						omnia peCcata nostra <hi rend="italic">(Pul.</hi> XXIV, 18). Quam<lb/>obrem si quid
 						tibi in nobis placuit, ut aliquam <lb/> observationem sermonis tui a nobis audire
 						quæretes, <lb/> melius videndo et audiendo nos cum hæc agimus, <lb/> quam legendo cum
-						hæc dictamus. edisceres.</p>
-					<p>CAPUT XVI. — 24. <hi rend="italic">Formula orationis catechistæ. <lb/> Exordium ductum
+						hæc dictamus. edisceres.</p></div>
+    	<div type="textpart" subtype="chapter" n="16"><p>CAPUT XVI. — 24. <hi rend="italic">Formula orationis catechistæ. <lb/> Exordium ductum
 							a laudabili proposito suscipiendæ <lb/> christianæ</hi> religionis, <hi rend="italic">propter futuram requiem. Requies</hi>
 						<lb/> in <hi rend="italic">rebus inquietis non quærenda. Non in divitiis,</hi> noc in <lb/>
 						<pb n="329"/> honoribus. <hi rend="italic">Requiem quærentes</hi> in <hi rend="italic">oblectamentis earnis</hi>
@@ -1022,8 +1022,8 @@
 						dulciores esse justitiæ fructus quam iniquitatis, <lb/> et verius atque jucundius
 						gaudere homiuem de bona <lb/> conscientia inter molestias, quam de mala inter de. <lb/>
 						licias; quia non sic venisti conjungi Ecclesiae Dei, ut <lb/> ex ea temporalem aliquam
-						utilitatem requiras.</p>
-					<p>CAPUT XVII.-26. <hi rend="italic">Reprehenditur</hi> qui <hi rend="italic">velit
+						utilitatem requiras.</p></div>
+    	<div type="textpart" subtype="chapter" n="17"><p>26. <hi rend="italic">Reprehenditur</hi> qui <hi rend="italic">velit
 							esseChri<lb/>stianus propter commodum</hi> temporale. <hi rend="italic">Christianus</hi> vere <lb/>
 						<hi rend="italic">est, qui religionem profitetur propter futuram</hi> requiem. <lb/>
 						<hi rend="italic">Transit ad narrationem eorum quæ credenda sunt. <lb/> Filius</hi> Dei
@@ -1101,8 +1101,8 @@
 						venit : ut diligeremus <lb/> Deum, qui sic nos dilexit, ut unicum Filium suma <lb/>
 						mitteret, qui humililale1 nostræ mortalitatis indultis , <lb/> et a peccatoribus et pro
 						peccatoribus moreretur. Jam <lb/> enim olim ab incuniibus sæculis mysterii hujus alti­
-						<lb/> tudo præfigurari prænuntiarique non cessat.</p>
-					<p>CAPUT XVIII. —29, <hi rend="italic">De hominis et rerum aliarum<lb/> creatione quid
+						<lb/> tudo præfigurari prænuntiarique non cessat.</p></div>
+    	<div type="textpart" subtype="chapter" n="18"><p>29. <hi rend="italic">De hominis et rerum aliarum<lb/> creatione quid
 							credendum. Homo</hi> in <hi rend="italic">paradiso</hi> constitu­ <lb/>
 						<hi rend="italic">tus. Cur creatus qui præsciebatur peccaturus. Lapsus <lb/> hominis et
 							angeli nihil Deo nocuit.</hi> Quoniam Deus <lb/> omnipotens, et bonus et justus et
@@ -1157,8 +1157,8 @@
 						<lb/> Creatorem suum converso vincendus proponeretur; <lb/> lit quicumque diabolo usque
 						in finem consentirent, <lb/> cum illo irent in æterna supplicia ; quicumque autem <lb/>
 						humiliarent se Deo, et per ejus gratiam diabolum <lb/> vincerent, æterna præmia
-						mererentur.</p>
-					<p>CAPUT XIX. — 31. In Ecclesia <hi rend="italic">boni et mali,</hi> in <lb/>
+						mererentur.</p></div>
+    	<div type="textpart" subtype="chapter" n="19"><p>31. In Ecclesia <hi rend="italic">boni et mali,</hi> in <lb/>
 						<hi rend="italic">fine separandi. Civitates duæ ab initio generis humani.<lb/> Diluvium
 							et arca sacramentum. De Abrahamo et Israe<lb/>litico populo. Horum dicta et facta,
 							prophetia fuit.</hi>
@@ -1244,8 +1244,8 @@
 						mann præmissa nati suut <hi rend="italic">(Gen. XXV,</hi> 23) : ita <lb/> omnes sanct!
 						qui ante Domini nostri Jesu Christi na<lb/>livitatcm in terris fuerunt, quamvis ante
 						nati sunt, <lb/> tamen universo corpori, cujus ille caput cst1, sub <lb/> capite
-						cohæserunt.</p>
-					<p>CAPUT XX.- 34. Israelitarum <hi rend="italic">servitus in Ægypto,<lb/> et liberatio
+						cohæserunt.</p></div>
+    	<div type="textpart" subtype="chapter" n="20"><p>34. Israelitarum <hi rend="italic">servitus in Ægypto,<lb/> et liberatio
 							viaque per mare Rubrum.</hi> Baptismus <hi rend="italic">figura<lb/>tus.</hi> Ovis
 							<hi rend="italic">immolatio</hi> passionis Christi <hi rend="italic">figura. Lex
 							scripla <lb/> digito Dei. Jerusalem typus civitatis cœlesits.</hi> Populus <lb/> ergo
@@ -1310,8 +1310,8 @@
 						Christus, <lb/>
 						<hi rend="italic">qui est super omnia Deus benedictus</hi> in sæcula <hi rend="italic">(Rom.</hi>
 						<lb/> ix, 5). Multa in illa terra promissionis gesta sunt in <lb/> figuram venturi
-						Christi ct Ecclesiæ, quæ in sanctis <lb/> Libris paulatim discere poteris.</p>
-					<p>CAPUT XXI. — 37. <hi rend="italic">Captivitas</hi> Babylonica <hi rend="italic">et in
+						Christi ct Ecclesiæ, quæ in sanctis <lb/> Libris paulatim discere poteris.</p></div>
+    	<div type="textpart" subtype="chapter" n="21"><p>37. <hi rend="italic">Captivitas</hi> Babylonica <hi rend="italic">et in
 							ea<lb/> gesta quid significent. Post captivitatem</hi> Babylonicam <lb/> libertas <hi rend="italic">qualis reddita.</hi> Post aliquot tamen generationes <lb/> ostendit
 						aliam typum ad rum maxime pertinentem- <lb/> Nam cap fiviia est illa civitas, ct multa
 						pars ejus edu- <lb/>
@@ -1381,8 +1381,8 @@
 						posteaquam templum trans<lb/>actis septuaginta annis restitutum cst, tantas pres­
 						<lb/> suras et calamitates a regibus Gentium Judæi perpessi <lb/> sunt, ut intelligerent
 						nondum venisse liheraiorem , <lb/> quem non spiritualiter liberaturum intelligebant, sed
-						<lb/> pro lihcralione carnali desiderabant.</p>
-					<p>CAPUT XXII. — 39. <hi rend="italic">Ætates</hi> mundi <hi rend="italic">sex. Sexta<lb/>
+						<lb/> pro lihcralione carnali desiderabant.</p></div>
+    	<div type="textpart" subtype="chapter" n="22"><p>39. <hi rend="italic">Ætates</hi> mundi <hi rend="italic">sex. Sexta<lb/>
 							œtas ex adventu Christi. Christus</hi> Novum <hi rend="italic">Testamentum <lb/>
 							sempiternœ hœreditatis</hi> manifestans, <hi rend="italic">terrena contemnere <lb/>
 							exemplo docet. Nalivitas ejus. vita et mors.</hi> Peractis <lb/> crgo quinque
@@ -1440,8 +1440,8 @@
 						omnium dolorum flagella de hominum corporibus cx<lb/>pulit : crucifixus est, qui
 						cruciafus nostros finivit : <lb/> mortuus cst, qui mortuos suscita vit. Scd ct resur­
 						<lb/> rexit nunquam moriturus, ne ab illo quisquam sic <lb/> disceret mortem contemuere,
-						quasi nunquam vi<lb/>eturus '.</p>
-					<p>CAPUT XXIII. — 41. Spiritus <hi rend="italic">sanctus die quinqua-<lb/> gcsima post
+						quasi nunquam vi<lb/>eturus '.</p></div>
+    	<div type="textpart" subtype="chapter" n="23"><p>41. Spiritus <hi rend="italic">sanctus die quinqua-<lb/> gcsima post
 							resurrectionem Christi missus. Judœi prœ<lb/>dicutione Apostolorum conversi, vitœ
 							evangelicœ sindio<lb/> flagrantes. Ecclesiœ apud Gentes per Paulum constitutre-</hi>
 						<lb/> Inde confirmatis discipulis, couversatus cum eis qua<lb/>draginta diebus ,
@@ -1513,8 +1513,8 @@
 						charitate copularentur <hi rend="italic">(Psal.</hi> CXVII, <lb/> 22, <hi rend="italic">et Isai.</hi> XXVIII, 16). Sed postea graviores et cre<lb/>briores persecutiones
 						ex incredulis gontibus adversus <lb/> Christi Ecclesiam surrexerunt, et implebatur in
 						dies <lb/> singulos verbum Domini prædicentis, <hi rend="italic">Ecce ego mitto</hi>
-						<lb/> vos <hi rend="italic">velut oves in medio luporum (Math.</hi> x, 16).</p>
-					<p>CAPUT XXIV. — 44. <hi rend="italic">Ecclesia quasi vitis pullulat, <lb/> et putatur. Ex
+						<lb/> vos <hi rend="italic">velut oves in medio luporum (Math.</hi> x, 16).</p></div>
+    	<div type="textpart" subtype="chapter" n="24"><p>44. <hi rend="italic">Ecclesia quasi vitis pullulat, <lb/> et putatur. Ex
 							iis quæ videntur impleta, credantur præ<lb/>dicta qum restant implenda, præsertim
 							judicium</hi> futu<lb/>rum. Sed illa vitis quæ per orbem terrarum, sicut de <lb/>
 						illa prophetatum, ct ab ip o Domino prænuntiatum <lb/> crat, fructuosos palmites
@@ -1549,8 +1549,8 @@
 						illis autem poenam <lb/> aeternam cum diabolo. Sed sicut nullum gaudium re<lb/>rum
 						temporalium ex aliqua parte simile potest inve<lb/>uiri gaudio vitae æternæ , quam
 						sancti accepturi <lb/> sunt ; ita nullus cruciatus poenarum temporalium po<lb/>test
-						sempiternis iniquorum cruciatibus comparari.</p>
-					<p>CAPUT XXV. — 46. Fides <hi rend="italic">resurrectionis suadetur.<lb/> Mors
+						sempiternis iniquorum cruciatibus comparari.</p></div>
+    	<div type="textpart" subtype="chapter" n="25"><p>46. Fides <hi rend="italic">resurrectionis suadetur.<lb/> Mors
 							perpetua</hi> in <hi rend="italic">tormentis. Vita æterna sanctornm. <lb/> Cavendum
 							non tantum</hi> a <hi rend="italic">Paganis,</hi> Judæis, <hi rend="italic">et hære­
 							<lb/> ticis, sed etiam a malis Christianis. Societas</hi> sit <hi rend="italic">cum
@@ -1657,8 +1657,8 @@
 						insultationes vcl tribulationes pro nomine <lb/> Christi passus non defeceris a fide,
 						nec a bona via 4 <lb/> deviaveris, majorem mercedem acceplurus es : qni <lb/> autem in
 						his diabolo cesserint, etiam minorem perdunt. <lb/> Sed humilis esto Dco, ut non te
-						permittat tentari ut<lb/>tra vires tuas.</p>
-					<p>CAPUT XXVI. - 50. <hi rend="italic">Initiatio catechumeni, cum<lb/> expositione
+						permittat tentari ut<lb/>tra vires tuas.</p></div>
+    	<div type="textpart" subtype="chapter" n="26"><p>50. <hi rend="italic">Initiatio catechumeni, cum<lb/> expositione
 							signorum. Sermo quandoque</hi> brevior adhi<lb/>bendus. <hi rend="italic">Incipit
 							sermo alius brevior. Filius Dei</hi> immissus, <lb/>
 						<hi rend="italic">ut a morte qnce per Adamum intravit,</hi> liberaremur. Ilis <lb/>
@@ -1721,8 +1721,8 @@
 						</note><note type="footnote"> Sit- Mss. Editi vcro, <hi rend="italic">discet,</hi>
 						</note><note type="footnote"> * Aliquot MSS., <hi rend="italic">mortalis.</hi>
 						</note>
-					</p>
-					<p>CAPUT XXVII. — 53. <hi rend="italic">Prophetias Veleris Testa­</hi>
+					</p></div>
+    	<div type="textpart" subtype="chapter" n="27"><p>53. <hi rend="italic">Prophetias Veleris Testa­</hi>
 						<lb/> menti <hi rend="italic">impletas cerni in Ecclesia. Hinc firmata fides eo. <lb/>
 							rum quæ ventura restant, judicii</hi> ultimi <hi rend="italic">et resurrectio­ <lb/>
 							nis. Cavendæ</hi> tentationes <hi rend="italic">a</hi> malis <hi rend="italic">etiam
@@ -1811,7 +1811,7 @@
 						toleravcrit, major ei merces dabitur : quod si cesse<lb/>rit diabolo, cum illo
 						damnabitur. Sed opera miseri<lb/>cordiæ cum pia humilitate impetrant a Domino, ut
 						<lb/> non permittat servos suos tentari plus quam possunt <lb/> sustinere (I <hi rend="italic">Cor.</hi> x, 13). <note type="footnote"> I Mss. omittiuit, <hi rend="italic">et sanctitas, etjusdtii, ct ch&gt;</hi> rit is. </note><note type="footnote"> * sola editio Lov. pro, <hi rend="italic">donum,</hi> iiabet, <hi rend="italic">Lominum.</hi>
-						</note></p>
+						</note></p></div>
 				</div>
 				</body>
   </text>


### PR DESCRIPTION
En réponse à l'issue #5, voici une proposition de capitainisation du [document stoa0040.stoa002](https://github.com/Chartes-TNAH/patrologia_latina-dev/blob/master/data/stoa0040/stoa002/stoa0040.stoa002.opp-lat1.xml). Plusieurs modifications ont été effectuées :
- Découpage du texte en chapitres citables selon le standard CapiTainS
- Déclaration de ce pattern dans le `<cRefPattern>`
- Correction de quelques erreurs d'OCR et des hyphénisations
- Déclaration des modifications appliquées au document dans le `<revisionDesc>`