### PR TITLE
Capitanisation stoa0040.stoa028

### DIFF
--- a/data/stoa0040/stoa028/stoa0040.stoa028.opp-lat1.xml
+++ b/data/stoa0040/stoa028/stoa0040.stoa028.opp-lat1.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-  <teiHeader>
-    <fileDesc>
+	<teiHeader>
+		<fileDesc>
 			<titleStmt>
 				<title>Patrologiae Cursus Completus. Series Latina (PL)</title>
 				<sponsor>University of Leipzig</sponsor>
@@ -30,8 +30,9 @@
 				<authority>University of Leipzig</authority>
 				<idno type="filename">PL42.xml</idno>
 				<availability>
-					<licence target="https://creativecommons.org/licenses/by-sa/4.0/">Available under a
-						Creative Commons Attribution-ShareAlike 4.0 International License</licence>
+					<licence target="https://creativecommons.org/licenses/by-sa/4.0/">Available
+						under a Creative Commons Attribution-ShareAlike 4.0 International
+						License</licence>
 				</availability>
 				<date>2014</date>
 				<publisher>University of Leipzig</publisher>
@@ -47,7 +48,8 @@
 									<name xml:lang="fr">Jacques Paul Migne</name>
 								</persName>
 							</editor>
-							<author ref="http://data.perseus.org/catalog/urn:cts:latinLit:stoa0040">Augustinus</author>
+							<author ref="http://data.perseus.org/catalog/urn:cts:latinLit:stoa0040"
+								>Augustinus</author>
 							<title>De Haeresibus</title>
 							<title>Tractatus Adversus Judaeos</title>
 							<title>Contra Adversarium Legis Et Prophetarum</title>
@@ -59,15 +61,17 @@
 							<title>Adversus Quinque Haereses</title>
 							<title>Contra Judaeos. Paganos Et Arianos Sermo De Symbolo</title>
 							<title>De Altercatione Ecclesiae Et Synagogae Dialogus</title>
-							<title>Commonitorium Quomodo Sit Agendum Cum Manichaeis Qui Convertuntur [Auctore
-								Incerto]</title>
+							<title>Commonitorium Quomodo Sit Agendum Cum Manichaeis Qui Convertuntur
+								[Auctore Incerto]</title>
 							<title>Contra Felicianum Arianum De Unitate Trinitatis [Auctore Vigilio
 								Tapsense]</title>
-							<title>De incarnatione verbi ad Januarium; ex Origenis opere Peri Archon</title>
+							<title>De incarnatione verbi ad Januarium; ex Origenis opere Peri
+								Archon</title>
 							<title>De Trinitate Et Unitate Dei [Incertus]</title>
 							<title>De Essentia Divinitatis [Incertus]</title>
 							<title>De Unitate Sanctae Trinitatis Dialogus [Incertus]</title>
-							<title>De Ecclesiasticis Dogmatibus [Incertus 'Gennadius Massiliensis']</title>
+							<title>De Ecclesiasticis Dogmatibus [Incertus 'Gennadius
+								Massiliensis']</title>
 							<imprint>
 								<publisher>Garnier</publisher>
 								<pubPlace>Paris</pubPlace>
@@ -106,7 +110,8 @@
 							<biblScope unit="volume">42</biblScope>
 						</monogr>
 						<monogr>
-							<author ref="http://data.perseus.org/catalog/urn:cts:latinLit:stoa0020">Alcuinus</author>
+							<author ref="http://data.perseus.org/catalog/urn:cts:latinLit:stoa0020"
+								>Alcuinus</author>
 							<title>Quaestiones De Trinitate Et De Genesi</title>
 							<imprint>
 								<publisher>Garnier</publisher>
@@ -123,12 +128,14 @@
 
 		</fileDesc>
 		<encodingDesc>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
-				Architecture.</p>
-		  <refsDecl n="CTS">
-        <cRefPattern n="no citable units founds" matchPattern="(.+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"/>
-      </refsDecl>
-    </encodingDesc>
+			<p>The following text is encoded in accordance with EpiDoc standards and with the
+				CTS/CITE Architecture.</p>
+			<refsDecl n="CTS">
+				<cRefPattern n="no citable units founds" matchPattern="(.+)"
+					replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"
+				/>
+			</refsDecl>
+		</encodingDesc>
 
 		<profileDesc>
 			<langUsage>
@@ -137,3278 +144,3942 @@
 		</profileDesc>
 
 	</teiHeader>
-  <text>
-    <body><div type="edition" n="urn:cts:latinLit:stoa0040.stoa028.opp-lat1">
-					<head>
-						<title type="main">S. AURELII AUGUSTINI HIPPONENSIS EPISCOPI CONTRA MAXIMINUM HÆRETICUM
-							Arianorum Episcopum LIBRI DUO (a).</title>
-					</head>
-					<ab>
-						<title type="sub">
-							<hi rend="italic">LIBER PRIMUS (b).</hi>
-						</title>
-					</ab>
-					<p>Ostendit Augustinus, ea quae in Collalione ipse dixit, Maximinum non poluisse
-						refellere.</p>
-					<p>Disputationi Miximini Arianorum episcopi , cujus <lb/> prolixitate spatium dici, quo
-						præsentes conferebamus, <lb/> absumpsit, responsionem debitam reddens, ad ipsum <lb/>
-						loqui utique debeo : sive adhuc existimet contradi­ <lb/> cendum esse cum legerit, sive
-						Domino in ejus corde <lb/> mirabiliter operante manifestatæ 1 consentiat veritati. <lb/>
-						Quid libi visum est, homo ariane, tam multa dicere, <lb/> ct pro causa quæ inter nos
-						agitur nihil dicere, quasi <lb/> hoc sit n spondete posse, quod est tacere non posse?
-						<lb/> Prius itaque ostendam refellere te non potuisse quae <lb/> dixi : deinde, quantum
-						nccessarium videbitur, ego <lb/> refellam qu:c ipse dixisti.</p>
-					<p>CAPUT PIUMUM. — <hi rend="italic">De duobus diis.</hi> De duobus <lb/> diis quæ ipse
-						dixisti, ego certe respondens verbis <lb/> tuis, uhi aisti a vobis unum Deum coli : <hi rend="italic">Consequens <lb/> est,</hi> inquam, <hi rend="italic">ut aut</hi> non <hi rend="italic">colatis</hi> Christum, <hi rend="italic">aut non unum <lb/> Deum colatis
-							, scd duos.</hi> Ad hoc tu respondere cona­ <lb/> tus, mullum quidem locutus es,
-						asserens quod et <lb/> Christum Deum colatis : sed duos deos a vobis coli <lb/> quamvis
-						non negaveris, tamen non ausus es confiteri. <lb/> Sensisti enim, duos esse deos
-						colendos, christianas au­ <lb/> res ferre non posse. 0 quam de proximo te corrigeres ,
-						<lb/> si timeres credere quod dicere timuisli! Cum enim <lb/> clamet I Apostolus, <hi rend="italic">Corde creditur ad justitiam,</hi> one <lb/>
-						<hi rend="italic">confessio fit ad salutem (Rom.</hi> x, 10); si ad justitiam <lb/>
-						putas pertinere quod credis, cur hoc ad salutem etiam <lb/> orc non confiteris ? Si
-						autem duos dens colendos ad <lb/> salutem non pertinet confiteri, sine dubio nec ad ju­
-						<lb/> stitiam pertinet credere. Qui ergo non vis tali con­ <lb/> fessione . cum teneri
-						os tuum , quare non mundas a <lb/> tali credulitate cor tuum? Tene cum Catholica fidem
-						<lb/> rectam , non te pudeat emendare perversam. Tene <lb/> cum Catholica, Patrem quidem
-						non esse qui Filius <lb/> est, et Filium non esse qui Pater est; et Deum esse <lb/>
-						Patrem, Deum esse Filium : verumtamen ambos si­ <lb/> mul non duos deos esse, sed unum.
-						Isto modo solo <lb/> fiet ut et Patrem colas et Filium , nee tamen duos <lb/> deos esse
-						colendos dicas, sed unum, ne reatu impie- <note type="footnote"> I E.r. Lugd. ven. et
-							Lov.. <hi rend="italic">mamfesice. II.</hi>
-						</note><note type="footnote"> I Er. Lugd. ven. Lov. clamal. M. </note>
-						<note type="footnote"> &lt;a) scrillli circiter annum -1m. </note><note type="footnote">
-							<hi rend="italic">(b)</hi> AliJtf, secundus. </note>
-						<lb/> tatis tua conscientia compungatur , quando sonuerint <lb/> in auribus tuis dicta
-						divina , quia Nullus <hi rend="italic">Deus,</hi> nisi <lb/> unus (I <hi rend="italic">Cor.</hi> VIII, 4); ct, <hi rend="italic">Audi Israel; Dominus Deus</hi>
-						<lb/> tuus, <hi rend="italic">Dominus unas est:</hi> et quando audis , <hi rend="italic">Dominum</hi>
-						<lb/> Deum tuum <hi rend="italic">adorabis et</hi> illi <hi rend="italic">soli servies
-							(Deut.</hi> VI, 4,13); <lb/> securus possis, non soli Patri, sed etiam Filio ea qu;e
-						<lb/> uni Deo debetur servitute servire. Memento ergo te <lb/> non respondisse ad illud
-						quod objeceram , non a vo­ <lb/> bis coli unum Dcum, sed duos.</p>
-					<p>CAPUT II. — <hi rend="italic">De humanis contagiis.</hi> Secundo loco <lb/> egi tecum
-						de verbis tuis, ubi dixeras, <hi rend="italic">Deum Patrem</hi>
-						<lb/> ad <hi rend="italic">humana</hi> non <hi rend="italic">descendisse contagia;</hi>
-						quasi Christus <lb/> illa in carne perpessus sit : et admonui, quomodo <lb/> contagium
-						intelligi soleat, non utique nisi in aliquo <lb/> vitio, a quibus omnibus immunem
-						novimus Christum. <lb/> Nec ad hoc quidquam respondere potuisti. Testimo­ <lb/> nia
-						quippe divina, quae abs te commemorata sunt, <lb/> nihil te adjuvare potuerunt : non
-						enim eis probare <lb/> potuisti humano Christum attaminatum esse conta­ <lb/> gio. Quod
-						enim Apostolum dixisse commemoras, <lb/>
-						<hi rend="italic">Quoniam Christus cum peccator non esset, peccatum</hi>
-						<lb/> pro <hi rend="italic">nobis fecit:</hi> lege diligentius &gt; et ne forte mendo­
-						<lb/> sum incurreris codicem, aut latinus interpres errave­ <lb/> rit, græcum inspice;
-						et invenies non Christum pro <lb/> nobis fecisse peccatum, sed a Patre Deo ipsum Chri»
-						<lb/> stum factum esse peccatum, id est, sacrificium pro <lb/> peccato. Ait enim
-						Apostolus: <hi rend="italic">Obsecramus pro Christo, <lb/> reconciliamini Deo 1:</hi>
-						tum <hi rend="italic">qui non noverat peccatum, <lb/> pro nobis peccatum fecit</hi> (II
-						Cor. v, 20, 21). Non ergo <lb/> fecit ipse peccatum, sed eum Deus pro nobis pecca­ <lb/>
-						tum fecit, hoc est, ut dixi, sacrificium pro peccato. <lb/> Si enim recolas vel relegas,
-						invenies in libris Veteris <lb/> Testamenti peccata appellari sacrificia pro peccatis.
-						<lb/> Similitudo etiam carnis peccati, in qua venit ad nos, <lb/> dicta est et ipsa
-						peccatum : Misit, inquit, <hi rend="italic">Deus Filium</hi>
-						<lb/> suum <hi rend="italic">in similitudine carnis peccati, et de peccato da­ <lb/>
-							mnavit peccatum</hi> in <hi rend="italic">carne (Rom.</hi> VIII, 5): hoc est, de <lb/>
-						similitudine carnis peccati, quæ ipsius erat, <unclear>damnavit</unclear>
-						<note type="footnote"> 1 AIt'.. Er. et Uss.v <unclear/><hi rend="italic">reconciliari</hi> ret* </note>
-						<lb/>
-						<pb n="745"/> percatum in carne peccati, quæ nostra est. Propter <lb/> hoc etiam de illo
-						dicitur : <hi rend="italic">Quod enim mortuus est pec­ <lb/> calo, mortuus est semel;
-							quod autem vivit, vivit Deo</hi> (Rom. <lb/> VI, 10). Peccato enim mortuus est semel.
-						quia simili­ <lb/> tudini 1 carnis peccati mortuus est, quando moriendo <lb/> exutus est
-						carne: ut per hoc mysterium significaret, <lb/> eos qui in morte ipsius baptizantur,
-						mori peccato, ut <lb/> vivant Deo, Sic etiam per crucem <hi rend="italic">factus</hi>
-						est <hi rend="italic">pro nobis<lb/> maledictum (Galat.</hi> III, 15). Pendens quippe in
-						ligno, <lb/> mortem quæ de maledicto Dei venerat , suspendit in <lb/> ligno, atque ita
-							<hi rend="italic">vetus homo noster simul confixus</hi> eat <lb/>
-						<hi rend="italic">cruci</hi> (Rom. VI. 6): ut non mendaciter dictum intelliga­ <lb/> tur
-						in Lege , <hi rend="italic">Maledictus omnis qui pendet in ligno <lb/> (Deut.</hi> xxi,
-						25). Quid est, <hi rend="italic">maledictus</hi> , nisi, <hi rend="italic">Terra
-							es,<lb/> et</hi> in <hi rend="italic">terram ibis (Gen.</hi> m , 19) ? Et quid est,
-							<hi rend="italic">omnis ;</hi>
-						<lb/> n'si quia et ipse Christus, qui cum esset vita , mor­ <lb/> tuus est tamen vera
-						morte , non ficta ? Si intelligas <lb/> ista mysteria , simul intelliges non esse
-						contagia. Sed <lb/> quid ad nos , si more tuo loquens, contactum forte <lb/> mortalium
-						voluisti appellare contagium; cum tamen <lb/> nobiscum sentias, Dominum Jesum, nec in
-						spiritu, <lb/> nec in carne ullum habuisse peccatum?</p>
-					<p>CAPUT III. — <hi rend="italic">De invisibili Deo.</hi> Tertio loco de in­ <lb/>
-						visibili Deo cum agerem, admonui ul crederes invisi­ <lb/> bilem , non solum Patrem, sed
-						etiam Filium secun­ <lb/> dun. divinit item, non secundum carnem, in qua eum <lb/>
-						visibilem mortalibus apparuisse quis negat? undeot <lb/> alio loco postea disputavi. Tu
-						antem cedens manife­ <lb/> stissimae veritati, consensisti esse invisibilem Filium :
-						<lb/> ac per hoc destruxisti quod dixeras, <hi rend="italic">unum invisibilem <lb/>
-							Patrem.</hi> Sed rursus tua consensione conturbatus, <lb/> quia invisibilem etiam
-						Filium esse consenseras, au­ <lb/> sus es dicere, min tra videri a majurihus, majora
-						vero <lb/> a minoribus non posse videri; dicens Angelos videri <lb/> ab Archangelis ,
-						animas ab Angelis, Angelos vero ab <lb/> animabus non videri : unde eliam Christum
-						secun­ <lb/> dum divinitatis suæ substantiam, non solum ab ho­ <lb/> minibus, sed nec a
-						Virtulibus coelestibus videri asse­ <lb/> rens, ideo Patrem solum invisibilem esse
-						dixisti, quia <lb/> superiorem non habet a quo circuminspiciatur. Dic <lb/> nobis, rogo
-						te, quando libi indicaverunt Archangeli , <lb/> quod ipsi vidcant Angelos, non autem
-						videantur ab <lb/> Augelis! Quibus narrantibus Angelis cognovisti, quod <lb/> ipsi
-						videam animas, animæ illos non vidcant? A quo <lb/> hæc audisti? unde didicisti? ubi
-						legisti ? Nonne me­ <lb/> lius divinis Libris animum intenderes, ubi legimus et <lb/> ab
-						hominibus Angelos visos,quando voluerunt, cet <lb/> quomodo voluerunt videri, jubente
-						vel sinente <lb/> omnium Creature? Verumtamen qui dixeras, ideo <lb/>
-						<hi rend="italic">solum</hi> dicendum <hi rend="italic">in visibilem Patrem, quia non
-							habet <lb/> superiorem a quo circuminspiciatur;</hi> confessus es po­ <lb/> sica,
-						Filio esse visibilem , contra te ipsum proferens <lb/> evangelicum testimonium, uhi
-						dicit ipse Filius, <hi rend="italic">Non <lb/> quia Patrem vidit quisquam, sed qui eat a
-							Deo, hic vi­ <lb/> dit Patrem (Joan.</hi> VI, 46). Ubi te quidem veritas apcr­ <lb/>
-						tissime vicit: sed tu nolens ab errore liberari, nolui- <note type="footnote"> 1 sola
-							edllio I.oV., <hi rend="italic">q1ria in siiwliludine.</hi> quidam Mss., <hi rend="italic">quia <lb/> fiudiUttdinc.</hi>
-						</note>
-						<lb/> sti salubriter vinci. Cum enim contra te commemo­ <lb/> rasses evangelicum
-						testimonium, quo claruit a Filio <lb/> videri Patrem, dicente ipso Filio, <hi rend="italic">Sed qui est</hi> a <hi rend="italic">Deo,<lb/> hic vidit Patrem;</hi>
-						mox addidisti de tuo, <hi rend="italic">Sed vidit in - <lb/> capabilem.</hi> Interim
-						quod dixeras perdidisti, solum <lb/> esse invisibilem Patrem, quia non habet superiorem
-						: <lb/> quandoquidem veritate victus, cum vidcri ab inferiore <lb/> confessus es. l'os
-						enim dicitis inferiorem Filium a <lb/> quo tamen Patrem videri, teste Filio cogente I,
-						dixi­ <lb/> sti. De incapabili postea videbimus, ut etiam te illic <lb/> veritas vincat.
-						Non enim de capabili et incapabili, sed <lb/> de visibili et invisibili inter nos
-						quæstio versabatur : <lb/> in qua quæstione si libi ipsi tu ip e visibilis es, vi. <lb/>
-						ctum te esse vides.</p>
-					<p>CAPUT IV. — <hi rend="italic">De immortali</hi>
-						<unclear/><hi rend="italic">Deo.</hi> Quarto loco egi <lb/> tecum de immortali Den etiam
-						Filio. Quoniam tu il­ <lb/> lud quod ait Apostolus , <hi rend="italic">Qui solus habet
-							immortalita­<lb/> tem</hi> (I <hi rend="italic">Tim.</hi> VI, 16) ; sic intelligi
-						voluibti, tanquam <lb/> de solo Patre sit dictum : cum ille hoc non de Patre <lb/>
-						dixerit, sed de Deo , quod est Pa er et Filius et Spiri- <lb/> Ius sanctus. Ostend! ergo
-						ct Filium habere immorta­ <lb/> litatem secundum substantiam divinitatis suæ. Nam <lb/>
-						secundum carnem quis negat eum fuisse mortalem ? <lb/> Tu autem cum mihi respondere ad
-						hunc locum vel­ <lb/> les, perspicua veritate conclusus, etiam Deum Filium <lb/>
-						immortalitatem habere confessus es. Victus es igitur <lb/> in eo quod dicebas de Patre
-						tantum dixisse Aposto­ <lb/> lam, quod solus habeat immortalitatem. Ncque enim <lb/>
-						propterea vinculis veritatis elaberis , quoniam dicis, <lb/>
-						<hi rend="italic">Habet quidem Filius immortalitatem, sed accipiens</hi> a <lb/>
-						<hi rend="italic">Patre.</hi> Non quæritur uude habcat, sed utrum habeat. <lb/> Tu enim
-						de Patre solo vis intelligi quod scriptum esi, <lb/>
-						<hi rend="italic">Solus habet immortalitatem.</hi> Prorsus a nullo acceptam <lb/> Pater
-						habet immortalitatem, et a Patre acceptam Fi <lb/> lius habet immortalitatem : tamen et
-						Pater ct Filius <lb/> habet immortalitatem. Alioquin si eam non habet <lb/> Filius ;
-						Pater eam non dedit Filio, aut acceptam per­ <lb/> didit Filius. Dedit autem Pater
-						Filio, nec perdidit Fi­ <lb/> lius : nec Pater dando perdidit quod generando dedi!.
-						<lb/> Habet ergo immorlalitalem et Pater et Filius, non <lb/> Pater solus. Cogeris
-						itaque confiteri non de solo Patre <lb/> dictum esse, <hi rend="italic">Qui solus habet
-							immortalitatem:</hi> quia jam <lb/> coactus es confiteri quod et Filius habeat
-						immorta­ <lb/> litatem. Habet autem hanc <hi rend="italic">solus,</hi> sed Deus: quod
-						<lb/> non solus est Pater; quia hoc est et Filius, et uter­ <lb/> que adjuncto Spiritu
-						sancto unus est Deus. Sed quaro <lb/> solus Deus dictus sit habere immortalitatem, cum
-						et <lb/> anima pro suo modo sit immortalis, et alia <unclear>spiritun­</unclear>
-						<lb/> lis coelestisque creatura, postea videbimus : nunc au­ <lb/> tem sufficit nobis,
-						quod ad ea quae dixi, nihii respon­ <lb/> dere potuisti, ct non solum Patrem ; sed
-						quamvis ab <lb/> ipso, habere tamen , immortalitatem etiam Filium <lb/> coactus es
-						confiteri.</p>
-					<p>CAPUT V. — <hi rend="italic">Unde major sit Pater.</hi> Quinto loco <lb/> ostendi, unde
-						major sit Pater Filio : quia nou Den <lb/> major est, unde illi coæternus est Filius;
-						sed homine <lb/> major est, quod ex tempore ,factus est Filius. Ibi <lb/> commemoravi
-						apostolicum testimonium : <hi rend="italic">Quia</hi> cum <hi rend="italic">in</hi>
-						<note type="footnote"> t Hic apud l.ov. additur, <hi rend="italic">veritate.</hi>
-						</note>
-						<note type="footnote"> PATROL. XLII. </note>
-						<note type="footnote">
-							<hi rend="italic">(Yingl-quatrl.)</hi>
-						</note>
-						<lb/>
-						<pb n="747"/>
-						<hi rend="italic">forma</hi> £Dei esset, <hi rend="italic">non rapinam arbitratus esl
-							esse æqua­</hi>
-						<lb/> lis Dec. Natura quippe illi fuerat Dei æqualitas , non <lb/> rapina. Ad quod tu
-						respondens dixisti : <hi rend="italic">Quis enim<lb/> vegat Filium esse in forma Dei ?
-							Qnod enim sit Dens, <lb/> quod sit Dominus , quod sit Rex, jam pulo latius</hi> expo­
-						<lb/> s <unclear>uimus</unclear>.<hi rend="italic">Et</hi> &lt; <hi rend="italic">quia
-							non rapinam arbitratus cat esse æqua­<lb/> lis Deo, » hoc nos beatus apostolus Paulus
-							instruit, quod <lb/> ille non rapuit, nee noa dicimus.</hi> Hæc verba tua non <lb/>
-						solum nihil habent adversus nos ; sed magis apparent <lb/> esse pro nobis. Si enim
-						confiteris Dei formam , cur <lb/> non aperte Dei Filium Deo confiteris æqualem ? Præ­
-						<lb/> sertim, quia de verbis Apostoli, ubi ait, <hi rend="italic">Non rapinam <lb/>
-							arbitratus eat esse æqualis Deo;</hi> non poluisti pro tuis <lb/> partibus invenire
-						quod diceres. Et quia hoc dixisse <lb/> Apostolum non potuisti negare, idco dixisti, <hi rend="italic">quod ille</hi>
-						<lb/> non <hi rend="italic">rapuit, nec nos dicimus</hi> : tanquam hoc sit <hi rend="italic">non ra­</hi>
-						<lb/> puit, qnod csl non hahuit, id est, æqualitatem Dei : <lb/> atque ita dictum sit,
-							<hi rend="italic">Non rapinam arbitratus eat esse<lb/> æqualis Deo;</hi> ac si
-						diceretur, Non arbitratus est esse <lb/> rapiendam æqualitatem Dei, co quod ab illo
-						fuerit <lb/> alicua. Raptor enim rei alienæ usurpator est: tan­ <lb/> quam hoc Filius,
-						cum posset, rapcre noluisset. Quod <lb/> vides quanta insipientia sentiatur. Ergo
-						intellige Apo­ <lb/> siolum ideo dixisse , <hi rend="italic">Non rapinam arbitratus eat
-							esse</hi>
-						<lb/> æqualis <hi rend="italic">Deo;</hi> quia non alienum arbitratus est esse <lb/>
-						quod natus est: sed tamen quamvis æqualitatem Dui <lb/> non fuerit arbitratus alienam,
-						sed suam, <hi rend="italic">semetipsum<lb/> exinanivit,</hi> non quærens quae sua sunt,
-						sed quae no­ <lb/> sira sunt. Quod ut noveris ita esse , attende unde ad <lb/> hoc
-						Apostolus venerit. Cum enim Christianis humili­ <lb/> tatem præciperet charitatis : <hi rend="italic">Alter alterum,</hi> inquit, <lb/> existimantes superiorem <hi rend="italic">sibi, non quæ sua sunt unusquis­ <lb/> que intendentes, sed et quæ
-							aliorumf.</hi> Deinde til exem­ <lb/> plo Christi hortaretur non sua quærere vel
-						intendere, <lb/> sed et quæ aliorum sunt: <hi rend="italic">Singuli quique,</hi> inquit,
-							<hi rend="italic">hoc<lb/> sentite</hi> in <hi rend="italic">vobis quod et in Christo
-							Jesu : qui cum in forma<lb/> Dei esset,</hi> quæ illi crat sua, non <hi rend="italic">rapinam arbitratus est,</hi>
-						<lb/> hoc cst, non alienum arbitratus est, <hi rend="italic">esse æquali, Deo ;</hi>
-						<lb/> sed tamen quærens nostra, non sua , <hi rend="italic">semetipsum ex­</hi>
-						<lb/> inanivit, non formam Dci amittens, sed fOrmam <hi rend="italic">servi ac.</hi>
-						<lb/> cipiens. Non enim est mutabilis illa natura ut se ex­ <lb/> inaniret perdendo quod
-						erat, sed accipiendo quod non <lb/> crat : nec consumendo quæ sua sunt, sed assumendo
-						<lb/> quæ nostra sunt; ac deinde in forma servi obediendo <lb/> sicut homo <hi rend="italic">usque ad mortem crucis. Propter quod et <lb/> Deus</hi> eum <hi rend="italic">exaltavit,</hi> et donarit ei <hi rend="italic">nomen</hi> qnod <hi rend="italic">eat super<lb/> omne nomen (Philipp.</hi> 11, 6-9) : et cætera. Homini
-						ergo <lb/> donavit ista, non Deo. Neque enim tum in forma ici <lb/> esset non excelsus
-						crat, aut non ei genua flectebant <lb/> « cœlestia, terrena et inferna. Sed cum dicitur,
-							<hi rend="italic">Propter<lb/> quod eum exaltavit;</hi> satis apparet propter quid
-						exalta­ <lb/> verit, id est, propter ohedicntiam <hi rend="italic">usque ad mortem
-							cru­</hi>
-						<lb/> cis. ITI qua ergo forma crucifixos est, ipsa exaltata <lb/> &lt;at, ipsi donatum
-						est <hi rend="italic">nomen quod eat super omne no­</hi>
-						<lb/> men; ut cum ipsa forma servi nominetur Filius Uni­ <lb/> genitus Dei 2. Non itaque
-						facias imparem Dco formam <note type="footnote"> * tor,, <hi rend="italic">aed ea
-								quæ</hi><hi rend="italic">atiorum.</hi> At sas., <hi rend="italic">sed et qua
-								aliorum :</hi>
-							<lb/> jux ui gJ":9CUlD, <hi rend="italic">atla kilL.</hi> . </note><note type="footnote"> ' I iiic cdili addiuit, <hi rend="italic">intelligetur.</hi> et
-							reluctantibus <lb/> Mss. <lb/> , </note>
-						<lb/> Dei : quod nee in ipsis hominibus did potest. Nam <lb/> cum dictum fuerit, Iste
-						homo in forma est illius ho­ <lb/> minis, nemo intelligit nisi æquales 1. An forte non
-						<lb/> vis sic accipere quod dictum est, <hi rend="italic">Cum</hi> in <hi rend="italic">forma Dci<lb/> esset,</hi> ut in forpia Dci Patris intelligas Filium, ubi <lb/> nihil
-						aliud quam æqualitas apparet amborum ; sed, <hi rend="italic">in <lb/> forma Dei,</hi>
-						putas intelligendum in forma sua, quia et <lb/> ipse utique Deus est ? Non multum curo
-						si etiam sic <lb/> intelligas. Ubi enim plenitudinem formæ aetatis in­ <lb/> crementa
-						non faciunt, sed Deo gignente perfectus <lb/> natus est Filius; procul dubio si forma
-						Filii formae <lb/> Patris non cst æqualis, non verus cst Filius. Scriptum <lb/> est
-						autem : Ut simus in <hi rend="italic">vero Filio ejus Jesu Christo</hi>
-						<lb/> (I <hi rend="italic">Joan.</hi> v , 20). Forma igitur vcri Filii, formæ Dei <lb/>
-						Patris esse non potest inæqualis. Proinde nee hu'c <lb/> loco prosecutionis meæ, ubi de
-						verbis Apostoli æqua­ <lb/> lem Patri Filium comptobavi, respondere aliquid pro <lb/>
-						vestra intentione potuisti.</p>
-					<p>CAPUT VI. — <hi rend="italic">De veris filiis animalium.</hi> Sexto loco <lb/> ut
-						ejusdem naturæ cujus ct Pater est, ostenderem <lb/> Filium, etiam mortalium fctus
-						animalium immanitati <lb/> vestri crroris objeci, increpans cor vestrum, qui ejus­ <lb/>
-						dem nature cujus est Pater, negatis esse Deum Fi­ <lb/> lium, quamvis verum esse Filium
-						non negetis; cunt <lb/> Deus ipse dederit animalibus hoc generare quod ipsa <lb/> sunt :
-						ubi non solum hominis homincm, verum etiam <lb/> canis canem filium nominavi; non ad
-						similitudinem <lb/> Dei, sed ad confusionem detrahentium Filio Dci : qui <lb/> cum
-						videant corruptibiles mortalesque naturas, habere <lb/> tamen naturæ de suis parentibus
-						unitatem, Filio Dei <lb/> vero nolunt concedere communionem naturae unius <lb/> habere
-						de Patre; cum sit inseparabilis a Patre, ct in­ <lb/> corruptibilis aeternusque cum
-						Patre. Unde etiam dixi, <lb/> quod melior sit secundum vos humana conditio , ubi <lb/>
-						conceditur crescere, ut ad robnr parentum vcl cre­ <lb/> scendo possint filii pervenire:
-						Filius autem Dci , sicut <lb/> dicitis et docetis, minor Patre genitus sic remansit,
-						<lb/> atque ut ad Patris formam non posset pervenire, nec <lb/> crevit. Hic tu, ut
-						appareret quam magna veritatis mole <lb/> premereris, omnino ad rem non respondisti :
-						sed <lb/> tanquam deficienti flatu I anhelarcs, reprehendendum <lb/> me putasti, dicens
-						quod tam foeda comparatio, de filio <lb/> scilicet hominis sive canis, in illam tantam
-						immen­ <lb/> sitatem produci non debuit. lloc respondere est , an <lb/> potius inopiam
-						responsionis ostendere ? Quasi ego <lb/> propterca terrenarum naturarum ista exempla
-						produ­ <lb/> xcrim, ut incorruptioni corruptionem, immortalitati <lb/> mortalitatem ,
-						invisibilibus visihilia, æternis tempo­ <lb/> ralia coæquarem : ac non potius ut vos in
-						magnis ct <lb/> summis rebus errantes , de rebus parvulis infimisque <lb/> convincerem,
-						qui non videtis bonum quod Creator <lb/> summe bonus dedit etiam extremis vilibusque
-						creatu­ <lb/> ris, ut cnm longe aliud sint quam est ipse, hoc tamen <lb/> gcnerent quod
-						sunt ipsæ. Nee attenditis quid niali di­ <lb/> catis, ut cum homines et canes, et cætera
-						hujusmodi <lb/> habeant filios veruS, quos illis gignentibus creat vcri­ <lb/> tas, nOli
-						sit vcrus Dei Filius ipsa vcritas. Aut si san­ <note type="footnote"> * Am. F.r. et
-							va,r., <hi rend="italic">rtiri fcquatis.</hi>
-						</note><note type="footnote"> t .to., <hi rend="italic">deficinlis</hi>
-							<unclear>fatus</unclear>. -, </note>
-						<lb/>
-						<pb n="749"/> cta Scriptura cogente permittitis ut verus Filius sit, <lb/> rogamus
-						permittite ut dcgener non sit. Et degener <lb/> quomodo? Andiant catholici, unde
-						erubescant hære­ <lb/> tici. Filius viri fortis si non habeat fortitudinem , de­ <lb/>
-						gener dicitur : tamen homo est, quod ct patcr est; <lb/> atque in dissimili vita , non
-						est tamen aliena substan­ <lb/> tia. Vos unigenitum Dei Filium ita degenerem vullis,
-						<lb/> ut ipsam Patris ei substantiam denegetis : minorem <lb/> natum, minorem remansisse
-						jactatis ; non ullam datis <lb/> ætatem qua possit augeri, non datis eamdem formam <lb/>
-						qua possit <unclear>æquari</unclear>. Cujus naturae tanta subtrahitis, <lb/> miror verum
-						Filium qua fronte dicatis : nisi quia in­ <lb/> fclicissimo errore non vos putatis ad
-						unius Patris glo­ <lb/> riam, nisi per unici Filii contumeliam pervenire (a).</p>
-					<p>CAPUT VII. — <hi rend="italic">De magnitudine Filii.</hi> Septimo loco <lb/> dixi : <hi rend="italic">Usque adeo autem Filium agnoscimus magnum <lb/> Deum , ut Patri dicamus
-							æqualem. Itaque</hi> sine <hi rend="italic">causa,</hi>
-						<lb/> inquam, nobis <hi rend="italic">quod valde profitemur, testimoniis, et <lb/>
-							multiloquio</hi> probas voluisti. Et his verbis meis addidi <lb/> disputationem, in
-						qua rationem redilidi, quare Filius <lb/> cum sit Patri æqualis, dicat cum tamcn Deum
-						suum, <lb/> ubi nil : <hi rend="italic">Ascendo ad Patrem meum et ad Patrem ve­</hi>
-						<lb/> strum , Deum meum <hi rend="italic">et Deum</hi> restrum <hi rend="italic">(Joan.</hi> xx, 17). <lb/> Quoniam tu commemoraveras hoc evangelicum testi­ <lb/>
-						monium , quo te probarc existimasti quod Patri Filius <lb/> non esset æqualis. Ego
-						itaque tibi ad ista respondens, <lb/> dixi Patrem propterea etiam Deum esse unigeniti
-						Filii, <lb/> quoniam factus est homo et natus ex femina : ct hoc <lb/> esse quod dicit
-						in Psalmo, ubi quod futurum fucrat <lb/> prænuntiavit, <hi rend="italic">De ventre
-							matris meæ Deus meus es tu<lb/> (Psal.</hi> xxi, 11) ; ut ostenderet Patrem hinc esse
-						Deum <lb/> suum , quia homo factus est. Homo enim de ventre <lb/> matris est natus, et
-						secundum hominem de virgine <lb/> natus est Deus : ut non solum Pater illi esset qui cum
-						<lb/> de se ipso genuil, verum etiam Deus ejus esset quem <lb/> de ventre matris hominem
-						creavit. Ad hacc tu cum <lb/> respondere voluisses, mu!ta dixisti, ct multa testimo­
-						<lb/> nia quæ te nihil adjuvant, protulisti. Quomodo ta­ <lb/> men dictum sit. <hi rend="italic">De ventre matris meæ Deus meus es tu;</hi>
-						<lb/> quamvis eadem Scripturæ sanct e verba memorasses, <lb/> nullo modo invenire
-						potuiti. Cur autcm in eo loco <lb/> posueris psalmi alterius testimonium, ubi scriptum
-						<lb/> est, <hi rend="italic">Tecum principium in die virtutis tuæ, in splendo­ <lb/>
-							ribus sanctorum, ex utero ante luciferum genui te (Psal.</hi>
-						<lb/> CIX, 5); omnino non video. Non enim Filii persona <lb/> est dicentis, Ex utero
-						tuo, aut, De ventre tuo, Deus <lb/> meus es tu. Illa ineffabilis generatio cHam si ex
-						utcro <lb/> Patris accipitur, hoc significatum cst, quia de 83 <lb/> ipso, hoc cst, de
-						substantia sua Deus Deum genuit, <lb/> sicuit ex utero matris quando natus est, homo
-						homi­ <lb/> nem genuit: ut intelligeremus in utraque generatione <lb/> non diversas ejus
-						qui cst natus, et eorum de quibus <lb/> est natus, esse substantias. Diversa quidem
-						substantia <lb/> cst, Deus Pater, et homo mater: non tamen diversa <lb/> substantia est,
-						Deus Pater, ct Deus 'ilius ; sicut non <lb/> est diversa substantia, homo mater, ct homo
-						filius. <lb/> Sed audi quid dicat in prophetia iste Filius : <hi rend="italic">De</hi>
-						ven­ <lb/> Ire, inquit, <hi rend="italic">matris</hi>
-						<unclear/><hi rend="italic">meæ Deus</hi> meuses <hi rend="italic">tu.</hi> Noli multis
-							<note type="footnote"> (r) vide scrin. 130, no. 4 et 3, tom, 5. </note>
-						<lb/> vetbis ad rem non necessariis conari operire res cla- <lb/> ras. Qui est Pater
-						Filio ex utero suo, de vontre ma­ <lb/> tris Deus ejus est, non de suo. Ad hoc ergo
-						prorsus <lb/> nihil respondere po:uisti.</p>
-					<p>CAPUT VIII. — <hi rend="italic">De subjectione Filii</hi> Octavo loco de <lb/>
-						subjectione qua subjectus est Patri Filius, respondi <lb/> libi : quoniam dixeras, <hi rend="italic">De sua subjectione unum sta­<lb/> tuit Deum.</hi> Respondi ergo ellam
-						hoc secundum homi­ <lb/> nen recte accipi, quod Filius subditus est Patri. Nc­ <lb/> que
-						hoc esse mirandum , cum legatur utique secun­ <lb/> dum ipsam servi formam etiam
-						parentibus subdimus <lb/>
-						<hi rend="italic">(Luc.</hi> n , 51) : et de illo sit scriptum, <hi rend="italic">Minorasti eum <lb/> paulo</hi> minus <hi rend="italic">ab Angelis (Psal.</hi> VIII,
-						6). Ad quod tu <lb/> quasi respondens dixisti me optime prosecutum, quo­ <lb/> niam ct
-						parentibus propter formam Servi esset subjg­ <lb/> ctus. Dcinde volens velut pro te esse
-						ostendere, quod <lb/> contra te esse cernebas; ac sic incautis
-							<unclear>minusquo</unclear>
-						<lb/> attentis hominibus, quicumque essent ista lecturi, <lb/> tanquam respondentem te
-						facere, ubi quod diceres <lb/> non habebas; adjungis et dicis : Si eni, t <hi rend="italic">parentibus <lb/> subjectus invenitur quos ipse creavit, qnia omnia pet
-							<lb/> ipsunt facta sunt : nec enim post tempora, sed ante tem­ <lb/> pora novimus
-							Filium genitum a Patre : si ergo parenti­</hi>
-						<lb/> bus , inquis , <hi rend="italic">subditus etat, ut</hi>
-						<unclear/><hi rend="italic">divinarum Scripturarum<lb/> auctoritas luce clarius
-							prat'dicat : quanto magis utique illl <lb/> suo genitori est subditus, qui tantum ac
-							tatem</hi> eum <hi rend="italic">ge­<lb/> nuit;</hi> secundum <hi rend="italic">quod
-							ait Paulus, Cum omnia fuerint <lb/> Filio</hi> subjecta, <hi rend="italic">tunc et
-							ipse Filius subjectus erit illi</hi> qui <lb/>
-						<hi rend="italic">sibi subjecit omnia</hi> (I <hi rend="italic">Cor.</hi> xv, 28) ? Hæc
-						verba tua pos- <lb/> sevit a me putari dicta esse, et omnino mca esse, nisi <lb/> tc
-						audientibus cum dicerentur, et postea hæc cuncti <lb/> legentibus, evidenter appareret
-						tc illa dixisse. Quis <lb/> enim crederet, consentire posse vos nobis, secundum <lb/>
-						formam servi, ac per hoc non secundum formam Det <lb/> Christum esse subjectum ?</p>
-					<p>CAPUT IX. — <hi rend="italic">Utrum adoret Patrem Spiritus san­<lb/> ctus.</hi> Nono
-						loco abs te quaesivimus, ut per Scripturas <lb/> divinas ostenderes, si valeres, utrum
-						adoret Patrem <lb/> Spiritus sanctus. Iloc cniin dixeras : sed sicut ipsi <lb/> tua
-						prosccutio, cui respondi, satis indicat, non pro­ <lb/> baveras. Ad hanc ergo
-						inquisitionem mcam vide quid <lb/> posteriore prosccutione responderis. Cum enim divis-
-						<lb/> scs quantum voluisti de judicio Filii, quod et nos fide­ <lb/> lissime credimus;
-						ct de subjectione, quam secundum <lb/> formam servi Filium Patri reddere non negamus :
-						<lb/> ubi venisti ut probares a sancto Spiritu adorari Pa­ <lb/> trem, rediiti ad illos
-						gemitus, de quibus tibi jam ante <lb/> responderam, secundum morem sanctarum Scriptu­
-						<lb/> rarum, qna locutione sil dictum, <hi rend="italic">Et</hi> ipse Spiritus <hi rend="italic">in­<lb/> terpellat gemitibus inenarrabilibus (Rom.</hi> VIII, 26) : no
-						<lb/> credamus Spiritum sanctum nunquam esse esine gc­ <lb/> mitibus posse, quomam nulus
-						dies, nulla hora, nul­ <lb/> lum momentum temporis invenitur, quo non a sanctis <lb/>
-						orationes Dco ubicumque fundamur, ab aliis hic, ab <lb/> aliis alibi. Cum tamen ab
-						orationibus sanctorum nul­ <lb/> lum sit tempus immune, quandoquidem dicbus et <lb/>
-						noctibus, cum alii cibo ac potu reficiuntur, alli quod­ <lb/> libet aliud agunt, alii
-						dormiunt, non utique desunt <unclear/><lb/> quos desiderium sancium orare compellat; ita
-						fit ut <lb/>
-						<pb n="751"/> Spiritus sanctus, qui ubique omnibus adest, aliquan­ <lb/> tulum cessare a
-						gemitibus nun sinatur, quod est ex­ <lb/> tremæ miseriæ, cum pro quibuscumque orantibus
-						<lb/> cogitur gemere : nisi gemitibus inenarrabilibus in­ <lb/> terpellare sic
-						intelligatur, ut dixi, id cst, quia gemi­ <lb/> tibus sanctorum desideriorum
-						interpellare sanctos <lb/> facit, quibus affectum pium gratiæ spiritualis infundit.
-						<lb/> Sed cum similes locutionum modos, quando per ef­ <lb/> ficientem significamur id
-						quod efficitur; sicut frigus <lb/> pigruin dicimus, quia pigros facit; et dicm tristem
-						<lb/> vel lætum, quia tristes vel lætos facit; etiam de Scri­ <lb/> puris sanctis
-						commemoraverim, ubi Deus dicit ad <lb/> Abraham , <hi rend="italic">Nunc cognovi
-							(Gen.</hi> XXII, 12); quod nihil <lb/> est aliud quam , Nunc ut cognosceres feci : non
-						enim <lb/> tunc Deus dicendus est cognovisse, quod antequam <lb/> fieret nunquam potuit
-						ignorare: quos locutionis modos <lb/> de divinis eloquiis a me prolatos, quomodo aliter
-						<lb/> interpretareris non invenisti; nullo modo utique ad <lb/> itos gemimus redire
-						debuisti. Nemo crum sic de <lb/> Spiritu sancto sapit, nisi qui secundum carnem , non
-						<lb/> secundum spiritum sapit. Quamvis et si libi concede­ <lb/> rctur, quomodo tu
-						sentis, sic Spiritum sanctum in­ <lb/> terpellare pro sanctis; aliud cst interpellare
-						vel orare, <lb/> aliud adorare. Omnis qui orat, rogal: non omuis <lb/> qui adorat,
-						rogat; nec omnis qui rogat, adorat. Re­ <lb/> cole consuctudincm regum, qni plerumque
-						adorantur, <lb/> ct non rogantur ; aliquando rogantur, et non adora n- <lb/> tur. Ac pcr
-						hoc a Spiritu sancto adorari Patrem <lb/> nullo modo demonstrarc potuisti.</p>
-					<p>CAPUTX.— <hi rend="italic">Quomodo sit unus Deus Pater et Filius <lb/> et</hi> Spiritus
-							<hi rend="italic">sanctus.</hi> Decimo loco egi lecum ut intelli­ <lb/> geres, quomodo
-						per ineffabilem copulationem sit unus <lb/> Deus ipsa Trinitas,quam dicimusunius esse
-						substan­ <lb/> tiæ : quandoquidem ctiam diversas substantias inve­ <lb/> nimus , hoc
-						est, spiritum hominis et Spiritum Domini, <lb/> per copulationem qua homo adhæret
-						Domino, unum <lb/> spiritum dictum, ubi ait Apostolus , Qui <hi rend="italic">autem
-							adhæ­<lb/> ret Domino,</hi> unus <hi rend="italic">spiritus est</hi> ( I <hi rend="italic">Cor.</hi> VI, 17). Ad quod <lb/> tu respondens, vcl potius non tacens,
-						conatus es <lb/> ostendere quomodo Patcr et Filius unum sint, non <lb/> unitate naturæ,
-						sed voluntatis. Hoc quidem dicere <lb/> soletis : sed tunc soletis, cum vobis objicitur
-						quod <lb/> ait Dominus, <hi rend="italic">Ego et Pater unum</hi> sumus <hi rend="italic">(Jonn.</hi> x, 50). <lb/> Ego autem hoc loco non boc volui probare, quod <lb/> Pater
-						et Filius ct Spiritus sanctus unum sint, quod <lb/> quidem propter unitatem substantiæ
-						fidelissime certe <lb/> creilimus; sed qnod cadem Trinitas unus est Deus. <lb/> Aliud
-						est quippc, unum sunt; aliud, unus est Deus. <lb/> Discerne, Est, ct Sunt. Nec ait
-						Apostolus, Qui adhae­ <lb/> rent Domino, unum sunt; quoniam diversa substantia <lb/> cst
-						: sed ait : <hi rend="italic">Qui</hi> adhaeret <hi rend="italic">Domino,</hi> unus
-						spiritus <hi rend="italic">est.</hi>
-						<lb/> Si autem vos, cum de duobus dicitur, Unus est, et di­ <lb/> citur quid unus, sicut
-						dicit Apostolus, <hi rend="italic">unus spiritus<lb/> est;</hi> hoc idem putatis esse ,
-						quod est cum de duobus <lb/> dicitur, Unum sunt, nee dicitur quid unum ; sicut <lb/> ait
-						Salvator, <hi rend="italic">Ego ct Pater</hi> unum sumus : cur non dici­ <lb/> tis,
-						Palcr et Filius uuus cst Deus? Quare quando an­ <lb/> ditis. <hi rend="italic">Audi,
-							Israel; Dominus Deus tuus, Dominus unus <lb/> est (Deut.</hi> v!. 4); de Patre tantum
-						vultis intelligi ? <lb/> Nempe Pater Dominus Deus est, ct Fillus Dominus <lb/> Heus cst
-						: cur non apud vos uterque unus Dominus <lb/> Deus csl, sicut apud beatum Apostolum,
-						spiritus ho­ <lb/> minis et Spiritus Domini 1 <hi rend="italic">unus spiritus est ?</hi>
-						Quid art­ <lb/> tem prodest causæ vestre, quia per consensionem <lb/> voluntatis hoc
-						dicitis fieri ? Quod quidem fit, sed ubi <lb/> est diversa natnra, sicut diversa natura
-						est hominis <lb/> et Domini : et tamen <hi rend="italic">qui</hi> adhæret <hi rend="italic">Domino,</hi> per con­ <lb/> sensionem utique voluntatis, <hi rend="italic">unus spiritus est.</hi> Si ergo <lb/> non vultis per unilatem
-						substantiæ; certe per consea­ <lb/> sionem voluntatis dicite, tamen aliquando dicite ,
-						<lb/> quoquo modo dicite, Pater ct Filius unus Deus cst. <lb/> Sed non dicitis, ne quod
-						nunquam voluistis, cogamini <lb/> confiteri de utroque dictum esse, non dc Patre solo , <lb/>
-						<hi rend="italic">Audi, Israel; Dominus Deus tuus, Dominus</hi> unus <hi rend="italic">cst:</hi>
-						<lb/> quoniam sanctum Spiritum non vultis Dcum, non <lb/> vultis Dominum confitcri.
-						Dicite, irnjuam , ratione <lb/> qua vultis , Patcr et Filius unus Dominus Deus cst:
-						<lb/> ut Patri et Filio servientes, non duobus diis ct duo­ <lb/> bus dominis contra
-						præceptum Dei, sed Domino uni <lb/> serviatis I. Sed nunc de hac re satis dictum sit.
-						Puto, <lb/> cum ista legeris, nihil te respondere potuisse ad id quod <lb/> de Apostolo
-						commemoravi, <hi rend="italic">qui</hi> adhæret <hi rend="italic">Domino,</hi> unus <lb/>
-						<hi rend="italic">spiritus</hi> est : si contentionem deposueris, non negabis.</p>
-					<p>CAPUT XI. — <hi rend="italic">De templo Spiritus sancti.</hi> Undecimo <lb/> loco, Deum
-						esse Spiritum sanctum, de templo ejus <lb/> quod nos ipsi sumus, teste Apostolo, ostendi
-						, ubi <lb/> ait, <hi rend="italic">Nescitis quia templum Dei estis, et</hi> Spiritus <hi rend="italic">Dei <lb/> habitat</hi> in <hi rend="italic">vobis</hi> (I <hi rend="italic">Cor.</hi> III, 16) ? et iterum , <hi rend="italic">Nescitis<lb/> qnia
-							corpora vestra templum in vobis est Spiritus</hi> sancti, <lb/>
-						<hi rend="italic">quem habetis a Deo (Id.</hi> vi, 19) ? Tu aulem ad isto re­ <lb/>
-						spondisti nihil. Aisti enim : <hi rend="italic">Suscipio quæ protulisti :</hi>
-						<lb/> i <hi rend="italic">Nescitis quia templum Dei estis, ci Spiritus Dei habi­<lb/>
-							tat</hi> in <hi rend="italic">vobis?</hi> &gt; <hi rend="italic">Neque enim Deus,</hi>
-						inquis , <hi rend="italic">inhabitat in <lb/> homine, quem non ante Spiritus
-							sanctificaverit atque <lb/> purgaverit.</hi> Atque isto modo intelligi voluisti, non
-						Spi­ <lb/> ritum sanctum esse dictum Deum, nec templum <lb/> Spiritus sancti nos a esse,
-						sed Dci : et hoc esse cii­ <lb/> ctum, <hi rend="italic">Templum Dei estis.</hi> Sed
-						ideo additum, <hi rend="italic">Spiritus<lb/> Dei habitat in vobis</hi> : quia purgat
-						Spiritus sancius <lb/> templum Dei, non suum ; ut cum ipse purgaverit, <lb/> tunc illic
-						inhabitet Deus. Quem sensum tuum quanta <lb/> sequatur absurditas, nolo nunc dicere.
-						Illud enirn <lb/> nunc ostendere debeo, quomodo multa dicendo, nihil <lb/> quod ad rcm
-						pertinet, dixeris. Dimisisti enim cau­ <lb/> sam, et perrexisti in laudem Spiritus
-						sancti, camque <lb/> copiose contra te ipsum exsecutus es. Centra te ipsum <lb/> ideo
-						dixi, quoniam non vis eum dicere Deum, cujus <lb/> tantam divinitatem per laudem coactus
-						es confiteri; <lb/> ut cum sit unus, ubique sit præsens, et nemini sancti­ <lb/> ficando
-						desit, ubicumque quisquc christianus esse et <lb/> Deum orare voluerit, simul se omnibus
-						exhibendo, <lb/> sive in oriente, sive in occidente baptizentur in Chri­ <lb/> sto : hoc
-						ct nos dicimus. Sed qucm dicimus talcm ac <lb/> tantum, absit a nohis ut eum negemus
-						Dcum : quod <lb/> etiam per suum templum, quod nos ipsi sumus, ci- <note type="footnote"> * Quidam vss., <hi rend="italic">Dommm.</hi>
-						</note><note type="footnote"> * Ain. Er. ct Mss., <hi rend="italic">ct Domini 'om1nå
-								&lt;U!&lt;M&lt; serviahs.</hi>
-						</note><note type="footnote"> I Abcst, nos, a '!ss. </note>
-						<lb/>
-						<pb n="753"/> tissime et facile ostenditur. Neque enim nisi Deus <lb/> noster esset,
-						templum nos ipsos habere potuisset: <lb/> quod tu ut occultares, et in sermone tuo
-						mentes <lb/> hominum a luce veritatis averteres, de templo Dei <lb/> quodeumque dixisti,
-						quem noluisti intelligi Spiritum <lb/> sanctum; de templo autem Spiritus sancti, quod
-						aper­ <lb/> tissimc demonstratum est, omnino tacuisti. Cum enim <lb/> tibi duo
-						testimonia Pauli apostoli proposuerim; <lb/> unnm ubi ait, <hi rend="italic">Nescitis</hi> quia <hi rend="italic">templum Dei estis, et Spi­<lb/> ritus Dei
-							habitat in</hi> vobis ? alterum ubi ait, <hi rend="italic">Nescitis <lb/> quia
-							corpora</hi> vestra <hi rend="italic">templum</hi> in <hi rend="italic">vobis Spiritus
-							sancti</hi> est ? <lb/> quare tam fraudulenter egisti, ut unum horum com­ <lb/>
-						memorares, quod dictum cst, <hi rend="italic">Templum Dei estis;</hi> et <lb/> alterum
-						taceres, quod dictum est, <hi rend="italic">Corpora vestra <lb/> templum in</hi> vobis
-							<hi rend="italic">est Spiritus</hi> sancti ? Cur hoc fccisti, <lb/> rogo te ; nisi
-						quia nullo pacto posses argumentari <lb/> quomodo Deus noster non esset, qui templtum
-						nos <lb/> ipsos haberet: quem sine dubio Deam cognoscere­ <lb/> mus, si ei templum de
-						lignis et lapidibus per divinam <lb/> Scripturam faccre juberemur?</p>
-					<p>CAPUT XII. — <hi rend="italic">De eo quod Pater et Filius unum<lb/> sint.</hi>
-						Duodecimo loco admonui te, ut proferres, si <lb/> posses, qua divina auctorilate sit
-						dictum, quod unum <lb/> sint, ubi substantiæ sunt diversae. Tu autem respon­ <lb/> dcre
-						ad hoc volens, nihil tale proferre potuisti; sed <lb/> magnis coarctatus angustiis
-						affirmare ausus es, quod <lb/> Apostoli unum siut cum Patre et Filio. Quod Christus
-						<lb/> omnino non dixit: sic enim abs te dictum est, tan­ <lb/> quam Pater et Filius et
-						Apostoli unum sint. Christus <lb/> autem non ait, Ut ipsi ct nos unum simus ; sed ait, <lb/>
-						<hi rend="italic">Ut sint</hi> unum, <hi rend="italic">sicut et</hi> nos unum sumus.
-						Nam, ut verba <lb/> ipsa evangelica ponam : <hi rend="italic">Pater sancte,</hi> inquit,
-							<hi rend="italic">serva eos</hi>
-						<lb/> in <hi rend="italic">nomine luo quos dedisti mihi,</hi> ut <hi rend="italic">sint
-							unum,</hi> sicut <hi rend="italic">el <lb/> nos unum.</hi> Numquid dixit, Ut nobiscum
-						sint unum; <lb/> aut, Ipsi et nos simus unum ? Item post aliquantum : <lb/>
-						<hi rend="italic">Non,</hi> inquit, <hi rend="italic">pro</hi> eia <hi rend="italic">rogo tantum; sed et pro eis qui cre­</hi>
-						<lb/> dituri <hi rend="italic">sunt per verbum eorum in</hi> me, <hi rend="italic">ut
-							omnes unum sint.</hi>
-						<lb/> Neque hic dixit, Ut nobiscum unum sint. Deinde se­ <lb/> quitur : <hi rend="italic">Sicut tu, Pater, in me et ego in te, et ipsi in <lb/> nobis unum
-							sint.</hi> Et hic non dixit, Unum simus ; aut, <lb/> Unum nobiscum sint: sed; <hi rend="italic">Unum sint in nobis;</hi> ut qui <lb/> natura unum sunt, quia homincs
-						sunt, etiam in Pa­ <lb/> tre et Filio sint unum; non cum ipsis unum, id est, <lb/> non
-						ut ipsi et isti sint unum. Adhuc adjungit, et dicit: <lb/>
-						<hi rend="italic">Ut mundus credat quia tu me</hi> misisti, <hi rend="italic">et ego
-							claritatem<lb/> quam dedisti mihi, dedi illis, ut sint unum, sicut nos</hi>
-						<lb/> unum <hi rend="italic">sumus: ego in eia et tu in me,</hi> ut sint <hi rend="italic">consummati <lb/> in</hi> unum <hi rend="italic">(Joan.</hi> XVII,
-						11-23). Cum ergo toties dixerit, <lb/>
-						<hi rend="italic">Ut sint</hi> unum ; non tamen alicubi dixit, Ut ipsi et nos <lb/>
-						simus unum, hoc est, ut nobiscum sint unum : sed <lb/> aut, <hi rend="italic">in
-							nobis</hi> dixit; aut, <hi rend="italic">sicut nos;</hi> id est, ipsi secun­ <lb/> dum
-						naturam suam, nos secundum nostram. Volebat <lb/> enim eos qui natura unum erant, in hoc
-						ipso quod <lb/> unum erant, esse perfectos. Non enim quia dicit , <lb/>
-						<hi rend="italic">Estote ergo et vos perfecti</hi> sicut <hi rend="italic">Puter
-							vester</hi> cælestis <hi rend="italic">per­ <lb/> fectus eit (Matth.</hi> v, 48); vult
-						illos Deo natura unitate <lb/> conjungere, tanquam illorum et illius una eademque <lb/>
-						oatura sit : sed perfectos vult esse in natura Sua, Sic­ <lb/> ut est Deus perfectus in
-						sua , quamvis diversa, non <lb/> una ; quod nisi in ipso simus, omnino esse non possu­
-						<lb/> mus. Non sicut in illo sunt omnes, quia ipse continet <lb/> omnia quae creavit;
-						propter quod dictus est <hi rend="italic">non longe <lb/> positus ab unoquoque</hi>
-						nostrum, quia <hi rend="italic">in illo vivimus, et <lb/> movemur, et sumus (Act.</hi>
-						XVII, 27, 28): sed sicut in illo <lb/> sunt tales qualibus dictum est, <hi rend="italic">Fuistis enim aliquando</hi>
-						<lb/> tenebræ, <hi rend="italic">nunc autem lux</hi> in <hi rend="italic">Domino (Ephes.
-							V,</hi> 8). Unde <lb/> et illud est, <hi rend="italic">Cui</hi> vult <hi rend="italic">nubat, tantum</hi> in <hi rend="italic">Domino</hi> (I <hi rend="italic">Cor.</hi>
-						<lb/> VII, 59). Non igitur proferre potuisti ubi dictum sit, <lb/> Unum sunt, quorum est
-						non una, sed diversa sub­ <lb/> stantia : et tamen 1 in obscuro loco nobis subrepere
-						<lb/> voluisti , ut diceres Apostolos unum esse cum Patre <lb/> et Filio , tanquam unum
-						essent Apos!oli et Pater et <lb/> Filius; cum Apostolorum substantiam manifestum sit
-						<lb/> a Patre et Filio esse diversam. Sed quoniam, Ut ipsi <lb/> et nos unum simus, aut,
-						Nobiscum sint unum, nus­ <lb/> quam Christum dixisse manifestum est; te quoque <lb/>
-						nobis respondere non potuisse, et fraudern facere vo­ <lb/> luisse manifestum sit.</p>
-					<p>CAPUT XIII. — <hi rend="italic">De testimonio quod Pater perhibuit<lb/> Filio.</hi>
-						Tertio decimo loco te commonui, non ideo Pa­ <lb/> irem Filio esse majorem, quia
-						testimonium perhibuit <lb/> Pater Filio. Nam et Propbetas ei testimonium perhi­ <lb/>
-						buisse memoravi, quos majores illo esse non potes <lb/> dicere. Dixeras enim quod Pater
-						Filio perhibuerit te­ <lb/> stimonium ; quod sic accepi, tanquam hinc ipse pro­ <lb/>
-						bare volueris, illo cui testimonium perhibuit, eum <lb/> esse majorem : sed quoniam
-						posteriore prosecutione <lb/> hinc omnino tacuisti, taciturnitatem tuam in locum <lb/>
-						consensionis accepi ; etsi fieri polost. ut ideo comme. <lb/> moraveris Patrem Filio
-						perhibuisse testimonium, ut <lb/> hinc illum esse alium , istum autem alium, non ut
-						<lb/> illum isto probares esse majorem. Alium vero esse <lb/> Patrem, aliutn esse
-						Filium, quoniam non est Pater <lb/> ipse qui Filius, et vobis et- nobis contra
-						Sabellianos <lb/> est dogma commune. Illi enim dicunt, nonalium, sed <lb/> eumdem Filium
-						esse qui est Pater : nos autem alium <lb/> quidem esse Patrem, et alium Filium; sed
-						tamen <lb/> quod Pater est, hoc esse dicimus Filium.</p>
-					<p>CAPUT XIV. — <hi rend="italic">De dilectione Patris et Filii.</hi> Quarto <lb/> decimo
-						loco ad illud quod dixeras, <hi rend="italic">Dilectum lego, et <lb/> credo quod Pater
-							eat qui diligit , et Filius qui diligitur;</hi>
-						<lb/> respondens dixi : <hi rend="italic">Sic autem dicis hinc inter Patrem et <lb/>
-							Filium esse diversitatem, quia Pater diligit, et Filius <lb/> diligitur; quasi negare
-							possis quod et Filius diligat Pa­<lb/> trem.</hi> Deinde addidi: <hi rend="italic">Si
-							ambo se invicem diligunt, cur<lb/> negatis eoa</hi> unius <hi rend="italic">esse
-							naturæ</hi> ? Quod utique ideo dixi, <lb/> ne hinc unam naturam negaretis amborum,
-						quia iI­ <lb/> lum diligere, hunc diligi ipse dixisti. Ad hoc tu re­ <lb/> spondens
-						consensisti quidem, quod et Filius diligat <lb/> Patrem , sed unius esse naturæ
-						consentire noluisti : <lb/> tanquam Filius ita diligat Patrem, sicut creatura <lb/>
-						Crratorcm , non sicut unigenitus geuitorcm, quem <lb/> diversitate substantiæ vultis
-						esse degenerem.</p>
-					<p>CAPUT XV. — <hi rend="italic">De invisibilitate Trinitatis.</hi> Quinto <lb/> decimo
-						loco dixi pariter esse invisibilem Trinitatem, <note type="footnote"> * ALD, fcr. et
-							Mas., <hi rend="italic">tanquam.</hi>
-						</note>
-						<lb/>
-						<pb n="755"/> nun solum Patrem : sed apparuisse tamen visibilem <lb/> :'ilium in forma
-						servi, propter quam dixit, <hi rend="italic">Pater ma­</hi>
-						<lb/> jor <hi rend="italic">me eat (Joan.</hi> xiv, 23). Sed quoniam patribus se di­
-						<lb/> vinilas demostrabat , dixi per subjectum crealurain <lb/> id osse factum, non per
-						naturam suam, qua est invi­ <lb/> sibilis Trinitas. Atque ut hoc probarem, Moysen com­
-						<lb/> memoravi ci dicentem, cum quo facie ad faciem lo­ <lb/> quebatur, Si <hi rend="italic">inveni</hi> gratiam <hi rend="italic">ante te, ostende mihi temet­<lb/>
-							ipsum</hi> manifeste <hi rend="italic">(Exod.</hi> XXXIII, 11, 13) : ut intelligeres
-						<lb/> quomodo cum vidcbat, quem sibi cupiebat ostendi ; <lb/> quia utique si Deum in
-						substantia qua Deus cst vide­ <lb/> rpt, profecto ut se illi ostenderet non rogaret.
-						Dixi <lb/> etiam esse Christum visibilium ct invisibilium creato­ <lb/> rem , ut ipsum
-						probarem per substantiam suam non <lb/> esse visibilem , a quo preari non solum
-						visibilia, <lb/> veram etiam invisibilia potuerunt. Ad hæc tu respon­ <lb/> dere
-						conatus, quam multa quæ ad rem non pertinent <lb/> dixeris , intueantur qui legunt : et
-						tamen de Moyse, <lb/> cur sibi Deum cum quo loquebatur, vellet ostendi , si <lb/> cnus
-						naturam substantiamque cernebat, prorsus nibil <lb/> ausus es dicere: ct adhuc affirmare
-						non destitisti, Dei <lb/> Filium invisibilium crcatorem , et antequam formam <lb/> servi
-						acciperet, in forma Dei fuisse visihilcm; quem <lb/> tupcrius in formi servi viden
-						potuisse , in substantia <lb/> vero suie divinitatis esse invisibilem, jam fueras et
-						<lb/> ipse confessus.</p>
-					<p>CAPUT XVI. — <hi rend="italic">De solo sapiente Deo.</hi> Sexto de­ <lb/> cimo loco;
-						quia de Patre tantum dixissc Apostolum <lb/> dixeras, <hi rend="italic">Soli sapienti
-							Deo (Rom.</hi> xvi, 27); ego dixi : <lb/>
-						<hi rend="italic">Ergo solus Pater est Deus sapiens, et non est sapiens<lb/> ipsa Dei
-							sapientia, quod est</hi> Christus; <hi rend="italic">de quo ait Aposto­</hi>
-						<lb/> lus : « <hi rend="italic">Christum Dei Virtutem et Dei</hi> Sapientiam <hi rend="italic">» (I Cor.</hi>
-						<lb/> I, 24) ! Deinde addidi : <hi rend="italic">Superest ut dicatis (quid enim <lb/>
-							non audetis? ) insipientem esse sapientiam Dei.</hi> Ad h:rc <lb/> tu : <hi rend="italic">Sapientem solum,</hi> inquis, <hi rend="italic">Patrem prædicat Paulus
-							<lb/> beatus apostolus, dicens sic:</hi> « <hi rend="italic">Soli sapienti Dco.</hi> i
-							<hi rend="italic">Sed <lb/> requirenda est ,</hi> inquis, <hi rend="italic">ratio
-							quemadmodum solus sapiens,</hi>
-						<lb/> non <hi rend="italic">quod Christus non sit sapiens.</hi> Scqucris dcinceps ,
-						<lb/> et adjungis quomodo sapientem confitearis et Chri­ <lb/> stum : nam post nonnulla
-						, quæ ad rem non perii.. <lb/> nentia texuisti , ut sermonem tempusque produceres, <lb/>
-						eliam hoc inseruisti verbis tuis ut diceres, <hi rend="italic">Sed vere <lb/> solus
-							sapiens</hi> Pater ; quasi Apostolus dixerit, Soli <lb/> sapienti Patri. Sed dixit,
-							<hi rend="italic">Soli sapienti Dco</hi> : quia Deus <lb/> est et Filius, quod et vos
-						vultis; Dcus est ct Spiritus <lb/> sanctus, etsi non vultis : ct ista Trinitas cst solus
-						sa­ <lb/> piens Deus, qui nec potuit unquam esse insipicns <lb/> omnino, nec poterit;
-						non per gratiam particeps sa­ <lb/> pientiae, sed sapiens immobilitate atque immuta­
-						<lb/> bilitate naturae. Nam si tibi dicam, itane vero, o <lb/> homo qui christiano
-						nomine gloriaris, Christus sic est <lb/> sapiens , ut non sit vere sapiens ? ergone
-						Christus qui <lb/> osi verus Deus, non est verb sapicns? nonne ita sub <lb/> hac
-						interrogatione turbaberis, ut continuo respon­ <lb/> deas , Christum vere esse sapientem
-						? Quid est ergo <lb/> quod dixisti, <hi rend="italic">Sed</hi> vere <hi rend="italic">solus sapiens</hi> Pater ? Nempe <lb/> quo per veneris , et a quanta blasphemia te
-						debeas re­ <lb/> yovare, jam sentis.</p>
-					<p>CAPUT XVII. — <hi rend="italic">De infecto Deo.</hi> Septimo decimo <lb/> loco egi
-						tecum, quod etiam Filius , non solus Pater, <lb/> infectus sit, hoc est, factus non sit.
-						Dixeras enim ideo <lb/> a vobis unum Deum pronuntiari, quia <hi rend="italic">unus est
-							super<lb/> omnia innatus,</hi> infectus. Respondens crgo huic aula. <lb/> ci:c tu:c :
-							<hi rend="italic">Sic antem</hi> , inquam, <hi rend="italic">dicis Patrem
-							infectum,<lb/> quasi Filius factus sit , per quem facta sunt omnia.</hi>
-						<lb/> Deinde addidi : <hi rend="italic">Scito factum esse Filium, sed in</hi> forma <lb/>
-						<hi rend="italic">servi.</hi> Nam in <hi rend="italic">forma Dei usque</hi> adeo <hi rend="italic">non est factus,</hi> ut <lb/>
-						<hi rend="italic">per illum facta sint omnia.</hi> Si <hi rend="italic">enim ipse
-							factus</hi> eat, in­ <lb/> quam, <hi rend="italic">non per illum facta sunt omnia,
-							aed</hi> caetera. Ad <lb/> hæc tu cum tota hii prolixitate sermonis, ita nihil <lb/>
-						quod diceres invenisti , ut hinc omnino, tanquam id <lb/> non audieris,
-						conticesceres.</p>
-					<p>CAPUT XVIII. <hi rend="italic">- De ingenito Patre.</hi> Octavo decimo <lb/> loco etiam
-						de innato Patre , id est ingenito , quia ct <lb/> hoc dixcras, tccum agendum putavi, et
-						dixi: <hi rend="italic">Non <lb/> itoque dico Filium ingenitum; aed Patrem genitorem,
-							<lb/> Filium genitum. Hoc tamen genuit Puter quod est : <lb/> alioquin non est verus
-							Filius ,</hi> si <hi rend="italic">qnod est Pater non est <lb/> Filius ; sicut de
-							partubus animalium supra jam diximus.</hi>
-						<lb/> Eliam ad hoc In nee verum nec falsum ali quid protulisti.</p>
-					<p>CAPUT XIX. — <hi rend="italic">De æqualitate Spiritus sancti cum Pa.<lb/> tre.</hi>
-						Nonodccimo loco, quia poposceras a mc, ut osten­ <lb/> derem æqualem esse I'atri i
-						Spiritum sanctum ; respondi <lb/> tibi dicens: <hi rend="italic">Quid est autem
-							quod</hi> poscis, <hi rend="italic">ut ostendam tibi</hi>
-						<lb/> aqualem Patri <hi rend="italic">esse Spiritum sanctum, quasi tu Patrem <lb/>
-							ostenderis majorem esse Spiritu sancto; sicut potuisti <lb/> ostendere de Filio,
-							propter formam servi? Scimus enim,</hi>
-						<lb/> inquam, <hi rend="italic">dictum esse Patrem Filio majorem, quia</hi> in <lb/>
-						<hi rend="italic">forma servi erat Filius ; ct adhuc in forma eat humana<lb/> Filius,
-							quam levavit in coelum : propterea de illo</hi> di­ <lb/> ctum <hi rend="italic">eat
-							quod et nunc</hi> a interpellat <hi rend="italic">pro</hi> nobis i <hi rend="italic">(Rom.</hi>
-						<lb/> VIII, 54). <hi rend="italic">Et sempiterna erit in regno hæc eadem forma <lb/>
-							immortalis : propter quod dictum</hi> eat « <hi rend="italic">Tunc et ipsa</hi> Fi­
-						<lb/> « <hi rend="italic">lius subjectus erit ei qui illi subjecit omnia</hi> » ( I <hi rend="italic">Cor.</hi>
-						<lb/> xv, 28). <hi rend="italic">Nam de Spiritu sancto qui nullam suscepit <lb/>
-							creaturam ad unitatem personæ suæ, quamvis se per <lb/> subjectam creaturam
-							visibiliter et ipse.. sive per</hi> columbae <lb/>
-						<hi rend="italic">speciem, sive per linguas igneas sit demonstrare digna­ <lb/> tua
-							(Matth</hi> III, 16 <hi rend="italic">, et Act.</hi> II, 3), <hi rend="italic">nunquam
-							dictus est <lb/> eo major Pater; nunquam dictus cst</hi> Spiiitus <hi rend="italic">adorasse <lb/> Patrem; nunquam dictus est minor Patre.</hi> Ad hæc tu <lb/> quasi
-						respondens, non tamen respandisti. Non enim <lb/> potuisti ostendere Spiritu sancto
-						alicubi Patrem dictum <lb/> fuissc majorem, sicuti Filius propter formam servi di­ <lb/>
-						xit, <hi rend="italic">Pater major me est (Joan.</hi> XIV, 28). Et cum ego <lb/>
-						dixerim, Spiritum sanctum non ad unitatem personæ <lb/> suæ ullam suscepisse creaturam;
-						tu ita Spiritum san­ <lb/> ctum in columba ct igne apparuisse dixisti, sicut ap­ <lb/>
-						paruit Christus in homine : quasi columba el Spiritus, <lb/> vel ignis et Spiritus una
-						persona sit, sicut Verbum et ' <lb/> homo una persona est. Ad horam quippe apparuerunt
-						<lb/> illa, quæ Spiritum sanctum significando monstrarent <lb/> visibiliter invisibilem
-						; columba, propter amorem san­ <lb/> ctum ; ignis autem , propter charitatis lumcn atque
-						<lb/> fervorem ; et peracto significationis officio, corporales <lb/> illæ species
-						transierunt, atque esse ulterius destite­ <lb/> runt; sicut columna nubis. nebulosa per
-						diem , lunii­ <lb/> nosa per noctem <hi rend="italic">(Exod.</hi> XIII, 21-22). Denique
-						ne puta­ <lb/>
-						<pb n="757"/> retur columba vel flamma ad substantiam pertinere <lb/> Spiritus sancti,
-						vel quod se in hæc visibilia tantæ ma­ <lb/> jestatis natura converterit, aut in
-						unitatem personæ <lb/> suae ista susceperit, nunquam postea sic apparuisse le­ <lb/>
-						gitur Spiritus sancius. Cbristus autem, qui humanam <lb/> non ad horam sumpsit effigiem,
-						in qua hominibus ap­ <lb/> pareret, ac deinde illa species praeteriret; sed in uni­
-						<lb/> tatem personæ suæ, manente invisibili Dei forma I, <lb/> accepit visibilem hominis
-						formam; non solum, natus <lb/> cst in ea de homine matre, verum etiam crevit in ea, et
-						<lb/> manducavit, et bibit, et dormivit in ea, et occisus est <lb/> in ea, et resurrexit
-						in ea, et ascendit in coelum, et <lb/> scdet ad dexteram Patris in ea, ad judicandos
-						vivos <lb/> et mortuos est venturus in ea, et in regno suo, ci qui <lb/> illi subjecit
-						omnia, erit subjectus in ea. Ilac tu in <lb/> mea responsione breviter dicta, quæ nunc
-						aliquanto <lb/> latius, ut vel sic intelligcres, explicavi, attendere et <lb/>
-						considcrare noluisti, irruens in tantam blasphemiam, <lb/> . ut naturam divinam Dei et
-						Spiritus sancli converti-, <lb/> bilem, proh nefas! et mutabilem diccres. Tua nam­ <lb/>
-						que ista sunt verba : <hi rend="italic">Ea,</hi> inquis, <hi rend="italic">quæ; de
-							invisibilitate <lb/> &gt; omnipotentis</hi> 2 <hi rend="italic">Dei prosecutus sum,
-							eliam et ipse, licet <lb/> alio</hi> proposito, attamen <hi rend="italic">tuis verbis
-							affirmasti, quod Spi­</hi>
-						<lb/> . <lb/> ritus sanctus in <hi rend="italic">specie columbæ sit MMM, necnon et
-							in<lb/> specie ignis : Filius sane,</hi> in forma hominis: <hi rend="italic">Pater<lb/> autem, neque</hi> in <hi rend="italic">specie columbx, nec</hi> in <hi rend="italic">forma hominis;. <lb/> nec aliquando vertit se in formas, sed nec
-							aliquando</hi>
-						<lb/> vertetur : <hi rend="italic">de quo scriptum est, « Ego</hi> sum <hi rend="italic">qui sum, et</hi>
-						<lb/> « <hi rend="italic">non sum mutatus.</hi> &gt; Deinde adjungis, et dicis: Fi­ <lb/>
-						<hi rend="italic">lius sane</hi> in forma <hi rend="italic">Dei constitutus jam,</hi> ut
-							<hi rend="italic">ipse protu- <lb/> Ii.,;, formam servi accepit, quod non Pater:
-							Spiritus <lb/> æque sanctus suscepit speciem columbæ, quam</hi> nonsta­ <lb/>
-						<hi rend="italic">cepit Parer. Scito ergo,</hi> inquis, <hi rend="italic">quia unus est,
-							invisi­ <lb/> bilis, unus eliam incapabilis atque immensus.</hi> Hæc <lb/> numquid
-						diceres, si secundum spiritum, non secun­ <lb/> dum carnem, posses cogitare quid diceres
-						? Homo <lb/> es enim, qui legis in Scripturis sanctis, <hi rend="italic">Ego</hi> sum
-							<hi rend="italic">qui <lb/> sum:, et non sum mutatus (Exod.</hi> III, 14, <hi rend="italic">et Malach.</hi>
-						<lb/> III, 6). Et cum verba ista sint, non Patris solius, sed <lb/> ipsius Trinitatis,
-						quæ unus est Deus; tu ea Patri <note type="footnote"> I Editio Lov., <hi rend="italic">sed unitate personae manenle, invisibUis <lb/> hei fortna accepit,</hi> etc. *
-							</note><note type="footnote"> I Am. ET. et Mss., <hi rend="italic">omnitenentis.</hi>
-						</note>
-						<lb/> tantummodo tribuens, Filium mutabilem credis! Uni­ <lb/> genitum per quem facta
-						sunt omnia mutabilem credis: <lb/> eum de quo dicit Evangelium, <hi rend="italic">In
-							principio erat Ver. <lb/> bum, et Verbum erat apud Deum, et Deus erat Verbum;</hi>
-						<lb/> et, <hi rend="italic">Omnia per</hi> ipsum <hi rend="italic">facta sunt
-							(Joan.</hi> i, 1, 5), muta­ <lb/> bilem credis! Quid jam dicam de Spiritu sancto,
-						<lb/> quando illum quem verum Filium Dei et verum con­ <lb/> fiteris Deum, mutahilem
-						credis ? Quod ufiquc non <lb/> crederes, si formam servi a forma Dei esse susce­ <lb/>
-						ptam, non formam Dci in formam servi esse muta. <lb/> tam, tanquam catholicus crederes;
-						et visibili homine <lb/> assumpto, permansisse invisibilem Deum, non car­ <lb/> nalitcr,
-						sed spiritualiter cogitares ; nee coptendend&gt; <lb/> diffideres, sed intelligendo
-						conspiceres : et Spiritum <lb/> sanctum invisibili sua manente natura, nullo modo <lb/>
-						in ignis aut columbæ speciem mutata atque conversa, <lb/> per subjectam creaturam
-						apparuisse, sicul voluit vi­ <lb/> sibiliter <hi rend="italic">(Act.</hi> n, 3, <hi rend="italic">et Matth.</hi> III, 16), tu posses consi- . <lb/> derare fideliter.
-						Memento tamen, nec majorem Pa- <lb/> Irem Spiritu sancto, nec adoratum Patrem ab Spiritu
-						<lb/> sancto, ullis divinis testimoniis contra propositionem <lb/> meam te demonstrare
-						potuisse.</p>
-					<p>CAPUT XX. — <hi rend="italic">Licet ingenitus Pater,</hi> æqualis <hi rend="italic">ta­<lb/> men Filius.</hi> Vigesimo loco, quoniam dixeras de Filio, <lb/> Si <hi rend="italic">æqualis. Patri, utique talis:</hi> si <hi rend="italic">talis, utique
-							innatus;</hi>
-						<lb/> ego respondens tibi: Sed dicis, inquam, de Filio, Si <lb/>
-						<hi rend="italic">æqualis, utique talis;</hi> id est, ut <hi rend="italic">quia non eat
-							ingenitus.<lb/> non videatur talis. Posses dtcere non esse hominem quem<lb/> genuit
-							Adam, quia ipse Adam non eat genitus, sed factus<lb/> a Deo.</hi> Si <hi rend="italic">autem potuit Adam et non esse genitus,</hi> et <lb/> tamen <hi rend="italic">hoc
-							generare quod erat ipse; non vis ut potue­<lb/> rit Deus Deum aquatem</hi> sibi ? Ad
-						hæc non miror <lb/> nullum te invenisse responsum : sed plane laudo nec <lb/> respondere
-						conatum. Atque utinam hoc ubique fe­ <lb/> cisses! nusquam enim in sermonibus nostris
-						quid <lb/> recte responderes invenire potuisti, et tamen pene <lb/> ubique tacere
-						noluisti. Sed cum in aliis tam multa <lb/> dixeris, causæ quoe inter nos agitur non
-						necessaria , <lb/> et tempus loquendo consumpseris; gratiæ tibi agendæ <lb/> sunt, ubi
-						nonnulla sic vidisti te refutare non posse, ut <lb/> ea malles summo silentio
-						praeterire. <note type="footnote"> I Apud Lov., <hi rend="italic">plene.</hi>
-						</note>
-					</p>
-					<ab>
-						<title type="sub">
-							<hi rend="italic">LIBER SECUNDUS (a).</hi>
-						</title>
-					</ab>
-					<p>Refelluntur singillatim quæ in Collatione Maximinus dixit ultima sua disputatione,
-						cujus disputationis suæ prolixitato <lb/> respondendi tempus tunc eripuit Augustino.</p>
-					<p>PRÆFATIO. - Res jam postulat ut in eoquod reliquum <lb/> est, opitulante Domino,
-						impleam promissionem meam. <lb/> In operis quippe hujus exordio, Prius, inquam,ostendam <lb/>
-						<hi rend="italic">refellere te non potuisse quæ dixi: deinde, quantum<lb/> necessarium
-							videbitur,</hi> ego <hi rend="italic">refellam quas ipse dixisti.</hi>
-						<lb/> Quia ergo, sicut adjuvante Deo potui, ostendi ea quæ <lb/> dixi non te potuisse
-						refellere; superest ut ea qux <lb/> dixisti, ego refellam, sicut Deo adjuvante potuero.
-						<lb/> Priores itaque prosecutiones tuas, quibus. continuo <note type="footnote"> (I.)
-							viias, reviius. </note>
-						<lb/> reddidi meas in hac disputatione quae nunc a me sus­ <lb/> cepta est, non
-						retractabo : illam vero ultimam lam <lb/> prolixam, ut milii die illo spatium
-						responsionis An­ <lb/> ferret, ita redarguam, si voluerit qui nos regit, ut <lb/>
-						acquiescas lumini veritatis, si contentionis tenebras <lb/> non amaveris. In primis ergo
-						superflua tua detrahant <lb/> necessitati responsionis meæ. Causa quippe inter nns <lb/>
-						agitur, utrum Pater et Filius et Spiritus sanctus di­ <lb/> versæ, ut vos dicitis, an
-						potius, ut nos dicimus, unius <lb/> sint ejusdemque substantiæ, unusque Deus sit ipsa <lb/>
-						<pb n="759"/> Trinitas : cum conveniat inter nos Patrem non esse <lb/> qui est Filius,
-						nee Filium esse qui est Pater, nec Pa­ <lb/> tremesse vel Filium qui Spiritus sanctus
-						est. Quid­ <lb/> quid igitur tanta tuæ prosecutionis prolixitate dixisti, <lb/> mule
-						ostenderes alium esse Patrem, alium esse Fi­ <lb/> lium, alium esse Spiritum sanctum
-						quando nobis­ <lb/> cum agitis. superfluum prorsus esse cognosce : et si <lb/> tibi
-						expugnandi occurrerint Sabelliani, in eos ista <lb/> nohis vobisque communia, si placet,
-						arma converte. <lb/> Multa eliam locutus es, ut probares magnum Deum <lb/> esse Dominum
-						Jesum Christum : hoc quid ad nos, <lb/> cum hoc dicamus et nos? Laudes quoque Spiritus
-						<lb/> sancti magnas verasque fudisti : sed nos eas augere <lb/> possumus, non negare :
-						non itaque opus erat ut eas <lb/> contra nos diceres, quas dicimus tecum. Christum <lb/>
-						scdere ad dexteram Patris, nonne pariter confite­ <lb/> mur? Quod tamen testimoniis
-						divinorum eloquio­ <lb/> rum sic probare voluisti, tanquam id alicubi negare­ <lb/> mus.
-						Christum in carne venisse, utrique novimus et <lb/> tenemus : sic adhibuisti ut hoc
-						doceres divina testi­ <lb/> monia, tanquam repugnemus. Hæc et alia quæ suis <lb/>
-						ostendam locis, in quibus operam supervacuam con­ <lb/> trivisti, ut moras necteres,
-						tempusque produceres, <lb/> commemorando attingere debeo, non redarguere <lb/>
-						disputando.</p>
-					<p>CAPUT PRIMUM. — Dicis me <hi rend="italic">auxilio</hi> principum mu­ <lb/>
-						<hi rend="italic">nitum, non loqui secundum timorem Dei;</hi> cum scias nobis <lb/> esse
-						praeceptum orare pro regibus, ut in agnitionem <lb/> veniant veritatis (I Tim. II, i,
-						4): quod in quibusdam <lb/> esse impletum, nos Deo agimus gratias, vos doletis. <lb/>
-						Verba autem nostra recte intelligentibus indicant, quis <lb/> nostrum loquatur secundum
-						timorem Dei : utrum qui <lb/> sic laudat Deum Patrem , ut ad ejus taudem referat, <lb/>
-						quod sibi Filium generavit xqualem; an qui sic geni­ <lb/> torem debonestat et genitum,
-						ut et illum dicat non <lb/> potuisse gignere per omnia sui similem filium, et <lb/>
-						isium dicat non dcgenerasse jam natum, sed dcgeae­ <lb/> rem natum.</p>
-					<p>CAPUT II. — Dicis <hi rend="italic">vos Christum colere, ut Deum <lb/> omnis creaturæ
-							cui flectitur</hi> omne <hi rend="italic">genu, cœlestium, ter­ <lb/> restrium et
-							infernorum</hi> : quem tamen Deo Patri esse <lb/> non vultis æqualem, quia <hi rend="italic">hoc Pater ei donavit:</hi> ait <lb/> enim Apostolus, <hi rend="italic">Propter quod et Deus eun. exaltavit, <lb/> et donavit ei nomen quod est super omne
-							nomen , ut</hi> in <lb/>
-						<hi rend="italic">nomine Jesu omne genu flectatur,</hi> etc. Nec quæritis cui <lb/>
-						donaverit; utrum homini, an Deo. Quomodo1 enim <lb/> donaverit, evidenter apparet. <hi rend="italic">Humiliavit,</hi> inquit, <hi rend="italic">se­ <lb/> metipsum usque ad
-							mortem, mortem autem crucis. Pro­</hi>
-						<lb/> pter <hi rend="italic">quod et Deus eum</hi> exaltavit, <hi rend="italic">et
-							donavit ei nomen <lb/> quod est super omne nomen (Philipp.</hi> II, 8, 9). Si ergo
-						<lb/> propterea donavit ei nomen quod est super omne no­ <lb/> men, quia factus est
-						obediens usque ad mortem cru­ <lb/> cis; numquid antequam hoc fieret, non erat altus Dei
-						<lb/> Filius Deus, Dei Verbum, Deus apud Deum; sed <lb/> posteaquam propter hoc
-						exaltatus est, quia factus est <lb/> obediens usque ad mortem crucis, tunc coepit esse
-						<lb/> altus Dei Filius, unicus Dei, Deus, tunc cœpit habere <lb/> nomen quad est super
-						omne nomcn? Quis hoc insi- <note type="footnote"> 1 In Mss., <hi rend="italic">Quando.</hi>
-						</note>
-						<lb/> pientissimus dixerit? Hoc illi ergo donatum est ut ho­ <lb/> mini, secundum quem
-						Filius factus est obediens usque <lb/> ad mortem crucis, quod jam habebat idem ipse Dei
-						<lb/> Filius, Deus de Deo natus aequalis.</p>
-					<p>CAPUT III. — Objicis mihi, quod dicam Spiritum <lb/> sanctum aequalem esse Filio. Dico
-						plane. <hi rend="italic">Da,</hi> inquis, <lb/>
-						<hi rend="italic">testimonia ubi adoratur Spiritus sanctus.</hi> Ut video, hinc <lb/>
-						eam vis ostendi æqualem Christo, si adoratur ut Chri­ <lb/> stus. Jam ergo confitere
-						Christum Patr! arqualcm, <lb/> quem tu ipse adorari confiteris ut Patrem. Quales au­
-						<lb/> tem homines estis, quam religiosas humilitatis, qui <lb/> Spiritum sanctum adorare
-						non vultis, ciim legntis, <lb/>
-						<hi rend="italic">Littera occidit, Spiritus</hi> autem <hi rend="italic">vivificat</hi>
-						( II <hi rend="italic">Cor.</hi> III, 6 ) ? <lb/> Non vultis ergo adorare, quem
-						vivificare animas non <lb/> negatis : cum pater Abraham homines adoraverit, <lb/> quia
-						concesserunt ei monumentum, ubi poneret mor- <lb/> tuae corpus uxoris. Sic cnim scriptum
-						est : <hi rend="italic">Venit au.<lb/> tem Abraham plangere Saram et lugere. Et</hi>
-						surrexit <lb/>
-						<hi rend="italic">Abraham de supra mortem ejus, et dixit filiis II et. : <lb/>
-							Peregrinus et advena sum ego vobiscum; daie ergo</hi> mihi <lb/>
-						<hi rend="italic">possessionem monumenti, ubi sepeliam mortuum</hi> meum. <lb/>
-						<hi rend="italic">Responderunt autem filii Heth ad</hi> Abraham , <hi rend="italic">dicentes :<lb/> Absit hoc, domine; audi nunc et noa : rex a Deo in</hi> es <lb/>
-						<hi rend="italic">in</hi> nobis ; <hi rend="italic">in electis monumentis nostris sepeli
-							mortuum <lb/> tuum : nemo enim nostrum prohibet te a monumento <lb/> suo, ut sepelias
-							mortuum tuum ibi. Surgens autem <lb/> Abraham adoravit plebem</hi> filiorum <hi rend="italic">Heth (Gen.</hi> XlIII, <lb/> 2-7). Et vos Spiritum sanctum non
-						permittitis adorari, <lb/> ut ipsi Dei gratiæ remaneatis ingrati ! Sed, <hi rend="italic">Da,</hi> in­ <lb/> quis, <hi rend="italic">testimonia ubi adoratur
-							Spiritus sanctus</hi> : quasi <lb/> non ex iis quae legimus , aliqua eliam quae non
-						legi­ <lb/> mus, intelligamus. Sed ne quaTere multa compellar, <lb/> tu ubi legisti
-						Patrem Deum ingenitum vel innatum? <lb/> Et tamen verum est. Quod vero aliquoties
-						dixisti, <lb/> etiam Filio esse incomparabilem Patrem, nec legis, <lb/> nec verum est.
-						Si autem religionem qua colitur Deus, <lb/> sicut dignum est cogitares, multo plus esse
-						cerneres <lb/> quod habet Spiritus sanctus templum, quam si cum <lb/> legeres adoratum.
-						Et homines enim , sicut supra do­ <lb/> cui, a sanctis novimus adoratos : templum vero
-						non <lb/> est factum ab hominibus, nisi aut vero Deo, sicut Sa­ <lb/> lomon fecit; aut
-						cis qui pro diis habentur, sicut gen­ <lb/> tes quae ignorant Deum. Spiritus autem
-						sanctus, quod <lb/> cum magno honore de Deo dictum est, <hi rend="italic">non in manu­
-							<lb/> factis templis habilat</hi> ( <hi rend="italic">Act.</hi> XVII, 24 ), sed corpus
-						no­ <lb/> strum templum est Spiritus sancti. Et ne corpora no­ <lb/> stra contemnas,
-						membra sunt Christi ( I <hi rend="italic">Cor.</hi> vi, 19, <lb/> 15). Qualis ergo Deus,
-						cui templum ædificatur, et a <lb/> Deo, et de membris Dei ?</p>
-					<p>CAPUT IV. — Dicis <hi rend="italic">Christum esse</hi> in <hi rend="italic">dextera
-							Dei,<lb/> et interpellare pro nobis (Rom.</hi> VIII, 34). Quod cur no­ <lb/> bis
-						objicis, si eum non solum Deum, verum etiam <lb/> hominem agnoscis? Quid te igitur
-						adjuvat, quod se­ <lb/> dere ad dexteram Patris assidue legitur ? Quid nobis, <lb/> non
-						quidem inanibus testimoniis, sed tamen inaniler, <lb/> probare niteris quod fatemur.</p>
-					<p>CAPUT V. — Dicis <hi rend="italic">vos Spiritum sanctum</hi> compe­ <lb/>
-						<hi rend="italic">tenter honorare ut doctorem, ut ducatorem,</hi> ut <hi rend="italic">illumina­</hi>
-						<lb/> torem, ut <hi rend="italic">sanctificatorem; Christum colere, ut creato­</hi>
-						<lb/>
-						<pb n="761"/>
-						<hi rend="italic">rem; Patrem</hi> cun, <hi rend="italic">sincera devotione
-							adorare,</hi> ut <hi rend="italic">aucto­</hi>
-						<lb/> rem. Si auctorem propterea dicis Patrem, quia de <lb/> ipso est Filius, non est
-						autem ipse de Filio; et quia <lb/> de illo et Filio sic procedit Spiritus sanctus, ut.
-						ipse <lb/> hoc dederit Filio gignendo eum talem, ut etiam de <lb/> ipso procedat
-						Spiritus sanctus : si creatorem sic dicis <lb/> Filium, ut creatorem non neges Patrem
-						nec Spiritum <lb/> sanctum; si denique Spiritum sanctum sic dicis do­ <lb/> ctorem ,
-						ducatorem, illuminatorem, sanctificatorem, <lb/> ut hæc opera nec Patri audeas auferre
-						nec Filio : ista <lb/> tua etiam nostra sint verba. Si autem talia tibi idola <lb/>
-						ponis in corde, ut duos facias deos, unum majorem, <lb/> id est, Patrenl, alium minorem,
-						id est, Filium ; Spi­ <lb/> ritum vero sanctum ita omnium trium minimum fin­ <lb/> gas,
-						ut nec Deum nuncupare digneris : non haec est <lb/> nostra fides, quoniam non est
-						christiana fides, ac per <lb/> hoc nec fides. Etiam hoc tibi ignoscimus, quod impe­
-						<lb/> rite usus verbo , Chritum significasti <hi rend="italic">ad terrena de­ <lb/>
-							scendisse contagia.</hi> Et quia hoc in te corrigere volui, <lb/> ut scires conlagia
-						quomodo appellare debeamus; ca­ <lb/> lumnias <hi rend="italic">esse</hi> istas dicis,
-							<hi rend="italic">et</hi> eas <hi rend="italic">de philosophicas artis<lb/>
-							instructione venire</hi> arbitraris. Sufficit mihi quod ita <lb/> putasti Christum ad
-						terrena descendisse contagia, <lb/> ut tamen confitereris nullum habuisse peccatum.</p>
-					<p>CAPUT VI. — Illud sane quod commemoravi, <lb/> partus animalium, quae cum terrena sint
-						atque mor­ <lb/> talia, hoc tamen gignunt quod ipsa sunt, ut homo ho­ <lb/> minem, canis
-						canem; puto quod non aspernatus hor­ <lb/> ruisti, sed te aspernari atque horrere
-						finixisti, dicens, <lb/>
-						<hi rend="italic">tam. fœdam comparationem</hi> in <hi rend="italic">illam tantam
-							immensita­ <lb/> tem non debuisse produci.</hi> Cur enim boc dixisti, nisi <lb/> ne
-						tibi de ipsis corruptibilibus fetibus fauces veritas <lb/> premeret, et te respirare non
-						sineret, sicut ct facit ? <lb/> Qandoquidem creaturam corruptibilem cernitis , hoc <lb/>
-						quod ipsa est gignere fetum situm, et Deum Patrem <lb/> omnipotentem creditis non
-						potuisse nisi ejus dege­ <lb/> nerante natura g:gnerc unicum suum.</p>
-					<p>CAPUT VII. — Sed dicis: <hi rend="italic">Dominus Dominum ge­<lb/> nuit, Deus</hi> Den.
-							<hi rend="italic">genuit, Rex Regem genuit, Creator <lb/> Creatorem</hi> genuit, <hi rend="italic">bonus bonum genuit, sapiens sapien­<lb/> tem genuit, clemens clementem,
-							potens potentem.</hi> Si sub <lb/> his verbis cavcre te putas quod vobis objicitur,
-						non <lb/> vos credere Dcum potuisse gignere id quod est ipse, <lb/> et ideo dicis, <hi rend="italic">Dominus Dominum genuit, Deus Deum <lb/> genuit,</hi> et cætera : cur
-						ergo sicut dixisti, <hi rend="italic">Potens po­<lb/> tentem;</hi> non dicis, Omnipotens
-						omnipotentem? Si quod <lb/> sentis vis dicere, dic: Dominus major, dominum mi­ <lb/>
-						norem genuit; Deus major, deum minorem; Rex ma­ <lb/> jor, regem miuorem; Creator major,
-						creatorem mi­ <lb/> norem; melior bonum, sapientior sapientem, clemen­ <lb/> tior
-						clementem, potentior potentem. Si autem ista <lb/> non dicis, et nihil minus quam Pater
-						habet, Filium <lb/> babere consentis, cur non dicis æqualem? Et illa <lb/> omnia cur non
-						sic percurris, ut dicas: D minus æqua­ <lb/> lem Dominum genuit, Deus æqualem Deum, Rex
-						<lb/> æqualem Regem, Creatoræqualem Creatorem, bonus <lb/> æqualiter bonum, sapiens
-						æqualiter sapientem, de­ <lb/> mens æqualiter clementem, potens æqualiter poten­ <lb/>
-						tem? Si autcm negasæqualem aperte dic esse dege­ <lb/> nerem. Non enim quem deum
-						minorem, de Deo ula... <lb/> jore natum esse dicitis, saltem sicut infantem crescere
-						<lb/> sinitis, ut aliquando suo Patri possit esse æqualis. Ad <lb/> hoc cnim eum
-						perfectum dicitis esse natum , non ut <lb/> binc laus ejus cresceret, sed ut minor ejus
-						natura re­ <lb/> nianerct. Et cum isia sentiatis. seqneris tamen, et di­ <lb/> cis :
-						Nihil sublraxtt <hi rend="italic">Pater in generando Filium.</hi> Quo­ <lb/> modo nihil
-						subtraxit in generando Filium, quem non <lb/> æqualem genuit, sed minorem? An ideo nihil
-						sub­ <lb/> traxit, quia nihi! corum quæ gignendo dedit, abstulit <lb/> genito ? Ita sane
-						nihil subtraxit: sed et filiis hominum <lb/> qui prospere nascuntur, nihil aufert
-						Creator jam na­ <lb/> tis ; quin potius addit, ut accedat crescentibus quod <lb/>
-						nascentibus defuit. Quid ergo magnum de Patre dixi­ <lb/> sti erga unicum Filium, qui
-						non ex nihilo vel ex ali­ <lb/> qua materia factus, sed ex ipso natus est? Quid ma­
-						<lb/> gnum est quia non subtraxit quod dedit, si quod dare <lb/> potuit, non dando
-						subtraxit? Ubi est, quod eum invi­ <lb/> dum non esse dixisti? An forte dare non potuit?
-						Uhi <lb/> est omnipotentia DeiTatris? Prorsus ad hunc articu­ <lb/> lum res colligitur,
-						ut Deus Pater æqualem sibi gignere <lb/> Filium aut non potuerit, aut noluerit. Si non
-						potuit, <lb/> infirmus; si noluit, invidus invenitur. Sed utrumque <lb/> hoc falsum est.
-						Patri igitur Deo Filius verus æqualis <lb/> eat. Si ergo, ut laudas, placet tibi quod a
-						me comme­ <lb/> moratum est, <hi rend="italic">Invisibilia enim ejus, per ea quce
-							facta<lb/> sunt, intellecta conspiciuntur (Rom.</hi> I, 20) : per id qnod <lb/> factum
-						est in creatura visibili, ut pnrentes id quod <lb/> ipsi sunt generent, intellige
-						ipvisibilcm nativitatem . <lb/> veri Filii Dei, ne Deum Patrem dicas id quod non est
-						<lb/> ipse gcnuisse. Si autem hoc genuit quod est ipse; <lb/> unam Patris et Filii esse
-						substantiam negare nolite.</p>
-					<p>CAPUT VIII. — Jam vero sequentia, quæ sic con­ <lb/> nexuisti, ut de cruce vel
-						incarnatione Christi probare <lb/> nobis velles quod pariter credimus; servasti morem
-						<lb/> mum : sed nihil tibi ad ista respondens, etiam ego <lb/> servo promissum meum.</p>
-					<p>CAPUT IX. — 1. De iuvisibili Filio cum agere­ <lb/> mus, quem consensisti esse
-						invisibilem secundum di­ <lb/> vinitatem, qui prius solum Patrem invisibilem esse <lb/>
-						præsumpseras, ad rem non pertinentia multa dixisti <lb/> de invisibilibus creaturis :
-						quod poterunt judicare qui <lb/> legerint. De invisibili Dco inter nos agitur : et hoc
-						<lb/> csl quod quæstionem facit, quia vos invisibilcm solum <lb/> Patrem dictum putatis,
-						ubi Apostolus ait, <hi rend="italic">Immortali,<lb/> invisibili soli Dco</hi> (I <hi rend="italic">Tim.</hi> I, 17). Si dixisset, Soli Patri ; <lb/> diflicilius fortasse
-						quæstio solverelur: quia vero dixit, <lb/>
-						<hi rend="italic">soli Deo;</hi> non est utique contra nos : et Unigenitus <lb/> quippe
-						in Dei forma, ct Spiritus sancius in sua na­ <lb/> tura est invisibilis. Unus enim et
-						solus Deus a nobis <lb/> ipsa Trinitas prædicatur. Quod utrum verum sapia­ <lb/> mus, in
-						aliis locis a nobis est demonstratum, et ubi <lb/> adhuc opus fuerit, demonstrabitur.
-						Nunc in ista quæ- <lb/> simone non immerito potest movere, quomodo de solo <lb/> Dco,
-						qui cst ipsa Trinitas, dictum sil, <hi rend="italic">Invisibili soli</hi>
-						<lb/> Deo : cum sil etiam quædam invisibilis creatura; <lb/> propter quod dictum ost de
-						Christo, quia <hi rend="italic">in ipso con­ <lb/> dita sunt</hi> omnia <hi rend="italic">visibilia et invisibilia ( Coloss.</hi> I, 16). <lb/> Quia ergo sunt dii
-						falsi vbibiles, ideo dicturi est, In­ <lb/>
-						<pb n="763"/> risibili <hi rend="italic">soli Deo honor et gloria.</hi> Etsi enim est
-						creatura <lb/> invisibilis, non tamen deus nobis est. Sed et si non <lb/> dictum esset,
-							<hi rend="italic">soli Dco;</hi> sed dictum esset, <hi rend="italic">Reg; autem<lb/>
-							sæculorum, immortali, invisibili soti honor et gloria:</hi>
-						<lb/> quis nisi Deus esset? Honor ergo ei gloria soli Deo, <lb/> qui Deus invisibilis
-						est, non qui solus invisibilis : <lb/> quoniam est, ut diximus, ct creatura invisibilis.
-						Item <lb/> quæri potest quomodo dictum sit, <hi rend="italic">Deum nemo vidit <lb/>
-							unquam (Joan.</hi> I, 18); cum ejusdem Domnini verba <lb/> sint, <hi rend="italic">Nescitis quia Angeli</hi> eorum <hi rend="italic">semper vident fuciem<lb/>
-							Patris</hi> mei <hi rend="italic">qui in cœlis est (Matth.</hi> XVIII, 10)? Quæ <lb/>
-						sententia vos rcdarguit, qui nescitis quemadmodum <lb/> dicatis invisibilem Patrem.
-						Illud autem quod ait, <lb/> Noti <hi rend="italic">quia Patrem vidit</hi> quisquam , <hi rend="italic">nisi qui eat a Deo, <lb/> hic vidit</hi> Patrem <hi rend="italic">(Joan.</hi> VI, 46); ad homines reforri <lb/> potest quod dictum est, <hi rend="italic">quisquam.</hi> Et quia ipse homo <lb/> erat qui tunc loquebatur in
-						carne, ita hoc dixit, ac si <lb/> diccret, Non quia Patrem vidit quisqunm bominum, <lb/>
-						nisi cgo : sicut dictum est, <hi rend="italic">Quis sapiens, et intelliget <lb/> hæc
-							(Psal.</hi> cvi, 43) ? Non enim et de sanctis Angelis <lb/> id accipi potest. Unde
-						Apostolus de invisibili Deo <lb/> apertius posuit: <hi rend="italic">Quem nemo hominum
-							vidit, nec videre<lb/> potest</hi> (I Tim. vi, 16). Non enirn ait, Nemo; sed, <hi rend="italic">Nemo <lb/> hominum.</hi> Ubi ostendit quemadmodum intelligi debeat <lb/>
-						quod dictum est, <hi rend="italic">Deum nemo vidit</hi> unquam ; id est, <lb/> nemo
-						hominum : <hi rend="italic">sicut, Nemo ascendit in</hi> coelum <hi rend="italic">(Joan.</hi>
-						<lb/> III, 15); cum Angeli soleant illuc ascendere, quin so­ <lb/> lent inde descendere.
-						Nec tamen Apostolus dixit, <lb/> Nemo hominum poterit videre Deum ; sed, <hi rend="italic">Nemo<lb/> potest,</hi> Poterit cnim homo, sed tunc cum æternum <lb/>
-						crit fidelium præmium , videre Deum. Propter quod <lb/> Joannes apostolus : <hi rend="italic">Dilectissimi,</hi> inquil, <hi rend="italic">filii Dei su­ <lb/> mus, et
-							nondum apparuit quid erimus</hi> : scimus <hi rend="italic">quia</hi>
-						<lb/> cum <hi rend="italic">apparuerit, similes ei erimus, quoniam</hi> videbimus <lb/>
-						<hi rend="italic">eum sicuti cst (</hi> I <hi rend="italic">Joan.</hi> III, 2). Quid est
-						ergo quod dicis, <lb/> solum esse invisibilem Patrem? quod fruslra diceres, <lb/>
-						etiamsi a solo Filio videretur. Nunc vera cum divina <lb/> testentur cloquia cum videri
-						et ab Angelis, videndum <lb/> etiam ab hominibus, cum facti fuerint æquales Ange­ <lb/>
-						lis <hi rend="italic">(Matth.</hi> XXII, 50); quid est quod dicis? Ubi est <lb/> quod
-						definire ausus es, <hi rend="italic">minora videri a</hi> ,Majoribus, <lb/>
-						<hi rend="italic">majora autem a minoribus</hi> non <hi rend="italic">videri?</hi> Quod
-						quidem <lb/> postea perdidisti, quando videri a Filio confessus cs <lb/> Patrem, cum ct
-						in ipsa substantia divinitatis dicas <lb/> Filium minorem, Patremque majorem. Sed quid
-						di­ <lb/> cturus os de Angelis , qui semper vident faciem Dei <lb/> Patris? Numquid
-						propter regulam tuam, quam sine <lb/> consideratione fixisti, putandi sunt Angeli Patre
-						Deo <lb/> esse majores?</p>
-					<p>2. Scd eleganter te existimas invenisse quod diceres, <lb/> ubi :isti de Filio: <hi rend="italic">Vidit ergo Patrem, sed vidit incapa­ <lb/> bilem.</hi> Nec attendis,
-						quia ctsi vidit incapabilcm, quem <lb/> sicut putas, capere non putuit; non tamen
-						invisibilcm, <lb/> quem videre potuit. Tu autem nobiscum non de ca­ <lb/> pabili ut
-						incapabili, scd dc visibili et invisibili, cum <lb/> ista diceres, disputabas : quia nHc
-						Apostolus ait, In­ <lb/> capabili; scd ait, <hi rend="italic">Invisibili soli Dco.</hi>
-						Unde hoc testi­ <lb/> monium pro te adhibendum putasti, ut binc etiam <lb/> decolorares
-						Filium, tanquam ipse in Dei forma invisi­ <lb/> bilis non sit. Sed quoniam veritate
-						convictus, et Filium <lb/> confessus cs invisibilcm, præparasti tibi, quantum exi­ <lb/>
-						Stimo, sic dicere, Invisibilis invisibilem genuit; quo­ <lb/> modo dixisti, <hi rend="italic">potens potentem :</hi> ut cum discutereris, <lb/> hoc a te quomodo
-						diceretur, responderes, Invisibilior <lb/> invisibilem gcnuit, sicut potentior potentem.
-						sapien­ <lb/> tiur sapientem, et caMera tua. Sed quain sapicnicr <lb/> oslendisli Filio
-						incapabilem Patrem, Filium vcro ca <lb/> pabilem Patri. Dixisti enim : fidit <hi rend="italic">ergo Patrem, sed <lb/> vidit incapabilem. Pater autem,</hi> ill'luis,
-							<hi rend="italic">sic videt Filium,<lb/> ut tenens in sinu suo et</hi> Iubens. Sic non
-						sapiunt, nisi <lb/> qui carnaliter sapiunt. Sinum quippe tibi fingis, ut vi­ <lb/> deo,
-						aliquam capacitatem majoris Patris, qua Filium <lb/> minorem capiat atque contineat :
-						sicut hominem cor­ <lb/> poralitcr capit domus, aut sicut sinus nutricis capit <lb/>
-						infantem. Ergo inter mirabilia Christi et hoc deputa­ <lb/> bitur, quia in forma servi
-						crevit, et major est factus <lb/> quam in forma Dei fuerat, ut cum prius portaretur in
-						<lb/> sinu Patris, nunc sedeat ad dexteram Patris. Abjice <lb/> ista puerilia vel
-						anicularia phantasmata de corde tuo: <lb/> et sinum Patris ideo dictum accipe, ut
-						intelligatur iste <lb/> gcnilus, ille genitor; non ut ille major, hic minor. <lb/> Nam
-						si incapabilis est Pater, Filius vero incapabilis <lb/> non est, non veraciter dictum
-						est, <hi rend="italic">Omnia quæ habet <lb/> Pater, mea sunt (Joan.</hi> XVI, 15) :
-						quandoquidem re­ <lb/> sponderi ei potest, Ecce incapabilitatem habet Pater, <lb/> quæ
-						non est tua. Sed quoniam veraciter dictum est <lb/> quod Veritas dixit, et omnia quae
-						habet Pater, Filii <lb/> sunt; non potest non esse Filii quantacumque sit in­ <lb/>
-						capabilitas Patris. EL hanc Domini sententiam, ubi <lb/> ait, <hi rend="italic">Omnia
-							quæ habet Pater, mea sunt;</hi> tanquam re­ <lb/> ctissimam regulam ad vos, sive
-						convincendos, sivc, <lb/> quod magis cupimus, corrigendos, per multa adhibere <lb/>
-						debemus : ut ubicumque aliquid tribuitis Patri quod <lb/> Filio denegatis, ipsam
-						fidclissimam testem contra er. <lb/> rores vestros, vel contra mendacia producamus. Quid
-						<lb/> opus cst autem in eo tibi resistere, quod bunnam <lb/> sapicnliam contendis esse
-						visibilcm; cum ipsam <lb/> animam humanam, in qua est utique humana sa­ <lb/> pientia,
-						invisibilem esse concesseris ? Sed quod­ <lb/> libet sentias de universa invisibili
-						creatura, quantum <lb/> ad Dcum pertinet, de quo inter nos agitur, satis tibi <lb/>
-						demonstratum est non esse solum invisibilem Pa­ <lb/> trem.</p>
-					<p>CAPUT X. — i. Putas Dcum Patrem cum F'ilio ct <lb/> Spirilu sancto unum Deum esse non
-						possc : timcs <lb/> cnim ne Palcr solus non sit unus Dcus, sed pars
-							<unclear>umus</unclear>
-						<lb/> Dei qui constat ex tribus. Noli liincre, nulla fit pur­ <lb/> tium in dcitatis
-						unitate divisio. Unus est Dcus Pater <lb/> et Filius ct Spiritus sanctus, hoc est ipsa
-						Trinitas. <lb/> Unus cst Deus, de quo dictum est, quia <hi rend="italic">Nullus Deus,
-							<lb/> nisi unus</hi> (I <hi rend="italic">Cor.</hi> VIII, 4) : et qui dixit, <hi rend="italic">Audi, Israel; <lb/> Dominus Deus tuus, Dominus unus cst.</hi> Cui uni et
-						soli <lb/> Ico servire nos sine ullo scrupulo agnoscimus, quan­ <lb/> do audimus ct
-						Icgimus : <hi rend="italic">Dominum Deum tuum adora.</hi>
-						<lb/> bis, <hi rend="italic">ct iili soli</hi> servies <hi rend="italic">(Deut.</hi> vi,
-						4, 13). Nc forte propter <lb/> hæc verba, Christo cujus membra sumus (I <hi rend="italic">Cor. vi,</hi>
-						<lb/> 13), vel Spiritui sancto cujus templum sumus <hi rend="italic">(Jd.</hi>
-						<lb/> III, 17), servire nolimus, si quod dictum C'Si, Domino <lb/>
-						<pb n="765"/> Dco tuo <hi rend="italic">soli servies,</hi> sic acceperimus, tanquam de
-						solo <lb/> Patre, et non de ipsa Trinilaie sil dictum. Vos autem, <lb/> cum
-							quæri<unclear>tur</unclear> a vobis, quem credatis esse de quo <lb/> scriptum cst, <hi rend="italic">Dominus Deus tuus, Dominus unus est;</hi>
-						<lb/> respondetis, Deus Pater est. Itemque cum quaeritur <lb/> de quo Domino Deo dictum
-						sil, <hi rend="italic">Dominum Deum tuum</hi>
-						<lb/> adorabis, <hi rend="italic">et illi soli servies;</hi> rursus respondetis, De Dco
-						<lb/> Patre. Tunc vobis dicitur : Si Domninus Deus noster <lb/> Dominus unus cst, et hic
-						Pater est; quare vos facitis <lb/> du<unclear>ns</unclear> dominos dcos, dicendo etiam
-						Christum esse Do­ <lb/> minum Deum ? Item si Pater est, cui uni Domino Deo <lb/> ac soli
-						serviendum cst; quomodo obtemperatis huic <lb/> praecepto, qui tanquam Domino Deo
-						servitis et Chri­ <lb/> sto? Neque enim illi soli servi, qui servit et huic. <lb/>
-						Secundum fidem autem rectam, quicumque ipsam <lb/> Trinitatem unum Dominum Deum esse
-						nostrum di­ <lb/> dicimus, profecto cum ei soli ea quas Deo dcbelur <lb/> servitute
-						servimus, Domino Deo soli nos servire con­ <lb/> fidimus.</p>
-					<p>2. <hi rend="italic">Ergo</hi> , inquis, <hi rend="italic">Deus Puler pars est
-							Dei.</hi> Absit. <lb/> Tres enim personæ sunt Pater et Filius et Spiri­ <lb/> tus
-						sanctus : et hi tres quia unius substantiæ sunt, <lb/> unum sunt, ct summc unum sunt,
-						ubi nulla natura­ <lb/> rum, nulla cst diversitas voluntatum. Si autem na­ <lb/> tura
-						unmn essent, et consensione non essent , non <lb/> summe unum essent : si vero natura
-						dispares essent, <lb/> unum non essent. Hi ergo tres, qui unum sunt-pro­ <lb/> pter
-						ineffabilem conjunctionem deitatis, qua ineffa­ <lb/> biliter copulantur, unus Ocus cst.
-						Porro autem Chri­ <lb/> stusuna persona est gemiæ substantiæ, quia et Deus <lb/> et homo
-						est. Nec tamen Deus pars hujus personæ <lb/> dici potest : alioquin Filius Dei Deus
-						antequam sus­ <lb/> ciperet formam sel'vi, non erat totus, et crevit cum <lb/> homo
-						divinitati cjus accessit. Quod si in una persona <lb/> absurdissime dicitur, quia pars
-						rci ullius esse non <lb/> .potest Deus; quanto magis pars Trinitatis esse non <lb/>
-						potest, quicumque unus in tribus ? Dcinde ubi ait <lb/> Apostolus, <hi rend="italic">Qui
-							adhæret Domino, unus spiritus est;</hi>
-						<lb/> (1 <hi rend="italic">Cor.</hi> vi, 11 ); numquid hujus unius pars est Domi­ <lb/>
-						nus ? Si cnim hoc dicimus , quid aliud dicere depre­ <lb/> hendimur, nisi quod augeatur
-						adhærente hominc, et <lb/> recedente minuatur ? In Trinilalc igitur qu:c Dcus <lb/> cst,
-						et Pater Deus est, et Filius Deus cst, ct Spiritus <lb/> sanctus Dens est, ct simul hi
-						Ires unus Deus : nec <lb/> hujus Trinitatis tertia pars cst unus, nuc major pars <lb/>
-						duo qnam unus est ibi; nec majus aliquid sunt onmes <lb/> quam singuli : quia
-						spiritualls, non corporalis est <lb/> magnitudo. Qui potest capere, capiat ( <hi rend="italic">Matth.</hi> xix , <lb/> 42 ) : qui autem non potest, credat, et oret ut
-						quod <lb/> credit intelligat. Verum cst enim quod dicitur per <lb/> prophetam, Nisi <hi rend="italic">credidcritis , non intelligetis ( Isa;.</hi>
-						<lb/> VII, 9 ).</p>
-					<p>5. Tu nempe dixisti; <hi rend="italic">unum Deum</hi> non <hi rend="italic">ex partibus
-							<lb/> esse compositum.</hi> Et quia de Patre hoc vis intelligi, <lb/>
-						<hi rend="italic">Ille,</hi> innuis , <hi rend="italic">quod est, virtus est
-							ingenita,</hi> simplex. <lb/> £t tamen in hac simplici virtute quam multa comme­ <lb/>
-						moraveris, vide. Nam superiora verbi tua sunt : <lb/>
-						<hi rend="italic">Deus Deum genuit, Dominus Dominum genuit, Rex lle­</hi>
-						<unclear/><lb/>
-						<hi rend="italic">qem genuit,</hi> Creator <hi rend="italic">Creatorem genuit, bonus
-							bonum</hi>
-						<lb/> genuit, <hi rend="italic">sapiens sapientem genuit, clemens</hi> clementem, <lb/>
-						<hi rend="italic">potens potentem.</hi> Cur ergo in virtute simplici, quod <lb/> est
-						Dcus, non timuisti tot commemorare virtutes ? <lb/> Ut enim omittam quatuor quas loco
-						superiore po­ <lb/> suisti, et alias quatuor dicam, quas enunt<unclear>iare</unclear>
-						usitatis <lb/> nominibus possimus; numquid bonitas ct sapiculia ct <lb/> clementia et
-						potentia partes sunt unius virtutis, <lb/> quam simplicem e.sc dixisti ? Si dixeris,
-						Partces sunt; <lb/> simplex crgo virtus ex partibus constat, et simplex <lb/> ista
-						virtus te definiente unus est Deus. Unum ergo <lb/> Deum ex partibus compositum esse
-						dicis ? Non dico , <lb/> inquis. Non sunt ergo partes : et tamen
-							quat<unclear>uor</unclear> sunt, <lb/> et una virtus est, eademque simplex est. Si
-						ergo in <lb/> una Patris persona , et plura invenis, et partes non <lb/> invenis; quanto
-						magis Pater ct Filius ct Spiritus <lb/> sanctus, et propter individuam deitatem unus
-						Deus <lb/> est, et propter uniuscujusque proprietatem tres per­ <lb/> sonæ sunt, et
-						propter singulorum perfectionem partes <lb/> unius Dci nan sunt? Virtus cst Pater,
-						virtus Filius, <lb/> virtus Spiritus sanctus. Hoc verum dicis : sed quod <lb/> virtutem
-						de virtute gcnitam, et virtutem de virtute <lb/> procedentem non vis eamdem habere
-						naturam, hoc <lb/> falsum dicis, hoc contra fidem rectam et catholicam <lb/> dicis.</p>
-					<p>CAPUT XI. — Redis ut quæras a me, quomodo <lb/> sit invisibilis Filius, unde jam dixi
-						superius, quod <lb/> visum est dicendum. Sed si <hi rend="italic">ob hoc,</hi> inquis,
-							<hi rend="italic">Filius</hi> in­ <lb/>
-						<hi rend="italic">visibilis a te pronuntiatur, eo quod oculis humanis con­ <lb/>
-							templari</hi> non <hi rend="italic">possit ; cur non et</hi> coelestes <hi rend="italic">virtutes pariter <lb/> invisibiles</hi> pronuntias, <hi rend="italic">quando nec ipsæ obtutibus huma­ <lb/> nis videri</hi> possunt ? Ita hoc dicis, quasi
-						possit ab ho­ <lb/> mine comprehendi quis ille sit modus, quo cœlestes <lb/> virtutes
-						sunt invisibiles; aut ad hoC quærendum esse <lb/> debeamus intenti, dicente Scriptura,
-							<hi rend="italic">Altiora te</hi> ne <lb/>
-						<hi rend="italic">quæsieris (Eccli.</hi> III, 22). Quod præceptum ipse con­ <lb/>
-						temnens, ausus es dicere angelum vidcri ab archan­ <lb/> gclo, archangelum ab angelo non
-						vidcri. Satis sit, <lb/> quod ostendi non esse consequens ut ideo credamus <lb/> in
-						forma Dei visibilem Filium, qnia scriptum est, <lb/>
-						<hi rend="italic">Invisibili soli Deo</hi> ( I <hi rend="italic">Tim.</hi> 1, 17 ). Quod
-						in de Patre <lb/> sic te accipere demonstrabas tanquam Filius invisibi­ <lb/> lis non
-						sit, cum cum ct invisibilium creatorem Scri­ <lb/> p'ura testetur. Verumtamen restat
-						utdicas, Ambo qui. <lb/> dem invisibilcs sunt, id cst, ct Pater et Filius , set! <lb/>
-						Patcr invisibilior est : ac sic dando aliquid Patri <lb/> quod non sit Filii, mendacem
-						facias cumdem Filium <lb/> dicentem, <hi rend="italic">Omnia quæ habet Pater, mea suni
-							(Joan.</hi>
-						<lb/> XVI, 15).</p>
-					<p>CAPUT XII. — i. HInc et de potentia sapis, quod <lb/> scilicet sit quidem potens ct
-						Filius, sed potentior Pa­ <lb/> ter Filio : ulauctoribus et doctoribus vobis potuerit
-						<lb/> potentem potens, nee potuerit omnipotcntem gignere <lb/> omnipotens. Ac per hoc si
-						habct Pater omnipoten- <lb/> liam quam non habet Filius, falsum est quod ait <lb/>
-						Filius, <hi rend="italic">Omnia quæ habet Pater, mea sunt.</hi> Deinde si <lb/> aliquid
-						facit Pater, quod facere non potest Filius, <lb/> mcrito dicitur potentior Pater quam
-						Filius : cum vero <lb/> dical, <hi rend="italic">Quæcumque Pater facit, hæc et Filius
-							similiter <lb/> facit</hi> ( <hi rend="italic">Joan.</hi> v, 19 ); nonne meiius
-							<unclear>audit</unclear>
-						<lb/>
-						<pb n="767"/> vos, nactusque ipsi creditur docenti quam dccipien­ <lb/> tibus vobis ?
-							<hi rend="italic">Sed potentiam</hi> Pater , inquis, <hi rend="italic">a nemine, <lb/>
-							Filius vero accepit a Patre.</hi> Fatemur et nos Filium ab <lb/> illo accepisse
-						potentiam, de quo natus est putens : <lb/> Patri vero potentiam nullus dedit, quia
-						nullus eum <lb/> genuit. Gignendo enin dedit potentiam Pater Filio, <lb/> sicut omnia
-						quæ habet in substantia sua , gignendo <lb/> dedit ei quem genuit de substantia sua. Sed
-						quæritur <lb/> utrum tantam, quanta ipsi est, potentiam Pater Filio <lb/> dederit, an
-						minorem. Si tantam, non solum potentem <lb/> poiens, verum etiam omnipotentem genuisse
-						dicatur, <lb/> credatur, intelligatur omnipotens : si minorem, <lb/> quomodo omnii qune
-						habet Pater, Filii sunt ? Si Pa­ <lb/> iris omnipotentia Filii non est, quomodo
-						quæcumque <lb/>
-						<hi rend="italic">Pater facit, h</hi>æ<hi rend="italic">c et Filius</hi> similiter <hi rend="italic">facit</hi> ? quod ulique <lb/> non potest, si omnipotens non est.</p>
-					<p>2. Ac per hoc quod ait Apostolus , <hi rend="italic">Beatus et solus</hi>
-						<lb/> potens : non cogor de Patre tantummodo accipere; <lb/> sed de Deo, quod est ipsa
-						Trinitas. Loquens enim <lb/> ad Timotheum : Praecipio, inquit, tibi <hi rend="italic">coram Deo, <lb/> qui vivificat omnia, et Christo Jesu qui</hi> testimonium <lb/>
-						<hi rend="italic">reddidit sub Pontio Pilato bonam confessionem, ut ser­ <lb/> ves
-							mandatum sine macula, irreprehensibile, usque ad<lb/> adventum Domini nostri Jesu
-							Christi; quem temporibus <lb/> propriis ostendet beatus et solus potens, Rex regum et
-							<lb/> Dominus dominantium;</hi> qui <hi rend="italic">solus habet immortalitatem,
-							<lb/> et lucem inhabitat inaccessibilem; quem nemo</hi> hominum <lb/>
-						<hi rend="italic">vidit, nec videre potest; eui est honor et gloria</hi> in sæcu­ <lb/>
-						la <hi rend="italic">sæculorum. Amen</hi> (I <hi rend="italic">Tim.</hi> VI, 13-16).
-						Nihil hic vi­ <lb/> deo dictum quod non conveniat Trinitati. Sed ut nunc <lb/> taceam de
-						Spiritu sancto, quem nec saltem minorem <lb/> Filio Deum vultis, quia omnino Deum esse
-						non vultis, <lb/> sufficit ut vos de Patre convincamus et Filio. Numquid <lb/> enim quia
-						dixit Apostolus, <hi rend="italic">Testificor tibi coram Deo <lb/> qui vivificat
-							omnia;</hi> Pater solus, non et Filius vivifi­ <lb/> cat omnia ? Si dixeris Patrem
-						solum vivificare omnia, <lb/> quomodo ergo <hi rend="italic">quæcumque Pater facit,
-							h</hi>æ<hi rend="italic">c et Filius</hi>
-						<lb/> similiter <hi rend="italic">facit ?</hi> Quandoquidem Pater, ut putas, vivifi­
-						<lb/> cat omnia, qnod Filius non facit. Deinde ubi ait, <lb/>
-						<hi rend="italic">SicuL Pater suscitat mortuos et vivificat, sic et Filius <lb/> quos
-							vult vivificat (Joan.</hi> v, 21); quomodo verum eSI, <lb/> si Pater sine Filio
-						vivificat omnia? Proinde quod <lb/> addidit, <hi rend="italic">Et Christo Jesu qui
-							testimonium reddidit sub</hi>
-						<lb/> Pollio <hi rend="italic">Pilato bonam confessionem;</hi> de Filio proprie <lb/>
-						diccre voluit: quia Filius quidem sicut Pater vivificat <lb/> omnia ; sed sub Pontio
-						Pilato in forma servi Filium <lb/> novimus passum fuisse, non Patrem. Deinde subjun­
-						<lb/> gitur, <hi rend="italic">Ut serves mandatum sine macula, irreprehensi­ <lb/> bile,
-							usque ad adventum Domini nostri Jesu Christi;<lb/> quem temporibus propriis ostendet
-							beatus et solus po­ <lb/> tens : quem,</hi> scilicet adventum Domini Christi ; osten­ <lb/>
-						<hi rend="italic">det</hi> utique Dcus, quod non solus est l'ater, quia <lb/> secundum
-						veritatem, non secundum vestrum errorem, <lb/> Trinitas unus est Deus <hi rend="italic">: beatus et solus</hi> potens, <hi rend="italic">Rex<lb/> regum et Dominus
-							dominantium.</hi> Numquid enim vel vos <lb/> dicere audetis Filium non esse Regem
-						regum et Do­ <lb/> minum dominantium ? De quo inter cætera scriptum est <lb/> in
-						Apocalypsi Joannis: <hi rend="italic">Et ipse calcat torcular vini po­ <lb/> tentis, et
-							in tunica et in femore habet nomen scriptum, <lb/> Rex regum et Dominus dominantium
-							(Apoc.</hi> XII, 15, <lb/> 16). Sed ne forte dicatis quod nomen Patris Filius <lb/>
-						habet scriptum in veste et in femore ; alio loco ejus­ <lb/> dem libri superius legitur
-						: <hi rend="italic">Et Agnus vincet eos, <lb/> quoniam Dominus dominantium est et Rex
-							regum (Id.</hi>
-						<lb/> XVII, 14). Quapropter secundum vos, duo suut regcs <lb/> regum et domini
-						dominantium : et contra vos est, si <lb/> de Patre tantum ait Apostolus, <hi rend="italic">Beatus et</hi> solus <hi rend="italic">votens,<lb/> Rex regum et Dominus
-							dominantium.</hi> V crum autem <lb/> secundum rectam fidem ipsa Trinitas unus est
-						Deus, <lb/>
-						<hi rend="italic">beatus et</hi> sotus <hi rend="italic">potens, Rex regum et Dominus
-							domi­<lb/> nantium, qui solus habet immortalitatem, et lucem ha­ <lb/> bitat
-							inaccessibilem.</hi> Et quomodo erit verum, <hi rend="italic">Accedite<lb/> ad eum,
-							et</hi> illuminamini <hi rend="italic">(Psal.</hi> XXIIII, 6) ; nisi quia hoc <lb/>
-						nemo potest, si de se quisque præsumpserit, sed si <lb/> ipse donaverit? Immortalitatem
-						autem Deus habere <lb/> dicitur solus, quia est immutabilis solus. In omni enim <lb/>
-						mutabili natura nonnulla mors est ipsa mutatio, quia <lb/> facit aliquid in ea non esse
-						quod erat. Proinde et <lb/> ipsa anima humana, quæ propterea dicitur immorta­ <lb/> lis,
-						quoniam qualilercurnque secundum modum suum <lb/> nunquam desinit vivere, habet tamen
-						pro ipto suo <lb/> modo quamdam mortem suam : quia si juste vivebat <lb/> et peccat,
-						moritur justitiae; si peccatrix erat et justi­ <lb/> ficatur, moritur peccato : ut alias
-						ejus mutationes <lb/> taceam, de quibus longum est disputare. Et creatu­ <lb/> rarum
-						natura coelestium mori potuit, quia peccare <lb/> potuit: nam et Angeli peccaverunt, et
-						daemones facti <lb/> sunt, quorum est diabolus princeps. Et qui non pec­ <lb/> caverunt,
-						peccare potuerunt. Et cuicumque creaturae <lb/> rationali præstatur ut peccare non
-						possit, non est hoc <lb/> naturæ propriae, sed Dei grali;c. Ac per boc solus Deus <lb/>
-						habct immortalitatem, qui non cujusquam gratia, sed <lb/> natura sua, nec potuit, nee
-						potest aliqua conversione <lb/> mutari, nec potuit nec poterit aliqua mutatione pec­
-						<lb/> care. Quem secundum naturam qua Deus est, <hi rend="italic">nemo<lb/> hominum
-							vidit, nec videre potest:</hi> sed poterit aliquan­ <lb/> do, si ad illum numerum
-						hominum pertinet, de quibus <lb/> dictum est, <hi rend="italic">Beati mundo corde,
-							quoniam</hi> ipsi Deum <lb/>
-						<hi rend="italic">videbunt (Matth.</hi> v, 8). Cui Deo, id est Patri et Filio <lb/> et
-						Spiritui sancio, qua; Trinitas unus est Deus, honor <lb/> et gloria in s;rcula
-						sæculorum; Amen.</p>
-					<p>3. Absit autem ut, quomodo putas, ideo sit Pater <lb/> potentior Filio, quia creatorem
-						genuit Pater, Filius <lb/> autem non genuit creatorem. Neque enim non po­ <lb/> luit <hi rend="italic">(a),</hi> sed non oportuit. Immoderata enim esset <lb/> divina generatio
-						, si genitus Filius nepotem gigneret <lb/> Patri : quia et ipse nepos, nisi avo suo
-						pronepotem <lb/> gigneret, secundum vestram mirabilem sapientiam <lb/> impotens
-						diceretur. Similiter etiam ille si nepotem <lb/> non gigneret avo suo, et pronepotem
-						proavo suo,.. <lb/> non a vobis appellaretur omnipotens : nec impleretur <lb/>
-						gencrationis series, si semper alter cx altero nasce- <note type="footnote"><hi rend="italic">(n)</hi> Plerique ac melioris notse Mss., <hi rend="italic">ycqne</hi>
-							enim <hi rend="italic">potnt.</hi>
-							<lb/> Altameo Magister Sent. in i, dist. 7, citat, seque <hi rend="italic">(',nm
-								lion<lb/> putuit:</hi> id est, non ex impotentia tilii, sed ex rui namra <lb/> venit
-							ut Filius noti generet. Neque c&gt;gimur intelligere, <lb/> Filium potuisse alium
-							geaerare filium, quod AugusUnuiu <lb/> existimassi! creilit Petavius in lib. 7
-							Theolog. dog:u. de <lb/> IriniUle, cap. 13, It. G. </note>
-						<lb/>
-						<pb n="769"/> retur; nec eam perficeret ullus, si non sufficeret unus. <lb/> Omnipotens
-						itaque omnipotentem genuit Filium ; <lb/> quoniam <hi rend="italic">quæcumque Pater
-							facit, h</hi>æc <hi rend="italic">et Filius simili­<lb/> ter facil.</hi> Filiurn
-						quippe ipsum genuit utique Pall'is <lb/> natura, non fecit.</p>
-					<p>CAPUT XIII. — i. In illo etiam testimonio, ubi <lb/> ait Apostulus, <hi rend="italic">Soli sapienti Deo;</hi> non dissimilis error <lb/> est vester : sed quod vobis
-						respondimus de potentia, <lb/> hoc etiam de sapientia respondemus. Si cnim dixis­ <lb/>
-						set Apostolus, Soli sapienti Patri; nec sic inde Filium <lb/> sepnrarct. Num enim quia
-						in Apocalypsi de Filio <lb/> legitur, <hi rend="italic">Habens nomen scriptum, quod nemo
-							scit</hi> nisi <lb/>
-						<hi rend="italic">ipse ( Apoc.</hi> xix, 12); ideo Pater nescit hoc nomen, <lb/> a quo
-						est inseparabilis Filius ? Sicut ergo scit et <lb/> Pater quod Demo scire dictus est
-						nisi Filius, quia <lb/> inseparabiles sunt: sic etiam si dictum esset, Soli <lb/>
-						sapienti Patri ; simul intelligi deberet ct Filius, quia <lb/> inseparabiles sunt. Cum
-						vero non sit dictum, Soli <lb/> sapienti Patri; sed <hi rend="italic">Soli sapienti
-							Deo;</hi> et Deus unus <lb/> sit ipsa Trinitas : multo cst facilior nobis bujus solu­
-						<lb/> tio quæstionis; ut sic intelligamus solum-Deum sa­ <lb/> picntem, sicut
-						intelleximus solum potentem, id est, <lb/> Patrem et Filium et Spiritum sanctum , qui
-						est unus <lb/> ct solus Deus, cui soli servire jussi sumus : ne male <lb/>
-						intelligentes, vel potius non intelligentes, contra boc <lb/> praeceptum facere
-						videamur, quia et Domino Christo <lb/> ea quae Deo debetur servitute servimus. Non enim
-						<lb/> dictum est, Dominum Deum tuum Patrem adorabis, <lb/> ctilii plus servies; ut
-						servire permitteremur et Filio, <lb/> plus tamen Patri tanquam majori, minus autem Filio
-						<lb/> tanquam minori Deo : sed dictum est, <hi rend="italic">Dominum <lb/> Deum</hi>
-						tuum <hi rend="italic">adorabis, et illi soli servies (Deut.</hi> vi, 43); <lb/> soli
-						scilicet omnipotenti, soli sapienti Deo; ut vos <lb/> repelleremini, qui nolentes
-						accipere unum solum <lb/> Deum Patrem et Filium et Spiritum sanctum, et <lb/> dicentes
-						unum Dominum Deum, cui soli serviendum <lb/> est, non esse nisi Deum Patrem, ct tamen
-						etiam <lb/> Filium Deum et Dominum confitentes; apertissime <lb/> duos deos et dominos,
-						majorem unum, minorem <lb/> alterum dicitis : et reos vos, secundum errorem ve­ <lb/>
-						strum, præcepti hujus violati esse monstratis, quia <lb/> non solum majori, verum etiam
-						minori, ea quæ Do­ <lb/> mino Deo debetur servitute servitis.</p>
-					<p>i. Ubi autem dixit Apostolus, <hi rend="italic">Soli sapienti Deo;</hi>
-						<lb/> cum scriberet ad Romanos, in fine Epistolæ sic Io­ <lb/> quitur: <hi rend="italic">Ei autem</hi> qui <hi rend="italic">potens est,</hi> inquit, vos <hi rend="italic">confirmare<lb/> secundum Evangelium</hi> meum, <hi rend="italic">et prceconium Jesu
-							Chri­</hi>
-						<lb/> sti ; <hi rend="italic">secundum revelationem mysterii temporibus</hi> æterni<hi rend="italic">s<lb/> taciti, manifestati autem nunc per Scripturam Propne­ <lb/>
-							tarum; secundum pr</hi>æ<hi rend="italic">ceptum</hi> æ<hi rend="italic">terni Dei, in
-							obedien­ <lb/> tinm fidei in omnes gentes cogniti; soli sapienti Deo <lb/> per Jesum
-							Christum, cui gloria in</hi> sæcula <hi rend="italic">saculorum<lb/> (Rom.</hi> xvi,
-						25 27). Hoc est, <hi rend="italic">Ei qui potens est vos<lb/> confirmare, soli sapienti
-							Deo gloria</hi> in <hi rend="italic">sæcula s</hi>æ<hi rend="italic">culo­</hi>
-						<lb/> rum. Quod autem interp ositum est, <hi rend="italic">per Jesum Chri­ <lb/> stum
-							;</hi> utrum soli Sapienti Deo per Jcsuin Christum <lb/> accipidebcat, ut scilicet
-						solus Deus sapicns pcr Je­ <lb/> sam Christum sapiens esse intelligatur, non partici
-						<lb/> pando, sed gignendo sapientiam, quod cst Christus <lb/> Jesus; an vero non per
-						Jcsum Christum sapienti, <lb/> sed per Jesnm Christum gloria Deo soli sapienti, <lb/>
-						videtur ambiguum. Sed quis audeat dicere per Jesum <lb/> Christum fieri ut sit sapiens
-						Deus Pater; cum secun­ <lb/> dum substantiam suam non dubitandum sit eum esse <lb/>
-						sapientem, potiusque sit substantia Filii pcr gignen­ <lb/> tem Patrem, quam substantia
-						Patris per genitum <lb/> Filium ? Restat ergo ut soli sapienti Deo gloria sit <lb/> per
-						Jesum Cbristum, hoc est, clara cum laude noti­ <lb/> tia, qua innotuit gentibus Deus
-						Trinitas : ideo per <lb/> Jesum Christum, quia, ut alia taceam, ipse præcepit <lb/>
-						baptizari gentes in nomine Patris ct Filii et Spiritus <lb/> sancti <hi rend="italic">(Malth.</hi> XXVIII, 19); ubi praecipue commendata <lb/> est hujus individuæ gloria
-						Trinitatis. Deus itaque, <lb/> quod est ipsa Trinitas, propterea solus sapiens recto
-						<lb/> dicitur, quia solus secundum substantiam suam sa­ <lb/> piens est: non secundum
-						accidentem vel accedentem <lb/> participationem sapientiæ, sicut sapiens est rationalis
-						<lb/> quæcumque creatura. Quod vero additum est, <hi rend="italic">cui,</hi> ut <lb/>
-						diceretur, <hi rend="italic">cui gloria ;</hi> cum sufficeret si dictum esset, <lb/> Ei
-						autem gloria : inusitatam nostrae linguae indicat <lb/> locutionem; non sensum quem
-						requiramus, vel de <lb/> quo ambigamus, insinuat. Quid enim sensui deperit, <lb/> si
-						dicatur, Ei gloria , cui per Cbrislum gloria ? Hoc <lb/> est namque, <hi rend="italic">per Jesum Christum cui gloria;</hi> quod est, <lb/> cui per Jesum Christum gloria.
-						Sed horum alter in­ <lb/> usitatus, alter usitatus est ordo verborum.</p>
-					<p>CAPUT XIV. — 1. Quæris a me, Si <hi rend="italic">de</hi> substantia <lb/>
-						<hi rend="italic">Patris eat Filius, de substantia Patris eat etiam Spiritus <lb/>
-							sanctus; cur unus Filius sit, et alius non sit filius.</hi>
-						<lb/> Ecce respondeo, sive capias, sive non capias. De <lb/> Patre est Filius, de Patrc
-						est Spiritus sanctus : sed <lb/> ille genitus, iste procedens : ideo ille Filius cst Pa­
-						<lb/> tris, de quo cst genitus ; iste autem Spiritus utrius­ <lb/> que, quoniam de
-						utroque procedit. Sed ideo cum de <lb/> illo Filius loqueretur, ait, <hi rend="italic">De Patre procedit (Joan.</hi>
-						<lb/> xv, 26); quoniam Pater processionis cjus esi auctor, <lb/> qui talem Filium
-						genuit, et gignendo ei dedit ut <lb/> etiam de ipso procederet Spiritus sanctus. Nam
-						nisi <lb/> procederet et de ipso, non diceret discipulis, <hi rend="italic">Accipite<lb/> Spiritum sanctum;</hi> eumque insufflando daret <hi rend="italic">(Id.</hi>
-						<lb/> xx, 22), ut a se quoque procedere significans, aperte <lb/> ostenderet flando,
-						quod spirando dabat occulle. Quia <lb/> ergo si nasceretur, non tantum de Patre, nec
-						tantum <lb/> de Filio, sed de ambobus utique nasceretur; sine <lb/> dubio filius
-						diceretur amborum. Ac per hoc quia <lb/> filius amborum nullo modo est, non oportuit
-						nasci <lb/> cum de ambobus. Amborum ea ergo Spiritus, pro­ <lb/> cedendo de ambobus.
-						Quid aulem inter nasci et pro­ <lb/> ceaere intersit, de illa excellentissima natura
-						loquens <lb/> explicare quis potest ? Non omne quod proccdit na­ <lb/> scitur, quamvis
-						omne procedat quod nascitur ; sicut <lb/> non omne quod bipes cst homo est, quamvis
-						bipes <lb/> sit omnis qui homo est. Hæc scio : distinguere autem <lb/> inter illam
-						generationem et hanc processinem ne­ <lb/> scio, nun valeo, non sufficio. Ac per hoc
-						quia et illa <lb/> et ista est ineffabilis, sicut propheta de Filio loquens <lb/> ait,
-							<hi rend="italic">Generationem ejus quis enarrabit (Isai.</hi> LUI, 8)? ita <lb/> de
-						Spiritu sancto verissimc dicitur, Processionem <lb/>
-						<pb n="771"/> ejus quis cnarrahil? Satis sit ergo nobis, quia non <lb/> est a scipso
-						Filius, sed ab illo de quo natus est: non <lb/> cst a seipso Spiri!us sanctus, sed ab
-						illo de quo pro­ <lb/> cedit. Et quia de utroque procedit, sicut jam osten. <lb/> dimus
-						: unde et Spiritus Patris dictus est, ubi legi- .tur, <lb/> lur, Si <hi rend="italic">autem Spiritus ejus qui</hi> suscitavit <hi rend="italic">Christum a</hi>
-						<lb/> mortuis, <hi rend="italic">habitat in vobis;</hi> ct Spiritus Filii, ubi legitur,
-						<lb/> Qui <hi rend="italic">autem Spiritum Christi</hi> MOM <hi rend="italic">habet,
-							hic</hi> non <hi rend="italic">est ejus<lb/> (Rom.</hi> VIII, ii, 9). Non enim duo
-						sunt Spirilus sancii, <lb/> tanquam singuli singulorum, unns Patris, aller Filii; <lb/>
-						ped unus potius Patris et Filii : de quo uno Spirilu <lb/> scriptum est, Etenim in <hi rend="italic">Spiritu</hi> uno nos <hi rend="italic">omnes</hi> in <lb/> unum <hi rend="italic">corpus laptizati</hi> sumus, sivc Judaei, <hi rend="italic">sive Græci,
-							<lb/> sive</hi> servi, <hi rend="italic">sive tiberi; et omnes</hi> unum <hi rend="italic">Spiritum</hi> potavi­ <lb/> mus (I <hi rend="italic">Cor.</hi> XII, 13).
-						Et alio ioco : <hi rend="italic">Unum corpus et</hi>
-						<lb/> unus <hi rend="italic">Spiritus (Ephes.</hi> IV, 4).</p>
-					<p>2. Quid ergo hæc Trinitas, nisi unius ejosdemque <lb/> substantiæ est? Quandoquidem non
-						de aliqua materia <lb/> vel de nihilo est Filius, sed de quo cst genitus : item­ <lb/>
-						que Spiritus sanctus non de aliqua maleria, vcl de <lb/> nihilo, sed indc est unde
-						proccdiL. Vos autem nec <lb/> Filium de Patris substantia genitum vultis, et tamen <lb/>
-						eum nee ex nihilo, nec ex aliqua materia, sed ex <lb/> Patre esse conceditis. Nee
-						videtis quam necesse sit, <lb/> ut qui non csl ex nihilo, non est cx aliqua re alia,
-						<lb/> scd ex Deo, nisi cx Dei substantia csse non possit, <lb/> et hoc esse quod Deus
-						est de quo cst, hoc est, Dcus <lb/> de Dco. Quocirca Deus de Dco natus, quia non aliud
-						<lb/> prius fuit, sed natura coæterna de Dco est, non est <lb/> aliud quam est ille de
-						quo est, hoc est, unius cjus­ <lb/> demquc naturæ, vel unius ejusdemque substantiæ.
-						<lb/> Quod cum auditis, qualc cor habcalis ignoro, qui <lb/> putatis nos sic Filium
-						dicere natum esse de Patre, <lb/> quomodo nascuntur de corporibus corpora : et quo­
-						<lb/> niam corruptibilitcr is'a nascuntur, accusatis nos <lb/> tanquam generationi
-						Unigeniti, quæ dc Patre est, <lb/> corporalem passionem corruptionemque tribuamus. <lb/>
-						Carnalibus quippe cogitationibus pleni substantiam <lb/> Ovi de se ipsa gignere possc
-						Filium non putatis, nisi <lb/> hoc patiatur quod substaulia quando gignit patitur <lb/>
-						carnis. Erratis, non scientes Scripturas, neque vir­ <lb/> lutem Dci <hi rend="italic">(Matth.</hi> XIII, 29). Quando legitis, <hi rend="italic">VI simus<lb/> in vero Filio
-							ejus Jesu Christo</hi> (I <hi rend="italic">Joan.</hi> v, 20); verum <lb/> Oei Filium
-						cogitate. Hunc autem Filium nullo modo <lb/> verum Dci Filium cogitatis, si eum natum
-						esse de <lb/> substantia Patris negatis. Num onim jam erat homi­ <lb/> nis filius, et
-						Deo donante factus est Dei filius; ex <lb/> Deo quidcm natus, sed grat a, non natura ?
-						An forte <lb/> eui non hominis lilius, tamen aliqua jam crat qualis­ <lb/> cumque
-						creatura, et in Dci filium, Deo mutante, , <lb/> conversa est? Si nihil horum. ergo aut
-						de nihilo aut <lb/> de aliqua substantia natus rst. Sed ne crederemus <lb/> de nihilo
-						esse Dei Filium vos putare, jam nus ab ista <lb/> sollicitudine liberasti : affirmasti
-						enim non vos dicere, <lb/> de nihilo esse Dei Filiuin. Dc aliqua ergo substantia <lb/>
-						est. Si non de Patris; de qua? Dicite. Sed non in­ <lb/> venitis. Jam igitur unigenitum
-						Dei Filium Jesum Chri­ <lb/> stum Dominum nostrum de Patris esse substantia non <lb/>
-						vos nobiscum pigeat conteri.</p>
-					<p>5. Pater crgo et Filius unius sunt ejusdemquc sub­ <lb/> stantiæ. noc est illud
-						Homousion, quod in concilio <lb/> Nicæno adversus hæreticos Arianos a catholicis Pa­
-						<lb/> tribus veritatis anctoritate et auctoritatis veritate fir­ <lb/> matum est : quod
-						postea in concilio Ariminensi, <lb/> propter novitatem verhi minus quam oportuit intel­
-						<lb/> lectum, quod tamen I fides antiqua pepererat, multis <lb/> paucorum fraude
-						deceptis , hæretica impietas sub <lb/> hæretico imperatore Constantio labefactare
-						tentavit. <lb/> Sed post non longum tempus libertate fidei catholicæ <lb/> prævalente,
-						posicaquam vis verbi, sicut debuit, in­ <lb/> tellecta est, Heroousion illud catholicæ
-						fidei sanitate <lb/> longe lateque defensum est. Quid est enim Homou­ <lb/> sion, nisi
-						unius ejusdemque substantiæ? Quid est, <lb/> inquam , Homousion, nisi, <hi rend="italic">Ego et Pater</hi> unum <hi rend="italic">su­</hi>
-						<lb/> mus ( <hi rend="italic">Joan. x,</hi> 50 ) i Sed nunc nec ego Nicænum, nee <lb/>
-						tu dehes Ariminense tanquam præjudicaturus pro­ <lb/> ferre concilium. Nec ego hujus
-						auctoritate, nec tu <lb/> illius detineris : Scripturarum auctoritatibus, non <lb/>
-						quorumque propriis, sed utrisque communibus testi­ <lb/> bus, res cum re, causa cum
-						causa, ratio cum rationo <lb/> concerlet. Utrique legimus, <hi rend="italic">Ut simus in
-							vero Filio<lb/> ejus Jesu Christo; ipse est verus Deus et vita</hi> æ<hi rend="italic">terna.</hi>
-						<lb/> Utriquc tanti ponderis molibus cedamus. Dic ergo <lb/> nobis, utrum iste verus Dei
-						Filius, ab eis qui gratia <lb/> lilii sunt hujus nominis quadam proprietate discretus,
-						<lb/> de nulla substantia sit, an de aliqua. <hi rend="italic">Non dico,</hi> inquis, <lb/>
-						<hi rend="italic">de nulla, ne de nihilo dicam.</hi> Ergo de aliqua est : <lb/> quTro,
-						de qua ? Si non de Patris, aliam quere. Si <lb/> aliam non invenis , quia omnino non
-						invenis; Patris <lb/> agnoscc, et Filium cum Patre Homousion confitere. <lb/> Caro de
-						carne nascitur, filius carnis de substantia <lb/> carnis nascitur. Corruptionem de medio
-						tollite, pas­ <lb/> siones carnales a lumine mentis abjicitc, et invisibilia <lb/> Dei,
-						per ca quæ facta sunt , intellecta conspicite <lb/>
-						<hi rend="italic">(Rom.</hi> I. 20). Credite Creatorem, qui dedit carui car­ <lb/> nrm
-						gignere, qui dedit parentibus vcros carnis filios <lb/> de carnis substantia generare,
-						ac sic filios cum parcn­ <lb/> tibus unius esse substantiæ , multo magis potuisse <lb/>
-						verum gignere Filium de sua substantia, et unam cum <lb/> vero Filio habere substantiam,
-						manente incorruptione <lb/> spirituali, ct longissime hinc alicna corruptione car­ <lb/>
-						nali.</p>
-					<p>4. Nam de anima quid dixeris, nescio. Verba enim <lb/> tua sunt, ubi dicis : <hi rend="italic">Nee enim ad</hi> animæ <hi rend="italic">ingenuitatem <lb/> comparatis
-							tantam illam magnificentiam, sed ad fragili­ <lb/> tatem corporis. De corpore
-							utique,</hi> inquis, <hi rend="italic">nascitur caro,<lb/> corporalis filius : non
-							tamen de anima anima nascitur.</hi>
-						<lb/> Post istam quasi definitionem tuam, rursus affirmas <lb/> animam filios generare.
-						Adjungis cuiun, et dicis : Si <lb/>
-						<hi rend="italic">ergo nostra anima incorruptibiliter</hi> generat <hi rend="italic">et</hi> impassi­ <lb/>
-						<hi rend="italic">biliter,</hi> nullam sentiens <hi rend="italic">diminutionem, non
-							inquinatio­</hi>
-						<lb/> nem <hi rend="italic">aliquam; scd legitime secundum</hi> jura <hi rend="italic">divina ge­ <lb/> ncrat</hi> filium , <hi rend="italic">sapientia</hi> consensum I <hi rend="italic">accommodans <lb/> corpori, ipsa integra</hi> manet : <hi rend="italic">quanta magis omnipotens</hi>
-						<note type="footnote"> I Mss., <hi rend="italic">mimis quam potuit intellectam, qucm
-								tamen,</hi> etc. </note><note type="footnote"> I Editio Erasmi, hic et supra in
-							collatione cum vaximino, <lb/>
-							<hi rend="italic">generatum Iiliunl, savientium</hi> COn.ensu, <hi rend="italic">acconunodans</hi> cor- <lb/> 1&gt;o i. Minus recte. tov. constanter, <hi rend="italic">ct</hi> capktuU.-6ed paiti­ <lb/> cuh, <hi rend="italic">et,</hi> aL
-							est a Mss. </note>
-						<lb/>
-						<pb n="773"/> Deus ? Et paulo post dicis : <hi rend="italic">Quanto magis Deus Puter
-							<lb/> meorruptibilis incorruptibiliter</hi> genuit <hi rend="italic">Filium</hi> ? Jam
-						<lb/> supra dixi, nescire me quid volueris de anima intel­ <lb/> ligi, de qua prius
-						dixisti quod non nascatur anima de <lb/> anima, et postea, quod anima incorruptibiliter
-						gignat <lb/> filium. Si animam gignit, quomodo non nascitur anima <lb/> de anima? Si
-						carnem, tu videris quomodo sit caro <lb/> verus animae filius. Christus enim, propter
-						quem pu­ <lb/> lasti hanc adhibendam similitudincm , verus est Dei <lb/> Filius. Si
-						autem incorruptibiliter gignere animam <lb/> filium sic accipi voluisti, quomodo ait
-						Apostolus , <hi rend="italic">In <lb/> Christo enim Jesu per Evángelium ego vos
-							genui</hi> (1 <hi rend="italic">Cor.</hi>
-						<lb/> iv, 15); cur non attendis, quod jam erant ilłæ animæ <lb/> in vctere vita, quas
-						per Evangelium renovando Apo­ <lb/> stolus genuit ? Verbum autem Dei Deus unigenitus
-						<lb/> Filius, sicut jam disputavimus, non prius aliquid <lb/> fuit, et renovatione est
-						generatus a Patre, sed cum <lb/> Patre semper fuit; sicut est semper atque erit mira­
-						<lb/> bili atque ineffabili modo genitus ab æterno coæter­ <lb/> nus. Sed si ob hoc
-						introduxisti hanc dissimilem simi­ <lb/> litudinem, ut assereres Deum Patrem
-						incorruptibi­ <lb/> liter genuisse : noli laborare; confiteor omnino, in­ <lb/>
-						corruptibiliter genuisse Deum Patrem , sed quod est <lb/> ipse genuisse. Iterum enim
-						dico hic, quod vobis sæpe <lb/> dicendum est: Aut de aliqua substantia natus est Dei
-						<lb/> Filius, aut de nulla. Si. de nulla, ergo de nihilo ; <lb/> quod vos non dicere jam
-						tencmus. Si de aliqua, nec <lb/> tamen de Patris, non vcrus est Filius. Si de Patris ,
-						<lb/> unius ejusdemque substantiae sunt Pater et Filius. <lb/> Quomodo autcm nihil Filio
-						subtraxit, ut dicis, si <lb/> ejusdem substantiae est, et tamen minor est, nec sicut
-						<lb/> infans crescere potest ?</p>
-					<p>5. Jam vero de immortalitate Dei, quia non Pa­ <lb/> irem, sed Deum qui et Patcr est et
-						Filius et Spiritus <lb/> sanctus , solum habere immortalitatem dixit Aposto­ <lb/> lus,
-						satis superius disputavi, quando ipsum aposto­ <lb/> icum testimonium et posui totum ,
-						et exposui.</p>
-					<p>6. Displicet tibi , quod æqualem Patri asserimus <lb/> Filium : quasi possit esse
-						inæqualis, qui verus est <lb/> Filius, non natus ex tempore, sed gignenti coæternus,
-						<lb/> sicut splendor ab igne genitus gignenti manifestatur <lb/> æquævus. Sed <hi rend="italic">habet,</hi> inquis , <hi rend="italic">Dei Filius auctorem</hi> Pa­ <lb/>
-						<hi rend="italic">trem.</hi> Si propterea Deum Patrem Deo Filio dicis <lb/> auctorem,
-						quia ille genuit, genitus est iste; quia iste <lb/> de illo est, non illc de isto;
-						fatcor et concedo. Si au­ <lb/> lem per nomen auctoris minorem vis facere Filium, <lb/>
-						Patrernque majorem, nec ejusdem substantiæ Filium <lb/> cujus est Pater; detestabor et
-						respuam : quia ct filius <lb/> hominis, in quantum est filius, habet auctorem do <lb/>
-						quo natus cst, patrem; nee tamen ideo non est ejus­ <lb/> dem substantiæ cujus est pater
-						; et quod iste minor, <lb/> major est ille, potest tamen ad formam patris valen­ <lb/>
-						tiamque pervenire crescendo, in qua patrem propterea <lb/> non omni modo invenit talem ,
-						quia et ille defecit <lb/> senescendo. Sic enim necesse est varietur ætale mor­ <lb/>
-						talitas, ubi temporalis est, non aeterna nativitas. Non <lb/> autem illa siC cst, ubi
-						nee crescit . FiliuS, nec sene­ <lb/> scit Pater. Et ideo amborum non impar cst ætas;
-						qnia <lb/> ubi est æternitas, nou est ætas : idco forma non im­ <lb/> par amborum;
-						quoniam verus Filius, qni non ut au­ <lb/> geretur cst natus, ne remanerct degener, a
-						qualis <lb/> est natus, Sit ergo nalivitatc humana longe melior ct <lb/> excellentior
-						divina nativitas, incorruptibili et invio­ <lb/> labili generatione : non tamen sit
-						deterior, diversi­ <lb/> late naturæ.</p>
-					<p>7. Sed <hi rend="italic">vitam Filius,</hi> inquit, <hi rend="italic">accepit a
-							Patre.</hi> Acce­ <lb/> pit sicut genitus a gignente. <hi rend="italic">Omnia,</hi>
-						inquit, <hi rend="italic">quæ ha­<lb/> bet Pater,mea sunt. (Joan.</hi> xvi, 15). Omnia
-						ergo quæ <lb/> habet Pater, dedit ille gignendo, accepit iste na­ <lb/> scendo. Nec
-						dando ille amisit quod habuit; nee iste <lb/> cum esset et non haberet accepit: sed
-						sicut ille per­ <lb/> mansit habens omnia, cum ea quæ habet Filio dede­ <lb/> rit omnia
-						; sic iste nunquam fuit sinc omnibus, quæ <lb/> non egendo, sed nascendo accepit ut
-						Filius : quia <lb/> nunquam potuit esse non natus, et ca sine quibus <lb/> non est
-						natus, ct est immutabilis natus, semper ha­ <lb/> buit, quia semper est natus. Si cniin
-						aliquid eorum <lb/> Quæ habet Pater non dedit Filio, falsum est quod ait <lb/> Filius :
-							<hi rend="italic">Omnia qum habet Pater, mea sunt.</hi> Sed quia <lb/> verum est,
-						prorsus omnia quæ habet Pater, dedit, <lb/> ut diximus, ille gignendo, accepit iste
-						nascendo. <lb/> Ac per hoc dedit ille vitam, quia gcnuit vitam; ac­ <lb/> cepit iste
-						vitam, quia natus est vita : si minor, si de­ <lb/> color *, si diversa, non ergo quam
-						Pater habuit hanc <lb/> dedit Filio. Et quomodo vcrum est, <hi rend="italic">Omnia
-							quæ</hi> ha­ <lb/>
-						<hi rend="italic">bet Pater, mea sunt ?</hi> Sed quis audeat dicere, Verum <lb/> non cst
-						. quod Veritas dixit? Quapropter <hi rend="italic">sicut habet <lb/> Pater vitam in
-							semetipso, sic dedit et Filio</hi> vitam <hi rend="italic">ha­<lb/> bere</hi> in <hi rend="italic">semetipso</hi> ( <hi rend="italic">Id.</hi> v, 26). Sicut habet dedit,
-						<lb/> quod habet dedit, qualem habeL, talem dedit; quan­ <lb/> tam habet, tantam dedit.
-						Omnia quæ habct Pater, <lb/> Filii sunt. Non ergo aliquid minus quam Pater habet <lb/>
-						Filio dedit; nec amisit Pater vitam, quam Filio dedit. <lb/> Vivendo enim tenuit, quam
-						pignendo dedit. Vita est <lb/> autem ipse Pater, vita est ipse Filius. Et ille quippe
-						<lb/> et iste id habet quod et ipse I : sed ille de nulle vita, <lb/> iste vita de vita;
-						sed talis qualis illa, tanta quanta <lb/> illa, hoc omnino quod illa ; quia ,crus est
-						Filius, qnia <lb/> perfectus cst Filius, quia non est degener ab uno Deo <lb/> Patre
-						Deus unicus Filius, Patri ergo æqualis est Fi­ <lb/> lius. Quidquid eum dicis a Patre
-						accepisse, fatemur <lb/> et nos : prorsus Pater dedit, Filius accepit. Sed cum <lb/>
-						Pater omnia quæ habet gignendo dedit, æqualem <lb/> utique genuit, quoniam nihil rninus
-						dedit. Quomodo <lb/> ergo tu dicis, quia ille dedit, ille accepit, ideo æqua­ <lb/> lem
-						Filium Patri non esse : cum eum cui data suut <lb/> omnia, et ipsam æqualitatem videas
-						accepisse ? <lb/> Scriptum est quidem, Beatum <hi rend="italic">est magis d(tre quam
-							<lb/> accipcre (Act.</hi> xx, 35) : sed in hac vita ubi est ino. <lb/> pia, qua utique
-						melior cst copia. Melius enim cst <lb/> habere, quam egere ; et melius est donare, quam
-						ac­ <lb/> cipere '; erogare, quam mendicare. Ubi antem qui <lb/> dcdit, gignendo dedit ;
-						ct qui accepit, nascendo ac­ <lb/> cepit: non inopi subventum est, scd ipsa copia gu­
-						<lb/> ncrata est. Nec potest qui accepit ei qui dedit esM <note type="footnote"> I
-							Editi, <hi rend="italic">discolor.</hi> At Mss., <hi rend="italic">decolor.</hi>
-						</note><note type="footnote"> 1 sic Mss. Editi vero, <hi rend="italic">quod est
-								ipse.</hi>
-						</note><note type="footnote"> I Mn. Er. et MSS. omittunt, <hi rend="italic">qutun
-								ucciiwe; crogare.</hi>
-						</note>
-						<lb/>
-						<pb n="775"/> inæqualis, qnia ct hoc accepit ut esset æqualis. Nihil <lb/> euim Patre
-						minus habet illc qui dicit, <hi rend="italic">Omnia quæ<lb/> habet Pater, mea sunt.</hi>
-						Æqualis est igitur. Sed quia <lb/>
-						<hi rend="italic">semetipsum exinanivit, fomam servi accipiens,</hi> non <lb/> formam
-						Dei perdens; ita factus cst in eadem servi <lb/> forma <hi rend="italic">obediens usque
-							ad</hi> mortem <hi rend="italic">crucis (Philipp. II,</hi>
-						<lb/> i, 8), in qua paulo minus minoratus est ab Angelis <lb/>
-						<hi rend="italic">( f'Bal.</hi> VIII, C), ut Patri in forma Dei maneret aequalis: <lb/>
-						quia non est forma illa mutabilis.</p>
-					<p>8. Quid itaque mirum est, si na quæ commemoras, <lb/> dicit, <hi rend="italic">Ego quæ
-							plucila sunt Patri, facio semper ( Joan.</hi>
-						<lb/> VIII, 29) : ct ad monumentum Lazari, <hi rend="italic">Pater. gratias<lb/> ago
-							tibi, qnia audisti me; et ego sciebam quia semper</hi> me <lb/>
-						<hi rend="italic">aidus, sed</hi> propter <hi rend="italic">eoa qui circumstant dixi, ut
-							credant <lb/> quia</hi> tu <hi rend="italic">me misisti (ld.</hi> XI, 41, 42) : ct
-						iterum, <hi rend="italic">Aie</hi> opor­ <lb/>
-						<hi rend="italic">tet operari opera ejus qui me misit (Id.</hi> IX, 4) : ct an­ <lb/>
-						tequam panes frangeret, prius <hi rend="italic">Patri gratias egit (Matth.</hi>
-						<lb/> XXVI, 26 ; <hi rend="italic">Marc.</hi> vin, 6, <hi rend="italic">et Joan.</hi>
-						vi, 11) ? Si his atque <lb/> hujusmodi testimoniis id ostendere voluisses, quod <lb/> in
-						forma servi Filius minor cst Patrc, et in ipsa for­ <lb/> ma Dei iste de illo non ille
-						de isto est; quod sæpe si­ <lb/> gnificans , multa ita dicit, ut cum non intelligentes
-						<lb/> etiain in ipsa divinitate arbitrentur minorem : sic te­ <lb/> neres rectam regulam
-						fidci, ut non contradiceres ve­ <lb/> rilati; nec per talia testimonia oppugnarcs
-						Evange­ <lb/> lium, sed doceres. Quæ suut eniin placita Patris , <lb/> quæ non sunt et
-						Filii V aut unde potest facerc Filius, <lb/> nisi quæ placita sunt Patri, a quo habet
-						omnia in qui­ <lb/> bus æqualis est Patri? Quomodo non gratias agit <lb/> Patri de quo
-						est, præsertim in forma servi , in qua <lb/> illo minor cst? Quomodo non Patrem rogat ut
-						homo, <lb/> qui cum Patrc cxaudit ut Deus ? Quis autem christia­ <lb/> nus ignorat qucd
-						Pater miserit, missusque SiL Filius? <lb/> Non euim genitorem ab co quem genuit, sed
-						genilum <lb/> a genitore mitti oportebat : verum hæc non est in­ <lb/> æqualitas
-						subsiantiæ, sed ordo naturæ ; non quodalter <lb/> prior esset allero, sed quod alter
-						esset ex allero. <lb/> Oportebat ergo operari eum qui missus cst, opera <lb/> ejus a quo
-						missus est: et quæ sunt opera Patris, quæ <lb/> non suut et Filii; cum dicat idem
-						Filius, <hi rend="italic">Quæcumque <lb/> Pater facit, hæc et Filius similiter facit
-							(Joan.</hi> v, 19) ? <lb/> Opera tamen Patiis esse dicit: non » nim obliviscitur <lb/>
-						a quo sit; a Patre quippe illi est ut operator talium <lb/> operum sit. Ilac autcm vos
-						ita intelligilis , ut hinc <lb/> etiam putetis Patrem Filio esse majorem, quia dixit
-						<lb/> passerem non caderc in lerram sine Patris voluntate <lb/>
-						<hi rend="italic">(Matth.</hi> x, 29); quasi cadat sine voluntate Filii. An <lb/> usque
-						adco minorem vultis Filium, ut non habcat in <lb/> potestate nec passeres? Sed si non
-						vultis huic regulæ <lb/> acquiescere , ut ubicumque legeritis in auctoritate <lb/>
-						divinorum eloquiorum , quo 1 minor Patre Filius vi­ <lb/> deatur ostendi, aut ex forma
-						servi dictum accipiatis, <lb/> in qua vcre innuor est Patre; aut ideo dictum , quo <lb/>
-						non demonstretur major vel minor ullus esse allero, <lb/> scd demonstretur esse alter ex
-						altero : si huic, in­ <lb/> quam, rectissimæ regulæ non vultis acquiescere ; certe <lb/>
-						tamcn verum Dni Filium nulla ratione dicetis, si non <lb/> ejusdem substantiæ, cujus
-						Pater es!, cum esse dica- <note type="footnote"> I falili, quibus. Concinnius ':ss., <hi rend="italic">q!:o.</hi>
-						</note>
-						<lb/> lis. Ut enim humanum aliquid dicam propter infirmi. <lb/> tatem carnalium : cum
-						homines duo sunt, pater et <lb/> filius, si obediens sit patri filius, et aliqua
-						existente <lb/> causa roget patrem , gratias agat patri, aliquo lIcui.. <lb/> que
-						Initiatur a patre, ubi se dicat non venisse facere <lb/> voluntatem suam, sed ejus a quo
-						missus est; num­ <lb/> quid hinc ostenditur non ejusdem cujus pater est esse <lb/>
-						substantix ? Cur ergo ubi de Filio Dei talia legitis, <lb/> statim in tantum sacrilcgium
-						corde atque ore prorui­ <lb/> tis, ut veri Filii Dei unam eamdemque cum Patre <lb/>
-						substantiam non esse credatis atque dicatis ?</p>
-					<p>9. Quid quod etiam illud commemorandum putasti, <lb/> quod manifestissime ut homo
-						loquitur: <hi rend="italic">Potestatem ha­ <lb/> beo ponendi animam meam, et potestatem
-							habeo iterum <lb/> sumendi eam. Hoc</hi> enim præceptum <hi rend="italic">accepi a
-							Patre meo?</hi>
-						<lb/> Quid hoc adjuvat causam tuam ? Numquid enim aliud <lb/> dixit, nisi, Potestatem
-						habco-moriendi et resurgendi ? <lb/> Quod itaque ait, <hi rend="italic">Nemo eam tollit
-							a me, sed ego</hi> eam <lb/>
-						<hi rend="italic">pono</hi> a me, <hi rend="italic">et iterum sumo eam (Joan.</hi> x,
-						18) ; quid in­ <lb/> telligi voluit, nisi se non fuisse moriturum, nisi ipse <lb/>
-						voluisset ? Numquid tamen nisi horno esset , mori et <lb/> resurgere potuisset ? Sic
-						autem introduxisti hoc testi­ <lb/> monium, ut præłoquereris, dicens, <hi rend="italic">Hic sane et de sua <lb/> potestate quam a Patre accepit dicebat,</hi> « <hi rend="italic">Potestatem <lb/> habeo ponendi animam</hi> meam, <hi rend="italic">ei
-							potestatem habeo ite­<lb/> rum sumendi eam</hi> : &gt; tanquam si homo non esset, po­
-						<lb/> siturus esset animam. Ut homo ergo, non ut Dcus, <lb/> accepit hanc potestatem :
-						quamvis non dixerit, Hanc <lb/> potestatem; sed, <hi rend="italic">hoc</hi> præceptum
-							<hi rend="italic">accepi a Patre</hi> meo. <lb/> Quis autem nesciat
-							<unclear>aluid</unclear> esse præceptum , aliud po­ <lb/> testatem ? Hoc enim habemus
-						in potestate, quod cum <lb/> volumus possumus. Pracceplum vcro id nobiscum agit, <lb/>
-						ut quod jam est in potestate faciamus : si autem non­ <lb/> dum est in potestate, oremus
-						nohis patestatem dari, <lb/> ut qnod præceptum cst impleamus. Quocirca si ea <lb/> qu:c
-						aperta sunt velitis attendere, ut homo acceperat <lb/> hanc potestatem. Sed propter
-						contentiosos ego ad <lb/> utrumque concludam : Si ut homo accepit hanc po­ <lb/>
-						testatem, nihil libi prodesse hoc testimonium et tu <lb/> vidcs; quia si ex hac
-						potestate a Patre accepta, mi­ <lb/> norem Patre Filium vis probare, nee nos dubitamus,
-						<lb/> quod in quantum homo est Christus, minor est Patre : <lb/> si autem ut Deum vis
-						accepisse hanc potestatem, Hi.. <lb/> gnendo cum Pater æqualem sibi, dedit ei omnium
-						<lb/> rerum tantam, quanta ipsi Patri est 1, potestatem. Si <lb/> enim minus habet in
-						potestate aliquid quam Patcr, <lb/> non sunt ejus omnia quæ habet Pater : sed quia ejus
-						<lb/> sunt, tantem procul dubio habel potestatem quantam <lb/> Pater. Praeceptum quoque
-						aut ut homo accepit, aut <lb/> ut Deus : si ut ho:no, nulla quæstio ea, quia ut homo
-						<lb/> est Patre minor: si ut Dcus, non hinc ostenditur mi­ <lb/> nor; quia nascendo id
-						accepit, non indigendo. In <lb/> Verbo cnim unico Dei omnia præcepta sunt Dei , quæ
-						<lb/> ille gignens dedit nascenti, non cum genuisset addi­ <lb/> dil indigenti : ac per
-						hoc tantum genuit quantus cst <lb/> ipse; quia de scipso genuit vcrum Filium, et perfc­
-						<lb/> ctum genuit plenitudine divinitatis, non perficiendum <note type="footnote"> 1
-							):ss., <hi rend="italic">qunnti ipsi:ts csl.rat. is.</hi>
-						</note>
-						<lb/>
-						<pb n="777"/> a tatis accessu 1. Sed humilius a tc quæro, quare <lb/> tilium hominis
-						quemlibet hominem, si preceptum ac­ <lb/> cipiat a patre, nun eum dicis alterius esse
-						substan­ <lb/> tiæ, et Filium Dci Demn ob hoc audes negare pa - <lb/> ternæ esse
-						substantiæ, quia præceptum accepit a <lb/> Patre? Prorsus, ct præceptum a Patre
-						accepit,et <lb/> ejusdem substantiæ est, cujus est ille qui dedit. Quis <lb/> te
-						contradicentem ferat, si ad te audiendum homines <lb/> patresfiliique concurrant,
-						ejusdem utrique substan­ <lb/> tiæ ; nec ideo filii degeneres, quod ita præcepta eis
-						<lb/> dederint patres? Sud forte dicis, patres doctos filiis <lb/> indoctis. dedisse
-						præcepta. Refer nuac te ad Dei fi­ <lb/> lium, de Dco Patrc natum Deum, qui utique
-						imper­ <lb/> fectus est natus, si præceptum accepit indoctus. Quia <lb/> vero perfectus
-						est natus, præceptum dedit ille gi­ <lb/> gnendo, accepit iste nascendo. Nunquam enim
-						verus <lb/> Dei Filius indoctus fuit : filius autem numquam non fuit.</p>
-					<p>CAPUT XV. — i. In forma Dei Filium esse non <lb/> negas, et Dco Patri æqualem negas,
-						majorem Patris <lb/> iormam putans esse quam Filii : tanquam non ha­ <lb/> buerit Pater
-						unde formam suam compleret in Filio, <lb/> quem de se ipso genuit ,non fecit ex nihilo,
-						non ex <lb/> alio. Aut si formam suam in unico Filio plonam gi­ <lb/> gnere potuit, nec
-						tamen genuit plenam, sed minorem ; <lb/> quid sequatur altenditc, et in viam redite, ne
-						coga­ <lb/> mini Patrem invidum dicere. Dicitis Deum Filium, <lb/> dicitis Dominum; sed
-						ut duos deos dominosque facia­ <lb/> tis, contra Scripturam clamantem, Audi, <hi rend="italic">Israel; Do­</hi>
-						<lb/> minus <hi rend="italic">Deus</hi> tuus, <hi rend="italic">Dominus</hi> unus est
-							<hi rend="italic">(Deut.</hi> VI, 4). Quid <lb/> autem in hoc sacrilegio vobis
-						prodest, quod Patri da­ <lb/> tis tantam formam, quantam non datis Filio? Num­ <lb/>
-						quid si unus major, alter est minor, ideo non suut <lb/> dii et domini duo? Si carere
-						cupitis hoc errore, sic <lb/> dicite alium esse Patrem, aliam esse filium, ut tamen
-						<lb/> simul ambos non duos dicatis, sed unum Dominum <lb/> Deum. Dicitis rogem Filium de
-						rege Patre utique na . <lb/> tum: nec intuemini in genere humano filios regum <lb/>
-						etiamsi non sunt ex ,regibus reges, esse tamen ex ho­ <lb/> minibus homines; nec habere
-						potestatem cum pa­ <lb/> tribus regiam, et tamen eamdem tenere naturam. Vos <lb/> autem
-						Filio Dei rogis regnum cum Patre conceditis, <lb/> ct naturam paternam, vanitate impia
-						denegatis ; cum­ <lb/> que Deo Patri dicitis inrqualem, <hi rend="italic">qui non
-							rapinam,</hi>
-						<lb/> hoc est, non alienum <hi rend="italic">arbitratus est esse æqualis Deo ;<lb/>
-							sed</hi> tamen non intendens quæ sua sunt , sed qu;c no­ <lb/> stra sunt, <hi rend="italic">semetipsum exinanivit;</hi> non formam Dei <lb/> perdens, sed formam <hi rend="italic">serii accipiens,</hi> in qua est Patri <lb/>
-						<hi rend="italic">factus obediens usque ad mortem crucis (Philipp.</hi> II, <lb/> C 8).
-						I.. qua forma cnm non vultis sic agnoscere Pa­ <lb/> tre Deo minorem. ut in Dci forma
-						Patri non negetis <lb/> æqualem. « Nos, i inquis, * dicti sumus filii gratia, <lb/> non
-						natura hoc nati : ideo unigenitus est Filius, quia <lb/> qnod est secundum divinitatis
-						suæ naturam , hoc cst <lb/> natus Filius. i Hæc non tua solum, verum etiam no­ <lb/>
-						stra suit verba. Cur erro quem Dei Filium natura <lb/> non gratia confiteris, ejusdem
-						naturæ, cujus Pater <lb/> cst, non esse contendis,nec quid mali abs tc dicatur <note type="footnote"> I Sic Am. F.r et Mss. At Lov., <hi rend="italic">el uc;'jert,znt
-								qcnuit plt';:i- <lb/> Vtdincm divinitatis, non perficiendam ætatis
-							accessu-</hi></note>
-						<lb/> attendis ? Nunnc regis <unclear>Dei</unclear> Filio paternum regnum au <lb/>
-						ferres tolerabilius quam naturam?</p>
-					<p>2, Dc Spiritu autem sancto, quomodo e' ipse de <lb/> Deo sit, nec tamen et ipse filius
-						sit, quoniam proce­ <lb/> dendo, non nascendo legitur esse de Deo, jam supe­ <lb/> rius,
-						quantum satis visum est, disputavi. Nos, inquis, <lb/>
-						<hi rend="italic">in Patrem Deum innatum,</hi> naturam non <hi rend="italic">accepimus.</hi>
-						<lb/> Et tanquam rationem reddens, cur Dei Patris non <lb/> dicatis esse naturam , mox
-						adjungis, et dicis, <hi rend="italic">Credi­</hi>
-						<lb/> mus <hi rend="italic">quod ait Christus,</hi> i <unclear/><hi rend="italic">Spirituc eat Deus</hi> » <hi rend="italic">(Joan. IV.</hi>
-						<lb/> 24) : quasi Christus secundum id quod Deus est, <lb/> non spiritus sit, quem tamen
-						natura Filium esse <lb/> dixisti. Nan ergo Pater ideo natura non est, quia spi­ <lb/>
-						ritus est. Sed forte quia natu uon est, idco eum non <lb/> vultis esse naturam; putatis
-						enim quod a nascendo <lb/> uatura sit dicta. Scitote ergo, quod unaquæque res <lb/> esse
-						dicitur per substantiam, hoc esse utique per <lb/> naturam. Certe si non putatis esse
-						dicendum, ejusdem <lb/> filium cujus Pater est esse naturne; dicite cujus Pa­ <lb/> ter
-						est esse substantiæ : ad causam quæ inter nog <lb/> agitur, sufficit nobis. Verumtamen
-						admonendi cstis, <lb/> ut intueamini quod ait Apostolus, <hi rend="italic">His qui
-							natura</hi> non <lb/> sunt <hi rend="italic">dii, servistis (Galat.</hi> IV, 8): ubi
-						certe nos Deo <lb/> qui natura est Deus, servire monstravit. Vos ergo qui <lb/> Deum
-						Patrem non natura Deum esse creditis, ubi <lb/> cum constituatis, advertite; et si ullus
-						in vobis pudor <lb/> est, erubescite. Eccc nos dicimus vobis, non servi­ <lb/> mus Deo
-						qui natura non est Deus; ne simus tales, <lb/> quales fuerunt illi quihus dictum cst,
-							<hi rend="italic">His</hi> qui <hi rend="italic">natura <lb/> non sunt dii,
-							servistis.</hi> Vos si tales esse vultis, <lb/> petimus ne velitis, et Deum Patrem
-						natura Dcum <lb/> esse dicatis : ejusque Filium, quem non gratia, sed na­ <lb/> tura
-						Filium jam esse dicitis, ejusdem nature cujus <lb/> Pater est non negetis, ne nihil
-						aliud qnam Filium <lb/> esse verum negetis. Quomodo enim dicitis, et ve­ <lb/> rum
-						Filium vos profiteri, et Putri similem non ne­ <lb/> gare, quando cum negatis unius cum
-						Patre esse sub­ <lb/> stantiæ ? Sicnt autem verum Filium indicat una sub­ <lb/> stantia,
-						sic non verum diversa substantia. Quomodo <lb/> autem Filium Patri similem dicitis, cui
-						Patris sub­ <lb/> stantium ,dare non vultis ? Nonnc similis homini est <lb/> pictura vel
-						statua, et tamen filius dici non potest, <lb/> qnia diversa substantia est ? Homo nempe
-						ad Dci si­ <lb/> militudine ii factus cst; tamen quia non est unius <lb/> ejusdemque
-						substantiæ, fton est verus filius; et ideo <lb/> fit gratia filius, quia non est natura.
-						Si ergo vultis <lb/> Dei Filium verum confiteri, prius illum ac praecipuc <lb/> dicite
-						unius ejusdemque substantiæ, ut tanquam ve­ <lb/> rum Filium ct Dei Filium pcr omnia
-						similem Patri <lb/> esse dicatis. Nam quem substantiam putatis habere <lb/> diversam,
-						plus eum dissimilem quam similem dicitis, <lb/> et omnino verum Filium denegatis. Nam
-						vultis I <lb/> nosse, ad ostendendum verum filium quantum va­ <lb/> leat una eademque
-						substantia : etiamsi filius hominis <lb/> homo in quibusdam similis, in quibusdam sit
-						disci­ <lb/> milis patri; tamen quia ejusdem substantiæ est, ne­ <lb/> gari vcrus filius
-						uon potest: et quia verus est filius, <lb/> negari ejusdem substantiæ non potest. Vos
-						autem ita <note type="footnote"> ' sola editio 1.0\'.: <hi rend="italic">Sec
-								vultis.</hi>
-						</note>
-						<note type="footnote"> PATROl... XLII. </note>
-						<note type="footnote">
-							<hi rend="italic">(Vingt-cinq.)</hi>
-						</note>
-						<lb/>
-						<pb n="779"/> dicitis verum Dei Filium similem Patri, ut substantiæ <lb/> velitis esse
-						diversa, per qnam solam potest filius ve­ <lb/> ros ostendi. Nam duo verihomines etsi
-						nullus corum <lb/> filius silahcrius, umus tamen suni et ejusdem sub. <lb/> stantiae :
-						homo autem alterius, hominis verus filius <lb/> nullo modo potest nisi ejusdem cum patre
-						esse sub­ <lb/> stantiæ,etiamsi non sit par omn a similis patri <lb/> Quocirca verus Dei
-						Filius ct unius cum Patre Fubstan <lb/> tiæ est, quia verus Filius est : et per omnia
-						est Patri <lb/> similis, quia Dei Filius est. Nequc enim sicut contin­ <lb/> git in
-						filiis hominum vel quoramcumque animalium, <lb/> ita fas est dicere, verum Dei Filium
-						substantiæ qui­ <lb/> dem unius esse cum Palrc, sed non per omina <lb/> similem Patri.
-						Nicaenum igitur tenete nobiscum con­ <lb/> cilium , si voltis Christum dicere verum Dei
-						Filium.</p>
-					<p>5. <hi rend="italic">Diversas,</hi> inquis, <hi rend="italic">accusamur dicere
-							natura.</hi> Et <lb/> quid aliud dicis de Den Patre ct Dco Filio? quid aliud <lb/>
-						dicis? An idco putas ab isia accusatione purgari% <lb/> quia continuo subjungis dicens :
-							<hi rend="italic">Hoc scito quod nos <lb/> dicimus, quod Puter</hi> spiritus spiritum
-							<hi rend="italic">genuit ante omnia<lb/> sæcula, Deus Deum genuit?</hi> .loc quidem
-						dicitis, et <lb/> veruin dicitis : sed hoc tacuisti, quod falsum ct exse­ <lb/> crabilc
-						dicitis. <hi rend="italic">Spiritus</hi> enim spiritum genuit, verum <lb/> dicitis : sed
-						hoc verum ea intentione vos dicitis, <lb/> quia etiam diversæ naturae dicitur spiritus.
-						Nam di­ <lb/> versa; naturæ sunt Spiritus Dei, sive Spiritus Deus, <lb/> et spiritus
-						hominis; et tamen uterque dicitur spiritus: <lb/> Itemdiversæ naturæ sunt spiritus
-						hominis et spiritus <lb/> pecoris; et tamen nihilominus uterque spiritus dicitur. <lb/>
-						hem dicitur, Deus Dens, et dicitur deus homo : sicut <lb/> dictum cst, <hi rend="italic">Dii estis</hi> ( <hi rend="italic">Psal.</hi> nIxi, 6). Et sicut datus <lb/> est 1
-						deus Moyses Pharaoni <hi rend="italic">( Exod.</hi> VII, 1). Et cum <lb/> sit Dei ct
-						hominis diversa substantia, tan:en uterque <lb/> appellatur Deus. Prorsus veraciter
-						arguimini, quam­ <lb/> vis dicatis de Deo Patre cl Deo Filio, <hi rend="italic">Spiritus
-							spiri­<lb/> tum</hi> genuit, naturas tamen diversas diccre : et quam­ <lb/> vis
-						dicatis, <hi rend="italic">Deus Deum genuit;</hi> etiam sic non recedere <lb/> a
-						diversitate naturæ, quia non per omnia similem <lb/> Patri esse dicitis Filium. Nam si
-						per omnia si­ <lb/> mitem diceretis correquenter intelligeremini quod <lb/> cos
-						diceretis etiam unius cjusdemque esse naturae <lb/> sive substantiæ. Si ergo ab hoc
-						crimine quod vobis <lb/> objicitur, Dei Patris et Dei Filii vos dicere naturas <lb/>
-						esse diversas, purgare te cogitas: sicut dicis, <hi rend="italic">Spiritus</hi>
-						<lb/> spiritum <hi rend="italic">genuit;</hi> ita dic, Spiritus ejusdem naturae sivc
-						<lb/> substantiæ spiritum genuit. Item, sicut dicis, <hi rend="italic">Dens<lb/> Deum
-							genuit;</hi> ita die, Deus ejusdem naturae sive sub­ <lb/> stantiæ Deum genuit. Hoc si
-						credideris, et dixeris, <lb/> nihil de bac re ulterius accusaberis. Si autem hoc non
-						<lb/> dixeris , quid prodest quia dicis, Verus <hi rend="italic">innatus Pater <lb/>
-							verum genuit Filium;</hi> cum procul dubio verus Filius <lb/> ton sit, si non est
-						unius ejusdemque substantiæ eum <lb/> illo qui genuit ?</p>
-					<p>4. Dicit quidem Filius ad Patrem , <hi rend="italic">Hæc</hi> est <hi rend="italic">autem<lb/> vita œterna,</hi> ut cognoscant te solum terum <hi rend="italic">Deum, et
-							<lb/> quem misisti</hi> Jesum <hi rend="italic">Christum (Joan.</hi> XVII, 5) : Id
-						est, . <lb/> te et quem misisti Jesum Christum, cognoscant solum <lb/> verum Deum. In
-						quibus verbis vos solum Patrem non <note type="footnote">a Sic, 3bd. Fditi autem, dictus
-							est. </note>
-						<lb/> cum Filio verum accipientes Deum , quid allud quita <lb/> Filium ncgatis 'crum
-						Deum? Quia vero Pater ct Fl- <lb/> lius, non duo dii, sed unus cst Deus; sine dubio et
-						<lb/> Filius vcrus est Deus, et adjuncto Spiritu sancto <lb/> solus est Deus. Ncque enim
-						movere nos debel, quod <lb/> nominatus non est hoc loco Spiritus sanctus, tanquam <lb/>
-						non sit Deus, aut non sit verus Deus. Tale est cnim <lb/> fioc quale si quis dicit,
-						nescire Christum ea quæ Dei <lb/> sunt; quoniam dixit Apostolus sic : <hi rend="italic">Et quæ Dei sunt,</hi>
-						<lb/> nemo <hi rend="italic">scit,</hi> nisi <hi rend="italic">Spiritus Dei</hi> (I <hi rend="italic">Cor.</hi> II, 11). Hoc cst <lb/> enim. Nemo <hi rend="italic">scit,</hi>
-						nisi Spiritus <hi rend="italic">Dei;</hi> quod est , Solus <lb/> ea scit Spiritus Dei.
-						Sieut ergo ab hac scientia, quam <lb/> non habere nisi Spiritus Dei dictus est, non
-						excludi. <lb/> tur Christus; sic ab eo quod Patcr et Christus dictus <lb/> est
-						solusverus Deus, non excluditur Spiritus sanctus. <lb/> Sic et nomen illud quod in
-						Apocalypsi nemo nosse <lb/> dictus est, nisi ipse qui hoc habebat scriptum <hi rend="italic">( Apoc.</hi>
-						<lb/> XIX, 12), id est Christus, noverat utique et Pater, <lb/> quod nrgare non
-						potestis; noverat et Spiritus sanctus, <lb/> etiamsi ncgetis. <hi rend="italic">Spiritus</hi> enim <hi rend="italic">omnia</hi> scrutatur, <hi rend="italic">etiam<lb/> altitudines Dei</hi> (I <hi rend="italic">Cor.</hi> II, 10). Nisi forte
-						quia scruta­ <lb/> tor dictus est, ncgatur apprehendere : negetur ergo <lb/> Dens
-						apprehendere corda et renes hominum; scri­ <lb/> ptum est enim , <hi rend="italic">Scrutans corda et renes Deus (Psal.</hi>
-						<lb/> VII,10). Ita ergo dictus est solus verus Deus Pater et <lb/> Jesus Christus, ut ab
-						bac veritate deitatis nullo modo <lb/> alienaretur Spiritus sanctus. Non autem Filius,
-						ut <lb/> tibi vidctur, <hi rend="italic">solum potentem , solum sapientem, solum</hi>
-						<lb/> bonum <hi rend="italic">Patrem</hi> dicit <hi rend="italic">esse Deum.</hi> Deus
-						autem unus ct <lb/> solus est ipsa Trinitas, ut ostendunt ea quae superius <lb/> jam
-						sæpissime diximus.</p>
-					<p>5. Quod autem <hi rend="italic">non</hi> proficientem , <hi rend="italic">sed perfectum
-							<lb/> Deus Pater genuerit Filium Deum;</hi> verum dicis. Sed <lb/> quod ipsam Filii
-						perfectionem, perfectioni Patris non <lb/> vis aquare; hoc falsum dicis, ct vcritati qua
-						verus <lb/> cst Filius contradicis. <hi rend="italic">Homo enim</hi> si <hi rend="italic">posset,</hi> inquis &gt; <lb/>
-						<hi rend="italic">perfectum mox generare filium, non parvulum genera­ <lb/> ret,</hi>
-						qui <hi rend="italic">coaugmentatis annis tandem aliquando</hi> aui <hi rend="italic">geni- ,</hi>
-						<lb/> toris <hi rend="italic">impleat voluntatem.</hi> Verissime 1 omnino contra <lb/>
-						te loqueris. Sed ut contra te non sit quod loqucris, <lb/> agnosce æqualitatem Patris et
-						Filii. Quia et homo si <lb/> posset, filium mox generaret arqpalem , nec exspe­ <lb/>
-						ctaret annos, per quos in forma filii posset voluntas <lb/> ejus impleri. Deus ergo cur
-						non æqualem genuit Fi­ <lb/> lium , cui nec anni necessarii fuerunt per quos id im­
-						<lb/> pleretur, nec omnipotentia defuit? An forte noluit? <lb/> Ergo, quod absit,
-						invidit. Sed non invidit : æqualeur <lb/> igitur gcnui:. Ac per hoc unius ejusdemque
-						substan­ <lb/> tiae : quandoquidem homo, qui propterea quia non <lb/> potest non gignit
-						æqualem , ejusdem tamen subslan­ <lb/> tiæ gignit filium, cujus est ipse. Quod si non
-						esset, <lb/> profecto verus filius esse non posset. Quid est ergo <lb/> quod dicis , <hi rend="italic">Pater tatem genuit</hi> Filium <hi rend="italic">qualis et</hi> nune
-						<lb/> eat, <hi rend="italic">qualis</hi> et <hi rend="italic">permanet sine fine?</hi>
-						Hoc bene diceres , si <lb/> Patri æqualem verum Filium non negares. Cum vero <lb/>
-						perfectum dicis, et aequalem negas, et talem qnalii <note type="footnote"> * EdSti: <hi rend="italic">Fcritatem</hi> veris <hi rend="italic">iiml,</hi> Pic. At Ma&lt;L
-							omiUnat <hi rend="italic">veri­<lb/> tctem.</hi>
-						</note>
-						<lb/>
-						<pb n="781"/> est natus sine line permanere non negas; procul dubio <lb/> minorem Patre
-						filium sine fine mancre pronuntias. <lb/> AC per hoc nascitur filius hominis minor Patre
-						; et <lb/> quia imperfectus nascitur, crescendo ad formam per­ <lb/> venit patris :
-						natus est filius Dei minor Patre; et <lb/> quia perfectus atque immortaliter natu est,
-						nullum <lb/> accipit incrementum , sed cum ipsa perfectio a forma <lb/> Patris in
-						æternum efficit alienum. Ecce qu:e creditis , <lb/> cccequae dicitis; ecce sunt, quod
-						pejus est, quæ docetis. <lb/> Sed <hi rend="italic">inauditorum,</hi> inquis , <hi rend="italic">eat arbitrio</hi> , nt <hi rend="italic">eligant alte­</hi>
-						<lb/> rum <hi rend="italic">de duobus : aut obedientem Patri Filium</hi> , qui i se <lb/>
-						<hi rend="italic">evinanivit, formam servi accipiens <unclear>o</unclear>, cui et Pater
-							« donavit <lb/> nomen quod est super omne nomen</hi> &gt; <hi rend="italic">(Philipp.</hi> II, 7, 9); <lb/>
-						<hi rend="italic">aut interpretationem tuam.</hi> Prorsus auditores quibus <lb/> donat
-						bominus intellectum, non unum de duobus <lb/> istis eligunt, sed utrumque; id cst, et
-						obedientem Pa- <lb/> Iri Filiuin , et interpretationem, vcl potius cxposilio­ <lb/> nem
-						meam, qua ostendi sic obedientem fuisse in for­ <lb/> nia servi, ut formam non amitteret
-						Dei, in qua :'qua­ <lb/> lis est Patri. Tu vero vide quam contumeliose Filio <lb/> Dci
-						tribuas obedientiam , cujus minuis in divinitate <lb/> naturam.</p>
-					<p>CAPUT XVI. - !. Quando autem a me audisti <lb/> prop. r Judæos , <hi rend="italic">humilitatis, non veritatis gratia , <lb/> dixisse Filium quod Deus ejus sit Puter
-							ejus ?</hi> Hoc a <lb/> me ita nunquam audire potuisti, sicut nunquam dixi: <lb/> sed
-						plane dili, propter formam servi dictum esse. <lb/> Sicut autem ipsa forma servi vera ,
-						non falsa ea; ita <lb/> Patrem suum esse eliam propter illam Deum suum * <lb/> veraciter
-						dixit, non humiliter finxit. Quis enim est <lb/> humilitatis, fructus ubi detrimentum
-						est veritatis ? <lb/> Tn autem istam certissimam veritatem ita es refutare <lb/>
-						conatus, ut diceres ideo verba ipsa, quibus ait Domi­ <lb/> nus , <hi rend="italic">Deum
-							meum et Deum vestrum,</hi> ad formam servi <lb/> non pertinere, quia eis verbis post
-						resurrectionem <lb/> ustis est Dominus, quasi formam servi resurrectione <lb/>
-						consumpserit, ac non potius in melius commutaverit: <lb/> quasi non qui mortuus est,
-						ipse etiam resurrexerit; <lb/> quasi non forma quae occisa est, ipsa rcvixerit; quasi
-						<lb/> uon ipsa in cælum levata sit , in ipsa Dei Filius se­ <lb/> deat ad dexteram
-						Patris, in ipsa venturus sit ad vivos <lb/> et mortuos judicandos. Nonnc clarissima
-						Contestatio <lb/> est Angelorum dicentium , <hi rend="italic">Sic veniet,
-							quemadmodum</hi>
-						<lb/> vidistis eum euntem in <hi rend="italic">cœlum (Act.</hi> I, 11). Cur ergo <lb/>
-						post resurrectionem non diceret, <hi rend="italic">Ascendo ad Patrem <lb/> meum et
-							Patrem restrum, Deum</hi> meum <hi rend="italic">et Deum re­</hi>
-						<lb/> strum <hi rend="italic">(Joan.</hi> xx, 47); quando in eadem forma fuerat <lb/>
-						ascensurus, propter quam ex tempore Deus est ejus,. <lb/> qui sine tempore Pater est
-						cjus ? Propter quam for­ <lb/> fam non solum post resurrectionem, verum etiam <lb/> post
-						judicium <hi rend="italic">subjectus erit ei , qui iUi subjecit onmia</hi>
-						<lb/> (1 <hi rend="italic">Cor.</hi> xv, 28). Quotquot ergo testimonia posuisti, <lb/>
-						quibus probares dictum esse Deum Christi, eum qui <lb/> Pater est Christi, discutere
-						quemadmodum dicta sint, <lb/> superfluum judico : sed a te frustra commemorata <lb/>
-						esse, puto quod nec tu dcbeas dubitare.</p>
-					<p>2. Jam vero illud ubi Dominos in eadem carne <lb/> quam resuscitaverat constitutus, et
-						eumdem homincm <lb/> g<unclear>erens</unclear> , ait ad discipulos suos, <hi rend="italic">Data</hi> est <hi rend="italic">mihi</hi> omnis <lb/>
-						<hi rend="italic">potestas in cœlo</hi> et in <hi rend="italic">terra : cuntes</hi>
-						<unclear/><hi rend="italic">avecte omnes gentes, <lb/> baptizantes</hi> toa <hi rend="italic">in</hi> numine <hi rend="italic">Patris ei Filii et</hi> Spiritus <lb/>
-						<hi rend="italic">sancti; docentes eoa servare omnia</hi> quæcumque <hi rend="italic">mandu<unclear>vi</unclear>
-							<lb/> vobis (matth.</hi> XXVIII, 18-20): utquid commemoraveris, <lb/> .et quid inde
-						probare volucris * prorsus nescio. Num­ <lb/> quid enim ait, Data est mihi a Deo meo
-						potestas <lb/> Quod si dixisset, propter ipsam humanam formam <lb/> dictum fuisse ambigi
-						non dcboret. Quia vero non dixit; <lb/> quid isto testimonio volueris agrre, non
-						intelligo. Imo <lb/> intelligo te id egisse , ut abundantius loquereris. Si <lb/> enim
-						tanquam Dco duta est hxc potestas , nascenti <lb/> cain Pater dedit, non indigenti; quia
-						gignendo dedit, <lb/> non augendo. Si vero tanquam homini data est hæc <lb/> potestas ,
-						qni I habet quæstionis? An forte nos admo­ <lb/> ncre voluisti, quod baptizari Dominus
-						jusserit gculcs <lb/> in nominc Patris ct Filii ct Spiritus sancti ? Ubi au­ <lb/> dis
-						unum nomen , ct unam non vis intelligere dcila­ <lb/> tem.</p>
-					<p>3. Quod autem dicisv ct ante incarnationem Chri­ <lb/> sti , Patrem dictuin csse Dum
-						ejus, quoniam scri. <lb/> ptum est \ Unxit <hi rend="italic">te, Deus, Deus</hi> tuus;
-						longe antequam <lb/> Christus venisset in carne : itane Ron intelligis in <lb/>
-						prophetia esse praed clum , tanquam fucrit factum <lb/> quod erat futurum ? Annon sic in
-						prophetia ait ipso <lb/> Dominus , <hi rend="italic">Foderunt manus meas et pedes
-							(Psal.</hi> xxi, <lb/> 48); ct cæterea quihus passionem suam tanto ante <lb/>
-							præ<unclear>nuntiavit</unclear>, et quod futurum fuerat, tanquam jam <lb/> factum
-						esset expressit? Dictum ea ergo in prophetia <lb/> rerum futurarum , tanquani locutione
-						rerum præteri­ <lb/> tarum, <hi rend="italic">Unxit te, Deus, Deus tuus oleo
-							exsultationis pra <lb/> participibus tuis :</hi> participes ejus significans, qui
-						futuri <lb/> fiii rant servi ejus, socii ejus, amici cjus, fratres ejus, <lb/> membra
-						ejus. Prædictum est ergo quod futurum erat, <lb/> ut ungeret Deus Christi hominem
-						Christum: qui tamen <lb/> sic factus est homo, ut maneret Deus. Ungeret autem. <lb/> non
-						visibili ct corporali oleo , sed Spiritu sancto, <lb/> quem Scriptura nomine olei
-						exsultationis, figurata, ut <lb/> solet, locutione significat. Dixit autem , <hi rend="italic">Unxit;</hi> non <lb/> dixit, Uncturus est: quia in prædestinatione jam
-						fa­ <lb/> ctum erat, quod suo tempore futurum erat. Ubi tn <lb/> timens ne Spiritus
-						sanctus, quo unctus est Christus . <lb/> major videatur esse quam Christus, quia revera
-						ma­ <lb/> jor est homine Christo; qui enim sanctificat, eo qui <lb/> sanctificatur est
-						major: hoc ergo timens, voluisti olco <lb/> exsultationis eam lætitiam significatam
-						videri, qua <lb/> Filius exsultavit cum Patre, quando est condita ere:.­ <lb/> tura. Et
-						commemorasti, ut soles, testimonia causa <lb/> tuæ non necessaria , de lætitia Patris et
-						Filii. Sed <lb/> quid facturus es? quo iturus i Quomodo id quod est <lb/> luce clarius,
-						aut negaturus, aut in aliud quodcumque <lb/> versurus es, cum recitatur tibi quod beatus
-						Petrus in <lb/> Apostolorum Actibus dixit : <hi rend="italic">Hunc</hi> Jesum a <hi rend="italic">Naza­ <lb/> reth, quem unxit Deus Spiritu sancto (Act.</hi> x, 38).
-						<lb/> Ecce quod prophetabatur, quando dictum est, <hi rend="italic">Unxit <lb/> te Deu,
-							Deus tuus oleo exsultationis,</hi> vel, <hi rend="italic">oleo lætitiæ,</hi>
-						<lb/> præ <hi rend="italic">participibus</hi> tuis. Deus enim cui dictum est in eo­
-						<lb/> dem Psahno , Thronus tuus, Deus, in <hi rend="italic">sæculum sæculi; <lb/> virga
-							directionis , virga regni tui : dilexisti justitiam,</hi> et <lb/>
-						<hi rend="italic">odio habuisti iniquitatem; propterea</hi> unxit <hi rend="italic">te
-							Deus, Deus</hi>
-						<lb/>
-						<pb n="783"/>
-						<hi rend="italic">tuus (Psal.</hi> XLIV, 7, 8) : a Deo Patre unctus est Filius, <lb/>
-						qui sic bomo factus est ut mancrel Deus, qua unctione <lb/> plenus erat, id est, Spiritu
-						sancto. Propter quod de <lb/> illo scriptum cst : Jesus <hi rend="italic">autem plenus
-							Spiritu sancto, <lb/> reversus est a Jordanc (Luc.</hi> iv, 1).</p>
-					<p>CAPUT XVII.— 1. Dicis in persona Spiritus sancti <lb/> non posse suscipi quod de Filio
-						dictum est, <hi rend="italic">Omnia <lb/> per ipsum fucta sunt</hi> , et <hi rend="italic">sine ipso</hi> facturi <hi rend="italic">est nihil <lb/> (Joan.</hi> I,
-						3). Et hoc ideo hidis, ut quibus potueris <lb/> persuadeas, qnod vobis male persuasum
-						est, Spiri­ <lb/> tum sanctum non esse creatorem : quasi legeris , <lb/> Omnia per ipsum
-						facta sunt sine Spiritu sancto ; aut, <lb/> Omnia per neminem facta sunt, nisi per
-						ipsum. Quan­ <lb/> quam si et tale aliquid legeres, sic Spiritum sanctum <lb/> ab hac
-						operatione , qua constituta est creatura , cre­ <lb/> dere non deberenmus exclusum;
-						sicut Filius non <lb/> excluditur ab ea scientia de qua dictum est, <hi rend="italic">Quce <lb/> Dei sunt, tiemo scit,</hi> nisi Spiritus <hi rend="italic">Dei</hi> (I <hi rend="italic">Cor.</hi> II, 11). <lb/> Si autem quia non est nominatus , quod etiam
-						per <lb/> ilium facta sit creatura, quando de Filio dictum <lb/> est , <hi rend="italic">Omnia per</hi> ipsum <hi rend="italic">facta</hi> sunt ; idco putas Dei <lb/>
-						Spiritum non esse creatorem : procnl dubio , lice <lb/> in ejus nomine poteris
-						baptizatos dicere , quibus <lb/> ait Petrus, <hi rend="italic">Agite pœnitentiam, et
-							baptizetur unus­ <lb/> quisque vestrum</hi> in <hi rend="italic">nomine Domini Jesu
-							Christi ( Act.</hi>
-						<lb/> II , 38) ; qnia non ait, Et S. iritus sancti : nee in <lb/> Patris nomine, quia
-						nec ipsc ibi et nominatus. <lb/> Si auteur etiam non nominatis Patre et Spiritu <lb/>
-						sancto , in nomine Jesu Christi jussi sun ba­ <lb/> plizari ; et tamen intelliguntur non
-						baptizati nisi in <lb/> nomine Patris et Filii et Spiritus sanct! : cur non sic <lb/>
-						audis de Filio Dei, Omnia pur <hi rend="italic">ipsum facta sunt;</hi> ut <lb/> et non
-						nominatum intellig <unclear>as</unclear> ibi ctiam Spiritum san­ <lb/> cium?</p>
-					<p>2. NaiD quid excellentius in creaturis quam virtu­ <lb/> tes cœlorum? Scriptum est
-						autem : <hi rend="italic">Verbo DOli,;,. i <lb/> cœli firmati sunt; et</hi> Spiritu <hi rend="italic">oris ejus, omnis virtus eo­ <lb/> rum (Psal.</hi> XXXII, 6). Dixeras
-						nempe non me talia re­ <lb/> perire in Scripturis divinis, quibus Spiritum sanctum <lb/>
-						aequalem asseram Filio. Ecce reperi ubi etiam major <lb/> possit videri, nisi revocet
-						pietas. quæ illum veraciter <lb/> confitetur æqualem. Nam utique majus aliquid sunt
-						<lb/> virtutes cœlorum, quæ firmatæ sunt Spiritu oris Do­ <lb/> mini, id est Spiritu
-						sancto, quam cœli, qui firmati <lb/> sunt Verto Domini, hoc est, unigentio Filio. Sed si
-						<lb/> consulas veritatem , res utraque ab utroque firmata <lb/> est; ct id quod de uno
-						dicitur et de altero tacetur, de <lb/> utroque intelligitur. Quid est autem
-						inconsideratius, <lb/> quam negare esse creatorem Spiritum Dei, cum Do­ <lb/> mino
-						dicatur : <hi rend="italic">Auferes spiritum eorum, et deficient, et</hi>
-						<lb/> in <hi rend="italic">pulverem</hi> suum convertentur : <hi rend="italic">emittes</hi> I <hi rend="italic">Spiritum</hi>
-						<lb/> tuum, et <hi rend="italic">creabuntur; et innovabis faciem</hi> terræ <hi rend="italic">(Psal.</hi>
-						<lb/> CIII, 29, 30) Nisi forte minus idoneus erat Spiritus <lb/> sanctus creandis rebus
-						quæ fuerant defecturæ, cum <lb/> sit idoneus creandis quæ sunt sine line mansuræ. <lb/>
-						Paulo ante dixi : Quid est excellentius in creaturis <lb/> quam virtutes cœłorum? Quid
-						dicam de carne Crea­ <note type="footnote"> * Pd'U, <hi rend="italic">emitte.</hi> At
-							Mss , <hi rend="italic">cmitl:s.</hi> F.L sic Aiigustiinis, Enarr. <lb/> ill ontodeui
-							psalmum 105. </note>
-						<lb/> toris ? Quandoquidem Creator ipse per quem facia <lb/> sunt omnia, <hi rend="italic">Panis,</hi> inquit, <hi rend="italic">quem ego dedero, caro mea<lb/> est
-							pro mundi vita (Joan.</hi> vi, 52). Quid ergo? Mundus <lb/> per Filium factus est, et
-						creator est Filius : caro cjus <lb/> quæ data est pro mundi viia , per Spiritum sanc tum
-						<lb/> facia est, et non cst creator Spiritus sanctus? Cum <lb/> enim virgo Maria
-						dixisset angelo promittenti Ci filium, <lb/>
-						<hi rend="italic">Quomodo fiet istud, quoniam virum non</hi> cognosco ? re­ <lb/>
-						spondit angelus, <hi rend="italic">Spiritus sanctus superveniet</hi> in te , <hi rend="italic">et <lb/> virtus Altissimi obumbrabit tibi; propterea quod nasce­<lb/>
-							tur ex te sanctum, vocabitur Filius Dei (Luc.</hi> I, 34, 35). <lb/> Hic tu, quod in
-						consequentibus quodam loco tuæ prose­ <lb/> cutionis adverti, asserere conaharis
-						Spiritum sanctum <lb/> pra'cessisse, ut mundaret et sanctificaret virginem <lb/> Mariam;
-						ac deinde veniret Virtus Altissimi, hoc est <lb/> Sapientia Uci, quod est Christus (I
-							<hi rend="italic">Cor.</hi> i, 24); ei <lb/> ipsa , sicut scriptum est, ædificaret
-						sibi domun <lb/>
-						<hi rend="italic">(Prov.</hi> IX, i), hoc est, ipsa sihi crearcl carnem, non <lb/>
-						Spiritus sanctus. Quid est ergo quod ait sa nctum Evan­ <lb/> gellum, <hi rend="italic">Inventa eat</hi> in <hi rend="italic">utero habens de Spiritu sancto<lb/>
-							(Matth.</hi> I, 18) ? Nempe obstructum cst os loquentium <lb/> iniqua ( <hi rend="italic">PsaL</hi> LXII, 12 ). Si ergo cogitas os veraciter <lb/> aperire, n on
-						solum Filium , verum etiam Spiritum <lb/> sanctum creatorem carnis Filii confitere.</p>
-					<p>3. An f orte dicturus es, ea facta esse per Spiritum <lb/> sanctum quæ commemoravi, id
-						est, quod omnis virtus <lb/> coelorum per eum firmata sit, quod per cum creaban­ <lb/>
-						tur homines denuo, qni primo ita creantur ut conver­ <lb/> tantur in pulverem suum ;
-						quod ipse carnem opera­ <lb/> tus est Christi (nam de anima nolo aliquid dicere , <lb/>
-						cujus difficillima quæstio est); et si quid aliud per <lb/> Spiritum sanctum creatum
-						potuerit inveniri: non ta­ <lb/> men omnii, sicut per unigcnitum Filium , de quo <lb/>
-						dictum est, Omnia per <hi rend="italic">ipsum facta</hi> sunt? Si hoc dicis, <lb/> non
-						limes ne tibi dicatur, eo potiorem esse Spiritum <lb/> sanctum Filio, quod elegit sibi
-						meliora qua; faceret, <lb/> nec facere inferiora dig<unclear>natus</unclear> est? Sed
-						quis hoc sapit, <lb/> nisi qui desipit? Facta sunt ergo cuncta per Filium ; <lb/> absit,
-						nt Spiritu sancto ab hoc opere separato : sicut <lb/> de illis magnis operibus dictum
-						est, <hi rend="italic">Omnia autem hæc<lb/> operatur unus atque</hi> idem <hi rend="italic">Spiritus</hi> (1 <hi rend="italic">Cor.</hi> XII, i 1); nec <lb/> tamen
-						ab hac operatione Filius separatur.</p>
-					<p>4. Magnum sane aliquid tibi dicere videris, quia di­ <lb/> cis : Filius <hi rend="italic">erat</hi> in <hi rend="italic">principio antequam aliquid esset; <lb/>
-							Pater vero, ante principium</hi> Ubi legisti, ut iirc cre- <lb/> dcres? Unde
-						præsumpsisti ut hæc diceres , ubi nec <lb/> auctoritas ulla, nec ratio est ? Quid est
-						enim ante <lb/> principium , quandoquidem quidquid ante esset, hoc <lb/> esset
-						principium ? Si ergo Pater antc 1 principtum <lb/> est, ante seipsum est; quia et ipse
-						principium est. <lb/> Quid est autem, <hi rend="italic">In</hi> principio erat <hi rend="italic">Verbum (Joan.</hi> I, i); <lb/> nisi, In Patre crat Filius ? Et ipse
-						Filius interrogatus <lb/> a ,ludaris quis esset, respondit : <hi rend="italic">Principium, quia et<lb/> loquor vobis (Id.</hi> VIII, 25). Pater crgo principium non
-						<lb/> de principio; Filius principiu.n de principio : scd <lb/> utrumque simul, non duo
-						, sed unum principium ; <lb/> sicut Pater Deus et Filius Deus, ambo autem siut <lb/> non
-						dun dii, sed unus Deus. Nee Spiritum sanctum <note type="footnote">1 Hie ajud l.ov.
-							omissum est, <unclear>esse</unclear>. </note>
-						<lb/>
-						<pb n="785"/> ab utroque procedentem negabo esse principium : <lb/> sed hæc tria simul
-						sicut unum Deum, ita unum dico <lb/> esse principium.</p>
-					<p>CAPUT XVIII — i. Quid, si <hi rend="italic">audierit,</hi> inquis, Pa­ <lb/> trem <hi rend="italic">dicentem,</hi> « <hi rend="italic">Tecum</hi> principium in <hi rend="italic">die</hi> virtuti, <hi rend="italic">tum, <lb/> in splendoribus
-							tanctorum, ex utero ante luciferum</hi> ge­ <lb/> nui <hi rend="italic">te &gt;
-							(Psal.</hi> CIX, 3) Quid promittis. vel quid mi­ <lb/> naris , si audiero quod
-						frequenter audio, et fideliter <lb/> credo? Sed hinc te nihil adjuvari , cur non videas,
-						<lb/> plurimum miror. Sive enim ex persona sua hoc pro­ <lb/> pheta dicat ad Dominum
-						Jesum , sive ex persona Pa­ <lb/> tris ad Filium, cum ego ambas generationes Christi,
-						<lb/> et ex Den Patrc sine tempore, et ex homine matre in <lb/> plenitudine temporis
-						accipiam, vencrer, prædicem, <lb/> non est hoc testimonium adversum me. Sed moras <lb/>
-						innectere voluisse indicat te, ubi ego potius intelligo, <lb/> quare <hi rend="italic">ex utero</hi> dixerit <hi rend="italic">genui te :</hi> quia huc et tu ex pcr- <lb/>
-						- sona Patris accipis dictum. Non enim quemadmodum <lb/> corporis humani sunt membra
-						disposita , sic habet <lb/> uterum Dens ; sed verbum translatum est a corporali <lb/> ad
-						incorporalem substantiam , ut intelligeremus de <lb/> Patris substantia genitum
-						unigenitum Filium ; ac per <lb/> hoc quid aliud quam unius ejusdemque substantiæ ? <lb/>
-						Ego itaque hoc testimonium proferre contra te debui : <lb/> sed gratias ago quia
-						commonuisti. Considera ergo <lb/> quantum mali sit, quod ejusdem subustantiæ Filiam
-						<lb/> negatis, quem genitum confitemini ex utero Patris, <lb/> injuriam gravissimam
-						facientes Deo , tanquam illud <lb/> quod ipse non esset,, ex utero gignere potuisset.
-						Non­ <lb/> ne sentitis vos generationem Dei credere vitiosam , <lb/> prædicare
-						monstruosam, qui dicere audctis ex utero. <lb/> Dei processisse diversam naturam? Si
-						antem hoc, sic­ <lb/> ut debclis, horretis, respuilaque nobiscum, jam tnn­ <lb/> dem
-						concilium Nicænum et Homousion laudate ac <lb/> tenete nobiscum.</p>
-					<p>2. Quis autem nou videat defectum tuum, ubi cum. <lb/> andisses, me commemorante,1 in
-						prophetia dixisse <lb/> Christum suo Patri, De <hi rend="italic">ventre</hi> matris meæ
-							<hi rend="italic">Deus</hi> meus <lb/>
-						<hi rend="italic">es tu (Psal</hi> xxi, ii ); ut intelligeremus ejus na­ <lb/> turæ
-						ilium esse Deum quam Filius ipsius ex tempore <lb/> de ventre matris accepit, Patrem
-						vero naturæ illius <lb/> quam do se ipse generavit: tu non inveniens quid re­ <lb/>
-						sponderes, tamen ne laceres dixisti, <hi rend="italic">Ex ventre</hi> matris <lb/> natum
-						profiteri. Christum secundum <hi rend="italic">carnem;</hi> et addi­ <lb/> disti, <hi rend="italic">quod nec</hi> Judæi <hi rend="italic">diffidunt.</hi> Ac deinde
-						quaesisti, <lb/>
-						<hi rend="italic">Car</hi> ista <hi rend="italic">testimonia in medium</hi> noR <hi rend="italic">proferantur, quæ <lb/> illam</hi> nativitatem <hi rend="italic">demonstrant in</hi> principio, sicut <hi rend="italic">et præ­ <lb/> cedent</hi> noa,
-						inquis, instruit testimonium ? Quasi ego <lb/> illam nativitatem Christi, non
-						temporalem, sad æter­ <lb/> nam, propter quam dictum est, <hi rend="italic">In principio
-							erat Ver­<lb/> bum,</hi> non credam, non prædicem, non amplectar; <lb/> sed tantum ex
-						ventre matris natum asseram Chri­ <lb/> stum? Ecce ego dico Deum Filium de Deo Patre
-						sine <lb/> tempore genitum. Quomodo sit autem etiam Deus <lb/> ejus qui Pater est ejus,
-						ostendi, propter hominem <lb/> quem suscepit, et in quo natus cst de ventre matris,
-						<lb/> sinc concubitu hominis patris. Ad quod probandum <lb/> testimonium dedi, ubi ait
-						in prophetia Patri sun, <hi rend="italic">De <lb/> ventre matris meæ Deut meus</hi> es
-							<hi rend="italic">tu.</hi> Tu qui dicis me es <lb/> ventre matris natum profiteri
-						Christum , quod nee Ju­ <lb/> dæi diffidunt, quasi ego istam nativitatem Christi In.
-						<lb/> lam profitear; Meli per inania conari evadere , et dic <lb/> potius quare mihi non
-						responderi, ubi dicit Christus <lb/> Patri, <hi rend="italic">De ventre matris meæ
-							Deut</hi> meut es <hi rend="italic">tu.</hi> Ad hoc <lb/> enim quoniam vidisti non te
-						habere quod diceres, <lb/> aliam nativitatem quae Dei de Deo. est, interponem <lb/> dam
-						putasti qua fugeres. Rogo te; quando quid rc­ <lb/> spondeas non habes, quanto melius
-						taceres?</p>
-					<p>3. Si propter <hi rend="italic">corpus,</hi> inquis, in <hi rend="italic">quo se</hi>
-						exinanivit, <lb/>
-						<hi rend="italic">debitorem</hi> te <hi rend="italic">sentit</hi> suo <hi rend="italic">genitori;</hi> multo magis qui illum <lb/>
-						<hi rend="italic">tantum ac talem genuit, necesse est</hi> x! eam <hi rend="italic">veneretur,<lb/> eique</hi> offerat <hi rend="italic">semper</hi> obsequium. Quodlibet
-						de venera­ <lb/> tione et obsequio Filii erga Patrem carnaliter sentias, <lb/> Puer
-						ejus, nisi de ventre matris ejus, non est Deus <lb/> ejus. Jam quantumvis obsequatur Deo
-						Patri Deus <lb/> Filius, quoniam ,-ideo te non intelligere quanta sil in <lb/> illa
-						generatione geniti et genitoris aequalitas, num­ <lb/> quid ideo est diversa natura
-						patris hominis et hominis <lb/> filii, quoniam filius obsequitur patri? Hoc est omnino
-						<lb/> intolerabile in vobis, qnia de obsequio Filii diversam <lb/> vultis probare
-						substantiam Patris et Filii. Prorsus <lb/> alia quæstio cst, Utruin sint unias
-						ejusdemque sub­ <lb/> stantiae Pater et Filius; et alia quacstio est, Utrum <lb/> Patri
-						Filius obsequatur. Interim verum Filium non <lb/> negemus, qui nullo modo est verus
-						Filius, si non est <lb/> ipsius et Patris ana eademque natura. Dicite ergo <lb/> Deum
-						Patrem; et Deum Filiium unius ejusdemque <lb/> esse substantia!. Extorqueat vobis
-						divinitas, quod <lb/> humanitati donavit ipsa divinitas. Obsequitur homo <lb/> patri
-						suo, de quo natus est homo; tamen obsequendo <lb/> esse non desinit homo. Ei si, non
-						dico pariter hono­ <lb/> ratus, sed honoratior esset ftlius, gauderet pater, non <lb/>
-						invideret: honoraret tamen etiam ille patrem, etsi <lb/> non parvulus, accessu augendus
-						aLlatis, sed ei natus <lb/> esset æqualis. Æqualem vero si pater homo potuis­ <lb/> set
-						, nullo dubitante genuisset. Quis ergo audeat di­ <lb/> cere, Hoc nec Omnipotens potuit?
-						Addo cHam, quia <lb/> si posset homo, majorem se ipso melioremque <lb/> gigneret filium
-						: sed majus vel melius Deo quidquam <lb/> non potest esse; ergo ei verum Filium credamus
-						<lb/> aequalem. Quod si dixeris, Eo ipso major est Pater <lb/> Filio, quia de nullo
-						genitus, genuit tamen aequaletn: <lb/> cito respondebo, Imo ideo non est major Pater
-						Filio, <lb/> quia æqualem genuit, non minorem. Originis enim <lb/> quæstio est, Quis de
-						quo sit :. æqualitatis autem, <lb/> Qualis aut quantus sit. Proinde si admittit ratio
-						veri - <lb/> tatis ut æquali Patri Filius obsequatur aequalis, non <lb/> negnmus
-						obsequium : si autem per obsequium mino­ <lb/> rem natura1 vultis credere, prohibemus:
-						nullo modo <lb/> enim Deus Pater ut babcre unici Filii posset obse­ <lb/> quium, vellet
-						denegare naturam.</p>
-					<p>4. Par entibus autom ut esset subditus Christus , <lb/> non dvinæ majestatis fuit, sed
-						aetatis humanæ Fru­ <lb/> stra itaque dixisti : <hi rend="italic">Si parentibus fuit
-							subditus quot<lb/> creavit</hi> ( <hi rend="italic">Luc.</hi> II, 51 ), <hi rend="italic">quanto magis suo genitori qui <lb/> eum tantum ac talem genuit?</hi>
-						Respondetur enim lihi ; <note type="footnote"> I AIR. ct Er., <hi rend="italic">minorem
-								natum</hi> plures Mss., <hi rend="italic">nnnorem</hi> fM' <lb/> turam. </note>
-						<lb/>
-						<pb n="787"/> Si parentibus fuit subditus propter pueritiam, quanto <lb/> magis Den
-						propter ipsam hominis formam? Quam <lb/> formam eum immortalem fecerit, non morti
-						perdide­ <lb/> rit; quid miraris si etiam post hujus saeculi finem sub­ <lb/> jectus
-						erit in ea illi, qui ei subjecit omnia ? Tu autem <lb/> non propter formam servi dicis
-						Filium Patri esse sub­ <lb/> jectum , sed quia cum tantum ac talem genuit. id est <lb/>
-						magnum Deum, quanvis Patre ipso minorem : ubi ct <lb/> Patri dcrogas, qui Filium sibi
-						unicum, aut non potuit, <lb/> aut noluit gignere æqualem; ut ipsi Filio qni unicus <lb/>
-						Patri non est generatus æqualis. et idco perfectus est <lb/> natus, ne unquam vel
-						crescendo fieret, quod non po­ <lb/> tuit esse nascendo.</p>
-					<p>5. Non autem, ut putas, corpus tantum Filii, id est, <lb/> corpus hominis, verum etiam
-						buinanum spiritum Pa­ <lb/> tri dicimus esse subjectum : et secundum id quod <lb/> botro
-						factus est intelligimus dictum. <hi rend="italic">Cnm antem omnia<lb/> tlli</hi>
-						subjecta fuerint <hi rend="italic">tunc et ipse Filius subjectus erit illi</hi>
-						<lb/> qui a subjecit <hi rend="italic">omnia</hi> (1 <hi rend="italic">Cor.</hi> xv,
-						28). Secundum id quod <lb/> Christus est caput ct corpus: caput scilicet ipse Sal­ <lb/>
-						vator qui surrexit a mortuis, et scdel ad dexteram Pa­ <lb/> tris; et Ecclesia quæ est
-						corpus ejus, plenitudo ejns, <lb/> sicut apertissime dicit Apostolus <hi rend="italic">(Coloss.</hi> I, 18). Ac <lb/> per boc cum omuia Christo subjecta fuerint, et capiti
-						<lb/> et corpori erunt sinc dubitatione subjecta. Nam secun­ <lb/> dum id quod sine
-						tempore Deus natus est, nihil un­ <lb/> qnam potuit ei non esse subjectum.</p>
-					<p>6. Scimus, quod nos commemoraridos putasti, <hi rend="italic">quia <lb/> Pater</hi> non
-							<hi rend="italic">judicat quemquam, sed omne judicium dedit</hi>
-						<lb/> Filio <hi rend="italic">(Joan.</hi> v, 22). Vellem tamen diceres nobis, quo­ <lb/>
-						modo Pater non judicat quemquam , cum dicat ipse <lb/> identidem Filius, <hi rend="italic">Ego non quæro</hi> gloriam <hi rend="italic">meam; est</hi>
-						<lb/> qui <hi rend="italic">quærat, et judicet (Id.</hi> VIII, 50) : ut srias idco di­
-						<lb/> ctum, <hi rend="italic">Pater non judicat</hi> quemquam, <hi rend="italic">sed
-							omne judicium <lb/> dedit Filio;</hi> quoniam judicandis vivis et marnis for­ <lb/> ma
-						hominis apparebit, quam non hahct Pater: pro­ <lb/> pter quod ait propheta, <hi rend="italic">Videbunt in quent pupugerunt<lb/> (Zach.</hi> XII, 10). Sed
-						invisibiliter etiam Pater erit cum <lb/> eo, quia inseparabilis est ab eo. Si enim, <hi rend="italic">Non</hi> sum <lb/>
-						<hi rend="italic">solus, quoniam Pater</hi> mecum est, ait ipse moriturus <lb/>
-						<hi rend="italic">(Joan.</hi> XVI, 52); quanto magis secum habebit Patrem, <lb/> de
-						mortuis et vivis judicaturus? Cum illo crit etiam <lb/> Spiritus sanctus. Quomodo enim
-						deseret eum Spiritus <lb/> sanctus in rcgali sede, quo plenas regressu! est a Jor­ <lb/>
-						dane <hi rend="italic">(Luc.</hi> IV, 1)! Quod itaque scriptum est ad lie.. <lb/> bræos,
-							<hi rend="italic">Nunc autem necdum videmus omnia subjecta ei :</hi>
-						<lb/> cum <hi rend="italic">autem modico minus ab Angelis minoratum videmus <lb/> Jesum
-							propter passionem mortis (Hebr.</hi> II, 8, 9): do­ <lb/> cere nos debet quomodo
-						intelligendum sit quod scri­ <lb/> ptum est ad Corinthios, Cum <hi rend="italic">autem
-							omnia illi subjecta</hi>
-						<lb/> fuerint: quia secundum id dictum est quod factus est <lb/> homo, non secundum id
-						quod est Deus. Sic ergo in <lb/> homine apparens, in quo per passionem mortis mino­
-						<lb/> ratus est modico minus ab Angelis, vivos et mortuos. <lb/> judicabit, quando
-						dicturus est : <hi rend="italic">Venite, benedicti Pa­</hi>
-						<lb/> tris <hi rend="italic">mei percipite regnum</hi> ( <hi rend="italic">Matth.</hi>
-						xxv, 34 ). Quo tu <lb/> testimonio non hominem, sed Deum minorem suo <lb/> Patre quasi
-						probare voluisti : sed sicut ab eit qui in­ <lb/> telligunt perspicitur, nun
-						probasti.</p>
-					<p>CAPUT XIX. — De Spiritus sancti autem gemiii­ <lb/> bus, quia non ipse gemit, sed
-						inspirans nobis deside­ <lb/> rium sanctum nos facit gemere quamdiu peregrina­ <lb/> mur
-						a Domino, jam tibi sunicienter respondisse me <lb/> existimo. £t tales de Scripturis
-						sanctis locutiones, <lb/> quantum satis videbatur ostendi, quoniam sic dicitur <lb/>
-						gemere Spiritus sanctus, quia nos facit gemere ; sicut <lb/> dixit Deus, <hi rend="italic">Nunc cognovi (Gen.</hi> XXII, 12), quando co­ <lb/> gnoscere hominem
-						fecit. Non eqim tunc cognoverat <lb/> quod tunc se dixerat cognovisse, qni omnia scit
-						an­ <lb/> tequam fiant. Ad quod te respondere non potuisse, <lb/> quid predest quia
-						scutis, quando non consentis ?</p>
-					<p>CAPUT XX. — i. Jam eliam de verbis Domini <lb/> ubi ait, <hi rend="italic">Ego</hi> et
-							<hi rend="italic">Pater</hi> unum sumus <hi rend="italic">(Joan.</hi> x, 30); nihil
-						<lb/> te respondere potuisse monstravi. Sed ut hic quoquo <lb/> ostendam, si exemplis,
-						ut dicis, quibus ego usus sum, <lb/> vis probare quomodo dictum sit, <hi rend="italic">Ego et Puter</hi> unum <lb/>
-						<hi rend="italic">sumus;</hi> ct ob hoc commemoras apostolicum testimo­ <lb/> nium. quod
-						a me p'situm est, ubi ait <hi rend="italic">Qui adhæret <lb/> Domino, unus spiritus
-							est</hi> ( I <hi rend="italic">Cor.</hi> VI 17): dic ct tu, <lb/> Cum adhæeret Patri
-						Filius, unus Deus e t. Nou enim <lb/> ait Apostolus, <hi rend="italic">Qui adhæret
-							Domino,</hi> unum sunt; sicut <lb/> dictum est, <hi rend="italic">Ego et Pater unum
-							sumus:</hi> sed ait, unus <lb/>
-						<hi rend="italic">spiritus edt.</hi> Cum autem tu non dicas, Cum adhære t <lb/> Patri
-						Filius, unus Deus est ; utquid et tu adhibes hoc <lb/> Apostoli testimonium, ubi ait,
-							<hi rend="italic">Qui adhæret Domino, <lb/> unus spiritus est ;</hi> nisi ut te etiam
-						a te producto teSte <lb/> convincam? Nunc saltem distingue duo bta, quæ non <lb/>
-						potuisti, cum simul essemus, in nostra disputatione <lb/> distinguere. Diligenter itaque
-						attende quod dico. <lb/> Quando de rcbus duabus nul plurimus dicitur, Unus <lb/> est,
-						vel, una est, et additur quid unus vel quid una; <lb/> ct de his quæ diversæ, et de his
-						quæ sunt unius sub­ <lb/> stantiae dici potest. Diversæ sunt enim substantiæ spi. <lb/>
-						ritus hominis et Spiritus Domini 1 :et tamen dictum <lb/> est, Qui <hi rend="italic">adhæret Domino unus spiritus tat.</hi> Unius au­ <lb/> tem substauti;e sunt animae
-						hominum ct corda homi­ <lb/> num; de quibus dictum est, <hi rend="italic">Erat Ulis
-							anima</hi> una <hi rend="italic">et<lb/> cor</hi> unum <hi rend="italic">(Act.</hi>
-						IV, 52). Ubi autem dicitur de duobus <lb/> aut pluribus, Unum sunt, nec additur quid
-						unum sint; <lb/> non diversæ intelliguntur, sed unius esse substantiæ: <lb/> sicut
-						dictum est, <hi rend="italic">Qui plantat et qui rigut,</hi> unum 'unt <lb/> (I <hi rend="italic">Cor.</hi> III, 8); et, <hi rend="italic">Ego et Pater</hi> unum <hi rend="italic">sumus.</hi> Tu au­ <lb/> tem qni Patrem cl Filium diversas vis rsse
-						substan­ <lb/> tias, invenire non potuisti, ubi de diversis substantiis <lb/> dic tum
-						fuerit, Unum sunt. Et qui non vis dicere, Cum <lb/> Filius adhæret Patri, unus Deus est;
-						adhibuisti et tu, <lb/> apostolicum testimonium quod ego adhibueram; sed <lb/>
-						adhibuisti contra te ipsum, uhi ait, <hi rend="italic">Qui adhæret</hi> Do- <lb/> Mnino,
-							<hi rend="italic">unus spiritus est.</hi> Si enim de his qui diversæ <lb/> substantiæ
-						sunt, recte dici potuit, <hi rend="italic">unus spiritus</hi> est; <lb/> quantQ magis de
-						bis qui unius substantiæ sunt recte <lb/> dicitur, Unus Deus est? Si hæc intelligis, non
-						te ad <lb/> ea respondisse jam perspicis, et de consensu volunta­ <lb/> tis tc inaniter
-						tam multa dixisse cognoscis. Etiam <lb/> nos quippe incompambilem consensum voluntatis
-						at­ <lb/> que individuæ charitatis Patris et Filii et Spiritus san­ <lb/> fti
-						confitemur, propter quod dirinms , Hæc Trinitas <note type="footnote">1 Antiquiores
-							Mss.t <hi rend="italic">et Spiritus nomimis.</hi>
-						</note>
-						<pb n="789"/>
-						<unclear/><lb/> unus est Deus. Sed nos boc etiam, quod vos non di­ <lb/> citis, dicimus,
-						propter unam eamdemque naturam at­ <lb/> que substantiam, Hi tres unum sunt. Hæc si
-						discre­ <lb/> veris, et contentiosus esse nolueris, non te ad ea re­ <lb/> spondisse
-						aliquid jam videbis, et de hac quæstione <lb/> procul dubio jam tacebis.</p>
-					<p>2, Ubi autem dixil Eilius Patri, <hi rend="italic">Verum non quod</hi>
-						<lb/> ego <hi rend="italic">volo, sed quod. tu vis;</hi> quid te adjuvat quod tua <lb/>
-						verba subjungis ctdicis, <hi rend="italic">Ostendit vere voluntatem suam <lb/>
-							subjectam</hi> suo genitori : quasi nos. negemus, hominis <lb/> voluntatem voluntati
-						Dei debere esse subjectam? Nam <lb/> ex natura hominis hoc dixisse Dominum cito vidct ,.
-						<lb/> qui locum ipsum sancti Evangelii pauLo attentius in­ <lb/> tuetur. Ibi enim dixit:
-							<hi rend="italic">Tristis est anima mea usque ad</hi>
-						<lb/> martem ( <hi rend="italic">Matth.</hi> XXVI, 39, 38 ). Numquid ex natura <lb/>
-						unici Verbi posset hoc dici? Sed homo qui putas ger <lb/> mere naturam Spiritus sancti,
-						cur non etiam naturam <lb/> Verbi Dei unigeniti tristem dicas esse potuissc?- Ille <lb/>
-						tamen, ne quid diceretur tale, non ait, Tristis sum ; <lb/> quamvis etiamsi line
-						dixisset, non nisi ex natum ho­ <lb/> minis oportuisset intelligi : sed ait, Tristis <hi rend="italic">est</hi> anima <lb/>
-						<hi rend="italic">mea ;</hi> quam sicut homo utique habebat humanam. <lb/> Quamquam ct
-						in hoc quod ait, <hi rend="italic">Non quod ego volo ;</hi>
-						<lb/> aliud se ostendit voluisse quam Pater : qnod nisi hu­ <lb/> mano corde non
-						potuisset, cum infirmitatem nostram <lb/> in suum, non divinum , sed humanum
-						transfiguraret <lb/> affectum. Homine quippe non assumpto, nullo modo <lb/> Patri
-						diceret unicum Veibum, <hi rend="italic">Non quod ego volo.</hi>
-						<lb/> Nunquam enim posset immutabilis illa natura quid­ <lb/> quam
-							<unclear>aliud</unclear> velle quam Pater. Hæc si distingueretis, <lb/> Ariani
-						hæretici non essetis.</p>
-					<p>3. Nam et illud quod dictum est, Descendi <hi rend="italic">de cœ­<lb/> to, non ut
-							faciam volunlatem meam, sed voluntatem ejus</hi>
-						<lb/> qui <hi rend="italic">me misit (Joan.</hi> V!, 58) : potest quidem accipi <lb/>
-						etiam secundum id quod est unigenitum Verbum ; ut <lb/> ideo voluntatem non suam dixerit
-						esse, sed Patris , <lb/> quoniam de Patre est quidquid est Filius; non est all­ <lb/>
-						tem de Filio quidquid est Pater : secundum quod di­ <lb/> ctum est, <hi rend="italic">Mea doctrina non eat mea, sed ejus qui me</hi>
-						<lb/> mit <hi rend="italic">(Id.</hi> vn, 16); quoniam Patris doctrina ipse est <lb/>
-						qui Patris est Verbum, et utique non ost a se ipso, <lb/> sed a Patre. Et rursus cum
-						dicit, <hi rend="italic">Omnia quæ</hi> habet <lb/>
-						<hi rend="italic">Pater,</hi> mea <hi rend="italic">sunt (Id.</hi> XVI, 15) ; Patri se
-						ostendit aequa­ <lb/> lem. Non absurdum est tamen , ut etiam hoc secun­ <lb/> dum id
-						quod homo factus est, dixisse accipiatur : <hi rend="italic">Dc­ <lb/> scendi de cælo,
-							non</hi> ut <hi rend="italic">faciam voluntatem meam, sed vo­ <lb/> luntatem ejus qui
-							me misit.</hi> Secundus enim Adam, qui <lb/> tollit peccatum mundi, isto modo se
-						discrevit a pri­ <lb/> mo Adam , per quem peccatum intravit in mundum <lb/>
-						<hi rend="italic">(Rom.</hi> v, t2) : quia iste non fecit voluntatem suam, <lb/> sed
-						ejus a quo missus est; cum ille fecerit suam, non <lb/> ejus a quo creatus est. Nee
-						moveat quomodo Christus <lb/> secundum id quod homo- est, descenderit de cœlo, <lb/> cum
-						de matre quae in terra erat factus sit homo. Hoc <lb/> enim propter unitatem personæ
-						dictum est, quoniam <lb/> una persona est Christus Deus et homo. Propter quod <lb/>
-						etiam : <hi rend="italic">Nemo,</hi> inquit, <hi rend="italic">ascendit</hi> in <hi rend="italic">caelum,</hi> nisi <hi rend="italic">qui de <lb/> cœlo descendit. Filius
-							hominis, qui eat in cælo (Joan.</hi>
-						<lb/> III, 13). Si ergo attendas distinctionem substantiarum, <lb/> Filius Dei de coelo
-						descendit, Filius hominis cruci­ <lb/> fixus est : si nnitatem personae, et Filius
-						hominis de­ <lb/> scendit de cælo, et Filius Dei est crucifhus. Ipso <lb/> est enim
-						Dominus gloriæ, de quo ait Apostolus : <hi rend="italic">Si<lb/> enim cognovissent,</hi>
-						nunquam Dominum <hi rend="italic">gloriÆ crucifixi<lb/> sent (I Cor.</hi> II, 8).
-						Propter hanc ergo unitatem perso­ <lb/> nae, non solum Filium hominis dixit descendisse
-						de <lb/> cœlo, sed esse dixit in coelo, cum loquerctur in terra. <lb/> Non ergo
-						voluntatem suam fecit, quia peccatum non <lb/> fecit: sed voluntatem fecit illius qui
-						eum misit. Tunc <lb/> enim facit homo voluntatem Dei, quando facit. justi. <lb/> tiam
-						qua: ex Deo est.</p>
-					<p>4. Nec sic arbitremur a Patre missum. esse Filium, <lb/> ut non sit missus ab Spiritu
-						sancto; cum vox ipsius <lb/> sit per prophetam, <hi rend="italic">Et nunc</hi> Dominus
-						misit <hi rend="italic">me, et Spi.</hi>
-						<lb/> ritus <hi rend="italic">ejus.</hi> Hoc enim Filium dixisse, indicant ea quai <lb/>
-						sunt dicta superius. Nam sic ad ista verba perventum <lb/> est : <hi rend="italic">Audite me,</hi> inquit, <hi rend="italic">Jacob,</hi> et <hi rend="italic">Israel
-							quem ego to <lb/> cabo. Ego sum</hi> primus, <hi rend="italic">et ego</hi> sum in <hi rend="italic">æternum ; et</hi> ma <lb/> nus <hi rend="italic">mea</hi> fundavit <hi rend="italic">terram, dextera mea solidavit ccelum. <lb/> Yocabo illos, et astabunt
-							simul ; convenient etiam</hi> uni­ <lb/>
-						<hi rend="italic">versi, et audient. Quis illi. nuntiavit hæc?</hi> Diligens te <lb/>
-						<hi rend="italic">feci voluntatem tuam</hi> super <hi rend="italic">Babylonia, ut</hi>
-						tollatur semen <lb/>
-						<hi rend="italic">Chaldæorum. Ego locutus sum, ego</hi> vocavi; <hi rend="italic">adduri<lb/> illum, et prosperam</hi> viam <hi rend="italic">ejus feci. Convenite ad
-							me, ei<lb/> audite ista. Nec enim ab initio in obscuro locutus sum : <lb/> cum
-								<unclear>fiebant</unclear>, ibi eram; et nunc Dominus misit</hi> me, et <lb/>
-						<hi rend="italic">Spiritus ejus (Isai.</hi> XLVIII, 12-16). Quid hoc apertius? <lb/> Nee
-						sic a Patre et Spiritu sancto missus est. ut se ipse <lb/> non miserit : sicut a Patre
-						ostenditur traditus, ubi <lb/> legitur, Qui <hi rend="italic">Filio proprio non
-							pepercit, scd pro nobis<lb/> omnibus tradidit eum (Rom.</hi> VIII, 32) ; alio autem
-						loco de <lb/> ipso Filio dicitur, <hi rend="italic">Qui me dilexit, et tradidit
-							scipsum<lb/> pro me (Galat.</hi> II. 20). Quomodo autem non facit va­ <lb/> luntatem
-						suam, qui dixit, Sicut <hi rend="italic">Pater</hi> suscitatmortuos <lb/>
-						<hi rend="italic">et vivificat, sic et Filius quos vult vivificat (Joan.</hi> V, 21);
-						<lb/> et cum ei dictuin esset <hi rend="italic">Si vis, potes me mundare;</hi>
-						<lb/> respondit, <hi rend="italic">Volo, mundare;</hi> et ad verbum continuo <lb/> f.
-						ctum est quod velle se dixit <hi rend="italic">(Matth.</hi> VIII, 2, 3) ? Sicci <lb/>
-						autcm Filias facit voluntatem Patris, sic et Pater facit <lb/> voluntatem Filii. Nam
-						Filius dicit: <hi rend="italic">Pater, volo</hi> ut <hi rend="italic">ubi <lb/> ego</hi>
-						sum, <hi rend="italic">et isti sint mecum (Joan.</hi> XVII, 24). Non dixit <lb/> Peto,
-						vel, Rogo; sed, vo!o : ut isto volente faceret <lb/> ille, sicut illo volente faciebat
-						iste : et non alia ille, <lb/> alia istc; sed quæ ille, hæc etiam iste. <hi rend="italic">Quæcumque<lb/> enim Pater facit, hæc et</hi> Filiussimiliter facit <hi rend="italic">(ld.</hi> v, 19). <lb/> Verba sunt ipsius, verba veritatis suut, falsa
-						esse non <lb/> possunt.</p>
-					<p>CAPUT XXJ. — 1. Suscipere tc dicis quod protuli, <lb/>
-						<hi rend="italic">Nescitis quia templum DA estis, et Spiritus Dei habitat</hi>
-						<lb/> in <hi rend="italic">vobis</hi> (I <hi rend="italic">Cor.</hi> III, 16) ? Quod
-						proposuisti 1 dicere idoo <lb/> dictum esse, quia <hi rend="italic">in nemine habitat
-							Deus, quem non<lb/> ante Spiritus sanctus sanctificaverit, atque purgaverit;</hi>
-						<lb/> quasi templum Den habitaturo, non sibi, sanctificet et <lb/> purget Spiritus
-						sanctus : cum Apostolus hincostenderit <lb/> ipsum esse Deum, cujus nos dixcrat templum
-						: quia <lb/> non ait,. et Spiritus Dei sanctificat et purgat vos, ut <lb/> Deus habitet
-						in vobis, sed ait, <hi rend="italic">Spiritus Dei</hi> habitat in <note type="footnote">* Sic aliquot Mss. At editi, <hi rend="italic">qvod potuisti.</hi>
-						</note>
-						<lb/>
-						<pb n="791"/> tobia. Uliqne in templo suo Deus habitat : nam quid <lb/> est templum Dei,
-						nisi habitaculum Dei ? Vidisti autem <lb/> etiam tu consequenter esse Deum nostrum cujus
-						StI­ <lb/> mus templum : et noluisti aliud testimonium comme­ <lb/> morare quod protuli,
-							<hi rend="italic">Nescitis qnia corpus vestrum <lb/> templum in vobis Spiritus sancti
-							est, quem habetis</hi> n Deo? <lb/> Jam ergo confitere Dcum esse Spiritum sanctum.
-						<lb/> Neque enim, nisi esset Deus, haberet templum, et <lb/> templum non manufactum, sed
-						ædificatum dememhris <lb/> Dei : <hi rend="italic">Christus</hi> enim <hi rend="italic">super omnia est Deus benedictus in</hi>
-						<lb/> sæcula <hi rend="italic">(Rom.</hi> IX, 5), cujus membra sunt nostra cor­ <lb/>
-						pora. Qui enim dixit, <hi rend="italic">Nescitis quia corpus vestrum <lb/> templum</hi>
-						in vobis <hi rend="italic">Spiritus sancti est?</hi> ipse dixit, <hi rend="italic">Ne­
-							<lb/> scitis quia corpora vestra membra sunt Christi (I</hi> Cor. VI, <lb/> 19, 15) ?
-						Itane vero cui de lignis lapidibus Salemon <lb/> ædificavit templum, Deus est, et cui
-						templum <unclear>ædilica­</unclear>
-						<lb/> tur de membris Christi, hoc est, de membris Dei, <lb/> D:iis uon est? cum loquens
-						de Deo beatissimus mar­ <lb/> tyr Stephanus dixerit : Salomon <hi rend="italic">ædificavit ei</hi> domum ; <lb/>
-						<hi rend="italic">sed Summus non</hi> in <hi rend="italic">manufactis templis inhabitat
-							(Act.</hi> VII, <lb/> 47. 48). Et tamen Christi membra, quorum caput eat <lb/> super
-						omnes cœlos, templum sunt Spiritus sain ti, <lb/> quem constat venisse de coelo. Istum
-						negare Deum <lb/> quid est, nisi non esse et nolle esae templum ejus? <lb/> Alloquitur
-						nos Apostolus dicens : Obsecro autem <hi rend="italic">vos.<unclear/><lb/> fiatres, per
-							miserationes Dei, ut exhibeatis corpora</hi> vestru <lb/>
-						<hi rend="italic">hostiam vivam,</hi> sanctam, Deo <hi rend="italic">placentem
-							(Rom.</hi> XII, 1). <lb/> Corpora itaque fidelium hostia sunt Deo, membra <lb/>
-						Christi, templum Spiritus sancti, et Deus non est <lb/> Spiritus sanctus! Quis hoc
-						dicit, nisi in quo non inha­ <lb/> hilal? Quoniam in quo habitat, utique templum ejus
-						<lb/> cst. Denique cum dixisset Apostolus : <hi rend="italic">Nescitis quia <lb/>
-							corpus</hi> vestrum templum <hi rend="italic">in vobis Spiritus sancti est, <lb/> quem
-							habetis a Deu, et non estis</hi> vestri? <hi rend="italic">empti</hi> enim <lb/>
-						<hi rend="italic">estis pretio magno ;</hi> continuo secutus adjunxit, <hi rend="italic">Clorifi­<lb/> cale</hi> ergo <hi rend="italic">Deum</hi> in <hi rend="italic">corpore
-							vestro</hi> (I <hi rend="italic">Cor.</hi> VI, 19, 20). <lb/> Ubi dilucido ostendit
-						Deum esse Spiritum sanctum, <lb/> glorificandum scilicet in corporc nostro, tanquam in
-						<lb/> templo suo. Et qnod Ananiæ, dixit apostolus Petrus, <lb/> Ausus <hi rend="italic">es mentiri Spiritui sancto?</hi> atque ostendens <lb/> Deum esse Spiritum sanctum,
-							<hi rend="italic">Non es,</hi> inquit, <hi rend="italic">homi­ <lb/> nibus mentitus,
-							sed Deo (Act.</hi> v, 3, 4).</p>
-					<p>2. Miror autem cor vestrum, quantum sermone <lb/> explicare uon possum, quomodo cum sic
-						laudctis" <lb/> Spiritum sanctum, ut eum sanctificandis fidelibus <lb/> ubique asseratis
-						esse præsentem, tamen negare att­ <lb/> deatis Deum. Itane Deus non est, qui replevit
-						orb m <lb/> terrarum? Scriptura enim dicit: <hi rend="italic">Spiritus</hi> Domini <hi rend="italic">re­</hi>
-						<lb/> plevit <hi rend="italic">orbem</hi> terrarum <hi rend="italic">(Sap.</hi> I, 7).
-						Sed quid dicamus <lb/> quod replevit orbem, qui replevit urbis etiam Re­ <lb/> demptorem
-						? Dominus enim <hi rend="italic">Jesus plenus Spiritu<lb/> sancto regressus</hi> est <hi rend="italic">a Jordane (Luc.</hi> IV, 1) : et præsu­ <lb/> mitis dicere, quia ipse
-						Dominus Jesus Deus erat, et <lb/> SpiritUs sanctus quo plenus erat, non erat Deus; tam
-						<lb/> male sentientes de Spiritu sancto, ul non ci tribuatis <lb/> saltum quod tributum
-						est Moysi famulo Dci, qii non <lb/> munera gratiarum, scd plagaruin prodigia in eodem
-						<lb/> Spiritu sancto, quia ipse est <hi rend="italic">digitus Dei(Exod.</hi> VIII, 19),
-						<lb/> Ægyptiis ingerebat, et tamen Phar.toni deus erat. <lb/> Uno luco erat ad
-						affligendos Ægyptios, et Pharaoni <lb/> deus erat ( Exod. VII, 1): ubique adest Spiritus
-						sanctus <lb/> ad homines in æternam vitam regenerandos, et non <lb/> est eis Deus! lino
-						vero est, et Deus verus est, quia <lb/> vcri Dei membra templum ejus est. Et uiiquc sub­
-						<lb/> jectum est templum illi cujus est templum : qUomodo <lb/> ergo Deus non cst, cui
-						sunt membra Dei subjecta' <lb/> Ac per hoC et Dominus est templi sui : qnis enim hoc
-						<lb/> neget, quis ila desipiat, ut dicat non esse aliquem <lb/> dominum domus suæ?
-						Quomodo ergo Spiritus sanctus <lb/> non est Dominus, qui Dominus est membrorum Do­ <lb/>
-						mini ? Ipse cst quippe Spiritus Domini, de quo uno <lb/> codemque loco dictum est : Cum
-							<hi rend="italic">autem</hi> conversus <lb/>
-						<hi rend="italic">fuerit ad Dominum, auferetur velamen. Dominus autem<lb/> Spiritus est
-							;</hi> ubi <hi rend="italic">autem Spiritus Domini, ibi libertas</hi>
-						<lb/> (II Cor. III, 16, 17).</p>
-					<p>3. Jam creatorcm superius demonstravi Spiritum <lb/> sanctum: quomodo autem rex non
-						est, cujus templum <lb/> est quæ membra sunt regis? Quomodo non consedet <lb/> Patri et
-						Filio, qui replevit Filium, qui membra Filii <lb/> suam possidct domum? Nisi forte
-						quando Filius re­ <lb/> gressus est a Jordane, plenus erat Spiritu sancto; et <lb/>
-						quando sedere cœpit ad dexteram Patris, exclusit a so <lb/> Spiritum sanctum? Deimle cum
-						de Patre procedat, <lb/> quomodo cum Patre non sedeat? Cuu ipsa sessio non <lb/> sit
-						utique cogitanda carnaliter : alioquin opinaturi <lb/> sumus honorabilius Filium sedere
-						quam Patrem; ho­ <lb/> norabilius quippe scdetur ad dexteram : cl videbitur <lb/> esse
-						consequens ut Pater sedeat ad sinistram. Postremo <lb/> qualis vobis persuaserit
-						spiritus, ut sancto Spiritui <lb/> denegctis quod sanctis hominibus sancta Scriptura
-						<lb/> concedit, vos videritis. Ait enim Apostolus : Cum <lb/>
-						<hi rend="italic">essemus mortui peccatis, convivificavit nos Christo, cujus<lb/>
-							gratia</hi> sumus salvi facti ; <hi rend="italic">et simul excitavit, et simul
-							se­<lb/> dere fecit</hi> in <hi rend="italic">cælestibus</hi> in <hi rend="italic">Christo Jesu (Ephes.</hi> II, 5, 6). <lb/> Sancti ergo quos sanctificat Spiritus
-						sanctus, convivi­ <lb/> ficati Christo, ita simul sessuri prædestinati sunt, ut <lb/>
-						jam factum dicat Apostolus, quod certum est adfutu • <lb/> rum : et ipsi Spiritui sancto
-						subtrahitur a vobis quis­ <lb/> quis est ille consessus, taoquam sedere cum Patre vel
-						<lb/> Filio sit indignus, qui eadem sede efficit dignos. Cui <lb/> movetis etiam
-						quæstionem quod non adoretur, et hoc <lb/> utique simillimo errore, cum legatis, ut jam
-						supra <lb/> docui, a sanctis ctiam homines adoratos. Et tamen ut <lb/> invidiam
-						blaspbemantis evites; ita laudas Spiritum <lb/> sanctum, ut tribuas ei quod non habet
-						ulla creatura, <lb/> et detrahas ei quod adipiscitur et humana creatura.</p>
-					<p>CAPUT XXII. — i. Dixisse me quod commemo­ <lb/> ras, fateor, et nunc dico , quod
-						Salvator noster non <lb/> dixerit, Ut ipsi et nos unum ; sed, <hi rend="italic">Ut ipsi
-							sint unum</hi>
-						<lb/> Et de his evangelicis verbis satis a ure rccolo jani <lb/> fuisse responsum, cum
-						ostenderem refellere te ion <lb/> potuisse quæ dixi. Quoniam poposci ut proferres ubi
-						<lb/> legeris. <hi rend="italic">Unum sunt,</hi> dictum esse de alquibus rebus <lb/> quæ
-						non essent unius ejusdemque substantiæ : <unclear>neque</unclear>
-						<lb/> protulisti. Quid enim te adjuvat, quod dilectionis <lb/> consensione affirmas
-						dictum esse de Paulo et Apollo, <lb/>
-						<hi rend="italic">Qui plantat autem et qui rigat, unum sunt (I Cor.</hi> III, 8), <lb/>
-						cum eos non ostendas diversæ fuisse substantiæ? <lb/>
-						<pb n="793"/> Ambo quippe homines crant. Si enim non diligerent <lb/> invicem, natura
-						unum essent. dileclione non essent : <lb/> si anilem unum natura uon essent, unum dici
-						dile­ <lb/> ctione non possent. Poscit ergo Filius ut ita sint <lb/> unum,quomodo ipse
-						ct Pater unum sunt; id est , <lb/> non solum natura, quod jam erant ; verum eliain <lb/>
-						perfectione charitatis atque justitiæ, pro suæ capaci­ <lb/> late naturae, quantum in
-						Dei regno esse potuerint: <lb/> ut etiam ipsi summe unum sint in natura sua, quem­ <lb/>
-						admodum Pater et Filius summe unum sunt, quamvis <lb/> in excellentiore atque
-						incomparabiliter meliore na­ <lb/> tura sua. Dixit ergo ad Patrem Filius : <hi rend="italic">Pater sancte, <lb/> serva eos</hi> in <hi rend="italic">nomine</hi> tuo,
-							<hi rend="italic">quos dedisti mihi ;</hi> ut <hi rend="italic">ant unum, <lb/> sicut
-							et nos.</hi> Non dixit, Ut sint unum nobiscum; <lb/> aut, Ut simus unum ipsi et nos.
-						Item pauk) post : <lb/>
-						<hi rend="italic">Non</hi> pro <hi rend="italic">Itis autem rogo tantum,</hi> sed <hi rend="italic">et pro</hi> eia <hi rend="italic">qui cre.</hi>
-						<lb/> dituri <hi rend="italic">sunt</hi> per verbum ipsorum in <hi rend="italic">me;</hi> ut <hi rend="italic">omnes</hi> unum <hi rend="italic">sint,<lb/> sicut</hi>
-						tu <hi rend="italic">Pater in me, et ego</hi> in te, ut <hi rend="italic">et</hi> ipsi
-						in nobis unum <lb/>
-						<hi rend="italic">sint.</hi> Neque hic dixit, Ut ipsi et nos unum simus, sed, <lb/>
-						<hi rend="italic">unum sint in nobis.</hi> Quoniam homines qni natura unum <lb/> suni,
-						summe atque perfecte secundum suum modum <lb/> unum esse non possunt justitiæ
-						plenitudine , nisi in <lb/> Deo perficiantur, ut unum sint in Patre et Filio; id <lb/>
-						est, in ipsis unum, non cum ipsis unum. Adhuc se­ <lb/> quitur, et adjungit : <hi rend="italic">Ut mundus credat</hi> quia <hi rend="italic">tu me mi- <lb/> sisti, et
-							ego</hi> claritatem quam mihi <hi rend="italic">dedisti, dedi illis</hi> , ut <lb/>
-						sint unum, sicut nos unum sumus: <hi rend="italic">ego</hi> in <hi rend="italic">eis,</hi> et tu <hi rend="italic">in</hi>
-						<lb/> me, <hi rend="italic">ut sint consummati</hi> in unum. Neque hie dixit, Ut <lb/>
-						nobiscum sint unum, ant, Ut ipsi et nos simus unum. <lb/> Deinde cum addidisset, <hi rend="italic">Ut cognoscat mundus quia tu</hi>
-						<lb/> me <hi rend="italic">misisti, et</hi> dilexisti <hi rend="italic">eos</hi> sicut
-							<hi rend="italic">et</hi> me <hi rend="italic">dilexisti;</hi> seculus <lb/> adjunxit,
-							<hi rend="italic">Pater, volo</hi> ut <hi rend="italic">ubi ego</hi> sum, <hi rend="italic">et</hi> ipsi <hi rend="italic">sint</hi> me­ <lb/> cum (Joan. XVII,
-							11-24).<hi rend="italic">Ubi</hi> sum,inquit, <hi rend="italic">mecum</hi> sint :
-						<lb/> non ait, Unum mecum sint 1. Hoc ergo voluit, ut cum <lb/> illo essent, non ut illi
-						et ipse unum essent. Quid est <lb/> quod dicere voluisti 4 <hi rend="italic">Dilectionis
-							fecit mentionem,</hi> et <lb/> non substantiæ ? Quamvis tu non eo loco ista Domini
-						<lb/> verba posueris, quo ab ipso sunt posita. Sed qnid <lb/> ad Hos ? quandoquidem non
-						ipsos et se, vel ipsos et <lb/> Patrem dixit aut voluit unam esse; sed ipsos unum <lb/>
-						esse voluit, quos noverat unius esse substantiæ. Sic­ <lb/> ut <hi rend="italic">ei
-							nos</hi> , inquit unum sumus : quos identidem no­ <lb/> verat unius essp
-						substantia.</p>
-					<p>2. Tu si vis aliquid respondere, ostende secundum <lb/> Scripturam sanctam de aliquibus
-						rebus dici, Unum <lb/> sunt, quarum est diversa substantia. Hoc enim Chri­ <lb/> stus
-						non dixit, quod tamen tu ausus es dicere, id est, <lb/>
-						<hi rend="italic">Apostolos</hi> unum esse <hi rend="italic">cum Patre et</hi> Filio ,
-							<hi rend="italic">in eo quod</hi> in <lb/> amnilus <hi rend="italic">ad
-							voluntatem</hi> Dei <hi rend="italic">Patris respicientes, ad</hi> imi­ <lb/>
-						<hi rend="italic">tationem Filii subditi uni Deo Patri et ipsi</hi> inveniun­ <lb/>
-						<hi rend="italic">tur</hi> (a). Hæc dicens, Deum et homines sanctos unum <lb/> esse
-						fecisti. Potest ergo quisquam sanctorum dicere , <lb/> Ego et Dens unum sumus? Absit hoc
-						a cordibus et <lb/> oribus sanctis. Puto autem qnod et vos a quocumque <lb/> hoc
-						audiatis, horrescilis , nec fertis quemquam ho­ <lb/> minem, quantolibet munere
-						sanctitatis excellat, di­ <lb/> contem , Ego et Deus unum sumus. Sed forte arro- <note type="footnote">4 I.ov. etquidain Mss. omitlunt, <hi rend="italic">yon ait, vnum mecum
-								sint</hi>
-						</note>
-						<note type="footnote"> !aj vide serm. i tO, n. ł, tom </note>
-						<lb/> gantiae videatur, si hoc de seipso aliquis dicat. Itane <lb/> vcro quisquam
-						vestrum etsi non audet dicere, Ego et <lb/> Deus unum sumus; saltem audet dicere, Paulus
-						et <lb/> Deus unum sunt; sicut incunctanter dicimus, Paulus <lb/> et Apollo unum sunt;
-						Deus Pater et Deus Filius <lb/> unum sunt? Porro, si non audetis dicere , Quilihet <lb/>
-						hono sanctus, quilibet propheta , quilibet apostolus, <lb/> et Deus, unum sunt; quis te
-						urgebal, quis te impin­ <lb/> gebat, quis te præcipitabat 1, ut diceres, <hi rend="italic">Apostoli<lb/> unum sunt cum Patre et Filio? Unum sunt,</hi> inquis, <lb/>
-						<hi rend="italic">Pater et Filius, non tamen</hi> unus : continuoque sub <lb/> jungis,
-							<hi rend="italic">Unum ad concordiam pertinet; Unus, ad</hi> nu­ <lb/>
-						<hi rend="italic">merum singularitatis.</hi> Volebas autem dicere , Unum <lb/> sunt, ad
-						concordiam pertinet; Unus est, ad numerum <lb/> singularitatis : sed te a consideratione
-						verborum tuo­ <lb/> rum impetus disputationis avertit. Nam et Unum et <lb/> Unus utique
-						ad numerum pertinet singularem. Scd <lb/> quod verum I est; Unum sunt, propter id quod
-						ad­ <lb/> dilum est, Sunt, pluralem indicat numerum , qua­ <lb/> dam singularitate
-						connexum : Unus est autem , aper­ <lb/> tissime est numerus singularis. Sed numquid
-						Aposto­ <lb/> lus diceret, Qui antem adhaeret Domino, unum sunt? <lb/> Quid enim aliud
-						diccret, si hoc diceret, nisi, Homo <lb/> sanctus, et Deus, unum sunt? Sed ahsit, absit
-						ab illa <lb/> sapientia ista sententia : et tamen dixit, Qui <hi rend="italic">autem<lb/> adhœret Domno,</hi> unus <hi rend="italic">spiritus</hi> eat (I <hi rend="italic">Cor.</hi> VI, 47); ut <lb/> noveris de his dici, Unum sunt, qaæ unius
-						sunt ejus­ <lb/> demque substantiæ : sient quibusdam bominibus di­ <lb/> etum est, <hi rend="italic">Omnes enim</hi> vos <hi rend="italic">unum estis in Christo</hi> Jesu <lb/>
-						<hi rend="italic">(Galat.</hi> III, 28); et sicut. ait Ipse Christus, <hi rend="italic">Ego et Pa­ <lb/> ter</hi> unum sumus <hi rend="italic">(Joan.</hi> x, 30). Cum autem
-						unns dici­ <lb/> tur, et qmd unus dicitur 3 : et de diversis substantiis <lb/> dici
-						potest, sicut dictum est, Qui adhæret Domino % <lb/>
-						<hi rend="italic">unus</hi> spiritus <hi rend="italic">est;</hi> et de rebus unius
-						substantiæ, sient, <lb/> dictum est, <hi rend="italic">Erat eis anima et cor unum
-							(Act.</hi> IV, 32). <lb/>
-						<hi rend="italic">Erat,</hi> dixit; non dixit, Erant: quoniam dixit et quid <lb/> crat;
-						id est, <hi rend="italic">anima et cor.</hi> Sic etiam de Patre et Filio, <lb/> et, Unum
-						sunt, dicimus, quia unius substantiae duo <lb/> sunt : et, Unus est, dicimus, sed
-						addimus quid unus; <lb/> id est, unusDeus, unus Dominus , unus Omnipotens, <lb/> et si
-						quid hujusmodi, Satis me vobis duarum istarum <lb/> locutionum arbitror inculcasse
-						distantiam. Scrutare <lb/> itaque Scripturas canonicas veteres et novas, et in­ <lb/>
-						vcni, si potes, ubi dicta sunt aliqua, Unum sunt, quæ <lb/> sunt diversae paturae atque
-						substantiæ.</p>
-					<p>3. Sane falli te nolo in Epistola Joannis apostoli, <lb/> ubi ait: <hi rend="italic">Tres sunt testes; spiritus, et aqua, et sanguis;<lb/> et tres unum sunt</hi> (I <hi rend="italic">Joan.</hi> v, 8). Ne forte dicas spiri­ <lb/> tum et aquam et sanguinem
-						diversas esse substantias, <lb/> et tamen dictum esse , <hi rend="italic">tres unum sunt
-							:</hi> propter hoc <lb/> admonui ne fallaris. Hæc enim sacramenta sunt, in <lb/>
-						quibus non quid sint, sed quid ostendant semper at - <lb/> tenditur : quoniam signa sunt
-						rerum , alind existen- <lb/> tia, et aliud significanlia. Si ergo illa quæ bis signifi
-						<lb/> canlur, intelligantur, ipsa inveniuntur unius esse sub- <note type="footnote">1
-							Apud Er. Lugd. et ven., <hi rend="italic">quis te wgebat, quis</hi> pr(r' <lb/>
-							<hi rend="italic">cipitahat ?</hi> M. </note><note type="footnote"> ' Apud Lov. et
-							quosdam Mss., <hi rend="italic">verbum.</hi>
-						</note><note type="footnote"> a sic Mss. Kdili auicm, <hi rend="italic">ct quid unus
-								naturaj ct quid</hi> :&lt;&lt; <lb/>
-							<hi rend="italic">ndjicitur.</hi>
-						</note>
-						<lb/>
-						<pb n="795"/> stantiæ ; tanquam si dicamus , Petra et aqua unum <lb/> sunt, volentes per
-						petram significare Christum ; per <lb/> aquam, Spiritum sanctum : quis dubitat petram et
-						<lb/> aquam diversas esse naturas ? Sed quia Christus et <lb/> Spiritus sanctus unius
-						sunt ejusdemque naturae ; idco <lb/> cum dicitur Petra et aqua unum sunt; ex ea parte
-						<lb/> recie accipi potest , qua istæ duae res quarum est di­ <lb/> versa natura, aliarum
-						quoque signa sunt rerum qua­ <unclear/>
-						<lb/> rumest una natura. Tria itaque novimus de corpor- <lb/> Domini exisse, cum
-						penderet in ligno : primo, spiri­ <lb/> tum ; unde scriptum est, <hi rend="italic">Et
-							inclinato capite tradidit</hi>
-						<lb/> spiritum ; deinde , quando latus ejus lancca perfora­ <lb/> tum est, sanguinem et
-						aquom <hi rend="italic">(Joan.</hi> XIX, 50, 34). <lb/> Quæ tria si per se ipsa
-						intueamur , diversas habent <lb/> singula quaeque substantias; ac per hoc non sunt <lb/>
-						unum. Si vero ea, quae his significata sunt, velimus <lb/> inquirere , non absurde
-						occurrit ipsa Trinitas , qui <lb/> unus, solus , verus, summus est Deus, Pater et Fi­
-						<lb/> lius et Spiritus sanctus, de quibus verissime dici. po­ <lb/> tuit, <hi rend="italic">Tres</hi> sunt testes , <hi rend="italic">et tres</hi> unum <hi rend="italic">sunt</hi> : ut nomine <lb/> spiritus significatum accipiamus Deum Patrem
-						: de <lb/> ipso quippe adorando loquebamur Dominus, ubi ait, <lb/> Spiritus <hi rend="italic">eat Deus (Id.</hi> IV, 24). Nomine autem sangui­ <lb/> nis, Filium :
-						quia, <hi rend="italic">Verbum caro factum est (Id.</hi> I, 14). <lb/> Et nomine aquæ
-						Spiritum sanctum : cum enim de <lb/> aqua loqueretur Jesus, quam daturus erat
-						sitientibus, <lb/> ait evangelista, <hi rend="italic">Hoc autem dixit de Spiritu, quem
-							ac­</hi>
-						<lb/> cepturi <hi rend="italic">erant credentes</hi> in <hi rend="italic">eum (Id.</hi>
-						VII, 39). Tesles <lb/> vero esse Patrem et Filium et Spiritum sanctum , <lb/> quis
-						Evangelio credit, et dubitat, dicente Filio, <hi rend="italic">Ego</hi>
-						<lb/> sum <hi rend="italic">qui testimonium perhibeo de me: et testimonium <lb/>
-							perhibet de</hi> me, <hi rend="italic">qui misit me, Pater (Jd.</hi> VIII, 18)? Ubi
-						<lb/> etsi non est commemoratus Spiritus sanctus, non ta­ <lb/> men intelligitur
-						separatus. Sed nec de ipso alihi ta­ <lb/> cua, eumque testem satis aperteque
-						monstravit. Nam <lb/> curi illum promitteret, ait : <hi rend="italic">Ipse testimonium
-							perhibebit <lb/> de me.</hi> Hi <hi rend="italic">sunt tres testes: et tres unum sunt
-							(Id.</hi> xv, <lb/> 26), quia unius substantiæ sunt. Quod antemi signa <lb/> quibus
-						significati sunt, de corpore Domini exierunt, <lb/> figuraverunt Ecclesiam prædicantem
-						Trinitatis unam <lb/> eamdemque naturam : quoniam hi tres qui trino mo* <lb/> do
-						significati sunt, unum sunt; Ecclesia vero eos <lb/> praedicans, corpus est Christi. Si
-						ergo. Ires res quibus <lb/> significati sunt, ex corpore Domini exierunt : sicut <lb/>
-						ex corpore Domini sonuit, ut baptizarentur gentes <hi rend="italic">in <lb/> nomine
-							Patris et Filii et Spiritus sancti (Matth.</hi> XXVIII, <lb/> 19). <hi rend="italic">In</hi> nomine; non, In nominibus : hi enim tres <lb/> unum sunt, et hi tres unus est
-						Deus. Si quo autem <lb/> ano modo tanti sacramenti ista profunditas , quae in <lb/>
-						Epistola Joannis legitur, exponi et intelligi potest <lb/> secundum catholicam fidem,
-						quæ nec confundit nec <lb/> separat Ti iuitatem , nec abnuit tres personas , nec <lb/>
-						diversas credit esse substantias, nulla ratione respu­ <lb/> endum est. Quod enim ad
-						exercendas mentes fide­ <lb/> lium in Scripturis sanctis obscure ponitur,gratulan­ <lb/>
-						dum cst, si multis modis, non tamen insipienter ex­ <lb/> punitur.</p>
-					<p>CAPUT XXIII. — 1. Quid est autem quod po- <lb/> Mis ut astruam , <hi rend="italic">Si
-							pater et Filias et Spiritus san­<lb/> ctus</hi> unus <hi rend="italic">est Deus</hi> ;
-						cum hoe astruat voce clarissima <lb/> Scriptura divina dicens , <hi rend="italic">Audi,
-							Israel; Dominus Deus</hi>
-						<lb/> tuus, <hi rend="italic">Dominus</hi> unus <hi rend="italic">est ( Deut,</hi> VI,
-						4)? Quod et vos <lb/> uiiquc audiretis, si Israel esse velletis, non carnali­ <lb/> ter
-						ut Judæri, sed spiritualiter ut Christiani. Qui enim <lb/> non vult fideliter audire
-						quod dictum est, <hi rend="italic">Audi, Israel; <lb/> Dominus Deus tuus, Dominus unus
-							est;</hi> superest ut <lb/> eum qui hoc dixit, credat esse mendacem. Si autem <lb/>
-						mendax ille non est, vox ista vera est : si vox ista <lb/> vera est, quæstio ista finita
-						est. Procul dubio quippe <lb/> vos veritascogit Patrem aL Filium et Spiritum sanctum
-						<lb/> confiteri unum Dominum Deum. Sed Spiritum san­ <lb/> ctum, cujus templum non
-						manufactum, sed corpus <lb/> est nostrum , cujus templum non ligna et lapides, sed <lb/>
-						membra sunt Christi, negatis Deum : de ipso Christo <lb/> quid dicturi estis, quem Deum
-						et Dominum confite­ <lb/> mini? Respondete itaque nobis, utrum Pater et Filius <lb/>
-						unus sit Dominus Deus. Si cnim non est <unclear>mius</unclear>, duo <lb/> sunt : si duo
-						sunt, mentitur qui dicit, <hi rend="italic">Audi , Israel; <lb/> Dominus Deus tuus,
-							Dominus unus est ;</hi> mentitur qui <lb/> dicit, <hi rend="italic">Videte quoniam ego
-							sum Deus , et non cst</hi>
-						<unclear>otius</unclear>
-						<lb/>
-						<hi rend="italic">praeter me (Id.</hi> XXIII, 39). Sed quia illum
-							<unclear>menten­</unclear>
-						<lb/> tem dicere non audetis, quare vos corrigere dubita­ <lb/> tis, et venire vel
-						redire ad catholicam fidem , quæ <lb/> Patrem et Filium et Spiritum sanctum non tres do­
-						<lb/> minos deos, sed unum Dominum Dcum credit et <lb/> audit clamantem populo suo, <hi rend="italic">Audi, Israel; Dominus, <lb/> Deus</hi> tuus, Dominus <hi rend="italic">unus est;</hi> et, <hi rend="italic">Videte quoniam egu</hi>
-						<lb/> sum <hi rend="italic">Dominus, et non est alius præter me ?</hi> Si te dicam <lb/>
-						surdum et cæcum, qui nec audis ista, nec vides, con­ <lb/> tumeliosum sine dubio me
-						putabis. Ecce non dico : <lb/> expone nobis quomodo accipias, <hi rend="italic">Audi,
-							Israel ; Do­ <lb/> minus Deus</hi> tuus , <hi rend="italic">Dominus</hi> unus <hi rend="italic">est :</hi> utrum ibi sit <lb/> intelligendus et Christus, an non sit. Si
-						enim dixeris, <lb/> Ibi est; confiteberis mecum Patrem et Filium unum <lb/> esse Dominum
-						Deum. Si autem responderis, Christum <lb/> non esse ibi intelligendum , duos contra
-						vocem divi­ <lb/> nam introducturus es dominos deos, quoniam non <lb/> nogas etiam
-						Christum esse Dominum Deum. Similiter <lb/> abs te quæro quomodo accipias, <hi rend="italic">Videte quoniam ego<lb/> sum Dominus, et non est alius pr</hi>æ<hi rend="italic">ter</hi> me. Ibi est et <lb/> Christus, an non est? Si ibi est, profecto
-						Pater ct <lb/> Filius unus est Dominus : si autem ibi non est, et <lb/> tamen Dominus
-						est; mentitur qui dicit, <hi rend="italic">Non est alius <lb/> præter me.</hi> Est enim
-						alius Dominus Filius, si non <lb/> unus est Domninus Pater et Filius. Quantumlibet enim
-						<lb/> excellentius laudes Patrem, et infra cum deprimas <lb/> Filium, id agis , ut
-						æquales non sint, non ut duo non <lb/> sint. Clama , quantum vis, Pater est major,
-						Filius <lb/> minor : respondetur tibi, Duo sunt tamen major ct <lb/> minor. Nec dictum
-						cst, Dominus Dens tuus major, <lb/> Dominus unus est : sed dictum est , <hi rend="italic">Dominus</hi> Deus <lb/>
-						<hi rend="italic">tuus, Dominus unus est.</hi> Neque dictum est, Non est <lb/> alius
-						æqualis mihi : sed diclum est, <hi rend="italic">Non est alius <lb/> Dominus præter
-							me.</hi> Aut ergo confitere Patrem et <lb/> Filium unum esse Dominum Dcum , aut apene
-						nega <lb/> Dominum Deum esse Christum , sicut aperte negas <lb/> Dominum Deum esse
-						Spiritum sanctum. Quod si <lb/> . leceris , istis quidem te divinis vocibus non urgebo, <lb/>
-						<pb n="797"/> sedalia testimonia divina proferam, quibus te et iii <lb/> isto errore
-						detestabiliorem convincam 1. Nunc autem <lb/> et si negas Dominum Deum e se Spiritum
-						sancium, <lb/> tamen ut istis Dei vocibus conteraris, satis est quod <lb/> Christum
-						Dominum Deum confiteris : qui si non est <lb/> cum Patre unus Dominus Ocus, duo domini
-						dii nostri <lb/> erunt, et falsæ illæ Dei voces erunt, <hi rend="italic">Dominus Deus
-							<lb/> tuus, Dominus unus est ;</hi> et, <hi rend="italic">Non eat alius</hi> praeter
-							<hi rend="italic">me.</hi>
-						<lb/> Scd quanto melius erunt vestra verba emendata, quam <lb/> pei verba mendacia ?</p>
-					<p>i. Quæris a me utrum , <hi rend="italic">Judaico modo te horter</hi> pro­ <lb/>
-						<hi rend="italic">fiteri</hi> unum <hi rend="italic">Denm; an de subjectione Filii
-							potius secun­<lb/> dum quod fides habet</hi> Christiana , <hi rend="italic">ostendatur
-							unus esse<lb/> Deus, cujus Filius noster est Deus.</hi> Ita hoc dicis, quasi <lb/>
-						Judaeorum sil vox, <hi rend="italic">Audi, Israel; Dominus Deus</hi> tuus, <lb/>
-						<hi rend="italic">Dominus unus est ;</hi> aut, <hi rend="italic">Ego sum Dominus, et non
-							eat <lb/> alius prœter me.</hi> Ipse Deus hoc dixit: agnosce, et <lb/> tace ; vel
-						potius edissere quomodo ,'crum dixerit, <lb/> quem nullus nostrum andet affirmare
-						mentitum. <lb/> Edissere, inquam, quomodo verum st, <hi rend="italic">Dominus Deus</hi>
-						<lb/> tuus, <hi rend="italic">Dominus unus est ;</hi> si domini dii nostri, nt di­ <lb/>
-						citis, duo sunt, unus major , alius minor : edissere <lb/> quomodo verum sit, <hi rend="italic">Ego sum Dominus, et non est</hi>
-						<lb/> alius <hi rend="italic">prœter me.</hi> Quis enim hoc dixcril qu;cro, utrum <lb/>
-						pater, an Filius. Si Pater dixit, <hi rend="italic">Ego</hi> sum Dominus, <lb/> et <hi rend="italic">non est alius præter me;</hi> non verum dixit, quia <lb/> est alius
-						Dominus Filius. Si Filius hoc dixit: nee ipse <lb/> verum dixit, quia est alius Dominus
-						Pater. Si autem <lb/> hoc dixit Trinitas ; profecto et verum dixit, et vos <lb/> falsum
-						diccre ostendit. Trinitas quippe secundum <lb/> rectam fidcm , id cst, Pater et Filius
-						et Spiritus san­ <lb/> ctus, in cujus nomine baptizamur, et unus Dominus <lb/> Deus
-						noster est, ct præter ipsum alius non est. Ipse <lb/> est enim Deus de quo dicit
-						Apostolus : <hi rend="italic">Nullus</hi><hi rend="italic">est<lb/> Deus,</hi> nisi unus
-						(I <hi rend="italic">Cor.</hi> VIII , 4). Nam si hoc de Patre <lb/> acceperis dictum ,
-						non tibi ent Deus Christus , quia <lb/> nun potest solvi Scriptura , dicens, <hi rend="italic">Nullus Deus, nisi</hi>
-						<lb/> unus : ut lic vobis taceam de Spiritu sancto , quem <lb/> superius Dominum Deum
-						ostendimus, vobis neganti­ <lb/> bus. Quapropter si Macedoniani hæretici essetis, qui
-						<lb/> de solo Spiritu sancto catholicæ fidei consentire de­ <lb/> trectant, Patrem vero
-						et Filium duos quidem esse, <lb/> id est, illum Patrem , illum Filium , et æquales esse,
-						<lb/> atque unius ejusdemque substantiae, nec tamen duos <lb/> dominos deos, sed ambos
-						simul unum Dominum <lb/> Deum essc consentiunt : si ergo et vos saltem har-te­ <lb/> nus
-						erraretis, noh utique his divinis vocibus urgerc­ <lb/> mini. Patrem quippe et Filium
-						assereretis unum Do­ <lb/> minum Deum dixisse , <hi rend="italic">Non est alius prœter
-							me.</hi> Uti­ <lb/> nam non restaret agere vobiscum, nisi ut adjungere­ <lb/> tis
-						Spiritum sanctum, et non dualitatem , sed Trini­ <lb/> tatem diceretis unum Dominum
-						Deum. Nunc vcro <lb/> cum sic asseritis Patrem Dominum Deum , et Filium <lb/> Dominum
-						Deum , ut simul ambos non dicatis unum <lb/> Dominum Deum, sed duos, majorem
-						unum,minorem <lb/> alterum ;prorsus confodimini gladio veritatis dicentis, <lb/>
-						<hi rend="italic">Audi, Israel ;</hi>Dominus <hi rend="italic">Deus tuus, Dominus unus
-							est:</hi>
-						<lb/> qui clamat, <hi rend="italic">Ego</hi> sum <hi rend="italic">Dominus, et non est
-							alius</hi> præter <note type="footnote">I f.r. Usyl. v en., <hi rend="italic">destestabiliorem</hi><hi rend="italic">comincam.</hi> M. </note>
-						<lb/> me. Neque enim Dom Pater sic rellet Israelitas a <lb/> cultu deorum revocare
-						multorum atque falsorum , ut <lb/> eis de uno Deo ac Domino mentiretur, et diceret non
-						<lb/> esse præter se alium Dominum, cnm sciret Deum et <lb/> Dominum esse suum Filium.
-						Absit ut veritas et veri­ <lb/> tatis Pater mendacio deciperet populum suum : hæ­ <lb/>
-						reticorum sit hæc , uon catholicorum tam horrenda <lb/> et detestanda blasphemia.
-						Prorsus Deus verum dicit, <lb/> cum dicit, <hi rend="italic">Audi, Israel; Dominus Dcus
-							tuus, Dominus<lb/> unus est:</hi> quia Patcr ct Filius et Sp ritus sanctus, non <lb/>
-						tres dii, sed unus Deus ; nec tres domini, sed unus <lb/> Dominus est. Prorsus verum
-						dicit, <hi rend="italic">Ego sum Dominus, <lb/> et non estalius prœter me ;</hi> quia
-						non hoc Pater tan­ <lb/> lum, sed ipsa Trinitas dicit : hic est Dominus unus, <lb/> ct
-						non alius præter ipsum, Nam si Pater diceret, <hi rend="italic">Ego <lb/> sum Dominus,
-							et non ert alius prœter me;</hi> negaretuti­ <lb/> que Dominum esse unigenitum Filium.
-						Et quis no­ <lb/> strum auderet eum Dominum confiteri, contradicente <lb/> Patre atquc
-						dicente, <hi rend="italic">Ego sum Dominus, et non eat alius <lb/> prater me?</hi> Ac
-						per boc secundumrectam fidem , non <lb/> Patris, sed T riniiatis hæc vox cst: et Patris
-						ergo, et Filii, <lb/> et Spiritus sancti. Obticescant igitur linguæ ignoran­ <lb/> tium
-						vcritatcm : hæc Trinitas Deus unus est. De hoc <lb/> uno Deo dicitur, Audi, <hi rend="italic">Israel; Dominus Deus tuus,</hi>
-						<lb/> Dominus unus <hi rend="italic">est.</hi> llic Deus unus dicit, <hi rend="italic">Ego</hi> sum <hi rend="italic">Do­ <lb/> minus, et non est alius præter me.</hi>
-						Subjectus est quidem <lb/> Patri filius secundumformam hominis : non tamen <lb/> sunt
-						duo dii ct duo domini secundum formam De!; <lb/> sed ambo cum Spirilu suo unus cst
-						Dominus.</p>
-					<p>3. Testimonia quæ de Paulo apostolo protulisti, <lb/> contra te loquuntur, ct nescis.
-						Dicit enim ille : <hi rend="italic">Gra­<lb/> tia vobis et pax a Deu Patre nostro et
-							Domino</hi> Jesu <lb/>
-						<hi rend="italic">Christo (Rom.</hi> I, 7; I <hi rend="italic">Cor.</hi> I, 3; II <hi rend="italic">Cor.</hi> I, 2; <hi rend="italic">Gulat.</hi> i, <lb/> 3, <hi rend="italic">et Ephes.</hi> I, 2). Quomodo est autem Dominus Je-<lb/> sus Christus,
-						si Pater dicit, <hi rend="italic">Ego sum Dominus,</hi> et non <lb/>
-						<hi rend="italic">eat</hi> alius <hi rend="italic">praeter me?</hi> Non ergo solius
-						Patris, ut dixi, <lb/> sed Trinitatis hæc vox est. Adhibes alterurn testimo­ <lb/> nium,
-						et ipsum contra te ipsum, ubi ait Apostolus, <lb/>
-						<hi rend="italic">Unus Deus</hi> Puter , <hi rend="italic">ex quo omnia, et noa in ipso
-							;</hi> et <lb/>
-						<hi rend="italic">unus Dominus</hi> Jesus <hi rend="italic">Christus, per quem omnia, et
-							<lb/> noa in ipso,</hi> sicut tu loculus es : Apostolus autem, <hi rend="italic">a</hi>
-						<lb/> noa <hi rend="italic">per ipsum</hi> ait; non ait, in <hi rend="italic">ipso.</hi>
-						Sed hoc quid ad <lb/> causam ? Solent ista contingere ex memoria proferen <lb/> tibus
-						testimonia, non ex codice illa legentibus : quod <lb/> ad rem pertinet potius intuere.
-						Ecce, dixit Aposto­ <lb/> lus, <hi rend="italic">Unus Deus Pater, ex quo omnia, et nos
-							in</hi> ipso, <lb/>
-						<hi rend="italic">et unus Dominus Jesus Christus,</hi><hi rend="italic">per quem omnia,
-							et</hi>
-						<lb/> noa <hi rend="italic">per</hi> ipsum <hi rend="italic">Cor.</hi> VIII, 6). Omnino
-						duas personas, <lb/> unam Patris, alteram Filii, sine ulla confusione et <lb/> sine ullo
-						errore distinxit. Neque enim duo sunt dii <lb/> patres, sed unus Deus Pater : nec duo
-						sunt domini <lb/> Jesu Christi, sed unus Dominus Jesus Christus. In <lb/> illa quippe
-						Trinitate quæDeus cst, unus est Pater, <lb/> non duo vel tres; et unus Filius, non duo
-						vel tres; <lb/> et unus amborum Spiritus, non duo vel tres : ct ipse <lb/> unus Pater
-						utique Deus est, et ipse unus Filius etiam <lb/> vobis fatentibus Deus cst, et ipse
-						amborum Spiritus <lb/> etiam vobis negantibus Deus cst. Sic et Dominiun s <lb/> quæras,
-						singulum quemque respondeo ; sed simu! <lb/>
-						<pb n="799"/> omnes non Ires dominos tlcos, sud unum Domiuum <lb/> Deum dico. Hæc est
-						fides nostra, qnoniam hæc fides <lb/> est recta, quæ fides etiam catholica nuncupatur.
-						Tu <lb/> antem qui huic fidei contradicis, quæso te, expone <lb/> nobis, eliam Josus
-						Christus quomodo sit Dominus, <lb/> qui non Trinitatis, sed solius Patris esse asseris
-						vo­ <lb/> cem, <hi rend="italic">Ego sum Dominus, et non est alius præter me.</hi>
-						<lb/> Nempe turbaris ; nempe quid respondeas non invenis, <lb/> nisi quia tacere, quando
-						convinceris, non vis. Si enim <lb/> non Deus Trinitas, sed Pater tantum dixit, <hi rend="italic">Ego sum <lb/> Dominus, et non est alius prœter me :</hi> procul dubio
-						ne­ <lb/> gavit esse Dominum Filium; quoniam si Dominus est <lb/> pt Filius, falso
-						dictum est, <hi rend="italic">Non eat alius Dominus<lb/> prœter me.</hi> Non enim agitur
-						de Domino, quales sunt <lb/> homines domini hominum servorum, quos Apostolus <lb/>
-						secundum carnem dominos esse dicit <hi rend="italic">(Ephes.</hi> VI, 5 ): <lb/> sed de
-						Domino agitur, cui servitus illa debetur, quæ <lb/> græce <foreign xml:lang="grc">λατρεία</foreign> dicitur, secundum quam dictum est, <lb/>
-						<hi rend="italic">Dominum Deum</hi> tuum <hi rend="italic">adorabis, et illi soli
-							servies (Deut,</hi>
-						<lb/> VI, 13). Qui Dominus Deus si non Trinitas, sed solus <lb/> est Pater : prohibemur
-						utique Domino Cbristo tali <lb/> servitude servire, in <hi rend="italic">eo</hi> quod
-						audimus, <hi rend="italic">Illi soli aer­</hi>
-						<lb/> vies ; si ita dictum est, ac si diccrelur, Deo Patri soli <lb/> servies. Qui
-						profecto si solus, et non ipsa Trinitas <lb/> dixit, <hi rend="italic">Ego</hi> sum
-						DorMiMus, <hi rend="italic">et</hi> non <hi rend="italic">eat alius</hi> prœter <hi rend="italic">me;</hi>
-						<lb/> negavit csse Filium Dominum talem, quali domino <lb/> servitus illa debetur, qua
-						nonnisi Deo cum vera ret!­ <lb/> gione servitur. Non enim dixit, Ego sum Dominus <lb/>
-						majoraut melior*et non est tantus aut talis praeter <lb/> ine : sed volens sibi soli ea
-						quae Domino Deo debetur <lb/> servitute serviri, <hi rend="italic">Ego sum,</hi> inquit,
-							<hi rend="italic">Dominus, et non est<lb/> alius</hi> præter <hi rend="italic">me.</hi> Porro si vox ista, sicut catholica fi­ <lb/> des dicit, unius Dei est, quod
-						est ipsa Trinitas; sine <lb/> ulla dubitatione huic soli serviendam est ea servitute,
-						<lb/> quae nonnisi Domino Deo debetur, quia ipse est Do­ <lb/> minus, et non est alius
-						praeter ipsum.</p>
-					<p>4. Deinde quæro quomodo accipias quod dictum <lb/> est, Unus <hi rend="italic">Deus
-							Pater, ex quo omnia, et nos</hi> in <hi rend="italic">ipso; <lb/> et</hi> unus <hi rend="italic">Dominus Jesus</hi> Christ: s, <hi rend="italic">per quem omnia, et noa
-							<lb/> per</hi> ipsum. Numquid non et ex Filio sunt omnia : <lb/> quandoquidem ipse
-						dicit, <hi rend="italic">Quœcumque Pater facit, hæc<lb/> et</hi> Filius <hi rend="italic">similiter facit (Joan.</hi> v, 19)? Si autem ita dis­ <lb/> linguis, ut
-						non sint per Patrem omnia, sed ex Patre; <lb/> nec omnia sint ex Filio, sed per Filium :
-						quis eorum <lb/> tihi vidctur esse illc de quo idem apostolus dicit, 0 <lb/>
-						<hi rend="italic">altitudo diritiarum</hi><hi rend="italic">sapientiœ et scientiœ Dei !
-							quam in­ <lb/> scrutabilia sunt judicia ejus, et investigabiles viœ ejus ! <lb/> Quis
-							enim cognovit sensum</hi> Domini ? <hi rend="italic">Aut quis consilia­</hi>
-						<lb/> rius <hi rend="italic">ejus</hi> fuit ? <hi rend="italic">Aut quis prior dcdit
-							illi, et retribuetur ei? <lb/> Quoniam ex</hi> ipso, <hi rend="italic">et per ipsum,
-							et in ipso</hi> sunt <hi rend="italic">omnia : <lb/> ip1i gloria in sœcula</hi>
-						sœculorum. Amen <hi rend="italic">(Rom.</hi>XI, 33-36). <lb/> Utrum Pater eat
-						intelligondus, an Filius? Deum nam­ <lb/> que prius nominavit, dicens : 0 <hi rend="italic">allitudo divitiarum sa­</hi>
-						<lb/> pientiae <hi rend="italic">et scientia Dei!</hi> Postea vcro eum Dominum ap­ <lb/>
-						pellait. ubi ait: <hi rend="italic">Quis enim</hi> cognovit sensum <hi rend="italic">Domini?</hi> Sed <lb/> hocnon habet controversiam :utrumque eniin nomen <lb/> etiam
-						vos et Patri assigNatis et Filio. Neque enim sic <lb/> dicitis DeumPatrem, ut negetis
-						esse Deum Filium; <lb/> tut sic dicitis Deum Filium, ut negetis esse Dcum Pa­ <lb/>
-						trem. Quatnvis in hoc ap ostolico testimonio quod ad­ <lb/> hibuisti, Deus dicatur
-						Pater, Do t imis Filius, id est, <lb/>
-						<hi rend="italic">Unus Deus</hi> Pater, <hi rend="italic">ex quo omnia; et</hi> unus
-						Dominus <hi rend="italic">Je­ <lb/> sus Christus, per quem omnia.</hi> Sed illud attende
-						abi di­ <lb/> ctum est. <hi rend="italic">0 altitudo divitiarum</hi><hi rend="italic">sapientiæ et</hi> scientiæ <lb/>
-						<hi rend="italic">Dei!</hi> Nam sive Pater sit iste, sive Filius, <hi rend="italic">ex
-							ipso, et <lb/> per</hi> ipsum, <hi rend="italic">et</hi> in <hi rend="italic">ipso
-							sunt omnia.</hi> Quomodo ergo ex <lb/> Patre omnia, non ex Filio; et per Filium omnia,
-						non <lb/> per Patrem : quandoquidem quemlibet eorum Apo­ <lb/> stolus voluerit hoc loco
-						intelligi, <hi rend="italic">Ex</hi> ipso , inquit, <hi rend="italic">et</hi>
-						<lb/> per ipsum, <hi rend="italic">et</hi> in <hi rend="italic">ipso sunt omnia?</hi> Si
-						ergo sive de Pa­ <lb/> tre sive de Filio, verissime tamen dicitur, quod ex <lb/> ipso
-							<hi rend="italic">et per ipsum, et in ipso sunt</hi> omnia; sine dubio <lb/> Patris et
-						Filii demonstratur æqualitas. Si autem quo­ <lb/> niam non nominavit Patrem et Filium et
-						Spiritum <lb/> sanctum, sed Dcum et Dominum, quod et ipsa Trini­ <lb/> tas dici potest,
-						singula horum trium referri ad singu­ <lb/> los voluit : <hi rend="italic">ex ipso</hi>
-						dicens, propter Patrem; <hi rend="italic">et per <lb/> ipsum,</hi> propter <hi rend="italic">Filium ; in ipso,</hi> propter Spiritum san­ <lb/> ctum : cur hanc
-						Trinitatem unum DominumDeum <lb/> non vultis agnoscere? Quandoquidem non ait, Ex <lb/>
-						ipsis, et per ipsos, et in ipsis; sed ait, <hi rend="italic">ex ipso; et per</hi>
-						<lb/> ipsum, <hi rend="italic">et in ipso sunt</hi> omnia : nec ait, Ipsis gloria; sed, <lb/>
-						<hi rend="italic">ipsi gloria</hi> in sæcula sPeculorum. <hi rend="italic">Amen.</hi>
-					</p>
-					<p>5. Falleris sane, qui putas de Patre solo esse di­ <lb/> ctum, <hi rend="italic">Nemo
-							bonus, nisi unus Deus.</hi> Si enim dixisset, <lb/> Nemo bonus, nisi unus Patcr; nee
-						sic exclusum Fi­ <lb/> lium et Spiritum sanctum ab ista unitate bonitatis vo­ <lb/>
-						luisset intelligi : quia et illud quod simili locutiono <lb/> dictum est, quam supra
-						commemoravi, <hi rend="italic">Ea quœ</hi><hi rend="italic">Dei <lb/> sunt, nemo scit,
-							nisi Spiritus Dei (I Cor.</hi> n, 41): non <lb/> excludit ab hac scientia Filium Dei.
-						Quanto ergo no­ <lb/> bis latitudo intelligentiæ magis patet, quia non dixit, <lb/> Nemo
-						bonus, nisi unus Pater; sed, <hi rend="italic">Nemo bonus,</hi> nisi <lb/> unus <hi rend="italic">Deus;</hi> quod est ipsa Trinitas. Quærebat quippe <lb/> ille cui hoc
-						respondit Jesus, non bonum qualecumque, <lb/> sed bonum quo fieret beatus; imo ipsam
-						beatitudinem <lb/> veram, id est, vitam desiderabat æternam : et inter­ <lb/> pellaverat
-						tanquam hominem Christum, nescicns eum <lb/> esse etiam Deum. Dixerat enim : <hi rend="italic">Magister bone, quid <lb/> faciam, ut vitam</hi> æternam consequar ? Tunc
-						ait ille: <lb/>
-						<hi rend="italic">Quid me dicis bonum? Nemo bonus,</hi> nisi unus <hi rend="italic">Deus
-							<lb/> (Marc.</hi> x, 17, 18). Vel, sicut legitur apud alium evan­ <lb/> gelistam, qnod
-						tantumdem valet, <hi rend="italic">Nemo bonus,</hi> nisi <lb/>
-						<hi rend="italic">solus Deus (Luc.</hi> XVIII, 19). Tanquam diceret : Recte <lb/> mc
-						appellabis bonum, si me noveris Deum. Nam <lb/> qnando me nihil aliud quam hominem
-						putas, quid me <lb/> dicis bonum ?Non te facit bonum nec bcatum, nisi <lb/> bonum
-						immutabile quod solus est Deus. Nam bonus <lb/> angelus, bonus homo, bona cætera
-						creatura : hæc <lb/> non ita bona sunt, ut ea quisquis adeptus fuerit, sit <lb/> beatus;
-						nec ulla est beata vita, si non sit æterna. <lb/> Quomodo autem non est tale bonum Dei
-						Filius ve­ <lb/> rus, cumsit verus Deus et vita aeterna, ad quam cu­ <lb/> piebat ille
-						qui interrogaverat pervenire ?</p>
-					<p>6. Proinde cum ego asseram, <hi rend="italic">Nemo bonus,</hi> nisi unus <lb/> et <hi rend="italic">solus Deus,</hi> de ipsa Trinitate dictum esse, qui Deus <lb/> unus et
-						solus est; tu autcm asseras de solo Dco Pa­ <lb/> tre dictum esse, quia ipse de nullo
-						alio Deus, de nullo <lb/>
-						<pb n="801"/> alio honus est ; Filius autem de Patre Dcus, de Patre <lb/> magnus et
-						bonus est diligenter attende quis nostrum <lb/> bene sentiat de Deo Patre et de Deo
-						Filio; utrum <lb/> ego qui dico, Dens quidem Pater, non de alio Dco <lb/> Deus est, Deus
-						autem Filius de Patre Deo Deus est, <lb/> sed tantus iste de illo, quantus ille de nullo
-						; et bo­ <lb/> nus Pater non de alio bono bonus est, Filius vero de <lb/> Pairc buno
-						bonus est, sed tam bonus hic de illo, <lb/> quam bonus ille de nullo : an tu qui
-						propterea dicis <lb/> solum esse Patrem Deum bonum, quia nec Deus est <lb/> de alio
-						Dco,nec bonus de alio bono; Filium vero <lb/> idco Patri non esse cocequandum, quia de
-						illo Deus <lb/> est, de illo bonus est? In qua sententia utrumque <lb/> blasphemas : et
-						Patrem scilicet, quia non tantum ge­ <lb/> nuit quantus cet ipse, nec talem qualis est
-						ipse; et <lb/> Filium, quia talis tantusque nasci non meruit, qualis <lb/> quantusque
-						est ille qui genuit. Denique ista ipsa duo <lb/> de quibus agimus, hoc cst, dcitas et
-						bonitas, quoniam <lb/> dictum est, <hi rend="italic">Nemo</hi> bonus, nisi <hi rend="italic">unus Deus,</hi> in hac tua <lb/> opinione deficiunt. Tantum enim quantus
-						est ipse, et <lb/> talem qualis est ipse, si non potuit gignere, quomodo <lb/> Dens est?
-						si noluit, quomodo bonus cst?</p>
-					<p>7. <hi rend="italic">Pater,</hi> inquis, <hi rend="italic">fons</hi> bonitatis <hi rend="italic">est, qui quod est</hi> bo­ <lb/> nIs <hi rend="italic">a nemine
-							accepit.</hi> Numquid ideo minus bonus est <lb/> Filius, quoniam quod bonus est, ab eo
-						Patrc accepit, <lb/> qui naseenli Filio tantam bonitatem quantacumque <lb/> illi est,
-						quia Deus est, dare potuit; et dedit, quia bo­ <lb/> nus invidere non potuit ? Nam si
-						minus bonitatis, <lb/> quam quod ipse habet unico dedit, minus bonus est <lb/> et ipse
-						quam debuit : quod sentire dementiæ est. Er­ <lb/> go quantum ipse habet bonitatis,
-						tantum F:lio de­ <lb/> dit *. Et quia natura est, non gratia Filius, na­ <lb/> scenti,
-						non indigenti dedit; et plenus plenum, fons <lb/> bonitatis fontem genuit bonitatis. Ac
-						per boc nec <lb/> auxit in se hic quod accepit, nec minuit in se ille qui <lb/> dedit 2:
-						quia non habet immutabilitas unde defi­ <lb/> ciat, non habet plenitudo quo crescat.
-						Quid est <lb/> autem ipsa bonitas , nisi vita vivificans ? Proin­ <lb/> de quia fons
-						fontem genuit, <hi rend="italic">sicut Pater suscitat mor­ <lb/> tuos et vivificat, sic
-							et Filius quos vult vivificat</hi> (Joan. <lb/> v , 21). Hoc ipse Filius dixit, non
-						ego. Unde merito <lb/> Deo Patri dicitur, <hi rend="italic">Quoniam apud te eat fons
-							vitæ.</hi> Quis <lb/> est autem iste fons vitæ apud Patrem, nisi de quo di­ <lb/>
-						citur, In <hi rend="italic">principio erat</hi> Verbum, <hi rend="italic">et</hi> Verbum
-							<hi rend="italic">erat apud <lb/> Deum, et Deus erat Verbum; hoc erat</hi> in <hi rend="italic">principio apud <lb/> Deum</hi> : de quo etiam paulo post dictum est, <hi rend="italic">Et tila<lb/> erat lux</hi> hominum <hi rend="italic">(Id.</hi> i, 1, 2,
-						4)? Hæc vita fons vitæ <lb/> est, et lux ista lux lucis est. Unde cum dictum esset, <lb/>
-						<hi rend="italic">Apud te est fons vitæ;</hi> continuo subjunctum est, <hi rend="italic">In <lb/> lumine tuo videbimus lumen</hi> (Psal. XXXV, 10), hoc est, <lb/> in Filio
-						luo Spiritum sanctum ; quem tu quoque esse <lb/> illuminatorem in Collationis nostræ
-						priina parte nrm <lb/> fessus es. Fons ergo de fonte, Filius de Patra, et si­ <lb/> mul
-						ambo fons unus: lux de luce, Filius de Patre, et <lb/> simul ambo lux una : sicut Dcus
-						de Dco, et simul <lb/> ambo utique Deus unus: et hoc totum non sine Spi­ <lb/> ritu
-						amborum. Ex hoc fonte bonitatis, ex hoc fonte <note type="footnote">* ouxlam Mss., <hi rend="italic">tantfui Vmco dedit.</hi>
-						</note><note type="footnote"> 'sic Myg. Editi vcro, <hi rend="italic">quod dedit.</hi>
-						</note>
-						<lb/> vitæ, ex hoc immutabili lumine, ex hac indeficiente <lb/> plenitudine, id est,
-						Patre, et Filio, et Spiritu sancto, <lb/> uno Domino Dco solo, sccundum mensuram fidei
-						su:e <lb/> quicumque veraciter credunt, sumentes boni fiunt, vi­ <lb/> vificantur,
-						illuminantur, implentur. Quibus tu unige <lb/> nilum Filium, pace tua dixcrim, nescio
-						qua incredi­ <lb/> bili temeritate junxisti. Tua quippe ista sunl verba : <lb/>
-						<hi rend="italic">Sive,</hi> inquis, <hi rend="italic">Filius, sive qui per Filium sunt
-							facti, de <lb/> illo uno fonte bonitatis unusquisque secundum mensu­ <lb/> ram fidei
-							suæ assumpserunt ut essent boni.</hi> Ubi est ergo <lb/> quod fueras ante confessus,
-						illum natura Filium esse, <lb/> non gratia 1? Ecce contra sententiam luam venis: ecce
-						<lb/> jam prodis nefarium secretum hæresis vestrae, quia <lb/> unigenitum verum Dei
-						Filium, verum Dcum, non na­ <lb/> tura Filium, sed gratia profitemini. Si enim et ipse,
-						<lb/> sicut verba tua clamant, secundum mensuram fidei <lb/> SUm, ut bonus esset,
-						assumpsit; gratia est ergo Fi­ <lb/> lius, non natura : cL fuit aliquando non bonus, et
-						cre­ <lb/> dendo factus est bonus; quia ut esset bonus, quemad­ <lb/> modum dicis,
-						secundum mensuram fidei suae de illo <lb/> qui Pater est, fonte bonitatis assumpsit.
-						Legimus qui­ <lb/> dcm quod <hi rend="italic">Jesus</hi> proficiebat ætate et <hi rend="italic">sapientia, et gratia <lb/> Dei erat</hi> in <hi rend="italic">illo
-							(Luc.</hi> II, 52) : sed secundum formaro <lb/> hominis quam pro nobis accepit ex
-						nobis, non secun­ <lb/> dum formam Dei, in qua non alienam arbitratus est <lb/> esse
-						aequalis Deo <hi rend="italic">(Philipp.</hi> II, 6). Verumtamen etiam <lb/> in ipsa
-						forma hominis legimus eum aetate et sapientia <lb/> profccissc, non tamen ut ex non bono
-						bonus fieret <lb/> credendo meruisse. Neque nunc inter nos quæstio <lb/> vertitur de
-						natura filii hominis, in qua Dei Filius mi­ <lb/> nor cst Patre: sed de natura Filii
-						Dei, in qua, ut nos <lb/> dicimus, vos negatis, æqualis es. Patri : quia Filius <lb/>
-						verus, Filius unicus, Filius de vero Deo verus Dcus, <lb/> in nullo degeneravit a Patre.
-						Proinde incomparabi­ <lb/> lem Patrem Filio, nec in Scripturis sanctis alicubi <lb/>
-						legere potuisti. Nec sana fide ipse dixisti immensum <lb/> etiam Patrem; quoniam
-						propterea dicis, ut Filium <lb/> non pariter immensum, sed mensura existimes ter­ <lb/>
-						minatum. Tecum habeto mensuram tuam, qua <lb/> tuum falsum dominum metiaris, et de vero
-						Domino <lb/> mentiaris.</p>
-					<p>CAPUT XXIV. — Bene confiteris quod et Pater <lb/> diligat Filium, et Filius diligat
-						Patrem : sed si et hoc <lb/> confitcaris, quia non est major dilectio in Patre quam
-						<lb/> in Filio. Quia cnim natura divinitatis a quales sunt, <lb/> æqualiter se invicem
-						diligunt. Facit autem Filius sic­ <lb/> ut homo mandatum Patris. Nani sicut Deus, ipse
-						Fr- <lb/>
-						<lb/> lius est mandatum Patris, quia ipse est Verbum Pa­ <lb/> tris. Unde alio loco de
-						mandato Patris, hoc est, de se <lb/> ipso dicit : <hi rend="italic">Scio quia mandatum
-							ejus vita æterna est <lb/> (Joan.</hi> XII, 50). Quod autem ipse Dei Filius sit vin
-						<lb/> aeterna, Scriptura divina testatur. Ubi autem ait, <hi rend="italic">Qni <lb/> me
-							vidit, vidit et Patrem (Id.</hi> XIV, 9); quis nesciat ideo <lb/> dictum, quoniam
-						quisquis per intelligentiam videt Fi­ <lb/> lium, Patri utique videt æqualem? Quod vos
-						ideo non <lb/> vultis, quia per oculos cordis, quantum ia bac <unclear>vita­</unclear>
-						<lb/> viden potest, Filium non videtis. <note type="footnote">* Plores Mss., <hi rend="italic">nvs gratia.</hi>
-						</note></p>
-					<pb n="803"/>
+	<text>
+		<body>
+			<div type="edition" n="urn:cts:latinLit:stoa0040.stoa028.opp-lat1">
+				<head>
+					<title type="main">S. AURELII AUGUSTINI HIPPONENSIS EPISCOPI CONTRA MAXIMINUM
+						HaeRETICUM Arianorum Episcopum LIBRI DUO (a).</title>
+				</head>
+				<ab>
+					<title type="sub">
+						<hi rend="italic">LIBER PRIMUS (b).</hi>
+					</title>
+				</ab>
+				<p>Ostendit Augustinus, ea quae in Collalione ipse dixit, Maximinum non poluisse
+					refellere.</p>
+				<p>Disputationi Miximini Arianorum episcopi , cujus <lb/> prolixitate spatium diei,
+					quo praesentes conferebamus, <lb/> absumpsit, responsionem debitam reddens, ad
+					ipsum <lb/> loqui utique debeo : sive adhuc existimet contradi­ <lb/> cendum
+					esse cum legerit, sive Domino in ejus corde <lb/> mirabiliter operante
+					manifestatae consentiat veritati. <lb/> Quid tibi visum est, homo ariane, tam
+					multa dicere, <lb/> ct pro causa quae inter nos agitur nihil dicere, quasi <lb/>
+					hoc sit n spondete posse, quod est tacere non posse? <lb/> Prius itaque ostendam
+					refellere te non potuisse quae <lb/> dixi : deinde, quantum nccessarium
+					videbitur, ego <lb/> refellam qu:c ipse dixisti.</p>
+				<p>CAPUT PIUMUM. — <hi rend="italic">De duobus diis.</hi> De duobus <lb/> diis quae
+					ipse dixisti, ego certe respondens verbis <lb/> tuis, ubi aisti a vobis unum
+					Deum colatis : <hi rend="italic">Consequens <lb/> est,</hi> inquam, <hi
+						rend="italic">ut aut</hi> non <hi rend="italic">colatis</hi> Christum, <hi
+						rend="italic">aut non unum <lb/> Deum colatis, sed duos.</hi> Ad hoc tu
+					respondere cona­ <lb/> tus, mullum quidem locutus es, asserens quod et <lb/>
+					Christum Deum colatis : sed duos deos a vobis coli <lb/> quamvis non negaveris,
+					tamen non ausus es confiteri. <lb/> Sensisti enim, duos esse deos colendos,
+					christianas au­ <lb/> res ferre non posse. O quam de proximo te corrigeres ,
+					<lb/> si timeres credere quod dicere timuisli! Cum enim <lb/> clamet I
+					Apostolus, <hi rend="italic">Corde creditur ad justitiam,</hi> ore <lb/>
+					<hi rend="italic">confessio fit ad salutem (Rom.</hi> x, 10); si ad justitiam
+					<lb/> putas pertinere quod credis, cur hoc ad salutem etiam <lb/> orc non
+					confiteris ? Si autem duos dens colendos ad <lb/> salutem non pertinet
+					confiteri, sine dubio nec ad ju­ <lb/> stitiam pertinet credere. Qui ergo non
+					vis tali con­ <lb/> fessione . cum teneri os tuum , quare non mundas a <lb/>
+					tali credulitate cor tuum ? Tene cum Catholica fidem <lb/> rectam , non te pudeat
+					emendare perversam. Tene <lb/> cum Catholica, Patrem quidem non esse qui Filius
+					<lb/> est, et Filium non esse qui Pater est; et Deum esse <lb/> Patrem, Deum
+					esse Filium : verumtamen ambos si­ <lb/> mul non duos deos esse, sed unum. Isto
+					modo solo <lb/> fiet ut et Patrem colas et Filium , nee tamen duos <lb/> deos
+					esse colendos dicas, sed unum, ne reatu impie- <note type="footnote"> I E.r.
+						Lugd. ven. et Lov.. <hi rend="italic">mamfesice. II.</hi>
+					</note><note type="footnote"> I Er. Lugd. ven. Lov. clamal. M. </note>
+					<note type="footnote"> &lt;a) scrillli circiter annum -1m. </note><note
+						type="footnote">
+						<hi rend="italic">(b)</hi> AliJtf, secundus. </note>
+					<lb/> tatis tua conscientia compungatur , quando sonuerint <lb/> in auribus tuis
+					dicta divina , quia Nullus <hi rend="italic">Deus,</hi> nisi <lb/> unus (I <hi
+						rend="italic">Cor.</hi> VIII, 4); ct, <hi rend="italic">Audi Israel; Dominus
+						Deus</hi>
+					<lb/> tuus, <hi rend="italic">Dominus unas est:</hi> et quando audis , <hi
+						rend="italic">Dominum</hi>
+					<lb/> Deum tuum <hi rend="italic">adorabis et</hi> illi <hi rend="italic">soli
+						servies (Deut.</hi> VI, 4,13); <lb/> securus possis, non soli Patri, sed
+					etiam Filio ea quae <lb/> uni Deo debetur servitute servire. Memento ergo te
+					<lb/> non respondisse ad illud quod objeceram , non a vo­ <lb/> bis coli unum
+					Dcum, sed duos.</p>
+				<p>CAPUT II. — <hi rend="italic">De humanis contagiis.</hi> Secundo loco <lb/> egi
+					tecum de verbis tuis, ubi dixeras, <hi rend="italic">Deum Patrem</hi>
+					<lb/> ad <hi rend="italic">humana</hi> non <hi rend="italic">descendisse
+						contagia;</hi> quasi Christus <lb/> illa in carne perpessus sit : et
+					admonui, quomodo <lb/> contagium intelligi soleat, non utique nisi in aliquo
+					<lb/> vitio, a quibus omnibus immunem novimus Christum. <lb/> Nec ad hoc
+					quidquam respondere potuisti. Testimo­ <lb/> nia quippe divina, quae abs te
+					commemorata sunt, <lb/> nihil te adjuvare potuerunt : non enim eis probare <lb/>
+					potuisti humano Christum attaminatum esse conta­ <lb/> gio. Quod enim Apostolum
+					dixisse commemoras, <lb/>
+					<hi rend="italic">Quoniam Christus cum peccator non esset, peccatum</hi>
+					<lb/> pro <hi rend="italic">nobis fecit:</hi> lege diligentius &gt; et ne forte
+					mendo­ <lb/> sum incurreris codicem, aut latinus interpres errave­ <lb/> rit,
+					graecum inspice; et invenies non Christum pro <lb/> nobis fecisse peccatum, sed
+					a Patre Deo ipsum Chri» <lb/> stum factum esse peccatum, id est, sacrificium pro
+					<lb/> peccato. Ait enim Apostolus: <hi rend="italic">Obsecramus pro Christo,
+						<lb/> reconciliamini Deo 1:</hi> tum <hi rend="italic">qui non noverat
+						peccatum, <lb/> pro nobis peccatum fecit</hi> (II Cor. v, 20, 21). Non ergo
+					<lb/> fecit ipse peccatum, sed eum Deus pro nobis pecca­ <lb/> tum fecit, hoc
+					est, ut dixi, sacrificium pro peccato. <lb/> Si enim recolas vel relegas,
+					invenies in libris Veteris <lb/> Testamenti peccata appellari sacrificia pro
+					peccatis. <lb/> Similitudo etiam carnis peccati, in qua venit ad nos, <lb/>
+					dicta est et ipsa peccatum : Misit, inquit, <hi rend="italic">Deus Filium</hi>
+					<lb/> suum <hi rend="italic">in similitudine carnis peccati, et de peccato da­
+						<lb/> mnavit peccatum</hi> in <hi rend="italic">carne (Rom.</hi> VIII, 5):
+					hoc est, de <lb/> similitudine carnis peccati, quae ipsius erat,
+						<unclear>damnavit</unclear>
+					<note type="footnote"> 1 AIt'.. Er. et Uss.v <unclear/><hi rend="italic"
+							>reconciliari</hi> ret* </note>
+					<lb/>
+					<pb n="745"/> percatum in carne peccati, quae nostra est. Propter <lb/> hoc
+					etiam de illo dicitur : <hi rend="italic">Quod enim mortuus est pec­ <lb/> calo,
+						mortuus est semel; quod autem vivit, vivit Deo</hi> (Rom. <lb/> VI, 10).
+					Peccato enim mortuus est semel. quia simili­ <lb/> tudini 1 carnis peccati
+					mortuus est, quando moriendo <lb/> exutus est carne: ut per hoc mysterium
+					significaret, <lb/> eos qui in morte ipsius baptizantur, mori peccato, ut <lb/>
+					vivant Deo, Sic etiam per crucem <hi rend="italic">factus</hi> est <hi
+						rend="italic">pro nobis<lb/> maledictum (Galat.</hi> III, 15). Pendens
+					quippe in ligno, <lb/> mortem quae de maledicto Dei venerat , suspendit in <lb/>
+					ligno, atque ita <hi rend="italic">vetus homo noster simul confixus</hi> eat <lb/>
+					<hi rend="italic">cruci</hi> (Rom. VI. 6): ut non mendaciter dictum intelliga­
+					<lb/> tur in Lege , <hi rend="italic">Maledictus omnis qui pendet in ligno <lb/>
+						(Deut.</hi> xxi, 25). Quid est, <hi rend="italic">maledictus</hi> , nisi,
+						<hi rend="italic">Terra es,<lb/> et</hi> in <hi rend="italic">terram ibis
+						(Gen.</hi> m , 19) ? Et quid est, <hi rend="italic">omnis ;</hi>
+					<lb/> n'si quia et ipse Christus, qui cum esset vita , mor­ <lb/> tuus est tamen
+					vera morte , non ficta ? Si intelligas <lb/> ista mysteria , simul intelliges
+					non esse contagia. Sed <lb/> quid ad nos , si more tuo loquens, contactum forte
+					<lb/> mortalium voluisti appellare contagium; cum tamen <lb/> nobiscum sentias,
+					Dominum Jesum, nec in spiritu, <lb/> nec in carne ullum habuisse peccatum?</p>
+				<p>CAPUT III. — <hi rend="italic">De invisibili Deo.</hi> Tertio loco de in­ <lb/>
+					visibili Deo cum agerem, admonui ul crederes invisi­ <lb/> bilem , non solum
+					Patrem, sed etiam Filium secun­ <lb/> dun. divinit item, non secundum carnem, in
+					qua eum <lb/> visibilem mortalibus apparuisse quis negat? undeot <lb/> alio loco
+					postea disputavi. Tu antem cedens manife­ <lb/> stissimae veritati, consensisti
+					esse invisibilem Filium : <lb/> ac per hoc destruxisti quod dixeras, <hi
+						rend="italic">unum invisibilem <lb/> Patrem.</hi> Sed rursus tua consensione
+					conturbatus, <lb/> quia invisibilem etiam Filium esse consenseras, au­ <lb/> sus
+					es dicere, min tra videri a majurihus, majora vero <lb/> a minoribus non posse
+					videri; dicens Angelos videri <lb/> ab Archangelis , animas ab Angelis, Angelos
+					vero ab <lb/> animabus non videri : unde eliam Christum secun­ <lb/> dum
+					divinitatis suae substantiam, non solum ab ho­ <lb/> minibus, sed nec a
+					Virtulibus coelestibus videri asse­ <lb/> rens, ideo Patrem solum invisibilem
+					esse dixisti, quia <lb/> superiorem non habet a quo circuminspiciatur. Dic <lb/>
+					nobis, rogo te, quando libi indicaverunt Archangeli , <lb/> quod ipsi vidcant
+					Angelos, non autem videantur ab <lb/> Augelis! Quibus narrantibus Angelis
+					cognovisti, quod <lb/> ipsi videam animas, animae illos non vidcant? A quo <lb/>
+					haec audisti? unde didicisti? ubi legisti ? Nonne me­ <lb/> lius divinis Libris
+					animum intenderes, ubi legimus et <lb/> ab hominibus Angelos visos,quando
+					voluerunt, cet <lb/> quomodo voluerunt videri, jubente vel sinente <lb/> omnium
+					Creature? Verumtamen qui dixeras, ideo <lb/>
+					<hi rend="italic">solum</hi> dicendum <hi rend="italic">in visibilem Patrem,
+						quia non habet <lb/> superiorem a quo circuminspiciatur;</hi> confessus es
+					po­ <lb/> sica, Filio esse visibilem , contra te ipsum proferens <lb/>
+					evangelicum testimonium, uhi dicit ipse Filius, <hi rend="italic">Non <lb/> quia
+						Patrem vidit quisquam, sed qui eat a Deo, hic vi­ <lb/> dit Patrem
+						(Joan.</hi> VI, 46). Ubi te quidem veritas apcr­ <lb/> tissime vicit: sed tu
+					nolens ab errore liberari, nolui- <note type="footnote"> 1 sola edllio I.oV.,
+							<hi rend="italic">q1ria in siiwliludine.</hi> quidam Mss., <hi
+							rend="italic">quia <lb/> fiudiUttdinc.</hi>
+					</note>
+					<lb/> sti salubriter vinci. Cum enim contra te commemo­ <lb/> rasses evangelicum
+					testimonium, quo claruit a Filio <lb/> videri Patrem, dicente ipso Filio, <hi
+						rend="italic">Sed qui est</hi> a <hi rend="italic">Deo,<lb/> hic vidit
+						Patrem;</hi> mox addidisti de tuo, <hi rend="italic">Sed vidit in - <lb/>
+						capabilem.</hi> Interim quod dixeras perdidisti, solum <lb/> esse
+					invisibilem Patrem, quia non habet superiorem : <lb/> quandoquidem veritate
+					victus, cum vidcri ab inferiore <lb/> confessus es. l'os enim dicitis inferiorem
+					Filium a <lb/> quo tamen Patrem videri, teste Filio cogente I, dixi­ <lb/> sti.
+					De incapabili postea videbimus, ut etiam te illic <lb/> veritas vincat. Non enim
+					de capabili et incapabili, sed <lb/> de visibili et invisibili inter nos
+					quaestio versabatur : <lb/> in qua quaestione si libi ipsi tu ip e visibilis es,
+					vi. <lb/> ctum te esse vides.</p>
+				<p>CAPUT IV. — <hi rend="italic">De immortali</hi>
+					<unclear/><hi rend="italic">Deo.</hi> Quarto loco egi <lb/> tecum de immortali
+					Den etiam Filio. Quoniam tu il­ <lb/> lud quod ait Apostolus , <hi rend="italic"
+						>Qui solus habet immortalita­<lb/> tem</hi> (I <hi rend="italic">Tim.</hi>
+					VI, 16) ; sic intelligi voluibti, tanquam <lb/> de solo Patre sit dictum : cum
+					ille hoc non de Patre <lb/> dixerit, sed de Deo , quod est Pa er et Filius et
+					Spirit <lb/> Ius sanctus. Ostend! ergo ct Filium habere immorta­ <lb/> litatem
+					secundum substantiam divinitatis suae. Nam <lb/> secundum carnem quis negat eum
+					fuisse mortalem ? <lb/> Tu autem cum mihi respondere ad hunc locum vel­ <lb/>
+					les, perspicua veritate conclusus, etiam Deum Filium <lb/> immortalitatem habere
+					confessus es. Victus es igitur <lb/> in eo quod dicebas de Patre tantum dixisse
+					Aposto­ <lb/> lam, quod solus habeat immortalitatem. Ncque enim <lb/> propterea
+					vinculis veritatis elaberis , quoniam dicis, <lb/>
+					<hi rend="italic">Habet quidem Filius immortalitatem, sed accipiens</hi> a <lb/>
+					<hi rend="italic">Patre.</hi> Non quaeritur uude habcat, sed utrum habeat. <lb/>
+					Tu enim de Patre solo vis intelligi quod scriptum esi, <lb/>
+					<hi rend="italic">Solus habet immortalitatem.</hi> Prorsus a nullo acceptam
+					<lb/> Pater habet immortalitatem, et a Patre acceptam Fi <lb/> lius habet
+					immortalitatem : tamen et Pater ct Filius <lb/> habet immortalitatem. Alioquin
+					si eam non habet <lb/> Filius ; Pater eam non dedit Filio, aut acceptam per­
+					<lb/> didit Filius. Dedit autem Pater Filio, nec perdidit Fi­ <lb/> lius : nec
+					Pater dando perdidit quod generando dedi!. <lb/> Habet ergo immorlalitalem et
+					Pater et Filius, non <lb/> Pater solus. Cogeris itaque confiteri non de solo
+					Patre <lb/> dictum esse, <hi rend="italic">Qui solus habet immortalitatem:</hi>
+					quia jam <lb/> coactus es confiteri quod et Filius habeat immorta­ <lb/>
+					litatem. Habet autem hanc <hi rend="italic">solus,</hi> sed Deus: quod <lb/> non
+					solus est Pater; quia hoc est et Filius, et uter­ <lb/> que adjuncto Spiritu
+					sancto unus est Deus. Sed quaro <lb/> solus Deus dictus sit habere
+					immortalitatem, cum et <lb/> anima pro suo modo sit immortalis, et alia
+						<unclear>spiritun­</unclear>
+					<lb/> lis coelestisque creatura, postea videbimus : nunc au­ <lb/> tem sufficit
+					nobis, quod ad ea quae dixi, nihii respon­ <lb/> dere potuisti, ct non solum
+					Patrem ; sed quamvis ab <lb/> ipso, habere tamen , immortalitatem etiam Filium
+					<lb/> coactus es confiteri.</p>
+				<p>CAPUT V. — <hi rend="italic">Unde major sit Pater.</hi> Quinto loco <lb/>
+					ostendi, unde major sit Pater Filio : quia nou Den <lb/> major est, unde illi
+					coaeternus est Filius; sed homine <lb/> major est, quod ex tempore ,factus est
+					Filius. Ibi <lb/> commemoravi apostolicum testimonium : <hi rend="italic"
+						>Quia</hi> cum <hi rend="italic">in</hi>
+					<note type="footnote"> t Hic apud l.ov. additur, <hi rend="italic"
+							>veritate.</hi>
+					</note>
+					<note type="footnote"> PATROL. XLII. </note>
+					<note type="footnote">
+						<hi rend="italic">(Yingl-quatrl.)</hi>
+					</note>
+					<lb/>
+					<pb n="747"/>
+					<hi rend="italic">forma</hi> £Dei esset, <hi rend="italic">non rapinam
+						arbitratus esl esse aequa­</hi>
+					<lb/> lis Dec. Natura quippe illi fuerat Dei aequalitas , non <lb/> rapina. Ad
+					quod tu respondens dixisti : <hi rend="italic">Quis enim<lb/> vegat Filium esse
+						in forma Dei ? Qnod enim sit Dens, <lb/> quod sit Dominus , quod sit Rex,
+						jam pulo latius</hi> expo­ <lb/> s <unclear>uimus</unclear>.<hi
+						rend="italic">Et</hi> &lt; <hi rend="italic">quia non rapinam arbitratus cat
+						esse aequa­<lb/> lis Deo, » hoc nos beatus apostolus Paulus instruit, quod
+						<lb/> ille non rapuit, nee noa dicimus.</hi> Haec verba tua non <lb/> solum
+					nihil habent adversus nos ; sed magis apparent <lb/> esse pro nobis. Si enim
+					confiteris Dei formam , cur <lb/> non aperte Dei Filium Deo confiteris aequalem
+					? Prae­ <lb/> sertim, quia de verbis Apostoli, ubi ait, <hi rend="italic">Non
+						rapinam <lb/> arbitratus eat esse aequalis Deo;</hi> non poluisti pro tuis
+					<lb/> partibus invenire quod diceres. Et quia hoc dixisse <lb/> Apostolum non
+					potuisti negare, idco dixisti, <hi rend="italic">quod ille</hi>
+					<lb/> non <hi rend="italic">rapuit, nec nos dicimus</hi> : tanquam hoc sit <hi
+						rend="italic">non ra­</hi>
+					<lb/> puit, qnod csl non hahuit, id est, aequalitatem Dei : <lb/> atque ita
+					dictum sit, <hi rend="italic">Non rapinam arbitratus eat esse<lb/> aequalis
+						Deo;</hi> ac si diceretur, Non arbitratus est esse <lb/> rapiendam
+					aequalitatem Dei, co quod ab illo fuerit <lb/> alicua. Raptor enim rei alienae
+					usurpator est: tan­ <lb/> quam hoc Filius, cum posset, rapcre noluisset. Quod
+					<lb/> vides quanta insipientia sentiatur. Ergo intellige Apo­ <lb/> siolum ideo
+					dixisse , <hi rend="italic">Non rapinam arbitratus eat esse</hi>
+					<lb/> aequalis <hi rend="italic">Deo;</hi> quia non alienum arbitratus est esse
+					<lb/> quod natus est: sed tamen quamvis aequalitatem Dui <lb/> non fuerit
+					arbitratus alienam, sed suam, <hi rend="italic">semetipsum<lb/> exinanivit,</hi>
+					non quaerens quae sua sunt, sed quae no­ <lb/> sira sunt. Quod ut noveris ita
+					esse , attende unde ad <lb/> hoc Apostolus venerit. Cum enim Christianis humili­
+					<lb/> tatem praeciperet charitatis : <hi rend="italic">Alter alterum,</hi>
+					inquit, <lb/> existimantes superiorem <hi rend="italic">sibi, non quae sua sunt
+						unusquis­ <lb/> que intendentes, sed et quae aliorumf.</hi> Deinde til exem­
+					<lb/> plo Christi hortaretur non sua quaerere vel intendere, <lb/> sed et quae
+					aliorum sunt: <hi rend="italic">Singuli quique,</hi> inquit, <hi rend="italic"
+						>hoc<lb/> sentite</hi> in <hi rend="italic">vobis quod et in Christo Jesu :
+						qui cum in forma<lb/> Dei esset,</hi> quae illi crat sua, non <hi
+						rend="italic">rapinam arbitratus est,</hi>
+					<lb/> hoc cst, non alienum arbitratus est, <hi rend="italic">esse aequali, Deo
+						;</hi>
+					<lb/> sed tamen quaerens nostra, non sua , <hi rend="italic">semetipsum ex­</hi>
+					<lb/> inanivit, non formam Dci amittens, sed fOrmam <hi rend="italic">servi
+						ac.</hi>
+					<lb/> cipiens. Non enim est mutabilis illa natura ut se ex­ <lb/> inaniret
+					perdendo quod erat, sed accipiendo quod non <lb/> crat : nec consumendo quae sua
+					sunt, sed assumendo <lb/> quae nostra sunt; ac deinde in forma servi obediendo
+					<lb/> sicut homo <hi rend="italic">usque ad mortem crucis. Propter quod et <lb/>
+						Deus</hi> eum <hi rend="italic">exaltavit,</hi> et donarit ei <hi
+						rend="italic">nomen</hi> qnod <hi rend="italic">eat super<lb/> omne nomen
+						(Philipp.</hi> 11, 6-9) : et caetera. Homini ergo <lb/> donavit ista, non
+					Deo. Neque enim tum in forma ici <lb/> esset non excelsus crat, aut non ei genua
+					flectebant <lb/> « cœlestia, terrena et inferna. Sed cum dicitur, <hi
+						rend="italic">Propter<lb/> quod eum exaltavit;</hi> satis apparet propter
+					quid exalta­ <lb/> verit, id est, propter ohedicntiam <hi rend="italic">usque ad
+						mortem cru­</hi>
+					<lb/> cis. ITI qua ergo forma crucifixos est, ipsa exaltata <lb/> &lt;at, ipsi
+					donatum est <hi rend="italic">nomen quod eat super omne no­</hi>
+					<lb/> men; ut cum ipsa forma servi nominetur Filius Uni­ <lb/> genitus Dei 2.
+					Non itaque facias imparem Dco formam <note type="footnote"> * tor,, <hi
+							rend="italic">aed ea quae</hi><hi rend="italic">atiorum.</hi> At sas.,
+							<hi rend="italic">sed et qua aliorum :</hi>
+						<lb/> jux ui gJ":9CUlD, <hi rend="italic">atla kilL.</hi> . </note><note
+						type="footnote"> ' I iiic cdili addiuit, <hi rend="italic"
+							>intelligetur.</hi> et reluctantibus <lb/> Mss. <lb/> , </note>
+					<lb/> Dei : quod nee in ipsis hominibus did potest. Nam <lb/> cum dictum fuerit,
+					Iste homo in forma est illius ho­ <lb/> minis, nemo intelligit nisi aequales 1.
+					An forte non <lb/> vis sic accipere quod dictum est, <hi rend="italic">Cum</hi>
+					in <hi rend="italic">forma Dci<lb/> esset,</hi> ut in forpia Dci Patris
+					intelligas Filium, ubi <lb/> nihil aliud quam aequalitas apparet amborum ; sed,
+						<hi rend="italic">in <lb/> forma Dei,</hi> putas intelligendum in forma sua,
+					quia et <lb/> ipse utique Deus est ? Non multum curo si etiam sic <lb/>
+					intelligas. Ubi enim plenitudinem formae aetatis in­ <lb/> crementa non faciunt,
+					sed Deo gignente perfectus <lb/> natus est Filius; procul dubio si forma Filii
+					formae <lb/> Patris non cst aequalis, non verus cst Filius. Scriptum <lb/> est
+					autem : Ut simus in <hi rend="italic">vero Filio ejus Jesu Christo</hi>
+					<lb/> (I <hi rend="italic">Joan.</hi> v , 20). Forma igitur vcri Filii, formae
+					Dei <lb/> Patris esse non potest inaequalis. Proinde nee hu'c <lb/> loco
+					prosecutionis meae, ubi de verbis Apostoli aequa­ <lb/> lem Patri Filium
+					comptobavi, respondere aliquid pro <lb/> vestra intentione potuisti.</p>
+				<p>CAPUT VI. — <hi rend="italic">De veris filiis animalium.</hi> Sexto loco <lb/> ut
+					ejusdem naturae cujus ct Pater est, ostenderem <lb/> Filium, etiam mortalium
+					fctus animalium immanitati <lb/> vestri crroris objeci, increpans cor vestrum,
+					qui ejus­ <lb/> dem nature cujus est Pater, negatis esse Deum Fi­ <lb/> lium,
+					quamvis verum esse Filium non negetis; cunt <lb/> Deus ipse dederit animalibus
+					hoc generare quod ipsa <lb/> sunt : ubi non solum hominis homincm, verum etiam
+					<lb/> canis canem filium nominavi; non ad similitudinem <lb/> Dei, sed ad
+					confusionem detrahentium Filio Dci : qui <lb/> cum videant corruptibiles
+					mortalesque naturas, habere <lb/> tamen naturae de suis parentibus unitatem,
+					Filio Dei <lb/> vero nolunt concedere communionem naturae unius <lb/> habere de
+					Patre; cum sit inseparabilis a Patre, ct in­ <lb/> corruptibilis aeternusque cum
+					Patre. Unde etiam dixi, <lb/> quod melior sit secundum vos humana conditio , ubi
+					<lb/> conceditur crescere, ut ad robnr parentum vcl cre­ <lb/> scendo possint
+					filii pervenire: Filius autem Dci , sicut <lb/> dicitis et docetis, minor Patre
+					genitus sic remansit, <lb/> atque ut ad Patris formam non posset pervenire, nec
+					<lb/> crevit. Hic tu, ut appareret quam magna veritatis mole <lb/> premereris,
+					omnino ad rem non respondisti : sed <lb/> tanquam deficienti flatu I anhelarcs,
+					reprehendendum <lb/> me putasti, dicens quod tam foeda comparatio, de filio
+					<lb/> scilicet hominis sive canis, in illam tantam immen­ <lb/> sitatem produci
+					non debuit. lloc respondere est , an <lb/> potius inopiam responsionis ostendere
+					? Quasi ego <lb/> propterca terrenarum naturarum ista exempla produ­ <lb/>
+					xcrim, ut incorruptioni corruptionem, immortalitati <lb/> mortalitatem ,
+					invisibilibus visihilia, aeternis tempo­ <lb/> ralia coaequarem : ac non potius
+					ut vos in magnis ct <lb/> summis rebus errantes , de rebus parvulis infimisque
+					<lb/> convincerem, qui non videtis bonum quod Creator <lb/> summe bonus dedit
+					etiam extremis vilibusque creatu­ <lb/> ris, ut cnm longe aliud sint quam est
+					ipse, hoc tamen <lb/> gcnerent quod sunt ipsae. Nee attenditis quid niali di­
+					<lb/> catis, ut cum homines et canes, et caetera hujusmodi <lb/> habeant filios
+					veruS, quos illis gignentibus creat vcri­ <lb/> tas, nOli sit vcrus Dei Filius
+					ipsa vcritas. Aut si san­ <note type="footnote"> * Am. F.r. et va,r., <hi
+							rend="italic">rtiri fcquatis.</hi>
+					</note><note type="footnote"> t .to., <hi rend="italic">deficinlis</hi>
+						<unclear>fatus</unclear>. -, </note>
+					<lb/>
+					<pb n="749"/> cta Scriptura cogente permittitis ut verus Filius sit, <lb/>
+					rogamus permittite ut dcgener non sit. Et degener <lb/> quomodo? Andiant
+					catholici, unde erubescant haere­ <lb/> tici. Filius viri fortis si non habeat
+					fortitudinem , de­ <lb/> gener dicitur : tamen homo est, quod ct patcr est;
+					<lb/> atque in dissimili vita , non est tamen aliena substan­ <lb/> tia. Vos
+					unigenitum Dei Filium ita degenerem vullis, <lb/> ut ipsam Patris ei substantiam
+					denegetis : minorem <lb/> natum, minorem remansisse jactatis ; non ullam datis
+					<lb/> aetatem qua possit augeri, non datis eamdem formam <lb/> qua possit
+						<unclear>aequari</unclear>. Cujus naturae tanta subtrahitis, <lb/> miror
+					verum Filium qua fronte dicatis : nisi quia in­ <lb/> fclicissimo errore non vos
+					putatis ad unius Patris glo­ <lb/> riam, nisi per unici Filii contumeliam
+					pervenire (a).</p>
+				<p>CAPUT VII. — <hi rend="italic">De magnitudine Filii.</hi> Septimo loco <lb/> dixi
+					: <hi rend="italic">Usque adeo autem Filium agnoscimus magnum <lb/> Deum , ut
+						Patri dicamus aequalem. Itaque</hi> sine <hi rend="italic">causa,</hi>
+					<lb/> inquam, nobis <hi rend="italic">quod valde profitemur, testimoniis, et
+						<lb/> multiloquio</hi> probas voluisti. Et his verbis meis addidi <lb/>
+					disputationem, in qua rationem redilidi, quare Filius <lb/> cum sit Patri
+					aequalis, dicat cum tamcn Deum suum, <lb/> ubi nil : <hi rend="italic">Ascendo
+						ad Patrem meum et ad Patrem ve­</hi>
+					<lb/> strum , Deum meum <hi rend="italic">et Deum</hi> restrum <hi rend="italic"
+						>(Joan.</hi> xx, 17). <lb/> Quoniam tu commemoraveras hoc evangelicum testi­
+					<lb/> monium , quo te probarc existimasti quod Patri Filius <lb/> non esset
+					aequalis. Ego itaque tibi ad ista respondens, <lb/> dixi Patrem propterea etiam
+					Deum esse unigeniti Filii, <lb/> quoniam factus est homo et natus ex femina : ct
+					hoc <lb/> esse quod dicit in Psalmo, ubi quod futurum fucrat <lb/>
+					praenuntiavit, <hi rend="italic">De ventre matris meae Deus meus es tu<lb/>
+						(Psal.</hi> xxi, 11) ; ut ostenderet Patrem hinc esse Deum <lb/> suum , quia
+					homo factus est. Homo enim de ventre <lb/> matris est natus, et secundum hominem
+					de virgine <lb/> natus est Deus : ut non solum Pater illi esset qui cum <lb/> de
+					se ipso genuil, verum etiam Deus ejus esset quem <lb/> de ventre matris hominem
+					creavit. Ad hacc tu cum <lb/> respondere voluisses, mu!ta dixisti, ct multa
+					testimo­ <lb/> nia quae te nihil adjuvant, protulisti. Quomodo ta­ <lb/> men
+					dictum sit. <hi rend="italic">De ventre matris meae Deus meus es tu;</hi>
+					<lb/> quamvis eadem Scripturae sanct e verba memorasses, <lb/> nullo modo
+					invenire potuiti. Cur autcm in eo loco <lb/> posueris psalmi alterius
+					testimonium, ubi scriptum <lb/> est, <hi rend="italic">Tecum principium in die
+						virtutis tuae, in splendo­ <lb/> ribus sanctorum, ex utero ante luciferum
+						genui te (Psal.</hi>
+					<lb/> CIX, 5); omnino non video. Non enim Filii persona <lb/> est dicentis, Ex
+					utero tuo, aut, De ventre tuo, Deus <lb/> meus es tu. Illa ineffabilis generatio
+					cHam si ex utcro <lb/> Patris accipitur, hoc significatum cst, quia de 83 <lb/>
+					ipso, hoc cst, de substantia sua Deus Deum genuit, <lb/> sicuit ex utero matris
+					quando natus est, homo homi­ <lb/> nem genuit: ut intelligeremus in utraque
+					generatione <lb/> non diversas ejus qui cst natus, et eorum de quibus <lb/> est
+					natus, esse substantias. Diversa quidem substantia <lb/> cst, Deus Pater, et
+					homo mater: non tamen diversa <lb/> substantia est, Deus Pater, ct Deus 'ilius ;
+					sicut non <lb/> est diversa substantia, homo mater, ct homo filius. <lb/> Sed
+					audi quid dicat in prophetia iste Filius : <hi rend="italic">De</hi> ven­ <lb/>
+					Ire, inquit, <hi rend="italic">matris</hi>
+					<unclear/><hi rend="italic">meae Deus</hi> meuses <hi rend="italic">tu.</hi>
+					Noli multis <note type="footnote"> (r) vide scrin. 130, no. 4 et 3, tom, 5. </note>
+					<lb/> vetbis ad rem non necessariis conari operire res cla<lb/>ras. Qui est
+					Pater Filio ex utero suo, de vontre ma­ <lb/> tris Deus ejus est, non de suo. Ad
+					hoc ergo prorsus <lb/> nihil respondere po:uisti.</p>
+				<p>CAPUT VIII. — <hi rend="italic">De subjectione Filii</hi> Octavo loco de <lb/>
+					subjectione qua subjectus est Patri Filius, respondi <lb/> libi : quoniam
+					dixeras, <hi rend="italic">De sua subjectione unum sta­<lb/> tuit Deum.</hi>
+					Respondi ergo ellam hoc secundum homi­ <lb/> nen recte accipi, quod Filius
+					subditus est Patri. Nc­ <lb/> que hoc esse mirandum , cum legatur utique secun­
+					<lb/> dum ipsam servi formam etiam parentibus subdimus <lb/>
+					<hi rend="italic">(Luc.</hi> n , 51) : et de illo sit scriptum, <hi
+						rend="italic">Minorasti eum <lb/> paulo</hi> minus <hi rend="italic">ab
+						Angelis (Psal.</hi> VIII, 6). Ad quod tu <lb/> quasi respondens dixisti me
+					optime prosecutum, quo­ <lb/> niam ct parentibus propter formam Servi esset
+					subjg­ <lb/> ctus. Dcinde volens velut pro te esse ostendere, quod <lb/> contra
+					te esse cernebas; ac sic incautis <unclear>minusquo</unclear>
+					<lb/> attentis hominibus, quicumque essent ista lecturi, <lb/> tanquam
+					respondentem te facere, ubi quod diceres <lb/> non habebas; adjungis et dicis :
+					Si eni, t <hi rend="italic">parentibus <lb/> subjectus invenitur quos ipse
+						creavit, qnia omnia pet <lb/> ipsunt facta sunt : nec enim post tempora, sed
+						ante tem­ <lb/> pora novimus Filium genitum a Patre : si ergo parenti­</hi>
+					<lb/> bus , inquis , <hi rend="italic">subditus etat, ut</hi>
+					<unclear/><hi rend="italic">divinarum Scripturarum<lb/> auctoritas luce clarius
+						prat'dicat : quanto magis utique illl <lb/> suo genitori est subditus, qui
+						tantum ac tatem</hi> eum <hi rend="italic">ge­<lb/> nuit;</hi> secundum <hi
+						rend="italic">quod ait Paulus, Cum omnia fuerint <lb/> Filio</hi> subjecta,
+						<hi rend="italic">tunc et ipse Filius subjectus erit illi</hi> qui <lb/>
+					<hi rend="italic">sibi subjecit omnia</hi> (I <hi rend="italic">Cor.</hi> xv,
+					28) ? Haec verba tua pos<lb/>sevit a me putari dicta esse, et omnino mca
+					esse, nisi <lb/> tc audientibus cum dicerentur, et postea haec cuncti <lb/>
+					legentibus, evidenter appareret tc illa dixisse. Quis <lb/> enim crederet,
+					consentire posse vos nobis, secundum <lb/> formam servi, ac per hoc non secundum
+					formam Det <lb/> Christum esse subjectum ?</p>
+				<p>CAPUT IX. — <hi rend="italic">Utrum adoret Patrem Spiritus san­<lb/> ctus.</hi>
+					Nono loco abs te quaesivimus, ut per Scripturas <lb/> divinas ostenderes, si
+					valeres, utrum adoret Patrem <lb/> Spiritus sanctus. Iloc cniin dixeras : sed
+					sicut ipsi <lb/> tua prosccutio, cui respondi, satis indicat, non pro­ <lb/>
+					baveras. Ad hanc ergo inquisitionem mcam vide quid <lb/> posteriore prosccutione
+					responderis. Cum enim divis<lb/>ses quantum voluisti de judicio Filii, quod
+					et nos fide­ <lb/> lissime credimus; ct de subjectione, quam secundum <lb/>
+					formam servi Filium Patri reddere non negamus : <lb/> ubi venisti ut probares a
+					sancto Spiritu adorari Pa­ <lb/> trem, rediiti ad illos gemitus, de quibus tibi
+					jam ante <lb/> responderam, secundum morem sanctarum Scriptu­ <lb/> rarum, qna
+					locutione sil dictum, <hi rend="italic">Et</hi> ipse Spiritus <hi rend="italic"
+						>in­<lb/> terpellat gemitibus inenarrabilibus (Rom.</hi> VIII, 26) : no
+					<lb/> credamus Spiritum sanctum nunquam esse esine gc­ <lb/> mitibus posse,
+					quomam nulus dies, nulla hora, nul­ <lb/> lum momentum temporis invenitur, quo
+					non a sanctis <lb/> orationes Dco ubicumque fundamur, ab aliis hic, ab <lb/>
+					aliis alibi. Cum tamen ab orationibus sanctorum nul­ <lb/> lum sit tempus
+					immune, quandoquidem dicbus et <lb/> noctibus, cum alii cibo ac potu
+					reficiuntur, alli quod­ <lb/> libet aliud agunt, alii dormiunt, non utique
+					desunt <unclear/><lb/> quos desiderium sancium orare compellat; ita fit ut <lb/>
+					<pb n="751"/> Spiritus sanctus, qui ubique omnibus adest, aliquan­ <lb/> tulum
+					cessare a gemitibus nun sinatur, quod est ex­ <lb/> tremae miseriae, cum pro
+					quibuscumque orantibus <lb/> cogitur gemere : nisi gemitibus inenarrabilibus in­
+					<lb/> terpellare sic intelligatur, ut dixi, id cst, quia gemi­ <lb/> tibus
+					sanctorum desideriorum interpellare sanctos <lb/> facit, quibus affectum pium
+					gratiae spiritualis infundit. <lb/> Sed cum similes locutionum modos, quando per
+					ef­ <lb/> ficientem significamur id quod efficitur; sicut frigus <lb/> pigruin
+					dicimus, quia pigros facit; et dicm tristem <lb/> vel laetum, quia tristes vel
+					laetos facit; etiam de Scri­ <lb/> puris sanctis commemoraverim, ubi Deus dicit
+					ad <lb/> Abraham , <hi rend="italic">Nunc cognovi (Gen.</hi> XXII, 12); quod
+					nihil <lb/> est aliud quam , Nunc ut cognosceres feci : non enim <lb/> tunc Deus
+					dicendus est cognovisse, quod antequam <lb/> fieret nunquam potuit ignorare:
+					quos locutionis modos <lb/> de divinis eloquiis a me prolatos, quomodo aliter
+					<lb/> interpretareris non invenisti; nullo modo utique ad <lb/> itos gemimus
+					redire debuisti. Nemo crum sic de <lb/> Spiritu sancto sapit, nisi qui secundum
+					carnem , non <lb/> secundum spiritum sapit. Quamvis et si libi concede­ <lb/>
+					rctur, quomodo tu sentis, sic Spiritum sanctum in­ <lb/> terpellare pro sanctis;
+					aliud cst interpellare vel orare, <lb/> aliud adorare. Omnis qui orat, rogal:
+					non omuis <lb/> qui adorat, rogat; nec omnis qui rogat, adorat. Re­ <lb/> cole
+					consuctudincm regum, qni plerumque adorantur, <lb/> ct non rogantur ; aliquando
+					rogantur, et non adora n<lb/>tur. Ac pcr hoc a Spiritu sancto adorari Patrem
+					<lb/> nullo modo demonstrarc potuisti.</p>
+				<p>CAPUTX.— <hi rend="italic">Quomodo sit unus Deus Pater et Filius <lb/> et</hi>
+					Spiritus <hi rend="italic">sanctus.</hi> Decimo loco egi lecum ut intelli­ <lb/>
+					geres, quomodo per ineffabilem copulationem sit unus <lb/> Deus ipsa
+					Trinitas,quam dicimusunius esse substan­ <lb/> tiae : quandoquidem ctiam
+					diversas substantias inve­ <lb/> nimus , hoc est, spiritum hominis et Spiritum
+					Domini, <lb/> per copulationem qua homo adhaeret Domino, unum <lb/> spiritum
+					dictum, ubi ait Apostolus , Qui <hi rend="italic">autem adhae­<lb/> ret
+						Domino,</hi> unus <hi rend="italic">spiritus est</hi> ( I <hi rend="italic"
+						>Cor.</hi> VI, 17). Ad quod <lb/> tu respondens, vcl potius non tacens,
+					conatus es <lb/> ostendere quomodo Patcr et Filius unum sint, non <lb/> unitate
+					naturae, sed voluntatis. Hoc quidem dicere <lb/> soletis : sed tunc soletis, cum
+					vobis objicitur quod <lb/> ait Dominus, <hi rend="italic">Ego et Pater unum</hi>
+					sumus <hi rend="italic">(Jonn.</hi> x, 50). <lb/> Ego autem hoc loco non boc
+					volui probare, quod <lb/> Pater et Filius ct Spiritus sanctus unum sint, quod
+					<lb/> quidem propter unitatem substantiae fidelissime certe <lb/> creilimus; sed
+					qnod cadem Trinitas unus est Deus. <lb/> Aliud est quippc, unum sunt; aliud,
+					unus est Deus. <lb/> Discerne, Est, ct Sunt. Nec ait Apostolus, Qui adhae­ <lb/>
+					rent Domino, unum sunt; quoniam diversa substantia <lb/> cst : sed ait : <hi
+						rend="italic">Qui</hi> adhaeret <hi rend="italic">Domino,</hi> unus spiritus
+						<hi rend="italic">est.</hi>
+					<lb/> Si autem vos, cum de duobus dicitur, Unus est, et di­ <lb/> citur quid
+					unus, sicut dicit Apostolus, <hi rend="italic">unus spiritus<lb/> est;</hi> hoc
+					idem putatis esse , quod est cum de duobus <lb/> dicitur, Unum sunt, nee dicitur
+					quid unum ; sicut <lb/> ait Salvator, <hi rend="italic">Ego ct Pater</hi> unum
+					sumus : cur non dici­ <lb/> tis, Palcr et Filius uuus cst Deus? Quare quando an­
+					<lb/> ditis. <hi rend="italic">Audi, Israel; Dominus Deus tuus, Dominus unus
+						<lb/> est (Deut.</hi> v!. 4); de Patre tantum vultis intelligi ? <lb/> Nempe
+					Pater Dominus Deus est, ct Fillus Dominus <lb/> Heus cst : cur non apud vos
+					uterque unus Dominus <lb/> Deus csl, sicut apud beatum Apostolum, spiritus ho­
+					<lb/> minis et Spiritus Domini 1 <hi rend="italic">unus spiritus est ?</hi> Quid
+					art­ <lb/> tem prodest causae vestre, quia per consensionem <lb/> voluntatis hoc
+					dicitis fieri ? Quod quidem fit, sed ubi <lb/> est diversa natnra, sicut diversa
+					natura est hominis <lb/> et Domini : et tamen <hi rend="italic">qui</hi>
+					adhaeret <hi rend="italic">Domino,</hi> per con­ <lb/> sensionem utique
+					voluntatis, <hi rend="italic">unus spiritus est.</hi> Si ergo <lb/> non vultis
+					per unilatem substantiae; certe per consea­ <lb/> sionem voluntatis dicite,
+					tamen aliquando dicite , <lb/> quoquo modo dicite, Pater ct Filius unus Deus
+					cst. <lb/> Sed non dicitis, ne quod nunquam voluistis, cogamini <lb/> confiteri
+					de utroque dictum esse, non dc Patre solo , <lb/>
+					<hi rend="italic">Audi, Israel; Dominus Deus tuus, Dominus</hi> unus <hi
+						rend="italic">cst:</hi>
+					<lb/> quoniam sanctum Spiritum non vultis Dcum, non <lb/> vultis Dominum
+					confitcri. Dicite, irnjuam , ratione <lb/> qua vultis , Patcr et Filius unus
+					Dominus Deus cst: <lb/> ut Patri et Filio servientes, non duobus diis ct duo­
+					<lb/> bus dominis contra praeceptum Dei, sed Domino uni <lb/> serviatis I. Sed
+					nunc de hac re satis dictum sit. Puto, <lb/> cum ista legeris, nihil te
+					respondere potuisse ad id quod <lb/> de Apostolo commemoravi, <hi rend="italic"
+						>qui</hi> adhaeret <hi rend="italic">Domino,</hi> unus <lb/>
+					<hi rend="italic">spiritus</hi> est : si contentionem deposueris, non
+					negabis.</p>
+				<p>CAPUT XI. — <hi rend="italic">De templo Spiritus sancti.</hi> Undecimo <lb/>
+					loco, Deum esse Spiritum sanctum, de templo ejus <lb/> quod nos ipsi sumus,
+					teste Apostolo, ostendi , ubi <lb/> ait, <hi rend="italic">Nescitis quia templum
+						Dei estis, et</hi> Spiritus <hi rend="italic">Dei <lb/> habitat</hi> in <hi
+						rend="italic">vobis</hi> (I <hi rend="italic">Cor.</hi> III, 16) ? et iterum
+					, <hi rend="italic">Nescitis<lb/> qnia corpora vestra templum in vobis est
+						Spiritus</hi> sancti, <lb/>
+					<hi rend="italic">quem habetis a Deo (Id.</hi> vi, 19) ? Tu aulem ad isto re­
+					<lb/> spondisti nihil. Aisti enim : <hi rend="italic">Suscipio quae protulisti
+						:</hi>
+					<lb/> i <hi rend="italic">Nescitis quia templum Dei estis, ci Spiritus Dei
+						habi­<lb/> tat</hi> in <hi rend="italic">vobis?</hi> &gt; <hi rend="italic"
+						>Neque enim Deus,</hi> inquis , <hi rend="italic">inhabitat in <lb/> homine,
+						quem non ante Spiritus sanctificaverit atque <lb/> purgaverit.</hi> Atque
+					isto modo intelligi voluisti, non Spi­ <lb/> ritum sanctum esse dictum Deum, nec
+					templum <lb/> Spiritus sancti nos a esse, sed Dci : et hoc esse cii­ <lb/> ctum,
+						<hi rend="italic">Templum Dei estis.</hi> Sed ideo additum, <hi
+						rend="italic">Spiritus<lb/> Dei habitat in vobis</hi> : quia purgat Spiritus
+					sancius <lb/> templum Dei, non suum ; ut cum ipse purgaverit, <lb/> tunc illic
+					inhabitet Deus. Quem sensum tuum quanta <lb/> sequatur absurditas, nolo nunc
+					dicere. Illud enirn <lb/> nunc ostendere debeo, quomodo multa dicendo, nihil
+					<lb/> quod ad rcm pertinet, dixeris. Dimisisti enim cau­ <lb/> sam, et
+					perrexisti in laudem Spiritus sancti, camque <lb/> copiose contra te ipsum
+					exsecutus es. Centra te ipsum <lb/> ideo dixi, quoniam non vis eum dicere Deum,
+					cujus <lb/> tantam divinitatem per laudem coactus es confiteri; <lb/> ut cum sit
+					unus, ubique sit praesens, et nemini sancti­ <lb/> ficando desit, ubicumque
+					quisquc christianus esse et <lb/> Deum orare voluerit, simul se omnibus
+					exhibendo, <lb/> sive in oriente, sive in occidente baptizentur in Chri­ <lb/>
+					sto : hoc ct nos dicimus. Sed qucm dicimus talcm ac <lb/> tantum, absit a nohis
+					ut eum negemus Dcum : quod <lb/> etiam per suum templum, quod nos ipsi sumus,
+					ci- <note type="footnote"> * Quidam vss., <hi rend="italic">Dommm.</hi>
+					</note><note type="footnote"> * Ain. Er. ct Mss., <hi rend="italic">ct Domini
+							'om1nå &lt;U!&lt;M&lt; serviahs.</hi>
+					</note><note type="footnote"> I Abcst, nos, a '!ss. </note>
+					<lb/>
+					<pb n="753"/> tissime et facile ostenditur. Neque enim nisi Deus <lb/> noster
+					esset, templum nos ipsos habere potuisset: <lb/> quod tu ut occultares, et in
+					sermone tuo mentes <lb/> hominum a luce veritatis averteres, de templo Dei <lb/>
+					quodeumque dixisti, quem noluisti intelligi Spiritum <lb/> sanctum; de templo
+					autem Spiritus sancti, quod aper­ <lb/> tissimc demonstratum est, omnino
+					tacuisti. Cum enim <lb/> tibi duo testimonia Pauli apostoli proposuerim; <lb/>
+					unnm ubi ait, <hi rend="italic">Nescitis</hi> quia <hi rend="italic">templum Dei
+						estis, et Spi­<lb/> ritus Dei habitat in</hi> vobis ? alterum ubi ait, <hi
+						rend="italic">Nescitis <lb/> quia corpora</hi> vestra <hi rend="italic"
+						>templum</hi> in <hi rend="italic">vobis Spiritus sancti</hi> est ? <lb/>
+					quare tam fraudulenter egisti, ut unum horum com­ <lb/> memorares, quod dictum
+					cst, <hi rend="italic">Templum Dei estis;</hi> et <lb/> alterum taceres, quod
+					dictum est, <hi rend="italic">Corpora vestra <lb/> templum in</hi> vobis <hi
+						rend="italic">est Spiritus</hi> sancti ? Cur hoc fccisti, <lb/> rogo te ;
+					nisi quia nullo pacto posses argumentari <lb/> quomodo Deus noster non esset,
+					qui templtum nos <lb/> ipsos haberet: quem sine dubio Deam cognoscere­ <lb/>
+					mus, si ei templum de lignis et lapidibus per divinam <lb/> Scripturam faccre
+					juberemur?</p>
+				<p>CAPUT XII. — <hi rend="italic">De eo quod Pater et Filius unum<lb/> sint.</hi>
+					Duodecimo loco admonui te, ut proferres, si <lb/> posses, qua divina auctorilate
+					sit dictum, quod unum <lb/> sint, ubi substantiae sunt diversae. Tu autem
+					respon­ <lb/> dcre ad hoc volens, nihil tale proferre potuisti; sed <lb/> magnis
+					coarctatus angustiis affirmare ausus es, quod <lb/> Apostoli unum siut cum Patre
+					et Filio. Quod Christus <lb/> omnino non dixit: sic enim abs te dictum est, tan­
+					<lb/> quam Pater et Filius et Apostoli unum sint. Christus <lb/> autem non ait,
+					Ut ipsi ct nos unum simus ; sed ait, <lb/>
+					<hi rend="italic">Ut sint</hi> unum, <hi rend="italic">sicut et</hi> nos unum
+					sumus. Nam, ut verba <lb/> ipsa evangelica ponam : <hi rend="italic">Pater
+						sancte,</hi> inquit, <hi rend="italic">serva eos</hi>
+					<lb/> in <hi rend="italic">nomine luo quos dedisti mihi,</hi> ut <hi
+						rend="italic">sint unum,</hi> sicut <hi rend="italic">el <lb/> nos
+						unum.</hi> Numquid dixit, Ut nobiscum sint unum; <lb/> aut, Ipsi et nos
+					simus unum ? Item post aliquantum : <lb/>
+					<hi rend="italic">Non,</hi> inquit, <hi rend="italic">pro</hi> eia <hi
+						rend="italic">rogo tantum; sed et pro eis qui cre­</hi>
+					<lb/> dituri <hi rend="italic">sunt per verbum eorum in</hi> me, <hi
+						rend="italic">ut omnes unum sint.</hi>
+					<lb/> Neque hic dixit, Ut nobiscum unum sint. Deinde se­ <lb/> quitur : <hi
+						rend="italic">Sicut tu, Pater, in me et ego in te, et ipsi in <lb/> nobis
+						unum sint.</hi> Et hic non dixit, Unum simus ; aut, <lb/> Unum nobiscum
+					sint: sed; <hi rend="italic">Unum sint in nobis;</hi> ut qui <lb/> natura unum
+					sunt, quia homincs sunt, etiam in Pa­ <lb/> tre et Filio sint unum; non cum
+					ipsis unum, id est, <lb/> non ut ipsi et isti sint unum. Adhuc adjungit, et
+					dicit: <lb/>
+					<hi rend="italic">Ut mundus credat quia tu me</hi> misisti, <hi rend="italic">et
+						ego claritatem<lb/> quam dedisti mihi, dedi illis, ut sint unum, sicut
+						nos</hi>
+					<lb/> unum <hi rend="italic">sumus: ego in eia et tu in me,</hi> ut sint <hi
+						rend="italic">consummati <lb/> in</hi> unum <hi rend="italic">(Joan.</hi>
+					XVII, 11-23). Cum ergo toties dixerit, <lb/>
+					<hi rend="italic">Ut sint</hi> unum ; non tamen alicubi dixit, Ut ipsi et nos
+					<lb/> simus unum, hoc est, ut nobiscum sint unum : sed <lb/> aut, <hi
+						rend="italic">in nobis</hi> dixit; aut, <hi rend="italic">sicut nos;</hi> id
+					est, ipsi secun­ <lb/> dum naturam suam, nos secundum nostram. Volebat <lb/>
+					enim eos qui natura unum erant, in hoc ipso quod <lb/> unum erant, esse
+					perfectos. Non enim quia dicit , <lb/>
+					<hi rend="italic">Estote ergo et vos perfecti</hi> sicut <hi rend="italic">Puter
+						vester</hi> caelestis <hi rend="italic">per­ <lb/> fectus eit (Matth.</hi>
+					v, 48); vult illos Deo natura unitate <lb/> conjungere, tanquam illorum et
+					illius una eademque <lb/> oatura sit : sed perfectos vult esse in natura Sua,
+					Sic­ <lb/> ut est Deus perfectus in sua , quamvis diversa, non <lb/> una ; quod
+					nisi in ipso simus, omnino esse non possu­ <lb/> mus. Non sicut in illo sunt
+					omnes, quia ipse continet <lb/> omnia quae creavit; propter quod dictus est <hi
+						rend="italic">non longe <lb/> positus ab unoquoque</hi> nostrum, quia <hi
+						rend="italic">in illo vivimus, et <lb/> movemur, et sumus (Act.</hi> XVII,
+					27, 28): sed sicut in illo <lb/> sunt tales qualibus dictum est, <hi
+						rend="italic">Fuistis enim aliquando</hi>
+					<lb/> tenebrae, <hi rend="italic">nunc autem lux</hi> in <hi rend="italic"
+						>Domino (Ephes. V,</hi> 8). Unde <lb/> et illud est, <hi rend="italic"
+						>Cui</hi> vult <hi rend="italic">nubat, tantum</hi> in <hi rend="italic"
+						>Domino</hi> (I <hi rend="italic">Cor.</hi>
+					<lb/> VII, 59). Non igitur proferre potuisti ubi dictum sit, <lb/> Unum sunt,
+					quorum est non una, sed diversa sub­ <lb/> stantia : et tamen 1 in obscuro loco
+					nobis subrepere <lb/> voluisti , ut diceres Apostolos unum esse cum Patre <lb/>
+					et Filio , tanquam unum essent Apos!oli et Pater et <lb/> Filius; cum
+					Apostolorum substantiam manifestum sit <lb/> a Patre et Filio esse diversam. Sed
+					quoniam, Ut ipsi <lb/> et nos unum simus, aut, Nobiscum sint unum, nus­ <lb/>
+					quam Christum dixisse manifestum est; te quoque <lb/> nobis respondere non
+					potuisse, et fraudern facere vo­ <lb/> luisse manifestum sit.</p>
+				<p>CAPUT XIII. — <hi rend="italic">De testimonio quod Pater perhibuit<lb/>
+						Filio.</hi> Tertio decimo loco te commonui, non ideo Pa­ <lb/> irem Filio
+					esse majorem, quia testimonium perhibuit <lb/> Pater Filio. Nam et Propbetas ei
+					testimonium perhi­ <lb/> buisse memoravi, quos majores illo esse non potes <lb/>
+					dicere. Dixeras enim quod Pater Filio perhibuerit te­ <lb/> stimonium ; quod sic
+					accepi, tanquam hinc ipse pro­ <lb/> bare volueris, illo cui testimonium
+					perhibuit, eum <lb/> esse majorem : sed quoniam posteriore prosecutione <lb/>
+					hinc omnino tacuisti, taciturnitatem tuam in locum <lb/> consensionis accepi ;
+					etsi fieri polost. ut ideo comme. <lb/> moraveris Patrem Filio perhibuisse
+					testimonium, ut <lb/> hinc illum esse alium , istum autem alium, non ut <lb/>
+					illum isto probares esse majorem. Alium vero esse <lb/> Patrem, aliutn esse
+					Filium, quoniam non est Pater <lb/> ipse qui Filius, et vobis et nobis contra
+					Sabellianos <lb/> est dogma commune. Illi enim dicunt, nonalium, sed <lb/>
+					eumdem Filium esse qui est Pater : nos autem alium <lb/> quidem esse Patrem, et
+					alium Filium; sed tamen <lb/> quod Pater est, hoc esse dicimus Filium.</p>
+				<p>CAPUT XIV. — <hi rend="italic">De dilectione Patris et Filii.</hi> Quarto <lb/>
+					decimo loco ad illud quod dixeras, <hi rend="italic">Dilectum lego, et <lb/>
+						credo quod Pater eat qui diligit , et Filius qui diligitur;</hi>
+					<lb/> respondens dixi : <hi rend="italic">Sic autem dicis hinc inter Patrem et
+						<lb/> Filium esse diversitatem, quia Pater diligit, et Filius <lb/>
+						diligitur; quasi negare possis quod et Filius diligat Pa­<lb/> trem.</hi>
+					Deinde addidi: <hi rend="italic">Si ambo se invicem diligunt, cur<lb/> negatis
+						eoa</hi> unius <hi rend="italic">esse naturae</hi> ? Quod utique ideo dixi,
+					<lb/> ne hinc unam naturam negaretis amborum, quia iI­ <lb/> lum diligere, hunc
+					diligi ipse dixisti. Ad hoc tu re­ <lb/> spondens consensisti quidem, quod et
+					Filius diligat <lb/> Patrem , sed unius esse naturae consentire noluisti : <lb/>
+					tanquam Filius ita diligat Patrem, sicut creatura <lb/> Crratorcm , non sicut
+					unigenitus geuitorcm, quem <lb/> diversitate substantiae vultis esse
+					degenerem.</p>
+				<p>CAPUT XV. — <hi rend="italic">De invisibilitate Trinitatis.</hi> Quinto <lb/>
+					decimo loco dixi pariter esse invisibilem Trinitatem, <note type="footnote"> *
+						ALD, fcr. et Mas., <hi rend="italic">tanquam.</hi>
+					</note>
+					<lb/>
+					<pb n="755"/> nun solum Patrem : sed apparuisse tamen visibilem <lb/> :'ilium in
+					forma servi, propter quam dixit, <hi rend="italic">Pater ma­</hi>
+					<lb/> jor <hi rend="italic">me eat (Joan.</hi> xiv, 23). Sed quoniam patribus se
+					di­ <lb/> vinilas demostrabat , dixi per subjectum crealurain <lb/> id osse
+					factum, non per naturam suam, qua est invi­ <lb/> sibilis Trinitas. Atque ut hoc
+					probarem, Moysen com­ <lb/> memoravi ci dicentem, cum quo facie ad faciem lo­
+					<lb/> quebatur, Si <hi rend="italic">inveni</hi> gratiam <hi rend="italic">ante
+						te, ostende mihi temet­<lb/> ipsum</hi> manifeste <hi rend="italic"
+						>(Exod.</hi> XXXIII, 11, 13) : ut intelligeres <lb/> quomodo cum vidcbat,
+					quem sibi cupiebat ostendi ; <lb/> quia utique si Deum in substantia qua Deus
+					cst vide­ <lb/> rpt, profecto ut se illi ostenderet non rogaret. Dixi <lb/>
+					etiam esse Christum visibilium ct invisibilium creato­ <lb/> rem , ut ipsum
+					probarem per substantiam suam non <lb/> esse visibilem , a quo preari non solum
+					visibilia, <lb/> veram etiam invisibilia potuerunt. Ad haec tu respon­ <lb/>
+					dere conatus, quam multa quae ad rem non pertinent <lb/> dixeris , intueantur
+					qui legunt : et tamen de Moyse, <lb/> cur sibi Deum cum quo loquebatur, vellet
+					ostendi , si <lb/> cnus naturam substantiamque cernebat, prorsus nibil <lb/>
+					ausus es dicere: ct adhuc affirmare non destitisti, Dei <lb/> Filium
+					invisibilium crcatorem , et antequam formam <lb/> servi acciperet, in forma Dei
+					fuisse visihilcm; quem <lb/> tupcrius in formi servi viden potuisse , in
+					substantia <lb/> vero suie divinitatis esse invisibilem, jam fueras et <lb/>
+					ipse confessus.</p>
+				<p>CAPUT XVI. — <hi rend="italic">De solo sapiente Deo.</hi> Sexto de­ <lb/> cimo
+					loco; quia de Patre tantum dixissc Apostolum <lb/> dixeras, <hi rend="italic"
+						>Soli sapienti Deo (Rom.</hi> xvi, 27); ego dixi : <lb/>
+					<hi rend="italic">Ergo solus Pater est Deus sapiens, et non est sapiens<lb/>
+						ipsa Dei sapientia, quod est</hi> Christus; <hi rend="italic">de quo ait
+						Aposto­</hi>
+					<lb/> lus : « <hi rend="italic">Christum Dei Virtutem et Dei</hi> Sapientiam <hi
+						rend="italic">» (I Cor.</hi>
+					<lb/> I, 24) ! Deinde addidi : <hi rend="italic">Superest ut dicatis (quid enim
+						<lb/> non audetis? ) insipientem esse sapientiam Dei.</hi> Ad h:rc <lb/> tu
+					: <hi rend="italic">Sapientem solum,</hi> inquis, <hi rend="italic">Patrem
+						praedicat Paulus <lb/> beatus apostolus, dicens sic:</hi> « <hi
+						rend="italic">Soli sapienti Dco.</hi> i <hi rend="italic">Sed <lb/>
+						requirenda est ,</hi> inquis, <hi rend="italic">ratio quemadmodum solus
+						sapiens,</hi>
+					<lb/> non <hi rend="italic">quod Christus non sit sapiens.</hi> Scqucris
+					dcinceps , <lb/> et adjungis quomodo sapientem confitearis et Chri­ <lb/> stum :
+					nam post nonnulla , quae ad rem non perii.. <lb/> nentia texuisti , ut sermonem
+					tempusque produceres, <lb/> eliam hoc inseruisti verbis tuis ut diceres, <hi
+						rend="italic">Sed vere <lb/> solus sapiens</hi> Pater ; quasi Apostolus
+					dixerit, Soli <lb/> sapienti Patri. Sed dixit, <hi rend="italic">Soli sapienti
+						Dco</hi> : quia Deus <lb/> est et Filius, quod et vos vultis; Dcus est ct
+					Spiritus <lb/> sanctus, etsi non vultis : ct ista Trinitas cst solus sa­ <lb/>
+					piens Deus, qui nec potuit unquam esse insipicns <lb/> omnino, nec poterit; non
+					per gratiam particeps sa­ <lb/> pientiae, sed sapiens immobilitate atque immuta­
+					<lb/> bilitate naturae. Nam si tibi dicam, itane vero, o <lb/> homo qui
+					christiano nomine gloriaris, Christus sic est <lb/> sapiens , ut non sit vere
+					sapiens ? ergone Christus qui <lb/> osi verus Deus, non est verb sapicns? nonne
+					ita sub <lb/> hac interrogatione turbaberis, ut continuo respon­ <lb/> deas ,
+					Christum vere esse sapientem ? Quid est ergo <lb/> quod dixisti, <hi
+						rend="italic">Sed</hi> vere <hi rend="italic">solus sapiens</hi> Pater ?
+					Nempe <lb/> quo per veneris , et a quanta blasphemia te debeas re­ <lb/> yovare,
+					jam sentis.</p>
+				<p>CAPUT XVII. — <hi rend="italic">De infecto Deo.</hi> Septimo decimo <lb/> loco
+					egi tecum, quod etiam Filius , non solus Pater, <lb/> infectus sit, hoc est,
+					factus non sit. Dixeras enim ideo <lb/> a vobis unum Deum pronuntiari, quia <hi
+						rend="italic">unus est super<lb/> omnia innatus,</hi> infectus. Respondens
+					crgo huic aula. <lb/> ci:c tu:c : <hi rend="italic">Sic antem</hi> , inquam, <hi
+						rend="italic">dicis Patrem infectum,<lb/> quasi Filius factus sit , per quem
+						facta sunt omnia.</hi>
+					<lb/> Deinde addidi : <hi rend="italic">Scito factum esse Filium, sed in</hi>
+					forma <lb/>
+					<hi rend="italic">servi.</hi> Nam in <hi rend="italic">forma Dei usque</hi> adeo
+						<hi rend="italic">non est factus,</hi> ut <lb/>
+					<hi rend="italic">per illum facta sint omnia.</hi> Si <hi rend="italic">enim
+						ipse factus</hi> eat, in­ <lb/> quam, <hi rend="italic">non per illum facta
+						sunt omnia, aed</hi> caetera. Ad <lb/> haec tu cum tota hii prolixitate
+					sermonis, ita nihil <lb/> quod diceres invenisti , ut hinc omnino, tanquam id
+					<lb/> non audieris, conticesceres.</p>
+				<p>CAPUT XVIII. <hi rend="italic">- De ingenito Patre.</hi> Octavo decimo <lb/> loco
+					etiam de innato Patre , id est ingenito , quia ct <lb/> hoc dixcras, tccum
+					agendum putavi, et dixi: <hi rend="italic">Non <lb/> itoque dico Filium
+						ingenitum; aed Patrem genitorem, <lb/> Filium genitum. Hoc tamen genuit
+						Puter quod est : <lb/> alioquin non est verus Filius ,</hi> si <hi
+						rend="italic">qnod est Pater non est <lb/> Filius ; sicut de partubus
+						animalium supra jam diximus.</hi>
+					<lb/> Eliam ad hoc In nee verum nec falsum ali quid protulisti.</p>
+				<p>CAPUT XIX. — <hi rend="italic">De aequalitate Spiritus sancti cum Pa.<lb/>
+						tre.</hi> Nonodccimo loco, quia poposceras a mc, ut osten­ <lb/> derem
+					aequalem esse I'atri i Spiritum sanctum ; respondi <lb/> tibi dicens: <hi
+						rend="italic">Quid est autem quod</hi> poscis, <hi rend="italic">ut ostendam
+						tibi</hi>
+					<lb/> aqualem Patri <hi rend="italic">esse Spiritum sanctum, quasi tu Patrem
+						<lb/> ostenderis majorem esse Spiritu sancto; sicut potuisti <lb/> ostendere
+						de Filio, propter formam servi? Scimus enim,</hi>
+					<lb/> inquam, <hi rend="italic">dictum esse Patrem Filio majorem, quia</hi> in <lb/>
+					<hi rend="italic">forma servi erat Filius ; ct adhuc in forma eat humana<lb/>
+						Filius, quam levavit in coelum : propterea de illo</hi> di­ <lb/> ctum <hi
+						rend="italic">eat quod et nunc</hi> a interpellat <hi rend="italic">pro</hi>
+					nobis i <hi rend="italic">(Rom.</hi>
+					<lb/> VIII, 54). <hi rend="italic">Et sempiterna erit in regno haec eadem forma
+						<lb/> immortalis : propter quod dictum</hi> eat « <hi rend="italic">Tunc et
+						ipsa</hi> Fi­ <lb/> « <hi rend="italic">lius subjectus erit ei qui illi
+						subjecit omnia</hi> » ( I <hi rend="italic">Cor.</hi>
+					<lb/> xv, 28). <hi rend="italic">Nam de Spiritu sancto qui nullam suscepit <lb/>
+						creaturam ad unitatem personae suae, quamvis se per <lb/> subjectam
+						creaturam visibiliter et ipse.. sive per</hi> columbae <lb/>
+					<hi rend="italic">speciem, sive per linguas igneas sit demonstrare digna­ <lb/>
+						tua (Matth</hi> III, 16 <hi rend="italic">, et Act.</hi> II, 3), <hi
+						rend="italic">nunquam dictus est <lb/> eo major Pater; nunquam dictus
+						cst</hi> Spiiitus <hi rend="italic">adorasse <lb/> Patrem; nunquam dictus
+						est minor Patre.</hi> Ad haec tu <lb/> quasi respondens, non tamen
+					respandisti. Non enim <lb/> potuisti ostendere Spiritu sancto alicubi Patrem
+					dictum <lb/> fuissc majorem, sicuti Filius propter formam servi di­ <lb/> xit,
+						<hi rend="italic">Pater major me est (Joan.</hi> XIV, 28). Et cum ego <lb/>
+					dixerim, Spiritum sanctum non ad unitatem personae <lb/> suae ullam suscepisse
+					creaturam; tu ita Spiritum san­ <lb/> ctum in columba ct igne apparuisse
+					dixisti, sicut ap­ <lb/> paruit Christus in homine : quasi columba el Spiritus,
+					<lb/> vel ignis et Spiritus una persona sit, sicut Verbum et ' <lb/> homo una
+					persona est. Ad horam quippe apparuerunt <lb/> illa, quae Spiritum sanctum
+					significando monstrarent <lb/> visibiliter invisibilem ; columba, propter amorem
+					san­ <lb/> ctum ; ignis autem , propter charitatis lumcn atque <lb/> fervorem ;
+					et peracto significationis officio, corporales <lb/> illae species transierunt,
+					atque esse ulterius destite­ <lb/> runt; sicut columna nubis. nebulosa per diem
+					, lunii­ <lb/> nosa per noctem <hi rend="italic">(Exod.</hi> XIII, 21-22).
+					Denique ne puta­ <lb/>
+					<pb n="757"/> retur columba vel flamma ad substantiam pertinere <lb/> Spiritus
+					sancti, vel quod se in haec visibilia tantae ma­ <lb/> jestatis natura
+					converterit, aut in unitatem personae <lb/> suae ista susceperit, nunquam postea
+					sic apparuisse le­ <lb/> gitur Spiritus sancius. Cbristus autem, qui humanam
+					<lb/> non ad horam sumpsit effigiem, in qua hominibus ap­ <lb/> pareret, ac
+					deinde illa species praeteriret; sed in uni­ <lb/> tatem personae suae, manente
+					invisibili Dei forma I, <lb/> accepit visibilem hominis formam; non solum, natus
+					<lb/> cst in ea de homine matre, verum etiam crevit in ea, et <lb/> manducavit,
+					et bibit, et dormivit in ea, et occisus est <lb/> in ea, et resurrexit in ea, et
+					ascendit in coelum, et <lb/> scdet ad dexteram Patris in ea, ad judicandos vivos
+					<lb/> et mortuos est venturus in ea, et in regno suo, ci qui <lb/> illi subjecit
+					omnia, erit subjectus in ea. Ilac tu in <lb/> mea responsione breviter dicta,
+					quae nunc aliquanto <lb/> latius, ut vel sic intelligcres, explicavi, attendere
+					et <lb/> considcrare noluisti, irruens in tantam blasphemiam, <lb/> . ut naturam
+					divinam Dei et Spiritus sancli converti-, <lb/> bilem, proh nefas! et mutabilem
+					diccres. Tua nam­ <lb/> que ista sunt verba : <hi rend="italic">Ea,</hi> inquis,
+						<hi rend="italic">quae; de invisibilitate <lb/> &gt; omnipotentis</hi> 2 <hi
+						rend="italic">Dei prosecutus sum, eliam et ipse, licet <lb/> alio</hi>
+					proposito, attamen <hi rend="italic">tuis verbis affirmasti, quod Spi­</hi>
+					<lb/> . <lb/> ritus sanctus in <hi rend="italic">specie columbae sit MMM, necnon
+						et in<lb/> specie ignis : Filius sane,</hi> in forma hominis: <hi
+						rend="italic">Pater<lb/> autem, neque</hi> in <hi rend="italic">specie
+						columbx, nec</hi> in <hi rend="italic">forma hominis;. <lb/> nec aliquando
+						vertit se in formas, sed nec aliquando</hi>
+					<lb/> vertetur : <hi rend="italic">de quo scriptum est, « Ego</hi> sum <hi
+						rend="italic">qui sum, et</hi>
+					<lb/> « <hi rend="italic">non sum mutatus.</hi> &gt; Deinde adjungis, et dicis:
+					Fi­ <lb/>
+					<hi rend="italic">lius sane</hi> in forma <hi rend="italic">Dei constitutus
+						jam,</hi> ut <hi rend="italic">ipse protu<lb/>li.,;, formam servi
+						accepit, quod non Pater: Spiritus <lb/> aeque sanctus suscepit speciem
+						columbae, quam</hi> nonsta­ <lb/>
+					<hi rend="italic">cepit Parer. Scito ergo,</hi> inquis, <hi rend="italic">quia
+						unus est, invisi­ <lb/> bilis, unus eliam incapabilis atque immensus.</hi>
+					Haec <lb/> numquid diceres, si secundum spiritum, non secun­ <lb/> dum carnem,
+					posses cogitare quid diceres ? Homo <lb/> es enim, qui legis in Scripturis
+					sanctis, <hi rend="italic">Ego</hi> sum <hi rend="italic">qui <lb/> sum:, et non
+						sum mutatus (Exod.</hi> III, 14, <hi rend="italic">et Malach.</hi>
+					<lb/> III, 6). Et cum verba ista sint, non Patris solius, sed <lb/> ipsius
+					Trinitatis, quae unus est Deus; tu ea Patri <note type="footnote"> I Editio
+						Lov., <hi rend="italic">sed unitate personae manenle, invisibUis <lb/> hei
+							fortna accepit,</hi> etc. * </note><note type="footnote"> I Am. ET. et
+						Mss., <hi rend="italic">omnitenentis.</hi>
+					</note>
+					<lb/> tantummodo tribuens, Filium mutabilem credis! Uni­ <lb/> genitum per quem
+					facta sunt omnia mutabilem credis: <lb/> eum de quo dicit Evangelium, <hi
+						rend="italic">In principio erat Ver. <lb/> bum, et Verbum erat apud Deum, et
+						Deus erat Verbum;</hi>
+					<lb/> et, <hi rend="italic">Omnia per</hi> ipsum <hi rend="italic">facta sunt
+						(Joan.</hi> i, 1, 5), muta­ <lb/> bilem credis! Quid jam dicam de Spiritu
+					sancto, <lb/> quando illum quem verum Filium Dei et verum con­ <lb/> fiteris
+					Deum, mutahilem credis ? Quod ufiquc non <lb/> crederes, si formam servi a forma
+					Dei esse susce­ <lb/> ptam, non formam Dci in formam servi esse muta. <lb/> tam,
+					tanquam catholicus crederes; et visibili homine <lb/> assumpto, permansisse
+					invisibilem Deum, non car­ <lb/> nalitcr, sed spiritualiter cogitares ; nee
+					coptendend&gt; <lb/> diffideres, sed intelligendo conspiceres : et Spiritum
+					<lb/> sanctum invisibili sua manente natura, nullo modo <lb/> in ignis aut
+					columbae speciem mutata atque conversa, <lb/> per subjectam creaturam
+					apparuisse, sicul voluit vi­ <lb/> sibiliter <hi rend="italic">(Act.</hi> n, 3,
+						<hi rend="italic">et Matth.</hi> III, 16), tu posses consi<lb/>derare
+					fideliter. Memento tamen, nec majorem Pa<lb/> Irem Spiritu sancto, nec
+					adoratum Patrem ab Spiritu <lb/> sancto, ullis divinis testimoniis contra
+					propositionem <lb/> meam te demonstrare potuisse.</p>
+				<p>CAPUT XX. — <hi rend="italic">Licet ingenitus Pater,</hi> aequalis <hi
+						rend="italic">ta­<lb/> men Filius.</hi> Vigesimo loco, quoniam dixeras de
+					Filio, <lb/> Si <hi rend="italic">aequalis. Patri, utique talis:</hi> si <hi
+						rend="italic">talis, utique innatus;</hi>
+					<lb/> ego respondens tibi: Sed dicis, inquam, de Filio, Si <lb/>
+					<hi rend="italic">aequalis, utique talis;</hi> id est, ut <hi rend="italic">quia
+						non eat ingenitus.<lb/> non videatur talis. Posses dtcere non esse hominem
+						quem<lb/> genuit Adam, quia ipse Adam non eat genitus, sed factus<lb/> a
+						Deo.</hi> Si <hi rend="italic">autem potuit Adam et non esse genitus,</hi>
+					et <lb/> tamen <hi rend="italic">hoc generare quod erat ipse; non vis ut
+						potue­<lb/> rit Deus Deum aquatem</hi> sibi ? Ad haec non miror <lb/> nullum
+					te invenisse responsum : sed plane laudo nec <lb/> respondere conatum. Atque
+					utinam hoc ubique fe­ <lb/> cisses! nusquam enim in sermonibus nostris quid
+					<lb/> recte responderes invenire potuisti, et tamen pene <lb/> ubique tacere
+					noluisti. Sed cum in aliis tam multa <lb/> dixeris, causae quoe inter nos agitur
+					non necessaria , <lb/> et tempus loquendo consumpseris; gratiae tibi agendae
+					<lb/> sunt, ubi nonnulla sic vidisti te refutare non posse, ut <lb/> ea malles
+					summo silentio praeterire. <note type="footnote"> I Apud Lov., <hi rend="italic"
+							>plene.</hi>
+					</note>
+				</p>
+				<ab>
+					<title type="sub">
+						<hi rend="italic">LIBER SECUNDUS (a).</hi>
+					</title>
+				</ab>
+				<p>Refelluntur singillatim quae in Collatione Maximinus dixit ultima sua
+					disputatione, cujus disputationis suae prolixitato <lb/> respondendi tempus tunc
+					eripuit Augustino.</p>
+				<p>PRaeFATIO. - Res jam postulat ut in eoquod reliquum <lb/> est, opitulante Domino,
+					impleam promissionem meam. <lb/> In operis quippe hujus exordio, Prius,
+					inquam,ostendam <lb/>
+					<hi rend="italic">refellere te non potuisse quae dixi: deinde, quantum<lb/>
+						necessarium videbitur,</hi> ego <hi rend="italic">refellam quas ipse
+						dixisti.</hi>
+					<lb/> Quia ergo, sicut adjuvante Deo potui, ostendi ea quae <lb/> dixi non te
+					potuisse refellere; superest ut ea qux <lb/> dixisti, ego refellam, sicut Deo
+					adjuvante potuero. <lb/> Priores itaque prosecutiones tuas, quibus. continuo
+						<note type="footnote"> (I.) viias, reviius. </note>
+					<lb/> reddidi meas in hac disputatione quae nunc a me sus<lb/>cepta est, non
+					retractabo : illam vero ultimam lam <lb/> prolixam, ut milii die illo spatium
+					responsionis An­ <lb/> ferret, ita redarguam, si voluerit qui nos regit, ut
+					<lb/> acquiescas lumini veritatis, si contentionis tenebras <lb/> non amaveris.
+					In primis ergo superflua tua detrahant <lb/> necessitati responsionis meae.
+					Causa quippe inter nns <lb/> agitur, utrum Pater et Filius et Spiritus sanctus
+					di­ <lb/> versae, ut vos dicitis, an potius, ut nos dicimus, unius <lb/> sint
+					ejusdemque substantiae, unusque Deus sit ipsa <lb/>
+					<pb n="759"/> Trinitas : cum conveniat inter nos Patrem non esse <lb/> qui est
+					Filius, nee Filium esse qui est Pater, nec Pa­ <lb/> tremesse vel Filium qui
+					Spiritus sanctus est. Quid­ <lb/> quid igitur tanta tuae prosecutionis
+					prolixitate dixisti, <lb/> mule ostenderes alium esse Patrem, alium esse Fi­
+					<lb/> lium, alium esse Spiritum sanctum quando nobis­ <lb/> cum agitis.
+					superfluum prorsus esse cognosce : et si <lb/> tibi expugnandi occurrerint
+					Sabelliani, in eos ista <lb/> nohis vobisque communia, si placet, arma converte.
+					<lb/> Multa eliam locutus es, ut probares magnum Deum <lb/> esse Dominum Jesum
+					Christum : hoc quid ad nos, <lb/> cum hoc dicamus et nos? Laudes quoque Spiritus
+					<lb/> sancti magnas verasque fudisti : sed nos eas augere <lb/> possumus, non
+					negare : non itaque opus erat ut eas <lb/> contra nos diceres, quas dicimus
+					tecum. Christum <lb/> scdere ad dexteram Patris, nonne pariter confite­ <lb/>
+					mur? Quod tamen testimoniis divinorum eloquio­ <lb/> rum sic probare voluisti,
+					tanquam id alicubi negare­ <lb/> mus. Christum in carne venisse, utrique novimus
+					et <lb/> tenemus : sic adhibuisti ut hoc doceres divina testi­ <lb/> monia,
+					tanquam repugnemus. Haec et alia quae suis <lb/> ostendam locis, in quibus
+					operam supervacuam con­ <lb/> trivisti, ut moras necteres, tempusque produceres,
+					<lb/> commemorando attingere debeo, non redarguere <lb/> disputando.</p>
+				<p>CAPUT PRIMUM. — Dicis me <hi rend="italic">auxilio</hi> principum mu­ <lb/>
+					<hi rend="italic">nitum, non loqui secundum timorem Dei;</hi> cum scias nobis
+					<lb/> esse praeceptum orare pro regibus, ut in agnitionem <lb/> veniant
+					veritatis (I Tim. II, i, 4): quod in quibusdam <lb/> esse impletum, nos Deo
+					agimus gratias, vos doletis. <lb/> Verba autem nostra recte intelligentibus
+					indicant, quis <lb/> nostrum loquatur secundum timorem Dei : utrum qui <lb/> sic
+					laudat Deum Patrem , ut ad ejus taudem referat, <lb/> quod sibi Filium generavit
+					xqualem; an qui sic geni­ <lb/> torem debonestat et genitum, ut et illum dicat
+					non <lb/> potuisse gignere per omnia sui similem filium, et <lb/> isium dicat
+					non dcgenerasse jam natum, sed dcgeae­ <lb/> rem natum.</p>
+				<p>CAPUT II. — Dicis <hi rend="italic">vos Christum colere, ut Deum <lb/> omnis
+						creaturae cui flectitur</hi> omne <hi rend="italic">genu, cœlestium, ter­
+						<lb/> restrium et infernorum</hi> : quem tamen Deo Patri esse <lb/> non
+					vultis aequalem, quia <hi rend="italic">hoc Pater ei donavit:</hi> ait <lb/>
+					enim Apostolus, <hi rend="italic">Propter quod et Deus eun. exaltavit, <lb/> et
+						donavit ei nomen quod est super omne nomen , ut</hi> in <lb/>
+					<hi rend="italic">nomine Jesu omne genu flectatur,</hi> etc. Nec quaeritis cui
+					<lb/> donaverit; utrum homini, an Deo. Quomodo1 enim <lb/> donaverit, evidenter
+					apparet. <hi rend="italic">Humiliavit,</hi> inquit, <hi rend="italic">se­ <lb/>
+						metipsum usque ad mortem, mortem autem crucis. Pro­</hi>
+					<lb/> pter <hi rend="italic">quod et Deus eum</hi> exaltavit, <hi rend="italic"
+						>et donavit ei nomen <lb/> quod est super omne nomen (Philipp.</hi> II, 8,
+					9). Si ergo <lb/> propterea donavit ei nomen quod est super omne no­ <lb/> men,
+					quia factus est obediens usque ad mortem cru­ <lb/> cis; numquid antequam hoc
+					fieret, non erat altus Dei <lb/> Filius Deus, Dei Verbum, Deus apud Deum; sed
+					<lb/> posteaquam propter hoc exaltatus est, quia factus est <lb/> obediens usque
+					ad mortem crucis, tunc coepit esse <lb/> altus Dei Filius, unicus Dei, Deus,
+					tunc cœpit habere <lb/> nomen quad est super omne nomcn? Quis hoc insi- <note
+						type="footnote"> 1 In Mss., <hi rend="italic">Quando.</hi>
+					</note>
+					<lb/> pientissimus dixerit? Hoc illi ergo donatum est ut ho­ <lb/> mini,
+					secundum quem Filius factus est obediens usque <lb/> ad mortem crucis, quod jam
+					habebat idem ipse Dei <lb/> Filius, Deus de Deo natus aequalis.</p>
+				<p>CAPUT III. — Objicis mihi, quod dicam Spiritum <lb/> sanctum aequalem esse Filio.
+					Dico plane. <hi rend="italic">Da,</hi> inquis, <lb/>
+					<hi rend="italic">testimonia ubi adoratur Spiritus sanctus.</hi> Ut video, hinc
+					<lb/> eam vis ostendi aequalem Christo, si adoratur ut Chri­ <lb/> stus. Jam
+					ergo confitere Christum Patr! arqualcm, <lb/> quem tu ipse adorari confiteris ut
+					Patrem. Quales au­ <lb/> tem homines estis, quam religiosas humilitatis, qui
+					<lb/> Spiritum sanctum adorare non vultis, ciim legntis, <lb/>
+					<hi rend="italic">Littera occidit, Spiritus</hi> autem <hi rend="italic"
+						>vivificat</hi> ( II <hi rend="italic">Cor.</hi> III, 6 ) ? <lb/> Non vultis
+					ergo adorare, quem vivificare animas non <lb/> negatis : cum pater Abraham
+					homines adoraverit, <lb/> quia concesserunt ei monumentum, ubi poneret mor
+					<lb/>tuae corpus uxoris. Sic cnim scriptum est : <hi rend="italic">Venit
+						au.<lb/> tem Abraham plangere Saram et lugere. Et</hi> surrexit <lb/>
+					<hi rend="italic">Abraham de supra mortem ejus, et dixit filiis II et. : <lb/>
+						Peregrinus et advena sum ego vobiscum; daie ergo</hi> mihi <lb/>
+					<hi rend="italic">possessionem monumenti, ubi sepeliam mortuum</hi> meum. <lb/>
+					<hi rend="italic">Responderunt autem filii Heth ad</hi> Abraham , <hi
+						rend="italic">dicentes :<lb/> Absit hoc, domine; audi nunc et noa : rex a
+						Deo in</hi> es <lb/>
+					<hi rend="italic">in</hi> nobis ; <hi rend="italic">in electis monumentis
+						nostris sepeli mortuum <lb/> tuum : nemo enim nostrum prohibet te a
+						monumento <lb/> suo, ut sepelias mortuum tuum ibi. Surgens autem <lb/>
+						Abraham adoravit plebem</hi> filiorum <hi rend="italic">Heth (Gen.</hi>
+					XlIII, <lb/> 2-7). Et vos Spiritum sanctum non permittitis adorari, <lb/> ut
+					ipsi Dei gratiae remaneatis ingrati ! Sed, <hi rend="italic">Da,</hi> in­ <lb/>
+					quis, <hi rend="italic">testimonia ubi adoratur Spiritus sanctus</hi> : quasi
+					<lb/> non ex iis quae legimus , aliqua eliam quae non legi­ <lb/> mus,
+					intelligamus. Sed ne quaTere multa compellar, <lb/> tu ubi legisti Patrem Deum
+					ingenitum vel innatum? <lb/> Et tamen verum est. Quod vero aliquoties dixisti,
+					<lb/> etiam Filio esse incomparabilem Patrem, nec legis, <lb/> nec verum est. Si
+					autem religionem qua colitur Deus, <lb/> sicut dignum est cogitares, multo plus
+					esse cerneres <lb/> quod habet Spiritus sanctus templum, quam si cum <lb/>
+					legeres adoratum. Et homines enim , sicut supra do­ <lb/> cui, a sanctis novimus
+					adoratos : templum vero non <lb/> est factum ab hominibus, nisi aut vero Deo,
+					sicut Sa­ <lb/> lomon fecit; aut cis qui pro diis habentur, sicut gen­ <lb/> tes
+					quae ignorant Deum. Spiritus autem sanctus, quod <lb/> cum magno honore de Deo
+					dictum est, <hi rend="italic">non in manu­ <lb/> factis templis habilat</hi> (
+						<hi rend="italic">Act.</hi> XVII, 24 ), sed corpus no­ <lb/> strum templum
+					est Spiritus sancti. Et ne corpora no­ <lb/> stra contemnas, membra sunt Christi
+					( I <hi rend="italic">Cor.</hi> vi, 19, <lb/> 15). Qualis ergo Deus, cui templum
+					aedificatur, et a <lb/> Deo, et de membris Dei ?</p>
+				<p>CAPUT IV. — Dicis <hi rend="italic">Christum esse</hi> in <hi rend="italic"
+						>dextera Dei,<lb/> et interpellare pro nobis (Rom.</hi> VIII, 34). Quod cur
+					no­ <lb/> bis objicis, si eum non solum Deum, verum etiam <lb/> hominem
+					agnoscis? Quid te igitur adjuvat, quod se­ <lb/> dere ad dexteram Patris assidue
+					legitur ? Quid nobis, <lb/> non quidem inanibus testimoniis, sed tamen inaniler,
+					<lb/> probare niteris quod fatemur.</p>
+				<p>CAPUT V. — Dicis <hi rend="italic">vos Spiritum sanctum</hi> compe­ <lb/>
+					<hi rend="italic">tenter honorare ut doctorem, ut ducatorem,</hi> ut <hi
+						rend="italic">illumina­</hi>
+					<lb/> torem, ut <hi rend="italic">sanctificatorem; Christum colere, ut
+						creato­</hi>
+					<lb/>
+					<pb n="761"/>
+					<hi rend="italic">rem; Patrem</hi> cun, <hi rend="italic">sincera devotione
+						adorare,</hi> ut <hi rend="italic">aucto­</hi>
+					<lb/> rem. Si auctorem propterea dicis Patrem, quia de <lb/> ipso est Filius,
+					non est autem ipse de Filio; et quia <lb/> de illo et Filio sic procedit
+					Spiritus sanctus, ut. ipse <lb/> hoc dederit Filio gignendo eum talem, ut etiam
+					de <lb/> ipso procedat Spiritus sanctus : si creatorem sic dicis <lb/> Filium,
+					ut creatorem non neges Patrem nec Spiritum <lb/> sanctum; si denique Spiritum
+					sanctum sic dicis do­ <lb/> ctorem , ducatorem, illuminatorem, sanctificatorem,
+					<lb/> ut haec opera nec Patri audeas auferre nec Filio : ista <lb/> tua etiam
+					nostra sint verba. Si autem talia tibi idola <lb/> ponis in corde, ut duos
+					facias deos, unum majorem, <lb/> id est, Patrenl, alium minorem, id est, Filium
+					; Spi­ <lb/> ritum vero sanctum ita omnium trium minimum fin­ <lb/> gas, ut nec
+					Deum nuncupare digneris : non haec est <lb/> nostra fides, quoniam non est
+					christiana fides, ac per <lb/> hoc nec fides. Etiam hoc tibi ignoscimus, quod
+					impe­ <lb/> rite usus verbo , Chritum significasti <hi rend="italic">ad terrena
+						de­ <lb/> scendisse contagia.</hi> Et quia hoc in te corrigere volui, <lb/>
+					ut scires conlagia quomodo appellare debeamus; ca­ <lb/> lumnias <hi
+						rend="italic">esse</hi> istas dicis, <hi rend="italic">et</hi> eas <hi
+						rend="italic">de philosophicas artis<lb/> instructione venire</hi>
+					arbitraris. Sufficit mihi quod ita <lb/> putasti Christum ad terrena descendisse
+					contagia, <lb/> ut tamen confitereris nullum habuisse peccatum.</p>
+				<p>CAPUT VI. — Illud sane quod commemoravi, <lb/> partus animalium, quae cum terrena
+					sint atque mor­ <lb/> talia, hoc tamen gignunt quod ipsa sunt, ut homo ho­ <lb/>
+					minem, canis canem; puto quod non aspernatus hor­ <lb/> ruisti, sed te aspernari
+					atque horrere finixisti, dicens, <lb/>
+					<hi rend="italic">tam. fœdam comparationem</hi> in <hi rend="italic">illam
+						tantam immensita­ <lb/> tem non debuisse produci.</hi> Cur enim boc dixisti,
+					nisi <lb/> ne tibi de ipsis corruptibilibus fetibus fauces veritas <lb/>
+					premeret, et te respirare non sineret, sicut ct facit ? <lb/> Qandoquidem
+					creaturam corruptibilem cernitis , hoc <lb/> quod ipsa est gignere fetum situm,
+					et Deum Patrem <lb/> omnipotentem creditis non potuisse nisi ejus dege­ <lb/>
+					nerante natura g:gnerc unicum suum.</p>
+				<p>CAPUT VII. — Sed dicis: <hi rend="italic">Dominus Dominum ge­<lb/> nuit,
+						Deus</hi> Den. <hi rend="italic">genuit, Rex Regem genuit, Creator <lb/>
+						Creatorem</hi> genuit, <hi rend="italic">bonus bonum genuit, sapiens
+						sapien­<lb/> tem genuit, clemens clementem, potens potentem.</hi> Si sub
+					<lb/> his verbis cavcre te putas quod vobis objicitur, non <lb/> vos credere
+					Dcum potuisse gignere id quod est ipse, <lb/> et ideo dicis, <hi rend="italic"
+						>Dominus Dominum genuit, Deus Deum <lb/> genuit,</hi> et caetera : cur ergo
+					sicut dixisti, <hi rend="italic">Potens po­<lb/> tentem;</hi> non dicis,
+					Omnipotens omnipotentem? Si quod <lb/> sentis vis dicere, dic: Dominus major,
+					dominum mi­ <lb/> norem genuit; Deus major, deum minorem; Rex ma­ <lb/> jor,
+					regem miuorem; Creator major, creatorem mi­ <lb/> norem; melior bonum,
+					sapientior sapientem, clemen­ <lb/> tior clementem, potentior potentem. Si autem
+					ista <lb/> non dicis, et nihil minus quam Pater habet, Filium <lb/> babere
+					consentis, cur non dicis aequalem? Et illa <lb/> omnia cur non sic percurris, ut
+					dicas: D minus aequa­ <lb/> lem Dominum genuit, Deus aequalem Deum, Rex <lb/>
+					aequalem Regem, Creatoraequalem Creatorem, bonus <lb/> aequaliter bonum, sapiens
+					aequaliter sapientem, de­ <lb/> mens aequaliter clementem, potens aequaliter
+					poten­ <lb/> tem? Si autcm negasaequalem aperte dic esse dege­ <lb/> nerem. Non
+					enim quem deum minorem, de Deo ula... <lb/> jore natum esse dicitis, saltem
+					sicut infantem crescere <lb/> sinitis, ut aliquando suo Patri possit esse
+					aequalis. Ad <lb/> hoc cnim eum perfectum dicitis esse natum , non ut <lb/> binc
+					laus ejus cresceret, sed ut minor ejus natura re­ <lb/> nianerct. Et cum isia
+					sentiatis. seqneris tamen, et di­ <lb/> cis : Nihil sublraxtt <hi rend="italic"
+						>Pater in generando Filium.</hi> Quo­ <lb/> modo nihil subtraxit in
+					generando Filium, quem non <lb/> aequalem genuit, sed minorem? An ideo nihil
+					sub­ <lb/> traxit, quia nihi! corum quae gignendo dedit, abstulit <lb/> genito ?
+					Ita sane nihil subtraxit: sed et filiis hominum <lb/> qui prospere nascuntur,
+					nihil aufert Creator jam na­ <lb/> tis ; quin potius addit, ut accedat
+					crescentibus quod <lb/> nascentibus defuit. Quid ergo magnum de Patre dixi­
+					<lb/> sti erga unicum Filium, qui non ex nihilo vel ex ali­ <lb/> qua materia
+					factus, sed ex ipso natus est? Quid ma­ <lb/> gnum est quia non subtraxit quod
+					dedit, si quod dare <lb/> potuit, non dando subtraxit? Ubi est, quod eum invi­
+					<lb/> dum non esse dixisti? An forte dare non potuit? Uhi <lb/> est omnipotentia
+					DeiTatris? Prorsus ad hunc articu­ <lb/> lum res colligitur, ut Deus Pater
+					aequalem sibi gignere <lb/> Filium aut non potuerit, aut noluerit. Si non
+					potuit, <lb/> infirmus; si noluit, invidus invenitur. Sed utrumque <lb/> hoc
+					falsum est. Patri igitur Deo Filius verus aequalis <lb/> eat. Si ergo, ut
+					laudas, placet tibi quod a me comme­ <lb/> moratum est, <hi rend="italic"
+						>Invisibilia enim ejus, per ea quce facta<lb/> sunt, intellecta
+						conspiciuntur (Rom.</hi> I, 20) : per id qnod <lb/> factum est in creatura
+					visibili, ut pnrentes id quod <lb/> ipsi sunt generent, intellige ipvisibilcm
+					nativitatem . <lb/> veri Filii Dei, ne Deum Patrem dicas id quod non est <lb/>
+					ipse gcnuisse. Si autem hoc genuit quod est ipse; <lb/> unam Patris et Filii
+					esse substantiam negare nolite.</p>
+				<p>CAPUT VIII. — Jam vero sequentia, quae sic con­ <lb/> nexuisti, ut de cruce vel
+					incarnatione Christi probare <lb/> nobis velles quod pariter credimus; servasti
+					morem <lb/> mum : sed nihil tibi ad ista respondens, etiam ego <lb/> servo
+					promissum meum.</p>
+				<p>CAPUT IX. — 1. De iuvisibili Filio cum agere­ <lb/> mus, quem consensisti esse
+					invisibilem secundum di­ <lb/> vinitatem, qui prius solum Patrem invisibilem
+					esse <lb/> praesumpseras, ad rem non pertinentia multa dixisti <lb/> de
+					invisibilibus creaturis : quod poterunt judicare qui <lb/> legerint. De
+					invisibili Dco inter nos agitur : et hoc <lb/> csl quod quaestionem facit, quia
+					vos invisibilcm solum <lb/> Patrem dictum putatis, ubi Apostolus ait, <hi
+						rend="italic">Immortali,<lb/> invisibili soli Dco</hi> (I <hi rend="italic"
+						>Tim.</hi> I, 17). Si dixisset, Soli Patri ; <lb/> diflicilius fortasse
+					quaestio solverelur: quia vero dixit, <lb/>
+					<hi rend="italic">soli Deo;</hi> non est utique contra nos : et Unigenitus <lb/>
+					quippe in Dei forma, ct Spiritus sancius in sua na­ <lb/> tura est invisibilis.
+					Unus enim et solus Deus a nobis <lb/> ipsa Trinitas praedicatur. Quod utrum
+					verum sapia­ <lb/> mus, in aliis locis a nobis est demonstratum, et ubi <lb/>
+					adhuc opus fuerit, demonstrabitur. Nunc in ista quae<lb/>simone non immerito
+					potest movere, quomodo de solo <lb/> Dco, qui cst ipsa Trinitas, dictum sil, <hi
+						rend="italic">Invisibili soli</hi>
+					<lb/> Deo : cum sil etiam quaedam invisibilis creatura; <lb/> propter quod
+					dictum ost de Christo, quia <hi rend="italic">in ipso con­ <lb/> dita sunt</hi>
+					omnia <hi rend="italic">visibilia et invisibilia ( Coloss.</hi> I, 16). <lb/>
+					Quia ergo sunt dii falsi vbibiles, ideo dicturi est, In­ <lb/>
+					<pb n="763"/> risibili <hi rend="italic">soli Deo honor et gloria.</hi> Etsi
+					enim est creatura <lb/> invisibilis, non tamen deus nobis est. Sed et si non
+					<lb/> dictum esset, <hi rend="italic">soli Dco;</hi> sed dictum esset, <hi
+						rend="italic">Reg; autem<lb/> saeculorum, immortali, invisibili soti honor
+						et gloria:</hi>
+					<lb/> quis nisi Deus esset? Honor ergo ei gloria soli Deo, <lb/> qui Deus
+					invisibilis est, non qui solus invisibilis : <lb/> quoniam est, ut diximus, ct
+					creatura invisibilis. Item <lb/> quaeri potest quomodo dictum sit, <hi
+						rend="italic">Deum nemo vidit <lb/> unquam (Joan.</hi> I, 18); cum ejusdem
+					Domnini verba <lb/> sint, <hi rend="italic">Nescitis quia Angeli</hi> eorum <hi
+						rend="italic">semper vident fuciem<lb/> Patris</hi> mei <hi rend="italic"
+						>qui in cœlis est (Matth.</hi> XVIII, 10)? Quae <lb/> sententia vos
+					rcdarguit, qui nescitis quemadmodum <lb/> dicatis invisibilem Patrem. Illud
+					autem quod ait, <lb/> Noti <hi rend="italic">quia Patrem vidit</hi> quisquam ,
+						<hi rend="italic">nisi qui eat a Deo, <lb/> hic vidit</hi> Patrem <hi
+						rend="italic">(Joan.</hi> VI, 46); ad homines reforri <lb/> potest quod
+					dictum est, <hi rend="italic">quisquam.</hi> Et quia ipse homo <lb/> erat qui
+					tunc loquebatur in carne, ita hoc dixit, ac si <lb/> diccret, Non quia Patrem
+					vidit quisqunm bominum, <lb/> nisi cgo : sicut dictum est, <hi rend="italic"
+						>Quis sapiens, et intelliget <lb/> haec (Psal.</hi> cvi, 43) ? Non enim et
+					de sanctis Angelis <lb/> id accipi potest. Unde Apostolus de invisibili Deo
+					<lb/> apertius posuit: <hi rend="italic">Quem nemo hominum vidit, nec
+						videre<lb/> potest</hi> (I Tim. vi, 16). Non enirn ait, Nemo; sed, <hi
+						rend="italic">Nemo <lb/> hominum.</hi> Ubi ostendit quemadmodum intelligi
+					debeat <lb/> quod dictum est, <hi rend="italic">Deum nemo vidit</hi> unquam ; id
+					est, <lb/> nemo hominum : <hi rend="italic">sicut, Nemo ascendit in</hi> coelum
+						<hi rend="italic">(Joan.</hi>
+					<lb/> III, 15); cum Angeli soleant illuc ascendere, quin so­ <lb/> lent inde
+					descendere. Nec tamen Apostolus dixit, <lb/> Nemo hominum poterit videre Deum ;
+					sed, <hi rend="italic">Nemo<lb/> potest,</hi> Poterit cnim homo, sed tunc cum
+					aeternum <lb/> crit fidelium praemium , videre Deum. Propter quod <lb/> Joannes
+					apostolus : <hi rend="italic">Dilectissimi,</hi> inquil, <hi rend="italic">filii
+						Dei su­ <lb/> mus, et nondum apparuit quid erimus</hi> : scimus <hi
+						rend="italic">quia</hi>
+					<lb/> cum <hi rend="italic">apparuerit, similes ei erimus, quoniam</hi>
+					videbimus <lb/>
+					<hi rend="italic">eum sicuti cst (</hi> I <hi rend="italic">Joan.</hi> III, 2).
+					Quid est ergo quod dicis, <lb/> solum esse invisibilem Patrem? quod fruslra
+					diceres, <lb/> etiamsi a solo Filio videretur. Nunc vera cum divina <lb/>
+					testentur cloquia cum videri et ab Angelis, videndum <lb/> etiam ab hominibus,
+					cum facti fuerint aequales Ange­ <lb/> lis <hi rend="italic">(Matth.</hi> XXII,
+					50); quid est quod dicis? Ubi est <lb/> quod definire ausus es, <hi
+						rend="italic">minora videri a</hi> ,Majoribus, <lb/>
+					<hi rend="italic">majora autem a minoribus</hi> non <hi rend="italic"
+						>videri?</hi> Quod quidem <lb/> postea perdidisti, quando videri a Filio
+					confessus cs <lb/> Patrem, cum ct in ipsa substantia divinitatis dicas <lb/>
+					Filium minorem, Patremque majorem. Sed quid di­ <lb/> cturus os de Angelis , qui
+					semper vident faciem Dei <lb/> Patris? Numquid propter regulam tuam, quam sine
+					<lb/> consideratione fixisti, putandi sunt Angeli Patre Deo <lb/> esse
+					majores?</p>
+				<p>2. Scd eleganter te existimas invenisse quod diceres, <lb/> ubi :isti de Filio:
+						<hi rend="italic">Vidit ergo Patrem, sed vidit incapa­ <lb/> bilem.</hi> Nec
+					attendis, quia ctsi vidit incapabilcm, quem <lb/> sicut putas, capere non
+					putuit; non tamen invisibilcm, <lb/> quem videre potuit. Tu autem nobiscum non
+					de ca­ <lb/> pabili ut incapabili, scd dc visibili et invisibili, cum <lb/> ista
+					diceres, disputabas : quia nHc Apostolus ait, In­ <lb/> capabili; scd ait, <hi
+						rend="italic">Invisibili soli Dco.</hi> Unde hoc testi­ <lb/> monium pro te
+					adhibendum putasti, ut binc etiam <lb/> decolorares Filium, tanquam ipse in Dei
+					forma invisi­ <lb/> bilis non sit. Sed quoniam veritate convictus, et Filium
+					<lb/> confessus cs invisibilcm, praeparasti tibi, quantum exi­ <lb/> Stimo, sic
+					dicere, Invisibilis invisibilem genuit; quo­ <lb/> modo dixisti, <hi
+						rend="italic">potens potentem :</hi> ut cum discutereris, <lb/> hoc a te
+					quomodo diceretur, responderes, Invisibilior <lb/> invisibilem gcnuit, sicut
+					potentior potentem. sapien­ <lb/> tiur sapientem, et caMera tua. Sed quain
+					sapicnicr <lb/> oslendisli Filio incapabilem Patrem, Filium vcro ca <lb/>
+					pabilem Patri. Dixisti enim : fidit <hi rend="italic">ergo Patrem, sed <lb/>
+						vidit incapabilem. Pater autem,</hi> ill'luis, <hi rend="italic">sic videt
+						Filium,<lb/> ut tenens in sinu suo et</hi> Iubens. Sic non sapiunt, nisi
+					<lb/> qui carnaliter sapiunt. Sinum quippe tibi fingis, ut vi­ <lb/> deo,
+					aliquam capacitatem majoris Patris, qua Filium <lb/> minorem capiat atque
+					contineat : sicut hominem cor­ <lb/> poralitcr capit domus, aut sicut sinus
+					nutricis capit <lb/> infantem. Ergo inter mirabilia Christi et hoc deputa­ <lb/>
+					bitur, quia in forma servi crevit, et major est factus <lb/> quam in forma Dei
+					fuerat, ut cum prius portaretur in <lb/> sinu Patris, nunc sedeat ad dexteram
+					Patris. Abjice <lb/> ista puerilia vel anicularia phantasmata de corde tuo:
+					<lb/> et sinum Patris ideo dictum accipe, ut intelligatur iste <lb/> gcnilus,
+					ille genitor; non ut ille major, hic minor. <lb/> Nam si incapabilis est Pater,
+					Filius vero incapabilis <lb/> non est, non veraciter dictum est, <hi
+						rend="italic">Omnia quae habet <lb/> Pater, mea sunt (Joan.</hi> XVI, 15) :
+					quandoquidem re­ <lb/> sponderi ei potest, Ecce incapabilitatem habet Pater,
+					<lb/> quae non est tua. Sed quoniam veraciter dictum est <lb/> quod Veritas
+					dixit, et omnia quae habet Pater, Filii <lb/> sunt; non potest non esse Filii
+					quantacumque sit in­ <lb/> capabilitas Patris. EL hanc Domini sententiam, ubi
+					<lb/> ait, <hi rend="italic">Omnia quae habet Pater, mea sunt;</hi> tanquam re­
+					<lb/> ctissimam regulam ad vos, sive convincendos, sivc, <lb/> quod magis
+					cupimus, corrigendos, per multa adhibere <lb/> debemus : ut ubicumque aliquid
+					tribuitis Patri quod <lb/> Filio denegatis, ipsam fidclissimam testem contra er.
+					<lb/> rores vestros, vel contra mendacia producamus. Quid <lb/> opus cst autem
+					in eo tibi resistere, quod bunnam <lb/> sapicnliam contendis esse visibilcm; cum
+					ipsam <lb/> animam humanam, in qua est utique humana sa­ <lb/> pientia,
+					invisibilem esse concesseris ? Sed quod­ <lb/> libet sentias de universa
+					invisibili creatura, quantum <lb/> ad Dcum pertinet, de quo inter nos agitur,
+					satis tibi <lb/> demonstratum est non esse solum invisibilem Pa­ <lb/> trem.</p>
+				<p>CAPUT X. — i. Putas Dcum Patrem cum F'ilio ct <lb/> Spirilu sancto unum Deum esse
+					non possc : timcs <lb/> cnim ne Palcr solus non sit unus Dcus, sed pars
+						<unclear>umus</unclear>
+					<lb/> Dei qui constat ex tribus. Noli liincre, nulla fit pur­ <lb/> tium in
+					dcitatis unitate divisio. Unus est Dcus Pater <lb/> et Filius ct Spiritus
+					sanctus, hoc est ipsa Trinitas. <lb/> Unus cst Deus, de quo dictum est, quia <hi
+						rend="italic">Nullus Deus, <lb/> nisi unus</hi> (I <hi rend="italic"
+						>Cor.</hi> VIII, 4) : et qui dixit, <hi rend="italic">Audi, Israel; <lb/>
+						Dominus Deus tuus, Dominus unus cst.</hi> Cui uni et soli <lb/> Ico servire
+					nos sine ullo scrupulo agnoscimus, quan­ <lb/> do audimus ct Icgimus : <hi
+						rend="italic">Dominum Deum tuum adora.</hi>
+					<lb/> bis, <hi rend="italic">ct iili soli</hi> servies <hi rend="italic"
+						>(Deut.</hi> vi, 4, 13). Nc forte propter <lb/> haec verba, Christo cujus
+					membra sumus (I <hi rend="italic">Cor. vi,</hi>
+					<lb/> 13), vel Spiritui sancto cujus templum sumus <hi rend="italic">(Jd.</hi>
+					<lb/> III, 17), servire nolimus, si quod dictum C'Si, Domino <lb/>
+					<pb n="765"/> Dco tuo <hi rend="italic">soli servies,</hi> sic acceperimus,
+					tanquam de solo <lb/> Patre, et non de ipsa Trinilaie sil dictum. Vos autem,
+					<lb/> cum quaeri<unclear>tur</unclear> a vobis, quem credatis esse de quo <lb/>
+					scriptum cst, <hi rend="italic">Dominus Deus tuus, Dominus unus est;</hi>
+					<lb/> respondetis, Deus Pater est. Itemque cum quaeritur <lb/> de quo Domino Deo
+					dictum sil, <hi rend="italic">Dominum Deum tuum</hi>
+					<lb/> adorabis, <hi rend="italic">et illi soli servies;</hi> rursus respondetis,
+					De Dco <lb/> Patre. Tunc vobis dicitur : Si Domninus Deus noster <lb/> Dominus
+					unus cst, et hic Pater est; quare vos facitis <lb/> du<unclear>ns</unclear>
+					dominos dcos, dicendo etiam Christum esse Do­ <lb/> minum Deum ? Item si Pater
+					est, cui uni Domino Deo <lb/> ac soli serviendum cst; quomodo obtemperatis huic
+					<lb/> praecepto, qui tanquam Domino Deo servitis et Chri­ <lb/> sto? Neque enim
+					illi soli servi, qui servit et huic. <lb/> Secundum fidem autem rectam,
+					quicumque ipsam <lb/> Trinitatem unum Dominum Deum esse nostrum di­ <lb/>
+					dicimus, profecto cum ei soli ea quas Deo dcbelur <lb/> servitute servimus,
+					Domino Deo soli nos servire con­ <lb/> fidimus.</p>
+				<p>2. <hi rend="italic">Ergo</hi> , inquis, <hi rend="italic">Deus Puler pars est
+						Dei.</hi> Absit. <lb/> Tres enim personae sunt Pater et Filius et Spiri­
+					<lb/> tus sanctus : et hi tres quia unius substantiae sunt, <lb/> unum sunt, ct
+					summc unum sunt, ubi nulla natura­ <lb/> rum, nulla cst diversitas voluntatum.
+					Si autem na­ <lb/> tura unmn essent, et consensione non essent , non <lb/> summe
+					unum essent : si vero natura dispares essent, <lb/> unum non essent. Hi ergo
+					tres, qui unum sunt-pro­ <lb/> pter ineffabilem conjunctionem deitatis, qua
+					ineffa­ <lb/> biliter copulantur, unus Ocus cst. Porro autem Chri­ <lb/> stusuna
+					persona est gemiae substantiae, quia et Deus <lb/> et homo est. Nec tamen Deus
+					pars hujus personae <lb/> dici potest : alioquin Filius Dei Deus antequam sus­
+					<lb/> ciperet formam sel'vi, non erat totus, et crevit cum <lb/> homo divinitati
+					cjus accessit. Quod si in una persona <lb/> absurdissime dicitur, quia pars rci
+					ullius esse non <lb/> .potest Deus; quanto magis pars Trinitatis esse non <lb/>
+					potest, quicumque unus in tribus ? Dcinde ubi ait <lb/> Apostolus, <hi
+						rend="italic">Qui adhaeret Domino, unus spiritus est;</hi>
+					<lb/> (1 <hi rend="italic">Cor.</hi> vi, 11 ); numquid hujus unius pars est
+					Domi­ <lb/> nus ? Si cnim hoc dicimus , quid aliud dicere depre­ <lb/> hendimur,
+					nisi quod augeatur adhaerente hominc, et <lb/> recedente minuatur ? In Trinilalc
+					igitur qu:c Dcus <lb/> cst, et Pater Deus est, et Filius Deus cst, ct Spiritus
+					<lb/> sanctus Dens est, ct simul hi Ires unus Deus : nec <lb/> hujus Trinitatis
+					tertia pars cst unus, nuc major pars <lb/> duo qnam unus est ibi; nec majus
+					aliquid sunt onmes <lb/> quam singuli : quia spiritualls, non corporalis est
+					<lb/> magnitudo. Qui potest capere, capiat ( <hi rend="italic">Matth.</hi> xix ,
+					<lb/> 42 ) : qui autem non potest, credat, et oret ut quod <lb/> credit
+					intelligat. Verum cst enim quod dicitur per <lb/> prophetam, Nisi <hi
+						rend="italic">credidcritis , non intelligetis ( Isa;.</hi>
+					<lb/> VII, 9 ).</p>
+				<p>5. Tu nempe dixisti; <hi rend="italic">unum Deum</hi> non <hi rend="italic">ex
+						partibus <lb/> esse compositum.</hi> Et quia de Patre hoc vis intelligi, <lb/>
+					<hi rend="italic">Ille,</hi> innuis , <hi rend="italic">quod est, virtus est
+						ingenita,</hi> simplex. <lb/> £t tamen in hac simplici virtute quam multa
+					comme­ <lb/> moraveris, vide. Nam superiora verbi tua sunt : <lb/>
+					<hi rend="italic">Deus Deum genuit, Dominus Dominum genuit, Rex lle­</hi>
+					<unclear/><lb/>
+					<hi rend="italic">qem genuit,</hi> Creator <hi rend="italic">Creatorem genuit,
+						bonus bonum</hi>
+					<lb/> genuit, <hi rend="italic">sapiens sapientem genuit, clemens</hi>
+					clementem, <lb/>
+					<hi rend="italic">potens potentem.</hi> Cur ergo in virtute simplici, quod <lb/>
+					est Dcus, non timuisti tot commemorare virtutes ? <lb/> Ut enim omittam quatuor
+					quas loco superiore po­ <lb/> suisti, et alias quatuor dicam, quas
+						enunt<unclear>iare</unclear> usitatis <lb/> nominibus possimus; numquid
+					bonitas ct sapiculia ct <lb/> clementia et potentia partes sunt unius virtutis,
+					<lb/> quam simplicem e.sc dixisti ? Si dixeris, Partces sunt; <lb/> simplex crgo
+					virtus ex partibus constat, et simplex <lb/> ista virtus te definiente unus est
+					Deus. Unum ergo <lb/> Deum ex partibus compositum esse dicis ? Non dico , <lb/>
+					inquis. Non sunt ergo partes : et tamen quat<unclear>uor</unclear> sunt, <lb/>
+					et una virtus est, eademque simplex est. Si ergo in <lb/> una Patris persona ,
+					et plura invenis, et partes non <lb/> invenis; quanto magis Pater ct Filius ct
+					Spiritus <lb/> sanctus, et propter individuam deitatem unus Deus <lb/> est, et
+					propter uniuscujusque proprietatem tres per­ <lb/> sonae sunt, et propter
+					singulorum perfectionem partes <lb/> unius Dci nan sunt? Virtus cst Pater,
+					virtus Filius, <lb/> virtus Spiritus sanctus. Hoc verum dicis : sed quod <lb/>
+					virtutem de virtute gcnitam, et virtutem de virtute <lb/> procedentem non vis
+					eamdem habere naturam, hoc <lb/> falsum dicis, hoc contra fidem rectam et
+					catholicam <lb/> dicis.</p>
+				<p>CAPUT XI. — Redis ut quaeras a me, quomodo <lb/> sit invisibilis Filius, unde jam
+					dixi superius, quod <lb/> visum est dicendum. Sed si <hi rend="italic">ob
+						hoc,</hi> inquis, <hi rend="italic">Filius</hi> in­ <lb/>
+					<hi rend="italic">visibilis a te pronuntiatur, eo quod oculis humanis con­ <lb/>
+						templari</hi> non <hi rend="italic">possit ; cur non et</hi> coelestes <hi
+						rend="italic">virtutes pariter <lb/> invisibiles</hi> pronuntias, <hi
+						rend="italic">quando nec ipsae obtutibus huma­ <lb/> nis videri</hi> possunt
+					? Ita hoc dicis, quasi possit ab ho­ <lb/> mine comprehendi quis ille sit modus,
+					quo cœlestes <lb/> virtutes sunt invisibiles; aut ad hoC quaerendum esse <lb/>
+					debeamus intenti, dicente Scriptura, <hi rend="italic">Altiora te</hi> ne <lb/>
+					<hi rend="italic">quaesieris (Eccli.</hi> III, 22). Quod praeceptum ipse con­
+					<lb/> temnens, ausus es dicere angelum vidcri ab archan­ <lb/> gclo, archangelum
+					ab angelo non vidcri. Satis sit, <lb/> quod ostendi non esse consequens ut ideo
+					credamus <lb/> in forma Dei visibilem Filium, qnia scriptum est, <lb/>
+					<hi rend="italic">Invisibili soli Deo</hi> ( I <hi rend="italic">Tim.</hi> 1, 17
+					). Quod in de Patre <lb/> sic te accipere demonstrabas tanquam Filius invisibi­
+					<lb/> lis non sit, cum cum ct invisibilium creatorem Scri­ <lb/> p'ura testetur.
+					Verumtamen restat utdicas, Ambo qui. <lb/> dem invisibilcs sunt, id cst, ct
+					Pater et Filius , set! <lb/> Patcr invisibilior est : ac sic dando aliquid Patri
+					<lb/> quod non sit Filii, mendacem facias cumdem Filium <lb/> dicentem, <hi
+						rend="italic">Omnia quae habet Pater, mea suni (Joan.</hi>
+					<lb/> XVI, 15).</p>
+				<p>CAPUT XII. — i. HInc et de potentia sapis, quod <lb/> scilicet sit quidem potens
+					ct Filius, sed potentior Pa­ <lb/> ter Filio : ulauctoribus et doctoribus vobis
+					potuerit <lb/> potentem potens, nee potuerit omnipotcntem gignere <lb/>
+					omnipotens. Ac per hoc si habct Pater omnipoten<lb/>liam quam non habet
+					Filius, falsum est quod ait <lb/> Filius, <hi rend="italic">Omnia quae habet
+						Pater, mea sunt.</hi> Deinde si <lb/> aliquid facit Pater, quod facere non
+					potest Filius, <lb/> mcrito dicitur potentior Pater quam Filius : cum vero <lb/>
+					dical, <hi rend="italic">Quaecumque Pater facit, haec et Filius similiter <lb/>
+						facit</hi> ( <hi rend="italic">Joan.</hi> v, 19 ); nonne meiius
+						<unclear>audit</unclear>
+					<lb/>
+					<pb n="767"/> vos, nactusque ipsi creditur docenti quam dccipien­ <lb/> tibus
+					vobis ? <hi rend="italic">Sed potentiam</hi> Pater , inquis, <hi rend="italic">a
+						nemine, <lb/> Filius vero accepit a Patre.</hi> Fatemur et nos Filium ab
+					<lb/> illo accepisse potentiam, de quo natus est putens : <lb/> Patri vero
+					potentiam nullus dedit, quia nullus eum <lb/> genuit. Gignendo enin dedit
+					potentiam Pater Filio, <lb/> sicut omnia quae habet in substantia sua , gignendo
+					<lb/> dedit ei quem genuit de substantia sua. Sed quaeritur <lb/> utrum tantam,
+					quanta ipsi est, potentiam Pater Filio <lb/> dederit, an minorem. Si tantam, non
+					solum potentem <lb/> poiens, verum etiam omnipotentem genuisse dicatur, <lb/>
+					credatur, intelligatur omnipotens : si minorem, <lb/> quomodo omnii qune habet
+					Pater, Filii sunt ? Si Pa­ <lb/> iris omnipotentia Filii non est, quomodo
+					quaecumque <lb/>
+					<hi rend="italic">Pater facit, h</hi>ae<hi rend="italic">c et Filius</hi>
+					similiter <hi rend="italic">facit</hi> ? quod ulique <lb/> non potest, si
+					omnipotens non est.</p>
+				<p>2. Ac per hoc quod ait Apostolus , <hi rend="italic">Beatus et solus</hi>
+					<lb/> potens : non cogor de Patre tantummodo accipere; <lb/> sed de Deo, quod
+					est ipsa Trinitas. Loquens enim <lb/> ad Timotheum : Praecipio, inquit, tibi <hi
+						rend="italic">coram Deo, <lb/> qui vivificat omnia, et Christo Jesu qui</hi>
+					testimonium <lb/>
+					<hi rend="italic">reddidit sub Pontio Pilato bonam confessionem, ut ser­ <lb/>
+						ves mandatum sine macula, irreprehensibile, usque ad<lb/> adventum Domini
+						nostri Jesu Christi; quem temporibus <lb/> propriis ostendet beatus et solus
+						potens, Rex regum et <lb/> Dominus dominantium;</hi> qui <hi rend="italic"
+						>solus habet immortalitatem, <lb/> et lucem inhabitat inaccessibilem; quem
+						nemo</hi> hominum <lb/>
+					<hi rend="italic">vidit, nec videre potest; eui est honor et gloria</hi> in
+					saecu­ <lb/> la <hi rend="italic">saeculorum. Amen</hi> (I <hi rend="italic"
+						>Tim.</hi> VI, 13-16). Nihil hic vi­ <lb/> deo dictum quod non conveniat
+					Trinitati. Sed ut nunc <lb/> taceam de Spiritu sancto, quem nec saltem minorem
+					<lb/> Filio Deum vultis, quia omnino Deum esse non vultis, <lb/> sufficit ut vos
+					de Patre convincamus et Filio. Numquid <lb/> enim quia dixit Apostolus, <hi
+						rend="italic">Testificor tibi coram Deo <lb/> qui vivificat omnia;</hi>
+					Pater solus, non et Filius vivifi­ <lb/> cat omnia ? Si dixeris Patrem solum
+					vivificare omnia, <lb/> quomodo ergo <hi rend="italic">quaecumque Pater facit,
+						h</hi>ae<hi rend="italic">c et Filius</hi>
+					<lb/> similiter <hi rend="italic">facit ?</hi> Quandoquidem Pater, ut putas,
+					vivifi­ <lb/> cat omnia, qnod Filius non facit. Deinde ubi ait, <lb/>
+					<hi rend="italic">SicuL Pater suscitat mortuos et vivificat, sic et Filius <lb/>
+						quos vult vivificat (Joan.</hi> v, 21); quomodo verum eSI, <lb/> si Pater
+					sine Filio vivificat omnia? Proinde quod <lb/> addidit, <hi rend="italic">Et
+						Christo Jesu qui testimonium reddidit sub</hi>
+					<lb/> Pollio <hi rend="italic">Pilato bonam confessionem;</hi> de Filio proprie
+					<lb/> diccre voluit: quia Filius quidem sicut Pater vivificat <lb/> omnia ; sed
+					sub Pontio Pilato in forma servi Filium <lb/> novimus passum fuisse, non Patrem.
+					Deinde subjun­ <lb/> gitur, <hi rend="italic">Ut serves mandatum sine macula,
+						irreprehensi­ <lb/> bile, usque ad adventum Domini nostri Jesu Christi;<lb/>
+						quem temporibus propriis ostendet beatus et solus po­ <lb/> tens :
+						quem,</hi> scilicet adventum Domini Christi ; osten­ <lb/>
+					<hi rend="italic">det</hi> utique Dcus, quod non solus est l'ater, quia <lb/>
+					secundum veritatem, non secundum vestrum errorem, <lb/> Trinitas unus est Deus
+						<hi rend="italic">: beatus et solus</hi> potens, <hi rend="italic">Rex<lb/>
+						regum et Dominus dominantium.</hi> Numquid enim vel vos <lb/> dicere audetis
+					Filium non esse Regem regum et Do­ <lb/> minum dominantium ? De quo inter
+					caetera scriptum est <lb/> in Apocalypsi Joannis: <hi rend="italic">Et ipse
+						calcat torcular vini po­ <lb/> tentis, et in tunica et in femore habet nomen
+						scriptum, <lb/> Rex regum et Dominus dominantium (Apoc.</hi> XII, 15, <lb/>
+					16). Sed ne forte dicatis quod nomen Patris Filius <lb/> habet scriptum in veste
+					et in femore ; alio loco ejus­ <lb/> dem libri superius legitur : <hi
+						rend="italic">Et Agnus vincet eos, <lb/> quoniam Dominus dominantium est et
+						Rex regum (Id.</hi>
+					<lb/> XVII, 14). Quapropter secundum vos, duo suut regcs <lb/> regum et domini
+					dominantium : et contra vos est, si <lb/> de Patre tantum ait Apostolus, <hi
+						rend="italic">Beatus et</hi> solus <hi rend="italic">votens,<lb/> Rex regum
+						et Dominus dominantium.</hi> V crum autem <lb/> secundum rectam fidem ipsa
+					Trinitas unus est Deus, <lb/>
+					<hi rend="italic">beatus et</hi> sotus <hi rend="italic">potens, Rex regum et
+						Dominus domi­<lb/> nantium, qui solus habet immortalitatem, et lucem ha­
+						<lb/> bitat inaccessibilem.</hi> Et quomodo erit verum, <hi rend="italic"
+						>Accedite<lb/> ad eum, et</hi> illuminamini <hi rend="italic">(Psal.</hi>
+					XXIIII, 6) ; nisi quia hoc <lb/> nemo potest, si de se quisque praesumpserit,
+					sed si <lb/> ipse donaverit? Immortalitatem autem Deus habere <lb/> dicitur
+					solus, quia est immutabilis solus. In omni enim <lb/> mutabili natura nonnulla
+					mors est ipsa mutatio, quia <lb/> facit aliquid in ea non esse quod erat.
+					Proinde et <lb/> ipsa anima humana, quae propterea dicitur immorta­ <lb/> lis,
+					quoniam qualilercurnque secundum modum suum <lb/> nunquam desinit vivere, habet
+					tamen pro ipto suo <lb/> modo quamdam mortem suam : quia si juste vivebat <lb/>
+					et peccat, moritur justitiae; si peccatrix erat et justi­ <lb/> ficatur, moritur
+					peccato : ut alias ejus mutationes <lb/> taceam, de quibus longum est disputare.
+					Et creatu­ <lb/> rarum natura coelestium mori potuit, quia peccare <lb/> potuit:
+					nam et Angeli peccaverunt, et daemones facti <lb/> sunt, quorum est diabolus
+					princeps. Et qui non pec­ <lb/> caverunt, peccare potuerunt. Et cuicumque
+					creaturae <lb/> rationali praestatur ut peccare non possit, non est hoc <lb/>
+					naturae propriae, sed Dei grali;c. Ac per boc solus Deus <lb/> habct
+					immortalitatem, qui non cujusquam gratia, sed <lb/> natura sua, nec potuit, nee
+					potest aliqua conversione <lb/> mutari, nec potuit nec poterit aliqua mutatione
+					pec­ <lb/> care. Quem secundum naturam qua Deus est, <hi rend="italic">nemo<lb/>
+						hominum vidit, nec videre potest:</hi> sed poterit aliquan­ <lb/> do, si ad
+					illum numerum hominum pertinet, de quibus <lb/> dictum est, <hi rend="italic"
+						>Beati mundo corde, quoniam</hi> ipsi Deum <lb/>
+					<hi rend="italic">videbunt (Matth.</hi> v, 8). Cui Deo, id est Patri et Filio
+					<lb/> et Spiritui sancio, qua; Trinitas unus est Deus, honor <lb/> et gloria in
+					s;rcula saeculorum; Amen.</p>
+				<p>3. Absit autem ut, quomodo putas, ideo sit Pater <lb/> potentior Filio, quia
+					creatorem genuit Pater, Filius <lb/> autem non genuit creatorem. Neque enim non
+					po­ <lb/> luit <hi rend="italic">(a),</hi> sed non oportuit. Immoderata enim
+					esset <lb/> divina generatio , si genitus Filius nepotem gigneret <lb/> Patri :
+					quia et ipse nepos, nisi avo suo pronepotem <lb/> gigneret, secundum vestram
+					mirabilem sapientiam <lb/> impotens diceretur. Similiter etiam ille si nepotem
+					<lb/> non gigneret avo suo, et pronepotem proavo suo,.. <lb/> non a vobis
+					appellaretur omnipotens : nec impleretur <lb/> gencrationis series, si semper
+					alter cx altero nasce<note type="footnote"><hi rend="italic">(n)</hi> Plerique
+						ac melioris notse Mss., <hi rend="italic">ycqne</hi> enim <hi rend="italic"
+							>potnt.</hi>
+						<lb/> Altameo Magister Sent. in i, dist. 7, citat, seque <hi rend="italic"
+							>(',nm lion<lb/> putuit:</hi> id est, non ex impotentia tilii, sed ex
+						rui namra <lb/> venit ut Filius noti generet. Neque c&gt;gimur intelligere,
+						<lb/> Filium potuisse alium geaerare filium, quod AugusUnuiu <lb/>
+						existimassi! creilit Petavius in lib. 7 Theolog. dog:u. de <lb/> IriniUle,
+						cap. 13, It. G. </note>
+					<lb/>
+					<pb n="769"/> retur; nec eam perficeret ullus, si non sufficeret unus. <lb/>
+					Omnipotens itaque omnipotentem genuit Filium ; <lb/> quoniam <hi rend="italic"
+						>quaecumque Pater facit, h</hi>aec <hi rend="italic">et Filius simili­<lb/>
+						ter facil.</hi> Filiurn quippe ipsum genuit utique Pall'is <lb/> natura, non
+					fecit.</p>
+				<p>CAPUT XIII. — i. In illo etiam testimonio, ubi <lb/> ait Apostulus, <hi
+						rend="italic">Soli sapienti Deo;</hi> non dissimilis error <lb/> est vester
+					: sed quod vobis respondimus de potentia, <lb/> hoc etiam de sapientia
+					respondemus. Si cnim dixis­ <lb/> set Apostolus, Soli sapienti Patri; nec sic
+					inde Filium <lb/> sepnrarct. Num enim quia in Apocalypsi de Filio <lb/> legitur,
+						<hi rend="italic">Habens nomen scriptum, quod nemo scit</hi> nisi <lb/>
+					<hi rend="italic">ipse ( Apoc.</hi> xix, 12); ideo Pater nescit hoc nomen, <lb/>
+					a quo est inseparabilis Filius ? Sicut ergo scit et <lb/> Pater quod Demo scire
+					dictus est nisi Filius, quia <lb/> inseparabiles sunt: sic etiam si dictum
+					esset, Soli <lb/> sapienti Patri ; simul intelligi deberet ct Filius, quia <lb/>
+					inseparabiles sunt. Cum vero non sit dictum, Soli <lb/> sapienti Patri; sed <hi
+						rend="italic">Soli sapienti Deo;</hi> et Deus unus <lb/> sit ipsa Trinitas :
+					multo cst facilior nobis bujus solu­ <lb/> tio quaestionis; ut sic intelligamus
+					solum-Deum sa­ <lb/> picntem, sicut intelleximus solum potentem, id est, <lb/>
+					Patrem et Filium et Spiritum sanctum , qui est unus <lb/> ct solus Deus, cui
+					soli servire jussi sumus : ne male <lb/> intelligentes, vel potius non
+					intelligentes, contra boc <lb/> praeceptum facere videamur, quia et Domino
+					Christo <lb/> ea quae Deo debetur servitute servimus. Non enim <lb/> dictum est,
+					Dominum Deum tuum Patrem adorabis, <lb/> ctilii plus servies; ut servire
+					permitteremur et Filio, <lb/> plus tamen Patri tanquam majori, minus autem Filio
+					<lb/> tanquam minori Deo : sed dictum est, <hi rend="italic">Dominum <lb/>
+						Deum</hi> tuum <hi rend="italic">adorabis, et illi soli servies (Deut.</hi>
+					vi, 43); <lb/> soli scilicet omnipotenti, soli sapienti Deo; ut vos <lb/>
+					repelleremini, qui nolentes accipere unum solum <lb/> Deum Patrem et Filium et
+					Spiritum sanctum, et <lb/> dicentes unum Dominum Deum, cui soli serviendum <lb/>
+					est, non esse nisi Deum Patrem, ct tamen etiam <lb/> Filium Deum et Dominum
+					confitentes; apertissime <lb/> duos deos et dominos, majorem unum, minorem <lb/>
+					alterum dicitis : et reos vos, secundum errorem ve­ <lb/> strum, praecepti hujus
+					violati esse monstratis, quia <lb/> non solum majori, verum etiam minori, ea
+					quae Do­ <lb/> mino Deo debetur servitute servitis.</p>
+				<p>i. Ubi autem dixit Apostolus, <hi rend="italic">Soli sapienti Deo;</hi>
+					<lb/> cum scriberet ad Romanos, in fine Epistolae sic Io­ <lb/> quitur: <hi
+						rend="italic">Ei autem</hi> qui <hi rend="italic">potens est,</hi> inquit,
+					vos <hi rend="italic">confirmare<lb/> secundum Evangelium</hi> meum, <hi
+						rend="italic">et prceconium Jesu Chri­</hi>
+					<lb/> sti ; <hi rend="italic">secundum revelationem mysterii temporibus</hi>
+						aeterni<hi rend="italic">s<lb/> taciti, manifestati autem nunc per
+						Scripturam Propne­ <lb/> tarum; secundum pr</hi>ae<hi rend="italic"
+						>ceptum</hi> ae<hi rend="italic">terni Dei, in obedien­ <lb/> tinm fidei in
+						omnes gentes cogniti; soli sapienti Deo <lb/> per Jesum Christum, cui gloria
+						in</hi> saecula <hi rend="italic">saculorum<lb/> (Rom.</hi> xvi, 25 27). Hoc
+					est, <hi rend="italic">Ei qui potens est vos<lb/> confirmare, soli sapienti Deo
+						gloria</hi> in <hi rend="italic">saecula s</hi>ae<hi rend="italic"
+						>culo­</hi>
+					<lb/> rum. Quod autem interp ositum est, <hi rend="italic">per Jesum Chri­ <lb/>
+						stum ;</hi> utrum soli Sapienti Deo per Jcsuin Christum <lb/> accipidebcat,
+					ut scilicet solus Deus sapicns pcr Je­ <lb/> sam Christum sapiens esse
+					intelligatur, non partici <lb/> pando, sed gignendo sapientiam, quod cst
+					Christus <lb/> Jesus; an vero non per Jcsum Christum sapienti, <lb/> sed per
+					Jesnm Christum gloria Deo soli sapienti, <lb/> videtur ambiguum. Sed quis audeat
+					dicere per Jesum <lb/> Christum fieri ut sit sapiens Deus Pater; cum secun­
+					<lb/> dum substantiam suam non dubitandum sit eum esse <lb/> sapientem,
+					potiusque sit substantia Filii pcr gignen­ <lb/> tem Patrem, quam substantia
+					Patris per genitum <lb/> Filium ? Restat ergo ut soli sapienti Deo gloria sit
+					<lb/> per Jesum Cbristum, hoc est, clara cum laude noti­ <lb/> tia, qua innotuit
+					gentibus Deus Trinitas : ideo per <lb/> Jesum Christum, quia, ut alia taceam,
+					ipse praecepit <lb/> baptizari gentes in nomine Patris ct Filii et Spiritus
+					<lb/> sancti <hi rend="italic">(Malth.</hi> XXVIII, 19); ubi praecipue
+					commendata <lb/> est hujus individuae gloria Trinitatis. Deus itaque, <lb/> quod
+					est ipsa Trinitas, propterea solus sapiens recto <lb/> dicitur, quia solus
+					secundum substantiam suam sa­ <lb/> piens est: non secundum accidentem vel
+					accedentem <lb/> participationem sapientiae, sicut sapiens est rationalis <lb/>
+					quaecumque creatura. Quod vero additum est, <hi rend="italic">cui,</hi> ut <lb/>
+					diceretur, <hi rend="italic">cui gloria ;</hi> cum sufficeret si dictum esset,
+					<lb/> Ei autem gloria : inusitatam nostrae linguae indicat <lb/> locutionem; non
+					sensum quem requiramus, vel de <lb/> quo ambigamus, insinuat. Quid enim sensui
+					deperit, <lb/> si dicatur, Ei gloria , cui per Cbrislum gloria ? Hoc <lb/> est
+					namque, <hi rend="italic">per Jesum Christum cui gloria;</hi> quod est, <lb/>
+					cui per Jesum Christum gloria. Sed horum alter in­ <lb/> usitatus, alter
+					usitatus est ordo verborum.</p>
+				<p>CAPUT XIV. — 1. Quaeris a me, Si <hi rend="italic">de</hi> substantia <lb/>
+					<hi rend="italic">Patris eat Filius, de substantia Patris eat etiam Spiritus
+						<lb/> sanctus; cur unus Filius sit, et alius non sit filius.</hi>
+					<lb/> Ecce respondeo, sive capias, sive non capias. De <lb/> Patre est Filius,
+					de Patrc est Spiritus sanctus : sed <lb/> ille genitus, iste procedens : ideo
+					ille Filius cst Pa­ <lb/> tris, de quo cst genitus ; iste autem Spiritus utrius­
+					<lb/> que, quoniam de utroque procedit. Sed ideo cum de <lb/> illo Filius
+					loqueretur, ait, <hi rend="italic">De Patre procedit (Joan.</hi>
+					<lb/> xv, 26); quoniam Pater processionis cjus esi auctor, <lb/> qui talem
+					Filium genuit, et gignendo ei dedit ut <lb/> etiam de ipso procederet Spiritus
+					sanctus. Nam nisi <lb/> procederet et de ipso, non diceret discipulis, <hi
+						rend="italic">Accipite<lb/> Spiritum sanctum;</hi> eumque insufflando daret
+						<hi rend="italic">(Id.</hi>
+					<lb/> xx, 22), ut a se quoque procedere significans, aperte <lb/> ostenderet
+					flando, quod spirando dabat occulle. Quia <lb/> ergo si nasceretur, non tantum
+					de Patre, nec tantum <lb/> de Filio, sed de ambobus utique nasceretur; sine
+					<lb/> dubio filius diceretur amborum. Ac per hoc quia <lb/> filius amborum nullo
+					modo est, non oportuit nasci <lb/> cum de ambobus. Amborum ea ergo Spiritus,
+					pro­ <lb/> cedendo de ambobus. Quid aulem inter nasci et pro­ <lb/> ceaere
+					intersit, de illa excellentissima natura loquens <lb/> explicare quis potest ?
+					Non omne quod proccdit na­ <lb/> scitur, quamvis omne procedat quod nascitur ;
+					sicut <lb/> non omne quod bipes cst homo est, quamvis bipes <lb/> sit omnis qui
+					homo est. Haec scio : distinguere autem <lb/> inter illam generationem et hanc
+					processinem ne­ <lb/> scio, nun valeo, non sufficio. Ac per hoc quia et illa
+					<lb/> et ista est ineffabilis, sicut propheta de Filio loquens <lb/> ait, <hi
+						rend="italic">Generationem ejus quis enarrabit (Isai.</hi> LUI, 8)? ita
+					<lb/> de Spiritu sancto verissimc dicitur, Processionem <lb/>
+					<pb n="771"/> ejus quis cnarrahil? Satis sit ergo nobis, quia non <lb/> est a
+					scipso Filius, sed ab illo de quo natus est: non <lb/> cst a seipso Spiri!us
+					sanctus, sed ab illo de quo pro­ <lb/> cedit. Et quia de utroque procedit, sicut
+					jam osten. <lb/> dimus : unde et Spiritus Patris dictus est, ubi legi- .tur,
+					<lb/> lur, Si <hi rend="italic">autem Spiritus ejus qui</hi> suscitavit <hi
+						rend="italic">Christum a</hi>
+					<lb/> mortuis, <hi rend="italic">habitat in vobis;</hi> ct Spiritus Filii, ubi
+					legitur, <lb/> Qui <hi rend="italic">autem Spiritum Christi</hi> MOM <hi
+						rend="italic">habet, hic</hi> non <hi rend="italic">est ejus<lb/> (Rom.</hi>
+					VIII, ii, 9). Non enim duo sunt Spirilus sancii, <lb/> tanquam singuli
+					singulorum, unns Patris, aller Filii; <lb/> ped unus potius Patris et Filii : de
+					quo uno Spirilu <lb/> scriptum est, Etenim in <hi rend="italic">Spiritu</hi> uno
+					nos <hi rend="italic">omnes</hi> in <lb/> unum <hi rend="italic">corpus
+						laptizati</hi> sumus, sivc Judaei, <hi rend="italic">sive Graeci, <lb/>
+						sive</hi> servi, <hi rend="italic">sive tiberi; et omnes</hi> unum <hi
+						rend="italic">Spiritum</hi> potavi­ <lb/> mus (I <hi rend="italic">Cor.</hi>
+					XII, 13). Et alio ioco : <hi rend="italic">Unum corpus et</hi>
+					<lb/> unus <hi rend="italic">Spiritus (Ephes.</hi> IV, 4).</p>
+				<p>2. Quid ergo haec Trinitas, nisi unius ejosdemque <lb/> substantiae est?
+					Quandoquidem non de aliqua materia <lb/> vel de nihilo est Filius, sed de quo
+					cst genitus : item­ <lb/> que Spiritus sanctus non de aliqua maleria, vcl de
+					<lb/> nihilo, sed indc est unde proccdiL. Vos autem nec <lb/> Filium de Patris
+					substantia genitum vultis, et tamen <lb/> eum nee ex nihilo, nec ex aliqua
+					materia, sed ex <lb/> Patre esse conceditis. Nee videtis quam necesse sit, <lb/>
+					ut qui non csl ex nihilo, non est cx aliqua re alia, <lb/> scd ex Deo, nisi cx
+					Dei substantia csse non possit, <lb/> et hoc esse quod Deus est de quo cst, hoc
+					est, Dcus <lb/> de Dco. Quocirca Deus de Dco natus, quia non aliud <lb/> prius
+					fuit, sed natura coaeterna de Dco est, non est <lb/> aliud quam est ille de quo
+					est, hoc est, unius cjus­ <lb/> demquc naturae, vel unius ejusdemque
+					substantiae. <lb/> Quod cum auditis, qualc cor habcalis ignoro, qui <lb/>
+					putatis nos sic Filium dicere natum esse de Patre, <lb/> quomodo nascuntur de
+					corporibus corpora : et quo­ <lb/> niam corruptibilitcr is'a nascuntur,
+					accusatis nos <lb/> tanquam generationi Unigeniti, quae dc Patre est, <lb/>
+					corporalem passionem corruptionemque tribuamus. <lb/> Carnalibus quippe
+					cogitationibus pleni substantiam <lb/> Ovi de se ipsa gignere possc Filium non
+					putatis, nisi <lb/> hoc patiatur quod substaulia quando gignit patitur <lb/>
+					carnis. Erratis, non scientes Scripturas, neque vir­ <lb/> lutem Dci <hi
+						rend="italic">(Matth.</hi> XIII, 29). Quando legitis, <hi rend="italic">VI
+						simus<lb/> in vero Filio ejus Jesu Christo</hi> (I <hi rend="italic"
+						>Joan.</hi> v, 20); verum <lb/> Oei Filium cogitate. Hunc autem Filium nullo
+					modo <lb/> verum Dci Filium cogitatis, si eum natum esse de <lb/> substantia
+					Patris negatis. Num onim jam erat homi­ <lb/> nis filius, et Deo donante factus
+					est Dei filius; ex <lb/> Deo quidcm natus, sed grat a, non natura ? An forte
+					<lb/> eui non hominis lilius, tamen aliqua jam crat qualis­ <lb/> cumque
+					creatura, et in Dci filium, Deo mutante, , <lb/> conversa est? Si nihil horum.
+					ergo aut de nihilo aut <lb/> de aliqua substantia natus rst. Sed ne crederemus
+					<lb/> de nihilo esse Dei Filium vos putare, jam nus ab ista <lb/> sollicitudine
+					liberasti : affirmasti enim non vos dicere, <lb/> de nihilo esse Dei Filiuin. Dc
+					aliqua ergo substantia <lb/> est. Si non de Patris; de qua? Dicite. Sed non in­
+					<lb/> venitis. Jam igitur unigenitum Dei Filium Jesum Chri­ <lb/> stum Dominum
+					nostrum de Patris esse substantia non <lb/> vos nobiscum pigeat conteri.</p>
+				<p>5. Pater crgo et Filius unius sunt ejusdemquc sub­ <lb/> stantiae. noc est illud
+					Homousion, quod in concilio <lb/> Nicaeno adversus haereticos Arianos a
+					catholicis Pa­ <lb/> tribus veritatis anctoritate et auctoritatis veritate fir­
+					<lb/> matum est : quod postea in concilio Ariminensi, <lb/> propter novitatem
+					verhi minus quam oportuit intel­ <lb/> lectum, quod tamen I fides antiqua
+					pepererat, multis <lb/> paucorum fraude deceptis , haeretica impietas sub <lb/>
+					haeretico imperatore Constantio labefactare tentavit. <lb/> Sed post non longum
+					tempus libertate fidei catholicae <lb/> praevalente, posicaquam vis verbi, sicut
+					debuit, in­ <lb/> tellecta est, Heroousion illud catholicae fidei sanitate <lb/>
+					longe lateque defensum est. Quid est enim Homou­ <lb/> sion, nisi unius
+					ejusdemque substantiae? Quid est, <lb/> inquam , Homousion, nisi, <hi
+						rend="italic">Ego et Pater</hi> unum <hi rend="italic">su­</hi>
+					<lb/> mus ( <hi rend="italic">Joan. x,</hi> 50 ) i Sed nunc nec ego Nicaenum,
+					nee <lb/> tu dehes Ariminense tanquam praejudicaturus pro­ <lb/> ferre
+					concilium. Nec ego hujus auctoritate, nec tu <lb/> illius detineris :
+					Scripturarum auctoritatibus, non <lb/> quorumque propriis, sed utrisque
+					communibus testi­ <lb/> bus, res cum re, causa cum causa, ratio cum rationo
+					<lb/> concerlet. Utrique legimus, <hi rend="italic">Ut simus in vero Filio<lb/>
+						ejus Jesu Christo; ipse est verus Deus et vita</hi> ae<hi rend="italic"
+						>terna.</hi>
+					<lb/> Utriquc tanti ponderis molibus cedamus. Dic ergo <lb/> nobis, utrum iste
+					verus Dei Filius, ab eis qui gratia <lb/> lilii sunt hujus nominis quadam
+					proprietate discretus, <lb/> de nulla substantia sit, an de aliqua. <hi
+						rend="italic">Non dico,</hi> inquis, <lb/>
+					<hi rend="italic">de nulla, ne de nihilo dicam.</hi> Ergo de aliqua est : <lb/>
+					quTro, de qua ? Si non de Patris, aliam quere. Si <lb/> aliam non invenis , quia
+					omnino non invenis; Patris <lb/> agnoscc, et Filium cum Patre Homousion
+					confitere. <lb/> Caro de carne nascitur, filius carnis de substantia <lb/>
+					carnis nascitur. Corruptionem de medio tollite, pas­ <lb/> siones carnales a
+					lumine mentis abjicitc, et invisibilia <lb/> Dei, per ca quae facta sunt ,
+					intellecta conspicite <lb/>
+					<hi rend="italic">(Rom.</hi> I. 20). Credite Creatorem, qui dedit carui car­
+					<lb/> nrm gignere, qui dedit parentibus vcros carnis filios <lb/> de carnis
+					substantia generare, ac sic filios cum parcn­ <lb/> tibus unius esse substantiae
+					, multo magis potuisse <lb/> verum gignere Filium de sua substantia, et unam cum
+					<lb/> vero Filio habere substantiam, manente incorruptione <lb/> spirituali, ct
+					longissime hinc alicna corruptione car­ <lb/> nali.</p>
+				<p>4. Nam de anima quid dixeris, nescio. Verba enim <lb/> tua sunt, ubi dicis : <hi
+						rend="italic">Nee enim ad</hi> animae <hi rend="italic">ingenuitatem <lb/>
+						comparatis tantam illam magnificentiam, sed ad fragili­ <lb/> tatem
+						corporis. De corpore utique,</hi> inquis, <hi rend="italic">nascitur
+						caro,<lb/> corporalis filius : non tamen de anima anima nascitur.</hi>
+					<lb/> Post istam quasi definitionem tuam, rursus affirmas <lb/> animam filios
+					generare. Adjungis cuiun, et dicis : Si <lb/>
+					<hi rend="italic">ergo nostra anima incorruptibiliter</hi> generat <hi
+						rend="italic">et</hi> impassi­ <lb/>
+					<hi rend="italic">biliter,</hi> nullam sentiens <hi rend="italic">diminutionem,
+						non inquinatio­</hi>
+					<lb/> nem <hi rend="italic">aliquam; scd legitime secundum</hi> jura <hi
+						rend="italic">divina ge­ <lb/> ncrat</hi> filium , <hi rend="italic"
+						>sapientia</hi> consensum I <hi rend="italic">accommodans <lb/> corpori,
+						ipsa integra</hi> manet : <hi rend="italic">quanta magis omnipotens</hi>
+					<note type="footnote"> I Mss., <hi rend="italic">mimis quam potuit intellectam,
+							qucm tamen,</hi> etc. </note><note type="footnote"> I Editio Erasmi, hic
+						et supra in collatione cum vaximino, <lb/>
+						<hi rend="italic">generatum Iiliunl, savientium</hi> COn.ensu, <hi
+							rend="italic">acconunodans</hi> cor<lb/>1&gt;o i. Minus recte. tov.
+						constanter, <hi rend="italic">ct</hi> capktuU.-6ed paiti­ <lb/> cuh, <hi
+							rend="italic">et,</hi> aL est a Mss. </note>
+					<lb/>
+					<pb n="773"/> Deus ? Et paulo post dicis : <hi rend="italic">Quanto magis Deus
+						Puter <lb/> meorruptibilis incorruptibiliter</hi> genuit <hi rend="italic"
+						>Filium</hi> ? Jam <lb/> supra dixi, nescire me quid volueris de anima
+					intel­ <lb/> ligi, de qua prius dixisti quod non nascatur anima de <lb/> anima,
+					et postea, quod anima incorruptibiliter gignat <lb/> filium. Si animam gignit,
+					quomodo non nascitur anima <lb/> de anima? Si carnem, tu videris quomodo sit
+					caro <lb/> verus animae filius. Christus enim, propter quem pu­ <lb/> lasti hanc
+					adhibendam similitudincm , verus est Dei <lb/> Filius. Si autem
+					incorruptibiliter gignere animam <lb/> filium sic accipi voluisti, quomodo ait
+					Apostolus , <hi rend="italic">In <lb/> Christo enim Jesu per Evángelium ego vos
+						genui</hi> (1 <hi rend="italic">Cor.</hi>
+					<lb/> iv, 15); cur non attendis, quod jam erant ilłae animae <lb/> in vctere
+					vita, quas per Evangelium renovando Apo­ <lb/> stolus genuit ? Verbum autem Dei
+					Deus unigenitus <lb/> Filius, sicut jam disputavimus, non prius aliquid <lb/>
+					fuit, et renovatione est generatus a Patre, sed cum <lb/> Patre semper fuit;
+					sicut est semper atque erit mira­ <lb/> bili atque ineffabili modo genitus ab
+					aeterno coaeter­ <lb/> nus. Sed si ob hoc introduxisti hanc dissimilem simi­
+					<lb/> litudinem, ut assereres Deum Patrem incorruptibi­ <lb/> liter genuisse :
+					noli laborare; confiteor omnino, in­ <lb/> corruptibiliter genuisse Deum Patrem
+					, sed quod est <lb/> ipse genuisse. Iterum enim dico hic, quod vobis saepe <lb/>
+					dicendum est: Aut de aliqua substantia natus est Dei <lb/> Filius, aut de nulla.
+					Si. de nulla, ergo de nihilo ; <lb/> quod vos non dicere jam tencmus. Si de
+					aliqua, nec <lb/> tamen de Patris, non vcrus est Filius. Si de Patris , <lb/>
+					unius ejusdemque substantiae sunt Pater et Filius. <lb/> Quomodo autcm nihil
+					Filio subtraxit, ut dicis, si <lb/> ejusdem substantiae est, et tamen minor est,
+					nec sicut <lb/> infans crescere potest ?</p>
+				<p>5. Jam vero de immortalitate Dei, quia non Pa­ <lb/> irem, sed Deum qui et Patcr
+					est et Filius et Spiritus <lb/> sanctus , solum habere immortalitatem dixit
+					Aposto­ <lb/> lus, satis superius disputavi, quando ipsum aposto­ <lb/> icum
+					testimonium et posui totum , et exposui.</p>
+				<p>6. Displicet tibi , quod aequalem Patri asserimus <lb/> Filium : quasi possit
+					esse inaequalis, qui verus est <lb/> Filius, non natus ex tempore, sed gignenti
+					coaeternus, <lb/> sicut splendor ab igne genitus gignenti manifestatur <lb/>
+					aequaevus. Sed <hi rend="italic">habet,</hi> inquis , <hi rend="italic">Dei
+						Filius auctorem</hi> Pa­ <lb/>
+					<hi rend="italic">trem.</hi> Si propterea Deum Patrem Deo Filio dicis <lb/>
+					auctorem, quia ille genuit, genitus est iste; quia iste <lb/> de illo est, non
+					illc de isto; fatcor et concedo. Si au­ <lb/> lem per nomen auctoris minorem vis
+					facere Filium, <lb/> Patrernque majorem, nec ejusdem substantiae Filium <lb/>
+					cujus est Pater; detestabor et respuam : quia ct filius <lb/> hominis, in
+					quantum est filius, habet auctorem do <lb/> quo natus cst, patrem; nee tamen
+					ideo non est ejus­ <lb/> dem substantiae cujus est pater ; et quod iste minor,
+					<lb/> major est ille, potest tamen ad formam patris valen­ <lb/> tiamque
+					pervenire crescendo, in qua patrem propterea <lb/> non omni modo invenit talem ,
+					quia et ille defecit <lb/> senescendo. Sic enim necesse est varietur aetale mor­
+					<lb/> talitas, ubi temporalis est, non aeterna nativitas. Non <lb/> autem illa
+					siC cst, ubi nee crescit . FiliuS, nec sene­ <lb/> scit Pater. Et ideo amborum
+					non impar cst aetas; qnia <lb/> ubi est aeternitas, nou est aetas : idco forma
+					non im­ <lb/> par amborum; quoniam verus Filius, qni non ut au­ <lb/> geretur
+					cst natus, ne remanerct degener, a qualis <lb/> est natus, Sit ergo nalivitatc
+					humana longe melior ct <lb/> excellentior divina nativitas, incorruptibili et
+					invio­ <lb/> labili generatione : non tamen sit deterior, diversi­ <lb/> late
+					naturae.</p>
+				<p>7. Sed <hi rend="italic">vitam Filius,</hi> inquit, <hi rend="italic">accepit a
+						Patre.</hi> Acce­ <lb/> pit sicut genitus a gignente. <hi rend="italic"
+						>Omnia,</hi> inquit, <hi rend="italic">quae ha­<lb/> bet Pater,mea sunt.
+						(Joan.</hi> xvi, 15). Omnia ergo quae <lb/> habet Pater, dedit ille
+					gignendo, accepit iste na­ <lb/> scendo. Nec dando ille amisit quod habuit; nee
+					iste <lb/> cum esset et non haberet accepit: sed sicut ille per­ <lb/> mansit
+					habens omnia, cum ea quae habet Filio dede­ <lb/> rit omnia ; sic iste nunquam
+					fuit sinc omnibus, quae <lb/> non egendo, sed nascendo accepit ut Filius : quia
+					<lb/> nunquam potuit esse non natus, et ca sine quibus <lb/> non est natus, ct
+					est immutabilis natus, semper ha­ <lb/> buit, quia semper est natus. Si cniin
+					aliquid eorum <lb/> Quae habet Pater non dedit Filio, falsum est quod ait <lb/>
+					Filius : <hi rend="italic">Omnia qum habet Pater, mea sunt.</hi> Sed quia <lb/>
+					verum est, prorsus omnia quae habet Pater, dedit, <lb/> ut diximus, ille
+					gignendo, accepit iste nascendo. <lb/> Ac per hoc dedit ille vitam, quia gcnuit
+					vitam; ac­ <lb/> cepit iste vitam, quia natus est vita : si minor, si de­ <lb/>
+					color *, si diversa, non ergo quam Pater habuit hanc <lb/> dedit Filio. Et
+					quomodo vcrum est, <hi rend="italic">Omnia quae</hi> ha­ <lb/>
+					<hi rend="italic">bet Pater, mea sunt ?</hi> Sed quis audeat dicere, Verum <lb/>
+					non cst . quod Veritas dixit? Quapropter <hi rend="italic">sicut habet <lb/>
+						Pater vitam in semetipso, sic dedit et Filio</hi> vitam <hi rend="italic"
+						>ha­<lb/> bere</hi> in <hi rend="italic">semetipso</hi> ( <hi rend="italic"
+						>Id.</hi> v, 26). Sicut habet dedit, <lb/> quod habet dedit, qualem habeL,
+					talem dedit; quan­ <lb/> tam habet, tantam dedit. Omnia quae habct Pater, <lb/>
+					Filii sunt. Non ergo aliquid minus quam Pater habet <lb/> Filio dedit; nec
+					amisit Pater vitam, quam Filio dedit. <lb/> Vivendo enim tenuit, quam pignendo
+					dedit. Vita est <lb/> autem ipse Pater, vita est ipse Filius. Et ille quippe
+					<lb/> et iste id habet quod et ipse I : sed ille de nulle vita, <lb/> iste vita
+					de vita; sed talis qualis illa, tanta quanta <lb/> illa, hoc omnino quod illa ;
+					quia ,crus est Filius, qnia <lb/> perfectus cst Filius, quia non est degener ab
+					uno Deo <lb/> Patre Deus unicus Filius, Patri ergo aequalis est Fi­ <lb/> lius.
+					Quidquid eum dicis a Patre accepisse, fatemur <lb/> et nos : prorsus Pater
+					dedit, Filius accepit. Sed cum <lb/> Pater omnia quae habet gignendo dedit,
+					aequalem <lb/> utique genuit, quoniam nihil rninus dedit. Quomodo <lb/> ergo tu
+					dicis, quia ille dedit, ille accepit, ideo aequa­ <lb/> lem Filium Patri non
+					esse : cum eum cui data suut <lb/> omnia, et ipsam aequalitatem videas accepisse
+					? <lb/> Scriptum est quidem, Beatum <hi rend="italic">est magis d(tre quam <lb/>
+						accipcre (Act.</hi> xx, 35) : sed in hac vita ubi est ino. <lb/> pia, qua
+					utique melior cst copia. Melius enim cst <lb/> habere, quam egere ; et melius
+					est donare, quam ac­ <lb/> cipere '; erogare, quam mendicare. Ubi antem qui
+					<lb/> dcdit, gignendo dedit ; ct qui accepit, nascendo ac­ <lb/> cepit: non
+					inopi subventum est, scd ipsa copia gu­ <lb/> ncrata est. Nec potest qui accepit
+					ei qui dedit esM <note type="footnote"> I Editi, <hi rend="italic"
+							>discolor.</hi> At Mss., <hi rend="italic">decolor.</hi>
+					</note><note type="footnote"> 1 sic Mss. Editi vero, <hi rend="italic">quod est
+							ipse.</hi>
+					</note><note type="footnote"> I Mn. Er. et MSS. omittunt, <hi rend="italic"
+							>qutun ucciiwe; crogare.</hi>
+					</note>
+					<lb/>
+					<pb n="775"/> inaequalis, qnia ct hoc accepit ut esset aequalis. Nihil <lb/>
+					euim Patre minus habet illc qui dicit, <hi rend="italic">Omnia quae<lb/> habet
+						Pater, mea sunt.</hi> aequalis est igitur. Sed quia <lb/>
+					<hi rend="italic">semetipsum exinanivit, fomam servi accipiens,</hi> non <lb/>
+					formam Dei perdens; ita factus cst in eadem servi <lb/> forma <hi rend="italic"
+						>obediens usque ad</hi> mortem <hi rend="italic">crucis (Philipp. II,</hi>
+					<lb/> i, 8), in qua paulo minus minoratus est ab Angelis <lb/>
+					<hi rend="italic">( f'Bal.</hi> VIII, C), ut Patri in forma Dei maneret
+					aequalis: <lb/> quia non est forma illa mutabilis.</p>
+				<p>8. Quid itaque mirum est, si na quae commemoras, <lb/> dicit, <hi rend="italic"
+						>Ego quae plucila sunt Patri, facio semper ( Joan.</hi>
+					<lb/> VIII, 29) : ct ad monumentum Lazari, <hi rend="italic">Pater. gratias<lb/>
+						ago tibi, qnia audisti me; et ego sciebam quia semper</hi> me <lb/>
+					<hi rend="italic">aidus, sed</hi> propter <hi rend="italic">eoa qui circumstant
+						dixi, ut credant <lb/> quia</hi> tu <hi rend="italic">me misisti (ld.</hi>
+					XI, 41, 42) : ct iterum, <hi rend="italic">Aie</hi> opor­ <lb/>
+					<hi rend="italic">tet operari opera ejus qui me misit (Id.</hi> IX, 4) : ct an­
+					<lb/> tequam panes frangeret, prius <hi rend="italic">Patri gratias egit
+						(Matth.</hi>
+					<lb/> XXVI, 26 ; <hi rend="italic">Marc.</hi> vin, 6, <hi rend="italic">et
+						Joan.</hi> vi, 11) ? Si his atque <lb/> hujusmodi testimoniis id ostendere
+					voluisses, quod <lb/> in forma servi Filius minor cst Patrc, et in ipsa for­
+					<lb/> ma Dei iste de illo non ille de isto est; quod saepe si­ <lb/> gnificans ,
+					multa ita dicit, ut cum non intelligentes <lb/> etiain in ipsa divinitate
+					arbitrentur minorem : sic te­ <lb/> neres rectam regulam fidci, ut non
+					contradiceres ve­ <lb/> rilati; nec per talia testimonia oppugnarcs Evange­
+					<lb/> lium, sed doceres. Quae suut eniin placita Patris , <lb/> quae non sunt et
+					Filii V aut unde potest facerc Filius, <lb/> nisi quae placita sunt Patri, a quo
+					habet omnia in qui­ <lb/> bus aequalis est Patri? Quomodo non gratias agit <lb/>
+					Patri de quo est, praesertim in forma servi , in qua <lb/> illo minor cst?
+					Quomodo non Patrem rogat ut homo, <lb/> qui cum Patrc cxaudit ut Deus ? Quis
+					autem christia­ <lb/> nus ignorat qucd Pater miserit, missusque SiL Filius?
+					<lb/> Non euim genitorem ab co quem genuit, sed genilum <lb/> a genitore mitti
+					oportebat : verum haec non est in­ <lb/> aequalitas subsiantiae, sed ordo
+					naturae ; non quodalter <lb/> prior esset allero, sed quod alter esset ex
+					allero. <lb/> Oportebat ergo operari eum qui missus cst, opera <lb/> ejus a quo
+					missus est: et quae sunt opera Patris, quae <lb/> non suut et Filii; cum dicat
+					idem Filius, <hi rend="italic">Quaecumque <lb/> Pater facit, haec et Filius
+						similiter facit (Joan.</hi> v, 19) ? <lb/> Opera tamen Patiis esse dicit:
+					non » nim obliviscitur <lb/> a quo sit; a Patre quippe illi est ut operator
+					talium <lb/> operum sit. Ilac autcm vos ita intelligilis , ut hinc <lb/> etiam
+					putetis Patrem Filio esse majorem, quia dixit <lb/> passerem non caderc in
+					lerram sine Patris voluntate <lb/>
+					<hi rend="italic">(Matth.</hi> x, 29); quasi cadat sine voluntate Filii. An
+					<lb/> usque adco minorem vultis Filium, ut non habcat in <lb/> potestate nec
+					passeres? Sed si non vultis huic regulae <lb/> acquiescere , ut ubicumque
+					legeritis in auctoritate <lb/> divinorum eloquiorum , quo 1 minor Patre Filius
+					vi­ <lb/> deatur ostendi, aut ex forma servi dictum accipiatis, <lb/> in qua
+					vcre innuor est Patre; aut ideo dictum , quo <lb/> non demonstretur major vel
+					minor ullus esse allero, <lb/> scd demonstretur esse alter ex altero : si huic,
+					in­ <lb/> quam, rectissimae regulae non vultis acquiescere ; certe <lb/> tamcn
+					verum Dni Filium nulla ratione dicetis, si non <lb/> ejusdem substantiae, cujus
+					Pater es!, cum esse dica- <note type="footnote"> I falili, quibus. Concinnius
+						':ss., <hi rend="italic">q!:o.</hi>
+					</note>
+					<lb/> lis. Ut enim humanum aliquid dicam propter infirmi. <lb/> tatem carnalium
+					: cum homines duo sunt, pater et <lb/> filius, si obediens sit patri filius, et
+					aliqua existente <lb/> causa roget patrem , gratias agat patri, aliquo lIcui..
+					<lb/> que Initiatur a patre, ubi se dicat non venisse facere <lb/> voluntatem
+					suam, sed ejus a quo missus est; num­ <lb/> quid hinc ostenditur non ejusdem
+					cujus pater est esse <lb/> substantix ? Cur ergo ubi de Filio Dei talia legitis,
+					<lb/> statim in tantum sacrilcgium corde atque ore prorui­ <lb/> tis, ut veri
+					Filii Dei unam eamdemque cum Patre <lb/> substantiam non esse credatis atque
+					dicatis ?</p>
+				<p>9. Quid quod etiam illud commemorandum putasti, <lb/> quod manifestissime ut homo
+					loquitur: <hi rend="italic">Potestatem ha­ <lb/> beo ponendi animam meam, et
+						potestatem habeo iterum <lb/> sumendi eam. Hoc</hi> enim praeceptum <hi
+						rend="italic">accepi a Patre meo?</hi>
+					<lb/> Quid hoc adjuvat causam tuam ? Numquid enim aliud <lb/> dixit, nisi,
+					Potestatem habco-moriendi et resurgendi ? <lb/> Quod itaque ait, <hi
+						rend="italic">Nemo eam tollit a me, sed ego</hi> eam <lb/>
+					<hi rend="italic">pono</hi> a me, <hi rend="italic">et iterum sumo eam
+						(Joan.</hi> x, 18) ; quid in­ <lb/> telligi voluit, nisi se non fuisse
+					moriturum, nisi ipse <lb/> voluisset ? Numquid tamen nisi horno esset , mori et
+					<lb/> resurgere potuisset ? Sic autem introduxisti hoc testi­ <lb/> monium, ut
+					praełoquereris, dicens, <hi rend="italic">Hic sane et de sua <lb/> potestate
+						quam a Patre accepit dicebat,</hi> « <hi rend="italic">Potestatem <lb/>
+						habeo ponendi animam</hi> meam, <hi rend="italic">ei potestatem habeo
+						ite­<lb/> rum sumendi eam</hi> : &gt; tanquam si homo non esset, po­ <lb/>
+					siturus esset animam. Ut homo ergo, non ut Dcus, <lb/> accepit hanc potestatem :
+					quamvis non dixerit, Hanc <lb/> potestatem; sed, <hi rend="italic">hoc</hi>
+					praeceptum <hi rend="italic">accepi a Patre</hi> meo. <lb/> Quis autem nesciat
+						<unclear>aluid</unclear> esse praeceptum , aliud po­ <lb/> testatem ? Hoc
+					enim habemus in potestate, quod cum <lb/> volumus possumus. Pracceplum vcro id
+					nobiscum agit, <lb/> ut quod jam est in potestate faciamus : si autem non­ <lb/>
+					dum est in potestate, oremus nohis patestatem dari, <lb/> ut qnod praeceptum cst
+					impleamus. Quocirca si ea <lb/> qu:c aperta sunt velitis attendere, ut homo
+					acceperat <lb/> hanc potestatem. Sed propter contentiosos ego ad <lb/> utrumque
+					concludam : Si ut homo accepit hanc po­ <lb/> testatem, nihil libi prodesse hoc
+					testimonium et tu <lb/> vidcs; quia si ex hac potestate a Patre accepta, mi­
+					<lb/> norem Patre Filium vis probare, nee nos dubitamus, <lb/> quod in quantum
+					homo est Christus, minor est Patre : <lb/> si autem ut Deum vis accepisse hanc
+					potestatem, Hi.. <lb/> gnendo cum Pater aequalem sibi, dedit ei omnium <lb/>
+					rerum tantam, quanta ipsi Patri est 1, potestatem. Si <lb/> enim minus habet in
+					potestate aliquid quam Patcr, <lb/> non sunt ejus omnia quae habet Pater : sed
+					quia ejus <lb/> sunt, tantem procul dubio habel potestatem quantam <lb/> Pater.
+					Praeceptum quoque aut ut homo accepit, aut <lb/> ut Deus : si ut ho:no, nulla
+					quaestio ea, quia ut homo <lb/> est Patre minor: si ut Dcus, non hinc ostenditur
+					mi­ <lb/> nor; quia nascendo id accepit, non indigendo. In <lb/> Verbo cnim
+					unico Dei omnia praecepta sunt Dei , quae <lb/> ille gignens dedit nascenti, non
+					cum genuisset addi­ <lb/> dil indigenti : ac per hoc tantum genuit quantus cst
+					<lb/> ipse; quia de scipso genuit vcrum Filium, et perfc­ <lb/> ctum genuit
+					plenitudine divinitatis, non perficiendum <note type="footnote"> 1 ):ss., <hi
+							rend="italic">qunnti ipsi:ts csl.rat. is.</hi>
+					</note>
+					<lb/>
+					<pb n="777"/> a tatis accessu 1. Sed humilius a tc quaero, quare <lb/> tilium
+					hominis quemlibet hominem, si preceptum ac­ <lb/> cipiat a patre, nun eum dicis
+					alterius esse substan­ <lb/> tiae, et Filium Dci Demn ob hoc audes negare pa -
+					<lb/> ternae esse substantiae, quia praeceptum accepit a <lb/> Patre? Prorsus,
+					ct praeceptum a Patre accepit,et <lb/> ejusdem substantiae est, cujus est ille
+					qui dedit. Quis <lb/> te contradicentem ferat, si ad te audiendum homines <lb/>
+					patresfiliique concurrant, ejusdem utrique substan­ <lb/> tiae ; nec ideo filii
+					degeneres, quod ita praecepta eis <lb/> dederint patres? Sud forte dicis, patres
+					doctos filiis <lb/> indoctis. dedisse praecepta. Refer nuac te ad Dei fi­ <lb/>
+					lium, de Dco Patrc natum Deum, qui utique imper­ <lb/> fectus est natus, si
+					praeceptum accepit indoctus. Quia <lb/> vero perfectus est natus, praeceptum
+					dedit ille gi­ <lb/> gnendo, accepit iste nascendo. Nunquam enim verus <lb/> Dei
+					Filius indoctus fuit : filius autem numquam non fuit.</p>
+				<p>CAPUT XV. — i. In forma Dei Filium esse non <lb/> negas, et Dco Patri aequalem
+					negas, majorem Patris <lb/> iormam putans esse quam Filii : tanquam non ha­
+					<lb/> buerit Pater unde formam suam compleret in Filio, <lb/> quem de se ipso
+					genuit ,non fecit ex nihilo, non ex <lb/> alio. Aut si formam suam in unico
+					Filio plonam gi­ <lb/> gnere potuit, nec tamen genuit plenam, sed minorem ;
+					<lb/> quid sequatur altenditc, et in viam redite, ne coga­ <lb/> mini Patrem
+					invidum dicere. Dicitis Deum Filium, <lb/> dicitis Dominum; sed ut duos deos
+					dominosque facia­ <lb/> tis, contra Scripturam clamantem, Audi, <hi
+						rend="italic">Israel; Do­</hi>
+					<lb/> minus <hi rend="italic">Deus</hi> tuus, <hi rend="italic">Dominus</hi>
+					unus est <hi rend="italic">(Deut.</hi> VI, 4). Quid <lb/> autem in hoc
+					sacrilegio vobis prodest, quod Patri da­ <lb/> tis tantam formam, quantam non
+					datis Filio? Num­ <lb/> quid si unus major, alter est minor, ideo non suut <lb/>
+					dii et domini duo? Si carere cupitis hoc errore, sic <lb/> dicite alium esse
+					Patrem, aliam esse filium, ut tamen <lb/> simul ambos non duos dicatis, sed unum
+					Dominum <lb/> Deum. Dicitis rogem Filium de rege Patre utique na . <lb/> tum:
+					nec intuemini in genere humano filios regum <lb/> etiamsi non sunt ex ,regibus
+					reges, esse tamen ex ho­ <lb/> minibus homines; nec habere potestatem cum pa­
+					<lb/> tribus regiam, et tamen eamdem tenere naturam. Vos <lb/> autem Filio Dei
+					rogis regnum cum Patre conceditis, <lb/> ct naturam paternam, vanitate impia
+					denegatis ; cum­ <lb/> que Deo Patri dicitis inrqualem, <hi rend="italic">qui
+						non rapinam,</hi>
+					<lb/> hoc est, non alienum <hi rend="italic">arbitratus est esse aequalis Deo
+						;<lb/> sed</hi> tamen non intendens quae sua sunt , sed qu;c no­ <lb/> stra
+					sunt, <hi rend="italic">semetipsum exinanivit;</hi> non formam Dei <lb/>
+					perdens, sed formam <hi rend="italic">serii accipiens,</hi> in qua est Patri <lb/>
+					<hi rend="italic">factus obediens usque ad mortem crucis (Philipp.</hi> II,
+					<lb/> C 8). I.. qua forma cnm non vultis sic agnoscere Pa­ <lb/> tre Deo
+					minorem. ut in Dci forma Patri non negetis <lb/> aequalem. « Nos, i inquis, *
+					dicti sumus filii gratia, <lb/> non natura hoc nati : ideo unigenitus est
+					Filius, quia <lb/> qnod est secundum divinitatis suae naturam , hoc cst <lb/>
+					natus Filius. i Haec non tua solum, verum etiam no­ <lb/> stra suit verba. Cur
+					erro quem Dei Filium natura <lb/> non gratia confiteris, ejusdem naturae, cujus
+					Pater <lb/> cst, non esse contendis,nec quid mali abs tc dicatur <note
+						type="footnote"> I Sic Am. F.r et Mss. At Lov., <hi rend="italic">el
+							uc;'jert,znt qcnuit plt';:i- <lb/> Vtdincm divinitatis, non perficiendam
+							aetatis accessu</hi></note>
+					<lb/> attendis ? Nunnc regis <unclear>Dei</unclear> Filio paternum regnum au
+					<lb/> ferres tolerabilius quam naturam?</p>
+				<p>2, Dc Spiritu autem sancto, quomodo e' ipse de <lb/> Deo sit, nec tamen et ipse
+					filius sit, quoniam proce­ <lb/> dendo, non nascendo legitur esse de Deo, jam
+					supe­ <lb/> rius, quantum satis visum est, disputavi. Nos, inquis, <lb/>
+					<hi rend="italic">in Patrem Deum innatum,</hi> naturam non <hi rend="italic"
+						>accepimus.</hi>
+					<lb/> Et tanquam rationem reddens, cur Dei Patris non <lb/> dicatis esse naturam
+					, mox adjungis, et dicis, <hi rend="italic">Credi­</hi>
+					<lb/> mus <hi rend="italic">quod ait Christus,</hi> i <unclear/><hi
+						rend="italic">Spirituc eat Deus</hi> » <hi rend="italic">(Joan. IV.</hi>
+					<lb/> 24) : quasi Christus secundum id quod Deus est, <lb/> non spiritus sit,
+					quem tamen natura Filium esse <lb/> dixisti. Nan ergo Pater ideo natura non est,
+					quia spi­ <lb/> ritus est. Sed forte quia natu uon est, idco eum non <lb/>
+					vultis esse naturam; putatis enim quod a nascendo <lb/> uatura sit dicta.
+					Scitote ergo, quod unaquaeque res <lb/> esse dicitur per substantiam, hoc esse
+					utique per <lb/> naturam. Certe si non putatis esse dicendum, ejusdem <lb/>
+					filium cujus Pater est esse naturne; dicite cujus Pa­ <lb/> ter est esse
+					substantiae : ad causam quae inter nog <lb/> agitur, sufficit nobis. Verumtamen
+					admonendi cstis, <lb/> ut intueamini quod ait Apostolus, <hi rend="italic">His
+						qui natura</hi> non <lb/> sunt <hi rend="italic">dii, servistis (Galat.</hi>
+					IV, 8): ubi certe nos Deo <lb/> qui natura est Deus, servire monstravit. Vos
+					ergo qui <lb/> Deum Patrem non natura Deum esse creditis, ubi <lb/> cum
+					constituatis, advertite; et si ullus in vobis pudor <lb/> est, erubescite. Eccc
+					nos dicimus vobis, non servi­ <lb/> mus Deo qui natura non est Deus; ne simus
+					tales, <lb/> quales fuerunt illi quihus dictum cst, <hi rend="italic">His</hi>
+					qui <hi rend="italic">natura <lb/> non sunt dii, servistis.</hi> Vos si tales
+					esse vultis, <lb/> petimus ne velitis, et Deum Patrem natura Dcum <lb/> esse
+					dicatis : ejusque Filium, quem non gratia, sed na­ <lb/> tura Filium jam esse
+					dicitis, ejusdem nature cujus <lb/> Pater est non negetis, ne nihil aliud qnam
+					Filium <lb/> esse verum negetis. Quomodo enim dicitis, et ve­ <lb/> rum Filium
+					vos profiteri, et Putri similem non ne­ <lb/> gare, quando cum negatis unius cum
+					Patre esse sub­ <lb/> stantiae ? Sicnt autem verum Filium indicat una sub­ <lb/>
+					stantia, sic non verum diversa substantia. Quomodo <lb/> autem Filium Patri
+					similem dicitis, cui Patris sub­ <lb/> stantium ,dare non vultis ? Nonnc similis
+					homini est <lb/> pictura vel statua, et tamen filius dici non potest, <lb/> qnia
+					diversa substantia est ? Homo nempe ad Dci si­ <lb/> militudine ii factus cst;
+					tamen quia non est unius <lb/> ejusdemque substantiae, fton est verus filius; et
+					ideo <lb/> fit gratia filius, quia non est natura. Si ergo vultis <lb/> Dei
+					Filium verum confiteri, prius illum ac praecipuc <lb/> dicite unius ejusdemque
+					substantiae, ut tanquam ve­ <lb/> rum Filium ct Dei Filium pcr omnia similem
+					Patri <lb/> esse dicatis. Nam quem substantiam putatis habere <lb/> diversam,
+					plus eum dissimilem quam similem dicitis, <lb/> et omnino verum Filium
+					denegatis. Nam vultis I <lb/> nosse, ad ostendendum verum filium quantum va­
+					<lb/> leat una eademque substantia : etiamsi filius hominis <lb/> homo in
+					quibusdam similis, in quibusdam sit disci­ <lb/> milis patri; tamen quia ejusdem
+					substantiae est, ne­ <lb/> gari vcrus filius uon potest: et quia verus est
+					filius, <lb/> negari ejusdem substantiae non potest. Vos autem ita <note
+						type="footnote"> ' sola editio 1.0\'.: <hi rend="italic">Sec vultis.</hi>
+					</note>
+					<note type="footnote"> PATROl... XLII. </note>
+					<note type="footnote">
+						<hi rend="italic">(Vingt-cinq.)</hi>
+					</note>
+					<lb/>
+					<pb n="779"/> dicitis verum Dei Filium similem Patri, ut substantiae <lb/>
+					velitis esse diversa, per qnam solam potest filius ve­ <lb/> ros ostendi. Nam
+					duo verihomines etsi nullus corum <lb/> filius silahcrius, umus tamen suni et
+					ejusdem sub. <lb/> stantiae : homo autem alterius, hominis verus filius <lb/>
+					nullo modo potest nisi ejusdem cum patre esse sub­ <lb/> stantiae,etiamsi non
+					sit par omn a similis patri <lb/> Quocirca verus Dei Filius ct unius cum Patre
+					Fubstan <lb/> tiae est, quia verus Filius est : et per omnia est Patri <lb/>
+					similis, quia Dei Filius est. Nequc enim sicut contin­ <lb/> git in filiis
+					hominum vel quoramcumque animalium, <lb/> ita fas est dicere, verum Dei Filium
+					substantiae qui­ <lb/> dem unius esse cum Palrc, sed non per omina <lb/> similem
+					Patri. Nicaenum igitur tenete nobiscum con­ <lb/> cilium , si voltis Christum
+					dicere verum Dei Filium.</p>
+				<p>5. <hi rend="italic">Diversas,</hi> inquis, <hi rend="italic">accusamur dicere
+						natura.</hi> Et <lb/> quid aliud dicis de Den Patre ct Dco Filio? quid aliud
+					<lb/> dicis? An idco putas ab isia accusatione purgari% <lb/> quia continuo
+					subjungis dicens : <hi rend="italic">Hoc scito quod nos <lb/> dicimus, quod
+						Puter</hi> spiritus spiritum <hi rend="italic">genuit ante omnia<lb/>
+						saecula, Deus Deum genuit?</hi> .loc quidem dicitis, et <lb/> veruin dicitis
+					: sed hoc tacuisti, quod falsum ct exse­ <lb/> crabilc dicitis. <hi
+						rend="italic">Spiritus</hi> enim spiritum genuit, verum <lb/> dicitis : sed
+					hoc verum ea intentione vos dicitis, <lb/> quia etiam diversae naturae dicitur
+					spiritus. Nam di­ <lb/> versa; naturae sunt Spiritus Dei, sive Spiritus Deus,
+					<lb/> et spiritus hominis; et tamen uterque dicitur spiritus: <lb/> Itemdiversae
+					naturae sunt spiritus hominis et spiritus <lb/> pecoris; et tamen nihilominus
+					uterque spiritus dicitur. <lb/> hem dicitur, Deus Dens, et dicitur deus homo :
+					sicut <lb/> dictum cst, <hi rend="italic">Dii estis</hi> ( <hi rend="italic"
+						>Psal.</hi> nIxi, 6). Et sicut datus <lb/> est 1 deus Moyses Pharaoni <hi
+						rend="italic">( Exod.</hi> VII, 1). Et cum <lb/> sit Dei ct hominis diversa
+					substantia, tan:en uterque <lb/> appellatur Deus. Prorsus veraciter arguimini,
+					quam­ <lb/> vis dicatis de Deo Patre cl Deo Filio, <hi rend="italic">Spiritus
+						spiri­<lb/> tum</hi> genuit, naturas tamen diversas diccre : et quam­ <lb/>
+					vis dicatis, <hi rend="italic">Deus Deum genuit;</hi> etiam sic non recedere
+					<lb/> a diversitate naturae, quia non per omnia similem <lb/> Patri esse dicitis
+					Filium. Nam si per omnia si­ <lb/> mitem diceretis correquenter intelligeremini
+					quod <lb/> cos diceretis etiam unius cjusdemque esse naturae <lb/> sive
+					substantiae. Si ergo ab hoc crimine quod vobis <lb/> objicitur, Dei Patris et
+					Dei Filii vos dicere naturas <lb/> esse diversas, purgare te cogitas: sicut
+					dicis, <hi rend="italic">Spiritus</hi>
+					<lb/> spiritum <hi rend="italic">genuit;</hi> ita dic, Spiritus ejusdem naturae
+					sivc <lb/> substantiae spiritum genuit. Item, sicut dicis, <hi rend="italic"
+						>Dens<lb/> Deum genuit;</hi> ita die, Deus ejusdem naturae sive sub­ <lb/>
+					stantiae Deum genuit. Hoc si credideris, et dixeris, <lb/> nihil de bac re
+					ulterius accusaberis. Si autem hoc non <lb/> dixeris , quid prodest quia dicis,
+					Verus <hi rend="italic">innatus Pater <lb/> verum genuit Filium;</hi> cum procul
+					dubio verus Filius <lb/> ton sit, si non est unius ejusdemque substantiae eum
+					<lb/> illo qui genuit ?</p>
+				<p>4. Dicit quidem Filius ad Patrem , <hi rend="italic">Haec</hi> est <hi
+						rend="italic">autem<lb/> vita œterna,</hi> ut cognoscant te solum terum <hi
+						rend="italic">Deum, et <lb/> quem misisti</hi> Jesum <hi rend="italic"
+						>Christum (Joan.</hi> XVII, 5) : Id est, . <lb/> te et quem misisti Jesum
+					Christum, cognoscant solum <lb/> verum Deum. In quibus verbis vos solum Patrem
+					non <note type="footnote">a Sic, 3bd. Fditi autem, dictus est. </note>
+					<lb/> cum Filio verum accipientes Deum , quid allud quita <lb/> Filium ncgatis
+					'crum Deum? Quia vero Pater ct Fl- <lb/> lius, non duo dii, sed unus cst Deus;
+					sine dubio et <lb/> Filius vcrus est Deus, et adjuncto Spiritu sancto <lb/>
+					solus est Deus. Ncque enim movere nos debel, quod <lb/> nominatus non est hoc
+					loco Spiritus sanctus, tanquam <lb/> non sit Deus, aut non sit verus Deus. Tale
+					est cnim <lb/> fioc quale si quis dicit, nescire Christum ea quae Dei <lb/>
+					sunt; quoniam dixit Apostolus sic : <hi rend="italic">Et quae Dei sunt,</hi>
+					<lb/> nemo <hi rend="italic">scit,</hi> nisi <hi rend="italic">Spiritus Dei</hi>
+					(I <hi rend="italic">Cor.</hi> II, 11). Hoc cst <lb/> enim. Nemo <hi
+						rend="italic">scit,</hi> nisi Spiritus <hi rend="italic">Dei;</hi> quod est
+					, Solus <lb/> ea scit Spiritus Dei. Sieut ergo ab hac scientia, quam <lb/> non
+					habere nisi Spiritus Dei dictus est, non excludi. <lb/> tur Christus; sic ab eo
+					quod Patcr et Christus dictus <lb/> est solusverus Deus, non excluditur Spiritus
+					sanctus. <lb/> Sic et nomen illud quod in Apocalypsi nemo nosse <lb/> dictus
+					est, nisi ipse qui hoc habebat scriptum <hi rend="italic">( Apoc.</hi>
+					<lb/> XIX, 12), id est Christus, noverat utique et Pater, <lb/> quod nrgare non
+					potestis; noverat et Spiritus sanctus, <lb/> etiamsi ncgetis. <hi rend="italic"
+						>Spiritus</hi> enim <hi rend="italic">omnia</hi> scrutatur, <hi
+						rend="italic">etiam<lb/> altitudines Dei</hi> (I <hi rend="italic">Cor.</hi>
+					II, 10). Nisi forte quia scruta­ <lb/> tor dictus est, ncgatur apprehendere :
+					negetur ergo <lb/> Dens apprehendere corda et renes hominum; scri­ <lb/> ptum
+					est enim , <hi rend="italic">Scrutans corda et renes Deus (Psal.</hi>
+					<lb/> VII,10). Ita ergo dictus est solus verus Deus Pater et <lb/> Jesus
+					Christus, ut ab bac veritate deitatis nullo modo <lb/> alienaretur Spiritus
+					sanctus. Non autem Filius, ut <lb/> tibi vidctur, <hi rend="italic">solum
+						potentem , solum sapientem, solum</hi>
+					<lb/> bonum <hi rend="italic">Patrem</hi> dicit <hi rend="italic">esse
+						Deum.</hi> Deus autem unus ct <lb/> solus est ipsa Trinitas, ut ostendunt ea
+					quae superius <lb/> jam saepissime diximus.</p>
+				<p>5. Quod autem <hi rend="italic">non</hi> proficientem , <hi rend="italic">sed
+						perfectum <lb/> Deus Pater genuerit Filium Deum;</hi> verum dicis. Sed <lb/>
+					quod ipsam Filii perfectionem, perfectioni Patris non <lb/> vis aquare; hoc
+					falsum dicis, ct vcritati qua verus <lb/> cst Filius contradicis. <hi
+						rend="italic">Homo enim</hi> si <hi rend="italic">posset,</hi> inquis &gt; <lb/>
+					<hi rend="italic">perfectum mox generare filium, non parvulum genera­ <lb/>
+						ret,</hi> qui <hi rend="italic">coaugmentatis annis tandem aliquando</hi>
+					aui <hi rend="italic">geni- ,</hi>
+					<lb/> toris <hi rend="italic">impleat voluntatem.</hi> Verissime 1 omnino contra
+					<lb/> te loqueris. Sed ut contra te non sit quod loqucris, <lb/> agnosce
+					aequalitatem Patris et Filii. Quia et homo si <lb/> posset, filium mox generaret
+					arqpalem , nec exspe­ <lb/> ctaret annos, per quos in forma filii posset
+					voluntas <lb/> ejus impleri. Deus ergo cur non aequalem genuit Fi­ <lb/> lium ,
+					cui nec anni necessarii fuerunt per quos id im­ <lb/> pleretur, nec omnipotentia
+					defuit? An forte noluit? <lb/> Ergo, quod absit, invidit. Sed non invidit :
+					aequaleur <lb/> igitur gcnui:. Ac per hoc unius ejusdemque substan­ <lb/> tiae :
+					quandoquidem homo, qui propterea quia non <lb/> potest non gignit aequalem ,
+					ejusdem tamen subslan­ <lb/> tiae gignit filium, cujus est ipse. Quod si non
+					esset, <lb/> profecto verus filius esse non posset. Quid est ergo <lb/> quod
+					dicis , <hi rend="italic">Pater tatem genuit</hi> Filium <hi rend="italic"
+						>qualis et</hi> nune <lb/> eat, <hi rend="italic">qualis</hi> et <hi
+						rend="italic">permanet sine fine?</hi> Hoc bene diceres , si <lb/> Patri
+					aequalem verum Filium non negares. Cum vero <lb/> perfectum dicis, et aequalem
+					negas, et talem qnalii <note type="footnote"> * EdSti: <hi rend="italic"
+							>Fcritatem</hi> veris <hi rend="italic">iiml,</hi> Pic. At Ma&lt;L
+						omiUnat <hi rend="italic">veri­<lb/> tctem.</hi>
+					</note>
+					<lb/>
+					<pb n="781"/> est natus sine line permanere non negas; procul dubio <lb/>
+					minorem Patre filium sine fine mancre pronuntias. <lb/> AC per hoc nascitur
+					filius hominis minor Patre ; et <lb/> quia imperfectus nascitur, crescendo ad
+					formam per­ <lb/> venit patris : natus est filius Dei minor Patre; et <lb/> quia
+					perfectus atque immortaliter natu est, nullum <lb/> accipit incrementum , sed
+					cum ipsa perfectio a forma <lb/> Patris in aeternum efficit alienum. Ecce qu:e
+					creditis , <lb/> cccequae dicitis; ecce sunt, quod pejus est, quae docetis.
+					<lb/> Sed <hi rend="italic">inauditorum,</hi> inquis , <hi rend="italic">eat
+						arbitrio</hi> , nt <hi rend="italic">eligant alte­</hi>
+					<lb/> rum <hi rend="italic">de duobus : aut obedientem Patri Filium</hi> , qui i
+					se <lb/>
+					<hi rend="italic">evinanivit, formam servi accipiens <unclear>o</unclear>, cui
+						et Pater « donavit <lb/> nomen quod est super omne nomen</hi> &gt; <hi
+						rend="italic">(Philipp.</hi> II, 7, 9); <lb/>
+					<hi rend="italic">aut interpretationem tuam.</hi> Prorsus auditores quibus <lb/>
+					donat bominus intellectum, non unum de duobus <lb/> istis eligunt, sed utrumque;
+					id cst, et obedientem Pa<lb/>Iri Filiuin , et interpretationem, vcl potius
+					cxposilio­ <lb/> nem meam, qua ostendi sic obedientem fuisse in for­ <lb/> nia
+					servi, ut formam non amitteret Dei, in qua :'qua­ <lb/> lis est Patri. Tu vero
+					vide quam contumeliose Filio <lb/> Dci tribuas obedientiam , cujus minuis in
+					divinitate <lb/> naturam.</p>
+				<p>CAPUT XVI. - !. Quando autem a me audisti <lb/> prop. r Judaeos , <hi
+						rend="italic">humilitatis, non veritatis gratia , <lb/> dixisse Filium quod
+						Deus ejus sit Puter ejus ?</hi> Hoc a <lb/> me ita nunquam audire potuisti,
+					sicut nunquam dixi: <lb/> sed plane dili, propter formam servi dictum esse.
+					<lb/> Sicut autem ipsa forma servi vera , non falsa ea; ita <lb/> Patrem suum
+					esse eliam propter illam Deum suum * <lb/> veraciter dixit, non humiliter
+					finxit. Quis enim est <lb/> humilitatis, fructus ubi detrimentum est veritatis ?
+					<lb/> Tn autem istam certissimam veritatem ita es refutare <lb/> conatus, ut
+					diceres ideo verba ipsa, quibus ait Domi­ <lb/> nus , <hi rend="italic">Deum
+						meum et Deum vestrum,</hi> ad formam servi <lb/> non pertinere, quia eis
+					verbis post resurrectionem <lb/> ustis est Dominus, quasi formam servi
+					resurrectione <lb/> consumpserit, ac non potius in melius commutaverit: <lb/>
+					quasi non qui mortuus est, ipse etiam resurrexerit; <lb/> quasi non forma quae
+					occisa est, ipsa rcvixerit; quasi <lb/> uon ipsa in caelum levata sit , in ipsa
+					Dei Filius se­ <lb/> deat ad dexteram Patris, in ipsa venturus sit ad vivos
+					<lb/> et mortuos judicandos. Nonnc clarissima Contestatio <lb/> est Angelorum
+					dicentium , <hi rend="italic">Sic veniet, quemadmodum</hi>
+					<lb/> vidistis eum euntem in <hi rend="italic">cœlum (Act.</hi> I, 11). Cur ergo
+					<lb/> post resurrectionem non diceret, <hi rend="italic">Ascendo ad Patrem <lb/>
+						meum et Patrem restrum, Deum</hi> meum <hi rend="italic">et Deum re­</hi>
+					<lb/> strum <hi rend="italic">(Joan.</hi> xx, 47); quando in eadem forma fuerat
+					<lb/> ascensurus, propter quam ex tempore Deus est ejus,. <lb/> qui sine tempore
+					Pater est cjus ? Propter quam for­ <lb/> fam non solum post resurrectionem,
+					verum etiam <lb/> post judicium <hi rend="italic">subjectus erit ei , qui iUi
+						subjecit onmia</hi>
+					<lb/> (1 <hi rend="italic">Cor.</hi> xv, 28). Quotquot ergo testimonia posuisti,
+					<lb/> quibus probares dictum esse Deum Christi, eum qui <lb/> Pater est Christi,
+					discutere quemadmodum dicta sint, <lb/> superfluum judico : sed a te frustra
+					commemorata <lb/> esse, puto quod nec tu dcbeas dubitare.</p>
+				<p>2. Jam vero illud ubi Dominos in eadem carne <lb/> quam resuscitaverat
+					constitutus, et eumdem homincm <lb/> g<unclear>erens</unclear> , ait ad
+					discipulos suos, <hi rend="italic">Data</hi> est <hi rend="italic">mihi</hi>
+					omnis <lb/>
+					<hi rend="italic">potestas in cœlo</hi> et in <hi rend="italic">terra :
+						cuntes</hi>
+					<unclear/><hi rend="italic">avecte omnes gentes, <lb/> baptizantes</hi> toa <hi
+						rend="italic">in</hi> numine <hi rend="italic">Patris ei Filii et</hi>
+					Spiritus <lb/>
+					<hi rend="italic">sancti; docentes eoa servare omnia</hi> quaecumque <hi
+						rend="italic">mandu<unclear>vi</unclear>
+						<lb/> vobis (matth.</hi> XXVIII, 18-20): utquid commemoraveris, <lb/> .et
+					quid inde probare volucris * prorsus nescio. Num­ <lb/> quid enim ait, Data est
+					mihi a Deo meo potestas <lb/> Quod si dixisset, propter ipsam humanam formam
+					<lb/> dictum fuisse ambigi non dcboret. Quia vero non dixit; <lb/> quid isto
+					testimonio volueris agrre, non intelligo. Imo <lb/> intelligo te id egisse , ut
+					abundantius loquereris. Si <lb/> enim tanquam Dco duta est hxc potestas ,
+					nascenti <lb/> cain Pater dedit, non indigenti; quia gignendo dedit, <lb/> non
+					augendo. Si vero tanquam homini data est haec <lb/> potestas , qni I habet
+					quaestionis? An forte nos admo­ <lb/> ncre voluisti, quod baptizari Dominus
+					jusserit gculcs <lb/> in nominc Patris ct Filii ct Spiritus sancti ? Ubi au­
+					<lb/> dis unum nomen , ct unam non vis intelligere dcila­ <lb/> tem.</p>
+				<p>3. Quod autem dicisv ct ante incarnationem Chri­ <lb/> sti , Patrem dictuin csse
+					Dum ejus, quoniam scri. <lb/> ptum est \ Unxit <hi rend="italic">te, Deus,
+						Deus</hi> tuus; longe antequam <lb/> Christus venisset in carne : itane Ron
+					intelligis in <lb/> prophetia esse praed clum , tanquam fucrit factum <lb/> quod
+					erat futurum ? Annon sic in prophetia ait ipso <lb/> Dominus , <hi rend="italic"
+						>Foderunt manus meas et pedes (Psal.</hi> xxi, <lb/> 48); ct caeterea quihus
+					passionem suam tanto ante <lb/> prae<unclear>nuntiavit</unclear>, et quod
+					futurum fuerat, tanquam jam <lb/> factum esset expressit? Dictum ea ergo in
+					prophetia <lb/> rerum futurarum , tanquani locutione rerum praeteri­ <lb/>
+					tarum, <hi rend="italic">Unxit te, Deus, Deus tuus oleo exsultationis pra <lb/>
+						participibus tuis :</hi> participes ejus significans, qui futuri <lb/> fiii
+					rant servi ejus, socii ejus, amici cjus, fratres ejus, <lb/> membra ejus.
+					Praedictum est ergo quod futurum erat, <lb/> ut ungeret Deus Christi hominem
+					Christum: qui tamen <lb/> sic factus est homo, ut maneret Deus. Ungeret autem.
+					<lb/> non visibili ct corporali oleo , sed Spiritu sancto, <lb/> quem Scriptura
+					nomine olei exsultationis, figurata, ut <lb/> solet, locutione significat. Dixit
+					autem , <hi rend="italic">Unxit;</hi> non <lb/> dixit, Uncturus est: quia in
+					praedestinatione jam fa­ <lb/> ctum erat, quod suo tempore futurum erat. Ubi tn
+					<lb/> timens ne Spiritus sanctus, quo unctus est Christus . <lb/> major videatur
+					esse quam Christus, quia revera ma­ <lb/> jor est homine Christo; qui enim
+					sanctificat, eo qui <lb/> sanctificatur est major: hoc ergo timens, voluisti
+					olco <lb/> exsultationis eam laetitiam significatam videri, qua <lb/> Filius
+					exsultavit cum Patre, quando est condita ere:.­ <lb/> tura. Et commemorasti, ut
+					soles, testimonia causa <lb/> tuae non necessaria , de laetitia Patris et Filii.
+					Sed <lb/> quid facturus es? quo iturus i Quomodo id quod est <lb/> luce clarius,
+					aut negaturus, aut in aliud quodcumque <lb/> versurus es, cum recitatur tibi
+					quod beatus Petrus in <lb/> Apostolorum Actibus dixit : <hi rend="italic"
+						>Hunc</hi> Jesum a <hi rend="italic">Naza­ <lb/> reth, quem unxit Deus
+						Spiritu sancto (Act.</hi> x, 38). <lb/> Ecce quod prophetabatur, quando
+					dictum est, <hi rend="italic">Unxit <lb/> te Deu, Deus tuus oleo
+						exsultationis,</hi> vel, <hi rend="italic">oleo laetitiae,</hi>
+					<lb/> prae <hi rend="italic">participibus</hi> tuis. Deus enim cui dictum est in
+					eo­ <lb/> dem Psahno , Thronus tuus, Deus, in <hi rend="italic">saeculum
+						saeculi; <lb/> virga directionis , virga regni tui : dilexisti
+						justitiam,</hi> et <lb/>
+					<hi rend="italic">odio habuisti iniquitatem; propterea</hi> unxit <hi
+						rend="italic">te Deus, Deus</hi>
+					<lb/>
+					<pb n="783"/>
+					<hi rend="italic">tuus (Psal.</hi> XLIV, 7, 8) : a Deo Patre unctus est Filius,
+					<lb/> qui sic bomo factus est ut mancrel Deus, qua unctione <lb/> plenus erat,
+					id est, Spiritu sancto. Propter quod de <lb/> illo scriptum cst : Jesus <hi
+						rend="italic">autem plenus Spiritu sancto, <lb/> reversus est a Jordanc
+						(Luc.</hi> iv, 1).</p>
+				<p>CAPUT XVII.— 1. Dicis in persona Spiritus sancti <lb/> non posse suscipi quod de
+					Filio dictum est, <hi rend="italic">Omnia <lb/> per ipsum fucta sunt</hi> , et
+						<hi rend="italic">sine ipso</hi> facturi <hi rend="italic">est nihil <lb/>
+						(Joan.</hi> I, 3). Et hoc ideo hidis, ut quibus potueris <lb/> persuadeas,
+					qnod vobis male persuasum est, Spiri­ <lb/> tum sanctum non esse creatorem :
+					quasi legeris , <lb/> Omnia per ipsum facta sunt sine Spiritu sancto ; aut,
+					<lb/> Omnia per neminem facta sunt, nisi per ipsum. Quan­ <lb/> quam si et tale
+					aliquid legeres, sic Spiritum sanctum <lb/> ab hac operatione , qua constituta
+					est creatura , cre­ <lb/> dere non deberenmus exclusum; sicut Filius non <lb/>
+					excluditur ab ea scientia de qua dictum est, <hi rend="italic">Quce <lb/> Dei
+						sunt, tiemo scit,</hi> nisi Spiritus <hi rend="italic">Dei</hi> (I <hi
+						rend="italic">Cor.</hi> II, 11). <lb/> Si autem quia non est nominatus ,
+					quod etiam per <lb/> ilium facta sit creatura, quando de Filio dictum <lb/> est
+					, <hi rend="italic">Omnia per</hi> ipsum <hi rend="italic">facta</hi> sunt ;
+					idco putas Dei <lb/> Spiritum non esse creatorem : procnl dubio , lice <lb/> in
+					ejus nomine poteris baptizatos dicere , quibus <lb/> ait Petrus, <hi
+						rend="italic">Agite pœnitentiam, et baptizetur unus­ <lb/> quisque
+						vestrum</hi> in <hi rend="italic">nomine Domini Jesu Christi ( Act.</hi>
+					<lb/> II , 38) ; qnia non ait, Et S. iritus sancti : nee in <lb/> Patris nomine,
+					quia nec ipsc ibi et nominatus. <lb/> Si auteur etiam non nominatis Patre et
+					Spiritu <lb/> sancto , in nomine Jesu Christi jussi sun ba­ <lb/> plizari ; et
+					tamen intelliguntur non baptizati nisi in <lb/> nomine Patris et Filii et
+					Spiritus sanct! : cur non sic <lb/> audis de Filio Dei, Omnia pur <hi
+						rend="italic">ipsum facta sunt;</hi> ut <lb/> et non nominatum intellig
+						<unclear>as</unclear> ibi ctiam Spiritum san­ <lb/> cium?</p>
+				<p>2. NaiD quid excellentius in creaturis quam virtu­ <lb/> tes cœlorum? Scriptum
+					est autem : <hi rend="italic">Verbo DOli,;,. i <lb/> cœli firmati sunt; et</hi>
+					Spiritu <hi rend="italic">oris ejus, omnis virtus eo­ <lb/> rum (Psal.</hi>
+					XXXII, 6). Dixeras nempe non me talia re­ <lb/> perire in Scripturis divinis,
+					quibus Spiritum sanctum <lb/> aequalem asseram Filio. Ecce reperi ubi etiam
+					major <lb/> possit videri, nisi revocet pietas. quae illum veraciter <lb/>
+					confitetur aequalem. Nam utique majus aliquid sunt <lb/> virtutes cœlorum, quae
+					firmatae sunt Spiritu oris Do­ <lb/> mini, id est Spiritu sancto, quam cœli, qui
+					firmati <lb/> sunt Verto Domini, hoc est, unigentio Filio. Sed si <lb/> consulas
+					veritatem , res utraque ab utroque firmata <lb/> est; ct id quod de uno dicitur
+					et de altero tacetur, de <lb/> utroque intelligitur. Quid est autem
+					inconsideratius, <lb/> quam negare esse creatorem Spiritum Dei, cum Do­ <lb/>
+					mino dicatur : <hi rend="italic">Auferes spiritum eorum, et deficient, et</hi>
+					<lb/> in <hi rend="italic">pulverem</hi> suum convertentur : <hi rend="italic"
+						>emittes</hi> I <hi rend="italic">Spiritum</hi>
+					<lb/> tuum, et <hi rend="italic">creabuntur; et innovabis faciem</hi> terrae <hi
+						rend="italic">(Psal.</hi>
+					<lb/> CIII, 29, 30) Nisi forte minus idoneus erat Spiritus <lb/> sanctus
+					creandis rebus quae fuerant defecturae, cum <lb/> sit idoneus creandis quae sunt
+					sine line mansurae. <lb/> Paulo ante dixi : Quid est excellentius in creaturis
+					<lb/> quam virtutes cœłorum? Quid dicam de carne Crea­ <note type="footnote"> *
+						Pd'U, <hi rend="italic">emitte.</hi> At Mss , <hi rend="italic"
+							>cmitl:s.</hi> F.L sic Aiigustiinis, Enarr. <lb/> ill ontodeui psalmum
+						105. </note>
+					<lb/> toris ? Quandoquidem Creator ipse per quem facia <lb/> sunt omnia, <hi
+						rend="italic">Panis,</hi> inquit, <hi rend="italic">quem ego dedero, caro
+						mea<lb/> est pro mundi vita (Joan.</hi> vi, 52). Quid ergo? Mundus <lb/> per
+					Filium factus est, et creator est Filius : caro cjus <lb/> quae data est pro
+					mundi viia , per Spiritum sanc tum <lb/> facia est, et non cst creator Spiritus
+					sanctus? Cum <lb/> enim virgo Maria dixisset angelo promittenti Ci filium, <lb/>
+					<hi rend="italic">Quomodo fiet istud, quoniam virum non</hi> cognosco ? re­
+					<lb/> spondit angelus, <hi rend="italic">Spiritus sanctus superveniet</hi> in te
+					, <hi rend="italic">et <lb/> virtus Altissimi obumbrabit tibi; propterea quod
+						nasce­<lb/> tur ex te sanctum, vocabitur Filius Dei (Luc.</hi> I, 34, 35).
+					<lb/> Hic tu, quod in consequentibus quodam loco tuae prose­ <lb/> cutionis
+					adverti, asserere conaharis Spiritum sanctum <lb/> pra'cessisse, ut mundaret et
+					sanctificaret virginem <lb/> Mariam; ac deinde veniret Virtus Altissimi, hoc est
+					<lb/> Sapientia Uci, quod est Christus (I <hi rend="italic">Cor.</hi> i, 24); ei
+					<lb/> ipsa , sicut scriptum est, aedificaret sibi domun <lb/>
+					<hi rend="italic">(Prov.</hi> IX, i), hoc est, ipsa sihi crearcl carnem, non
+					<lb/> Spiritus sanctus. Quid est ergo quod ait sa nctum Evan­ <lb/> gellum, <hi
+						rend="italic">Inventa eat</hi> in <hi rend="italic">utero habens de Spiritu
+						sancto<lb/> (Matth.</hi> I, 18) ? Nempe obstructum cst os loquentium <lb/>
+					iniqua ( <hi rend="italic">PsaL</hi> LXII, 12 ). Si ergo cogitas os veraciter
+					<lb/> aperire, n on solum Filium , verum etiam Spiritum <lb/> sanctum creatorem
+					carnis Filii confitere.</p>
+				<p>3. An f orte dicturus es, ea facta esse per Spiritum <lb/> sanctum quae
+					commemoravi, id est, quod omnis virtus <lb/> coelorum per eum firmata sit, quod
+					per cum creaban­ <lb/> tur homines denuo, qni primo ita creantur ut conver­
+					<lb/> tantur in pulverem suum ; quod ipse carnem opera­ <lb/> tus est Christi
+					(nam de anima nolo aliquid dicere , <lb/> cujus difficillima quaestio est); et
+					si quid aliud per <lb/> Spiritum sanctum creatum potuerit inveniri: non ta­
+					<lb/> men omnii, sicut per unigcnitum Filium , de quo <lb/> dictum est, Omnia
+					per <hi rend="italic">ipsum facta</hi> sunt? Si hoc dicis, <lb/> non limes ne
+					tibi dicatur, eo potiorem esse Spiritum <lb/> sanctum Filio, quod elegit sibi
+					meliora qua; faceret, <lb/> nec facere inferiora dig<unclear>natus</unclear>
+					est? Sed quis hoc sapit, <lb/> nisi qui desipit? Facta sunt ergo cuncta per
+					Filium ; <lb/> absit, nt Spiritu sancto ab hoc opere separato : sicut <lb/> de
+					illis magnis operibus dictum est, <hi rend="italic">Omnia autem haec<lb/>
+						operatur unus atque</hi> idem <hi rend="italic">Spiritus</hi> (1 <hi
+						rend="italic">Cor.</hi> XII, i 1); nec <lb/> tamen ab hac operatione Filius
+					separatur.</p>
+				<p>4. Magnum sane aliquid tibi dicere videris, quia di­ <lb/> cis : Filius <hi
+						rend="italic">erat</hi> in <hi rend="italic">principio antequam aliquid
+						esset; <lb/> Pater vero, ante principium</hi> Ubi legisti, ut iirc cre
+					<lb/>dcres? Unde praesumpsisti ut haec diceres , ubi nec <lb/> auctoritas ulla,
+					nec ratio est ? Quid est enim ante <lb/> principium , quandoquidem quidquid ante
+					esset, hoc <lb/> esset principium ? Si ergo Pater antc 1 principtum <lb/> est,
+					ante seipsum est; quia et ipse principium est. <lb/> Quid est autem, <hi
+						rend="italic">In</hi> principio erat <hi rend="italic">Verbum (Joan.</hi> I,
+					i); <lb/> nisi, In Patre crat Filius ? Et ipse Filius interrogatus <lb/> a
+					,ludaris quis esset, respondit : <hi rend="italic">Principium, quia et<lb/>
+						loquor vobis (Id.</hi> VIII, 25). Pater crgo principium non <lb/> de
+					principio; Filius principiu.n de principio : scd <lb/> utrumque simul, non duo ,
+					sed unum principium ; <lb/> sicut Pater Deus et Filius Deus, ambo autem siut
+					<lb/> non dun dii, sed unus Deus. Nee Spiritum sanctum <note type="footnote">1
+						Hie ajud l.ov. omissum est, <unclear>esse</unclear>. </note>
+					<lb/>
+					<pb n="785"/> ab utroque procedentem negabo esse principium : <lb/> sed haec
+					tria simul sicut unum Deum, ita unum dico <lb/> esse principium.</p>
+				<p>CAPUT XVIII — i. Quid, si <hi rend="italic">audierit,</hi> inquis, Pa­ <lb/> trem
+						<hi rend="italic">dicentem,</hi> « <hi rend="italic">Tecum</hi> principium
+					in <hi rend="italic">die</hi> virtuti, <hi rend="italic">tum, <lb/> in
+						splendoribus tanctorum, ex utero ante luciferum</hi> ge­ <lb/> nui <hi
+						rend="italic">te &gt; (Psal.</hi> CIX, 3) Quid promittis. vel quid mi­ <lb/>
+					naris , si audiero quod frequenter audio, et fideliter <lb/> credo? Sed hinc te
+					nihil adjuvari , cur non videas, <lb/> plurimum miror. Sive enim ex persona sua
+					hoc pro­ <lb/> pheta dicat ad Dominum Jesum , sive ex persona Pa­ <lb/> tris ad
+					Filium, cum ego ambas generationes Christi, <lb/> et ex Den Patrc sine tempore,
+					et ex homine matre in <lb/> plenitudine temporis accipiam, vencrer, praedicem,
+					<lb/> non est hoc testimonium adversum me. Sed moras <lb/> innectere voluisse
+					indicat te, ubi ego potius intelligo, <lb/> quare <hi rend="italic">ex
+						utero</hi> dixerit <hi rend="italic">genui te :</hi> quia huc et tu ex per
+					<lb/>sona Patris accipis dictum. Non enim quemadmodum <lb/> corporis humani
+					sunt membra disposita , sic habet <lb/> uterum Dens ; sed verbum translatum est
+					a corporali <lb/> ad incorporalem substantiam , ut intelligeremus de <lb/>
+					Patris substantia genitum unigenitum Filium ; ac per <lb/> hoc quid aliud quam
+					unius ejusdemque substantiae ? <lb/> Ego itaque hoc testimonium proferre contra
+					te debui : <lb/> sed gratias ago quia commonuisti. Considera ergo <lb/> quantum
+					mali sit, quod ejusdem subustantiae Filiam <lb/> negatis, quem genitum
+					confitemini ex utero Patris, <lb/> injuriam gravissimam facientes Deo , tanquam
+					illud <lb/> quod ipse non esset,, ex utero gignere potuisset. Non­ <lb/> ne
+					sentitis vos generationem Dei credere vitiosam , <lb/> praedicare monstruosam,
+					qui dicere audctis ex utero. <lb/> Dei processisse diversam naturam? Si antem
+					hoc, sic­ <lb/> ut debclis, horretis, respuilaque nobiscum, jam tnn­ <lb/> dem
+					concilium Nicaenum et Homousion laudate ac <lb/> tenete nobiscum.</p>
+				<p>2. Quis autem nou videat defectum tuum, ubi cum. <lb/> andisses, me
+					commemorante,1 in prophetia dixisse <lb/> Christum suo Patri, De <hi
+						rend="italic">ventre</hi> matris meae <hi rend="italic">Deus</hi> meus <lb/>
+					<hi rend="italic">es tu (Psal</hi> xxi, ii ); ut intelligeremus ejus na­ <lb/>
+					turae ilium esse Deum quam Filius ipsius ex tempore <lb/> de ventre matris
+					accepit, Patrem vero naturae illius <lb/> quam do se ipse generavit: tu non
+					inveniens quid re­ <lb/> sponderes, tamen ne laceres dixisti, <hi rend="italic"
+						>Ex ventre</hi> matris <lb/> natum profiteri. Christum secundum <hi
+						rend="italic">carnem;</hi> et addi­ <lb/> disti, <hi rend="italic">quod
+						nec</hi> Judaei <hi rend="italic">diffidunt.</hi> Ac deinde quaesisti, <lb/>
+					<hi rend="italic">Car</hi> ista <hi rend="italic">testimonia in medium</hi> noR
+						<hi rend="italic">proferantur, quae <lb/> illam</hi> nativitatem <hi
+						rend="italic">demonstrant in</hi> principio, sicut <hi rend="italic">et
+						prae­ <lb/> cedent</hi> noa, inquis, instruit testimonium ? Quasi ego <lb/>
+					illam nativitatem Christi, non temporalem, sad aeter­ <lb/> nam, propter quam
+					dictum est, <hi rend="italic">In principio erat Ver­<lb/> bum,</hi> non credam,
+					non praedicem, non amplectar; <lb/> sed tantum ex ventre matris natum asseram
+					Chri­ <lb/> stum? Ecce ego dico Deum Filium de Deo Patre sine <lb/> tempore
+					genitum. Quomodo sit autem etiam Deus <lb/> ejus qui Pater est ejus, ostendi,
+					propter hominem <lb/> quem suscepit, et in quo natus cst de ventre matris, <lb/>
+					sinc concubitu hominis patris. Ad quod probandum <lb/> testimonium dedi, ubi ait
+					in prophetia Patri sun, <hi rend="italic">De <lb/> ventre matris meae Deut
+						meus</hi> es <hi rend="italic">tu.</hi> Tu qui dicis me es <lb/> ventre
+					matris natum profiteri Christum , quod nee Ju­ <lb/> daei diffidunt, quasi ego
+					istam nativitatem Christi In. <lb/> lam profitear; Meli per inania conari
+					evadere , et dic <lb/> potius quare mihi non responderi, ubi dicit Christus
+					<lb/> Patri, <hi rend="italic">De ventre matris meae Deut</hi> meut es <hi
+						rend="italic">tu.</hi> Ad hoc <lb/> enim quoniam vidisti non te habere quod
+					diceres, <lb/> aliam nativitatem quae Dei de Deo. est, interponem <lb/> dam
+					putasti qua fugeres. Rogo te; quando quid rc­ <lb/> spondeas non habes, quanto
+					melius taceres?</p>
+				<p>3. Si propter <hi rend="italic">corpus,</hi> inquis, in <hi rend="italic">quo
+						se</hi> exinanivit, <lb/>
+					<hi rend="italic">debitorem</hi> te <hi rend="italic">sentit</hi> suo <hi
+						rend="italic">genitori;</hi> multo magis qui illum <lb/>
+					<hi rend="italic">tantum ac talem genuit, necesse est</hi> x! eam <hi
+						rend="italic">veneretur,<lb/> eique</hi> offerat <hi rend="italic"
+						>semper</hi> obsequium. Quodlibet de venera­ <lb/> tione et obsequio Filii
+					erga Patrem carnaliter sentias, <lb/> Puer ejus, nisi de ventre matris ejus, non
+					est Deus <lb/> ejus. Jam quantumvis obsequatur Deo Patri Deus <lb/> Filius,
+					quoniam ,-ideo te non intelligere quanta sil in <lb/> illa generatione geniti et
+					genitoris aequalitas, num­ <lb/> quid ideo est diversa natura patris hominis et
+					hominis <lb/> filii, quoniam filius obsequitur patri? Hoc est omnino <lb/>
+					intolerabile in vobis, qnia de obsequio Filii diversam <lb/> vultis probare
+					substantiam Patris et Filii. Prorsus <lb/> alia quaestio cst, Utruin sint unias
+					ejusdemque sub­ <lb/> stantiae Pater et Filius; et alia quacstio est, Utrum
+					<lb/> Patri Filius obsequatur. Interim verum Filium non <lb/> negemus, qui nullo
+					modo est verus Filius, si non est <lb/> ipsius et Patris ana eademque natura.
+					Dicite ergo <lb/> Deum Patrem; et Deum Filiium unius ejusdemque <lb/> esse
+					substantia!. Extorqueat vobis divinitas, quod <lb/> humanitati donavit ipsa
+					divinitas. Obsequitur homo <lb/> patri suo, de quo natus est homo; tamen
+					obsequendo <lb/> esse non desinit homo. Ei si, non dico pariter hono­ <lb/>
+					ratus, sed honoratior esset ftlius, gauderet pater, non <lb/> invideret:
+					honoraret tamen etiam ille patrem, etsi <lb/> non parvulus, accessu augendus
+					aLlatis, sed ei natus <lb/> esset aequalis. aequalem vero si pater homo potuis­
+					<lb/> set , nullo dubitante genuisset. Quis ergo audeat di­ <lb/> cere, Hoc nec
+					Omnipotens potuit? Addo cHam, quia <lb/> si posset homo, majorem se ipso
+					melioremque <lb/> gigneret filium : sed majus vel melius Deo quidquam <lb/> non
+					potest esse; ergo ei verum Filium credamus <lb/> aequalem. Quod si dixeris, Eo
+					ipso major est Pater <lb/> Filio, quia de nullo genitus, genuit tamen aequaletn:
+					<lb/> cito respondebo, Imo ideo non est major Pater Filio, <lb/> quia aequalem
+					genuit, non minorem. Originis enim <lb/> quaestio est, Quis de quo sit :.
+					aequalitatis autem, <lb/> Qualis aut quantus sit. Proinde si admittit ratio veri<lb/>tatis ut aequali Patri Filius obsequatur aequalis, non <lb/> negnmus
+					obsequium : si autem per obsequium mino­ <lb/> rem natura1 vultis credere,
+					prohibemus: nullo modo <lb/> enim Deus Pater ut babcre unici Filii posset obse­
+					<lb/> quium, vellet denegare naturam.</p>
+				<p>4. Par entibus autom ut esset subditus Christus , <lb/> non dvinae majestatis
+					fuit, sed aetatis humanae Fru­ <lb/> stra itaque dixisti : <hi rend="italic">Si
+						parentibus fuit subditus quot<lb/> creavit</hi> ( <hi rend="italic"
+						>Luc.</hi> II, 51 ), <hi rend="italic">quanto magis suo genitori qui <lb/>
+						eum tantum ac talem genuit?</hi> Respondetur enim lihi ; <note
+						type="footnote"> I AIR. ct Er., <hi rend="italic">minorem natum</hi> plures
+						Mss., <hi rend="italic">nnnorem</hi> fM' <lb/> turam. </note>
+					<lb/>
+					<pb n="787"/> Si parentibus fuit subditus propter pueritiam, quanto <lb/> magis
+					Den propter ipsam hominis formam? Quam <lb/> formam eum immortalem fecerit, non
+					morti perdide­ <lb/> rit; quid miraris si etiam post hujus saeculi finem sub­
+					<lb/> jectus erit in ea illi, qui ei subjecit omnia ? Tu autem <lb/> non propter
+					formam servi dicis Filium Patri esse sub­ <lb/> jectum , sed quia cum tantum ac
+					talem genuit. id est <lb/> magnum Deum, quanvis Patre ipso minorem : ubi ct
+					<lb/> Patri dcrogas, qui Filium sibi unicum, aut non potuit, <lb/> aut noluit
+					gignere aequalem; ut ipsi Filio qni unicus <lb/> Patri non est generatus
+					aequalis. et idco perfectus est <lb/> natus, ne unquam vel crescendo fieret,
+					quod non po­ <lb/> tuit esse nascendo.</p>
+				<p>5. Non autem, ut putas, corpus tantum Filii, id est, <lb/> corpus hominis, verum
+					etiam buinanum spiritum Pa­ <lb/> tri dicimus esse subjectum : et secundum id
+					quod <lb/> botro factus est intelligimus dictum. <hi rend="italic">Cnm antem
+						omnia<lb/> tlli</hi> subjecta fuerint <hi rend="italic">tunc et ipse Filius
+						subjectus erit illi</hi>
+					<lb/> qui a subjecit <hi rend="italic">omnia</hi> (1 <hi rend="italic">Cor.</hi>
+					xv, 28). Secundum id quod <lb/> Christus est caput ct corpus: caput scilicet
+					ipse Sal­ <lb/> vator qui surrexit a mortuis, et scdel ad dexteram Pa­ <lb/>
+					tris; et Ecclesia quae est corpus ejus, plenitudo ejns, <lb/> sicut apertissime
+					dicit Apostolus <hi rend="italic">(Coloss.</hi> I, 18). Ac <lb/> per boc cum
+					omuia Christo subjecta fuerint, et capiti <lb/> et corpori erunt sinc
+					dubitatione subjecta. Nam secun­ <lb/> dum id quod sine tempore Deus natus est,
+					nihil un­ <lb/> qnam potuit ei non esse subjectum.</p>
+				<p>6. Scimus, quod nos commemoraridos putasti, <hi rend="italic">quia <lb/>
+						Pater</hi> non <hi rend="italic">judicat quemquam, sed omne judicium
+						dedit</hi>
+					<lb/> Filio <hi rend="italic">(Joan.</hi> v, 22). Vellem tamen diceres nobis,
+					quo­ <lb/> modo Pater non judicat quemquam , cum dicat ipse <lb/> identidem
+					Filius, <hi rend="italic">Ego non quaero</hi> gloriam <hi rend="italic">meam;
+						est</hi>
+					<lb/> qui <hi rend="italic">quaerat, et judicet (Id.</hi> VIII, 50) : ut srias
+					idco di­ <lb/> ctum, <hi rend="italic">Pater non judicat</hi> quemquam, <hi
+						rend="italic">sed omne judicium <lb/> dedit Filio;</hi> quoniam judicandis
+					vivis et marnis for­ <lb/> ma hominis apparebit, quam non hahct Pater: pro­
+					<lb/> pter quod ait propheta, <hi rend="italic">Videbunt in quent
+						pupugerunt<lb/> (Zach.</hi> XII, 10). Sed invisibiliter etiam Pater erit cum
+					<lb/> eo, quia inseparabilis est ab eo. Si enim, <hi rend="italic">Non</hi> sum <lb/>
+					<hi rend="italic">solus, quoniam Pater</hi> mecum est, ait ipse moriturus <lb/>
+					<hi rend="italic">(Joan.</hi> XVI, 52); quanto magis secum habebit Patrem, <lb/>
+					de mortuis et vivis judicaturus? Cum illo crit etiam <lb/> Spiritus sanctus.
+					Quomodo enim deseret eum Spiritus <lb/> sanctus in rcgali sede, quo plenas
+					regressu! est a Jor­ <lb/> dane <hi rend="italic">(Luc.</hi> IV, 1)! Quod itaque
+					scriptum est ad lie.. <lb/> braeos, <hi rend="italic">Nunc autem necdum videmus
+						omnia subjecta ei :</hi>
+					<lb/> cum <hi rend="italic">autem modico minus ab Angelis minoratum videmus
+						<lb/> Jesum propter passionem mortis (Hebr.</hi> II, 8, 9): do­ <lb/> cere
+					nos debet quomodo intelligendum sit quod scri­ <lb/> ptum est ad Corinthios, Cum
+						<hi rend="italic">autem omnia illi subjecta</hi>
+					<lb/> fuerint: quia secundum id dictum est quod factus est <lb/> homo, non
+					secundum id quod est Deus. Sic ergo in <lb/> homine apparens, in quo per
+					passionem mortis mino­ <lb/> ratus est modico minus ab Angelis, vivos et
+					mortuos. <lb/> judicabit, quando dicturus est : <hi rend="italic">Venite,
+						benedicti Pa­</hi>
+					<lb/> tris <hi rend="italic">mei percipite regnum</hi> ( <hi rend="italic"
+						>Matth.</hi> xxv, 34 ). Quo tu <lb/> testimonio non hominem, sed Deum
+					minorem suo <lb/> Patre quasi probare voluisti : sed sicut ab eit qui in­ <lb/>
+					telligunt perspicitur, nun probasti.</p>
+				<p>CAPUT XIX. — De Spiritus sancti autem gemiii­ <lb/> bus, quia non ipse gemit, sed
+					inspirans nobis deside­ <lb/> rium sanctum nos facit gemere quamdiu peregrina­
+					<lb/> mur a Domino, jam tibi sunicienter respondisse me <lb/> existimo. £t tales
+					de Scripturis sanctis locutiones, <lb/> quantum satis videbatur ostendi, quoniam
+					sic dicitur <lb/> gemere Spiritus sanctus, quia nos facit gemere ; sicut <lb/>
+					dixit Deus, <hi rend="italic">Nunc cognovi (Gen.</hi> XXII, 12), quando co­
+					<lb/> gnoscere hominem fecit. Non eqim tunc cognoverat <lb/> quod tunc se
+					dixerat cognovisse, qni omnia scit an­ <lb/> tequam fiant. Ad quod te respondere
+					non potuisse, <lb/> quid predest quia scutis, quando non consentis ?</p>
+				<p>CAPUT XX. — i. Jam eliam de verbis Domini <lb/> ubi ait, <hi rend="italic"
+						>Ego</hi> et <hi rend="italic">Pater</hi> unum sumus <hi rend="italic"
+						>(Joan.</hi> x, 30); nihil <lb/> te respondere potuisse monstravi. Sed ut
+					hic quoquo <lb/> ostendam, si exemplis, ut dicis, quibus ego usus sum, <lb/> vis
+					probare quomodo dictum sit, <hi rend="italic">Ego et Puter</hi> unum <lb/>
+					<hi rend="italic">sumus;</hi> ct ob hoc commemoras apostolicum testimo­ <lb/>
+					nium. quod a me p'situm est, ubi ait <hi rend="italic">Qui adhaeret <lb/>
+						Domino, unus spiritus est</hi> ( I <hi rend="italic">Cor.</hi> VI 17): dic
+					ct tu, <lb/> Cum adhaeeret Patri Filius, unus Deus e t. Nou enim <lb/> ait
+					Apostolus, <hi rend="italic">Qui adhaeret Domino,</hi> unum sunt; sicut <lb/>
+					dictum est, <hi rend="italic">Ego et Pater unum sumus:</hi> sed ait, unus <lb/>
+					<hi rend="italic">spiritus edt.</hi> Cum autem tu non dicas, Cum adhaere t <lb/>
+					Patri Filius, unus Deus est ; utquid et tu adhibes hoc <lb/> Apostoli
+					testimonium, ubi ait, <hi rend="italic">Qui adhaeret Domino, <lb/> unus spiritus
+						est ;</hi> nisi ut te etiam a te producto teSte <lb/> convincam? Nunc saltem
+					distingue duo bta, quae non <lb/> potuisti, cum simul essemus, in nostra
+					disputatione <lb/> distinguere. Diligenter itaque attende quod dico. <lb/>
+					Quando de rcbus duabus nul plurimus dicitur, Unus <lb/> est, vel, una est, et
+					additur quid unus vel quid una; <lb/> ct de his quae diversae, et de his quae
+					sunt unius sub­ <lb/> stantiae dici potest. Diversae sunt enim substantiae spi.
+					<lb/> ritus hominis et Spiritus Domini 1 :et tamen dictum <lb/> est, Qui <hi
+						rend="italic">adhaeret Domino unus spiritus tat.</hi> Unius au­ <lb/> tem
+					substauti;e sunt animae hominum ct corda homi­ <lb/> num; de quibus dictum est,
+						<hi rend="italic">Erat Ulis anima</hi> una <hi rend="italic">et<lb/>
+						cor</hi> unum <hi rend="italic">(Act.</hi> IV, 52). Ubi autem dicitur de
+					duobus <lb/> aut pluribus, Unum sunt, nec additur quid unum sint; <lb/> non
+					diversae intelliguntur, sed unius esse substantiae: <lb/> sicut dictum est, <hi
+						rend="italic">Qui plantat et qui rigut,</hi> unum 'unt <lb/> (I <hi
+						rend="italic">Cor.</hi> III, 8); et, <hi rend="italic">Ego et Pater</hi>
+					unum <hi rend="italic">sumus.</hi> Tu au­ <lb/> tem qni Patrem cl Filium
+					diversas vis rsse substan­ <lb/> tias, invenire non potuisti, ubi de diversis
+					substantiis <lb/> dic tum fuerit, Unum sunt. Et qui non vis dicere, Cum <lb/>
+					Filius adhaeret Patri, unus Deus est; adhibuisti et tu, <lb/> apostolicum
+					testimonium quod ego adhibueram; sed <lb/> adhibuisti contra te ipsum, uhi ait,
+						<hi rend="italic">Qui adhaeret</hi> Do<lb/>Mnino, <hi rend="italic">unus
+						spiritus est.</hi> Si enim de his qui diversae <lb/> substantiae sunt, recte
+					dici potuit, <hi rend="italic">unus spiritus</hi> est; <lb/> quantQ magis de bis
+					qui unius substantiae sunt recte <lb/> dicitur, Unus Deus est? Si haec
+					intelligis, non te ad <lb/> ea respondisse jam perspicis, et de consensu
+					volunta­ <lb/> tis tc inaniter tam multa dixisse cognoscis. Etiam <lb/> nos
+					quippe incompambilem consensum voluntatis at­ <lb/> que individuae charitatis
+					Patris et Filii et Spiritus san­ <lb/> fti confitemur, propter quod dirinms ,
+					Haec Trinitas <note type="footnote">1 Antiquiores Mss.t <hi rend="italic">et
+							Spiritus nomimis.</hi>
+					</note>
+					<pb n="789"/>
+					<unclear/><lb/> unus est Deus. Sed nos boc etiam, quod vos non di­ <lb/> citis,
+					dicimus, propter unam eamdemque naturam at­ <lb/> que substantiam, Hi tres unum
+					sunt. Haec si discre­ <lb/> veris, et contentiosus esse nolueris, non te ad ea
+					re­ <lb/> spondisse aliquid jam videbis, et de hac quaestione <lb/> procul dubio
+					jam tacebis.</p>
+				<p>2, Ubi autem dixil Eilius Patri, <hi rend="italic">Verum non quod</hi>
+					<lb/> ego <hi rend="italic">volo, sed quod. tu vis;</hi> quid te adjuvat quod
+					tua <lb/> verba subjungis ctdicis, <hi rend="italic">Ostendit vere voluntatem
+						suam <lb/> subjectam</hi> suo genitori : quasi nos. negemus, hominis <lb/>
+					voluntatem voluntati Dei debere esse subjectam? Nam <lb/> ex natura hominis hoc
+					dixisse Dominum cito vidct ,. <lb/> qui locum ipsum sancti Evangelii pauLo
+					attentius in­ <lb/> tuetur. Ibi enim dixit: <hi rend="italic">Tristis est anima
+						mea usque ad</hi>
+					<lb/> martem ( <hi rend="italic">Matth.</hi> XXVI, 39, 38 ). Numquid ex natura
+					<lb/> unici Verbi posset hoc dici? Sed homo qui putas ger <lb/> mere naturam
+					Spiritus sancti, cur non etiam naturam <lb/> Verbi Dei unigeniti tristem dicas
+					esse potuissc?- Ille <lb/> tamen, ne quid diceretur tale, non ait, Tristis sum ;
+					<lb/> quamvis etiamsi line dixisset, non nisi ex natum ho­ <lb/> minis
+					oportuisset intelligi : sed ait, Tristis <hi rend="italic">est</hi> anima <lb/>
+					<hi rend="italic">mea ;</hi> quam sicut homo utique habebat humanam. <lb/>
+					Quamquam ct in hoc quod ait, <hi rend="italic">Non quod ego volo ;</hi>
+					<lb/> aliud se ostendit voluisse quam Pater : qnod nisi hu­ <lb/> mano corde non
+					potuisset, cum infirmitatem nostram <lb/> in suum, non divinum , sed humanum
+					transfiguraret <lb/> affectum. Homine quippe non assumpto, nullo modo <lb/>
+					Patri diceret unicum Veibum, <hi rend="italic">Non quod ego volo.</hi>
+					<lb/> Nunquam enim posset immutabilis illa natura quid­ <lb/> quam
+						<unclear>aliud</unclear> velle quam Pater. Haec si distingueretis, <lb/>
+					Ariani haeretici non essetis.</p>
+				<p>3. Nam et illud quod dictum est, Descendi <hi rend="italic">de cœ­<lb/> to, non
+						ut faciam volunlatem meam, sed voluntatem ejus</hi>
+					<lb/> qui <hi rend="italic">me misit (Joan.</hi> V!, 58) : potest quidem accipi
+					<lb/> etiam secundum id quod est unigenitum Verbum ; ut <lb/> ideo voluntatem
+					non suam dixerit esse, sed Patris , <lb/> quoniam de Patre est quidquid est
+					Filius; non est all­ <lb/> tem de Filio quidquid est Pater : secundum quod di­
+					<lb/> ctum est, <hi rend="italic">Mea doctrina non eat mea, sed ejus qui me</hi>
+					<lb/> mit <hi rend="italic">(Id.</hi> vn, 16); quoniam Patris doctrina ipse est
+					<lb/> qui Patris est Verbum, et utique non ost a se ipso, <lb/> sed a Patre. Et
+					rursus cum dicit, <hi rend="italic">Omnia quae</hi> habet <lb/>
+					<hi rend="italic">Pater,</hi> mea <hi rend="italic">sunt (Id.</hi> XVI, 15) ;
+					Patri se ostendit aequa­ <lb/> lem. Non absurdum est tamen , ut etiam hoc secun­
+					<lb/> dum id quod homo factus est, dixisse accipiatur : <hi rend="italic">Dc­
+						<lb/> scendi de caelo, non</hi> ut <hi rend="italic">faciam voluntatem meam,
+						sed vo­ <lb/> luntatem ejus qui me misit.</hi> Secundus enim Adam, qui <lb/>
+					tollit peccatum mundi, isto modo se discrevit a pri­ <lb/> mo Adam , per quem
+					peccatum intravit in mundum <lb/>
+					<hi rend="italic">(Rom.</hi> v, t2) : quia iste non fecit voluntatem suam, <lb/>
+					sed ejus a quo missus est; cum ille fecerit suam, non <lb/> ejus a quo creatus
+					est. Nee moveat quomodo Christus <lb/> secundum id quod homo- est, descenderit
+					de cœlo, <lb/> cum de matre quae in terra erat factus sit homo. Hoc <lb/> enim
+					propter unitatem personae dictum est, quoniam <lb/> una persona est Christus
+					Deus et homo. Propter quod <lb/> etiam : <hi rend="italic">Nemo,</hi> inquit,
+						<hi rend="italic">ascendit</hi> in <hi rend="italic">caelum,</hi> nisi <hi
+						rend="italic">qui de <lb/> cœlo descendit. Filius hominis, qui eat in caelo
+						(Joan.</hi>
+					<lb/> III, 13). Si ergo attendas distinctionem substantiarum, <lb/> Filius Dei
+					de coelo descendit, Filius hominis cruci­ <lb/> fixus est : si nnitatem
+					personae, et Filius hominis de­ <lb/> scendit de caelo, et Filius Dei est
+					crucifhus. Ipso <lb/> est enim Dominus gloriae, de quo ait Apostolus : <hi
+						rend="italic">Si<lb/> enim cognovissent,</hi> nunquam Dominum <hi
+						rend="italic">gloriae crucifixi<lb/> sent (I Cor.</hi> II, 8). Propter hanc
+					ergo unitatem perso­ <lb/> nae, non solum Filium hominis dixit descendisse de
+					<lb/> cœlo, sed esse dixit in coelo, cum loquerctur in terra. <lb/> Non ergo
+					voluntatem suam fecit, quia peccatum non <lb/> fecit: sed voluntatem fecit
+					illius qui eum misit. Tunc <lb/> enim facit homo voluntatem Dei, quando facit.
+					justi. <lb/> tiam qua: ex Deo est.</p>
+				<p>4. Nec sic arbitremur a Patre missum. esse Filium, <lb/> ut non sit missus ab
+					Spiritu sancto; cum vox ipsius <lb/> sit per prophetam, <hi rend="italic">Et
+						nunc</hi> Dominus misit <hi rend="italic">me, et Spi.</hi>
+					<lb/> ritus <hi rend="italic">ejus.</hi> Hoc enim Filium dixisse, indicant ea
+					quai <lb/> sunt dicta superius. Nam sic ad ista verba perventum <lb/> est : <hi
+						rend="italic">Audite me,</hi> inquit, <hi rend="italic">Jacob,</hi> et <hi
+						rend="italic">Israel quem ego to <lb/> cabo. Ego sum</hi> primus, <hi
+						rend="italic">et ego</hi> sum in <hi rend="italic">aeternum ; et</hi> ma
+					<lb/> nus <hi rend="italic">mea</hi> fundavit <hi rend="italic">terram, dextera
+						mea solidavit ccelum. <lb/> Yocabo illos, et astabunt simul ; convenient
+						etiam</hi> uni­ <lb/>
+					<hi rend="italic">versi, et audient. Quis illi. nuntiavit haec?</hi> Diligens te <lb/>
+					<hi rend="italic">feci voluntatem tuam</hi> super <hi rend="italic">Babylonia,
+						ut</hi> tollatur semen <lb/>
+					<hi rend="italic">Chaldaeorum. Ego locutus sum, ego</hi> vocavi; <hi
+						rend="italic">adduri<lb/> illum, et prosperam</hi> viam <hi rend="italic"
+						>ejus feci. Convenite ad me, ei<lb/> audite ista. Nec enim ab initio in
+						obscuro locutus sum : <lb/> cum <unclear>fiebant</unclear>, ibi eram; et
+						nunc Dominus misit</hi> me, et <lb/>
+					<hi rend="italic">Spiritus ejus (Isai.</hi> XLVIII, 12-16). Quid hoc apertius?
+					<lb/> Nee sic a Patre et Spiritu sancto missus est. ut se ipse <lb/> non miserit
+					: sicut a Patre ostenditur traditus, ubi <lb/> legitur, Qui <hi rend="italic"
+						>Filio proprio non pepercit, scd pro nobis<lb/> omnibus tradidit eum
+						(Rom.</hi> VIII, 32) ; alio autem loco de <lb/> ipso Filio dicitur, <hi
+						rend="italic">Qui me dilexit, et tradidit scipsum<lb/> pro me (Galat.</hi>
+					II. 20). Quomodo autem non facit va­ <lb/> luntatem suam, qui dixit, Sicut <hi
+						rend="italic">Pater</hi> suscitatmortuos <lb/>
+					<hi rend="italic">et vivificat, sic et Filius quos vult vivificat (Joan.</hi> V,
+					21); <lb/> et cum ei dictuin esset <hi rend="italic">Si vis, potes me
+						mundare;</hi>
+					<lb/> respondit, <hi rend="italic">Volo, mundare;</hi> et ad verbum continuo
+					<lb/> f. ctum est quod velle se dixit <hi rend="italic">(Matth.</hi> VIII, 2, 3)
+					? Sicci <lb/> autcm Filias facit voluntatem Patris, sic et Pater facit <lb/>
+					voluntatem Filii. Nam Filius dicit: <hi rend="italic">Pater, volo</hi> ut <hi
+						rend="italic">ubi <lb/> ego</hi> sum, <hi rend="italic">et isti sint mecum
+						(Joan.</hi> XVII, 24). Non dixit <lb/> Peto, vel, Rogo; sed, vo!o : ut isto
+					volente faceret <lb/> ille, sicut illo volente faciebat iste : et non alia ille,
+					<lb/> alia istc; sed quae ille, haec etiam iste. <hi rend="italic"
+						>Quaecumque<lb/> enim Pater facit, haec et</hi> Filiussimiliter facit <hi
+						rend="italic">(ld.</hi> v, 19). <lb/> Verba sunt ipsius, verba veritatis
+					suut, falsa esse non <lb/> possunt.</p>
+				<p>CAPUT XXJ. — 1. Suscipere tc dicis quod protuli, <lb/>
+					<hi rend="italic">Nescitis quia templum DA estis, et Spiritus Dei habitat</hi>
+					<lb/> in <hi rend="italic">vobis</hi> (I <hi rend="italic">Cor.</hi> III, 16) ?
+					Quod proposuisti 1 dicere idoo <lb/> dictum esse, quia <hi rend="italic">in
+						nemine habitat Deus, quem non<lb/> ante Spiritus sanctus sanctificaverit,
+						atque purgaverit;</hi>
+					<lb/> quasi templum Den habitaturo, non sibi, sanctificet et <lb/> purget
+					Spiritus sanctus : cum Apostolus hincostenderit <lb/> ipsum esse Deum, cujus nos
+					dixcrat templum : quia <lb/> non ait,. et Spiritus Dei sanctificat et purgat
+					vos, ut <lb/> Deus habitet in vobis, sed ait, <hi rend="italic">Spiritus
+						Dei</hi> habitat in <note type="footnote">* Sic aliquot Mss. At editi, <hi
+							rend="italic">qvod potuisti.</hi>
+					</note>
+					<lb/>
+					<pb n="791"/> tobia. Uliqne in templo suo Deus habitat : nam quid <lb/> est
+					templum Dei, nisi habitaculum Dei ? Vidisti autem <lb/> etiam tu consequenter
+					esse Deum nostrum cujus StI­ <lb/> mus templum : et noluisti aliud testimonium
+					comme­ <lb/> morare quod protuli, <hi rend="italic">Nescitis qnia corpus vestrum
+						<lb/> templum in vobis Spiritus sancti est, quem habetis</hi> n Deo? <lb/>
+					Jam ergo confitere Dcum esse Spiritum sanctum. <lb/> Neque enim, nisi esset
+					Deus, haberet templum, et <lb/> templum non manufactum, sed aedificatum
+					dememhris <lb/> Dei : <hi rend="italic">Christus</hi> enim <hi rend="italic"
+						>super omnia est Deus benedictus in</hi>
+					<lb/> saecula <hi rend="italic">(Rom.</hi> IX, 5), cujus membra sunt nostra cor­
+					<lb/> pora. Qui enim dixit, <hi rend="italic">Nescitis quia corpus vestrum <lb/>
+						templum</hi> in vobis <hi rend="italic">Spiritus sancti est?</hi> ipse
+					dixit, <hi rend="italic">Ne­ <lb/> scitis quia corpora vestra membra sunt
+						Christi (I</hi> Cor. VI, <lb/> 19, 15) ? Itane vero cui de lignis lapidibus
+					Salemon <lb/> aedificavit templum, Deus est, et cui templum
+						<unclear>aedilica­</unclear>
+					<lb/> tur de membris Christi, hoc est, de membris Dei, <lb/> D:iis uon est? cum
+					loquens de Deo beatissimus mar­ <lb/> tyr Stephanus dixerit : Salomon <hi
+						rend="italic">aedificavit ei</hi> domum ; <lb/>
+					<hi rend="italic">sed Summus non</hi> in <hi rend="italic">manufactis templis
+						inhabitat (Act.</hi> VII, <lb/> 47. 48). Et tamen Christi membra, quorum
+					caput eat <lb/> super omnes cœlos, templum sunt Spiritus sain ti, <lb/> quem
+					constat venisse de coelo. Istum negare Deum <lb/> quid est, nisi non esse et
+					nolle esae templum ejus? <lb/> Alloquitur nos Apostolus dicens : Obsecro autem
+						<hi rend="italic">vos.<unclear/><lb/> fiatres, per miserationes Dei, ut
+						exhibeatis corpora</hi> vestru <lb/>
+					<hi rend="italic">hostiam vivam,</hi> sanctam, Deo <hi rend="italic">placentem
+						(Rom.</hi> XII, 1). <lb/> Corpora itaque fidelium hostia sunt Deo, membra
+					<lb/> Christi, templum Spiritus sancti, et Deus non est <lb/> Spiritus sanctus!
+					Quis hoc dicit, nisi in quo non inha­ <lb/> hilal? Quoniam in quo habitat,
+					utique templum ejus <lb/> cst. Denique cum dixisset Apostolus : <hi
+						rend="italic">Nescitis quia <lb/> corpus</hi> vestrum templum <hi
+						rend="italic">in vobis Spiritus sancti est, <lb/> quem habetis a Deu, et non
+						estis</hi> vestri? <hi rend="italic">empti</hi> enim <lb/>
+					<hi rend="italic">estis pretio magno ;</hi> continuo secutus adjunxit, <hi
+						rend="italic">Clorifi­<lb/> cale</hi> ergo <hi rend="italic">Deum</hi> in
+						<hi rend="italic">corpore vestro</hi> (I <hi rend="italic">Cor.</hi> VI, 19,
+					20). <lb/> Ubi dilucido ostendit Deum esse Spiritum sanctum, <lb/> glorificandum
+					scilicet in corporc nostro, tanquam in <lb/> templo suo. Et qnod Ananiae, dixit
+					apostolus Petrus, <lb/> Ausus <hi rend="italic">es mentiri Spiritui sancto?</hi>
+					atque ostendens <lb/> Deum esse Spiritum sanctum, <hi rend="italic">Non es,</hi>
+					inquit, <hi rend="italic">homi­ <lb/> nibus mentitus, sed Deo (Act.</hi> v, 3,
+					4).</p>
+				<p>2. Miror autem cor vestrum, quantum sermone <lb/> explicare uon possum, quomodo
+					cum sic laudctis" <lb/> Spiritum sanctum, ut eum sanctificandis fidelibus <lb/>
+					ubique asseratis esse praesentem, tamen negare att­ <lb/> deatis Deum. Itane
+					Deus non est, qui replevit orb m <lb/> terrarum? Scriptura enim dicit: <hi
+						rend="italic">Spiritus</hi> Domini <hi rend="italic">re­</hi>
+					<lb/> plevit <hi rend="italic">orbem</hi> terrarum <hi rend="italic">(Sap.</hi>
+					I, 7). Sed quid dicamus <lb/> quod replevit orbem, qui replevit urbis etiam Re­
+					<lb/> demptorem ? Dominus enim <hi rend="italic">Jesus plenus Spiritu<lb/>
+						sancto regressus</hi> est <hi rend="italic">a Jordane (Luc.</hi> IV, 1) : et
+					praesu­ <lb/> mitis dicere, quia ipse Dominus Jesus Deus erat, et <lb/> SpiritUs
+					sanctus quo plenus erat, non erat Deus; tam <lb/> male sentientes de Spiritu
+					sancto, ul non ci tribuatis <lb/> saltum quod tributum est Moysi famulo Dci, qii
+					non <lb/> munera gratiarum, scd plagaruin prodigia in eodem <lb/> Spiritu
+					sancto, quia ipse est <hi rend="italic">digitus Dei(Exod.</hi> VIII, 19), <lb/>
+					aegyptiis ingerebat, et tamen Phar.toni deus erat. <lb/> Uno luco erat ad
+					affligendos aegyptios, et Pharaoni <lb/> deus erat ( Exod. VII, 1): ubique adest
+					Spiritus sanctus <lb/> ad homines in aeternam vitam regenerandos, et non <lb/>
+					est eis Deus! lino vero est, et Deus verus est, quia <lb/> vcri Dei membra
+					templum ejus est. Et uiiquc sub­ <lb/> jectum est templum illi cujus est templum
+					: qUomodo <lb/> ergo Deus non cst, cui sunt membra Dei subjecta' <lb/> Ac per
+					hoC et Dominus est templi sui : qnis enim hoc <lb/> neget, quis ila desipiat, ut
+					dicat non esse aliquem <lb/> dominum domus suae? Quomodo ergo Spiritus sanctus
+					<lb/> non est Dominus, qui Dominus est membrorum Do­ <lb/> mini ? Ipse cst
+					quippe Spiritus Domini, de quo uno <lb/> codemque loco dictum est : Cum <hi
+						rend="italic">autem</hi> conversus <lb/>
+					<hi rend="italic">fuerit ad Dominum, auferetur velamen. Dominus autem<lb/>
+						Spiritus est ;</hi> ubi <hi rend="italic">autem Spiritus Domini, ibi
+						libertas</hi>
+					<lb/> (II Cor. III, 16, 17).</p>
+				<p>3. Jam creatorcm superius demonstravi Spiritum <lb/> sanctum: quomodo autem rex
+					non est, cujus templum <lb/> est quae membra sunt regis? Quomodo non consedet
+					<lb/> Patri et Filio, qui replevit Filium, qui membra Filii <lb/> suam possidct
+					domum? Nisi forte quando Filius re­ <lb/> gressus est a Jordane, plenus erat
+					Spiritu sancto; et <lb/> quando sedere cœpit ad dexteram Patris, exclusit a so
+					<lb/> Spiritum sanctum? Deimle cum de Patre procedat, <lb/> quomodo cum Patre
+					non sedeat? Cuu ipsa sessio non <lb/> sit utique cogitanda carnaliter : alioquin
+					opinaturi <lb/> sumus honorabilius Filium sedere quam Patrem; ho­ <lb/>
+					norabilius quippe scdetur ad dexteram : cl videbitur <lb/> esse consequens ut
+					Pater sedeat ad sinistram. Postremo <lb/> qualis vobis persuaserit spiritus, ut
+					sancto Spiritui <lb/> denegctis quod sanctis hominibus sancta Scriptura <lb/>
+					concedit, vos videritis. Ait enim Apostolus : Cum <lb/>
+					<hi rend="italic">essemus mortui peccatis, convivificavit nos Christo,
+						cujus<lb/> gratia</hi> sumus salvi facti ; <hi rend="italic">et simul
+						excitavit, et simul se­<lb/> dere fecit</hi> in <hi rend="italic"
+						>caelestibus</hi> in <hi rend="italic">Christo Jesu (Ephes.</hi> II, 5, 6).
+					<lb/> Sancti ergo quos sanctificat Spiritus sanctus, convivi­ <lb/> ficati
+					Christo, ita simul sessuri praedestinati sunt, ut <lb/> jam factum dicat
+					Apostolus, quod certum est adfutu • <lb/> rum : et ipsi Spiritui sancto
+					subtrahitur a vobis quis­ <lb/> quis est ille consessus, taoquam sedere cum
+					Patre vel <lb/> Filio sit indignus, qui eadem sede efficit dignos. Cui <lb/>
+					movetis etiam quaestionem quod non adoretur, et hoc <lb/> utique simillimo
+					errore, cum legatis, ut jam supra <lb/> docui, a sanctis ctiam homines adoratos.
+					Et tamen ut <lb/> invidiam blaspbemantis evites; ita laudas Spiritum <lb/>
+					sanctum, ut tribuas ei quod non habet ulla creatura, <lb/> et detrahas ei quod
+					adipiscitur et humana creatura.</p>
+				<p>CAPUT XXII. — i. Dixisse me quod commemo­ <lb/> ras, fateor, et nunc dico , quod
+					Salvator noster non <lb/> dixerit, Ut ipsi et nos unum ; sed, <hi rend="italic"
+						>Ut ipsi sint unum</hi>
+					<lb/> Et de his evangelicis verbis satis a ure rccolo jani <lb/> fuisse
+					responsum, cum ostenderem refellere te ion <lb/> potuisse quae dixi. Quoniam
+					poposci ut proferres ubi <lb/> legeris. <hi rend="italic">Unum sunt,</hi> dictum
+					esse de alquibus rebus <lb/> quae non essent unius ejusdemque substantiae :
+						<unclear>neque</unclear>
+					<lb/> protulisti. Quid enim te adjuvat, quod dilectionis <lb/> consensione
+					affirmas dictum esse de Paulo et Apollo, <lb/>
+					<hi rend="italic">Qui plantat autem et qui rigat, unum sunt (I Cor.</hi> III,
+					8), <lb/> cum eos non ostendas diversae fuisse substantiae? <lb/>
+					<pb n="793"/> Ambo quippe homines crant. Si enim non diligerent <lb/> invicem,
+					natura unum essent. dileclione non essent : <lb/> si anilem unum natura uon
+					essent, unum dici dile­ <lb/> ctione non possent. Poscit ergo Filius ut ita sint
+					<lb/> unum,quomodo ipse ct Pater unum sunt; id est , <lb/> non solum natura,
+					quod jam erant ; verum eliain <lb/> perfectione charitatis atque justitiae, pro
+					suae capaci­ <lb/> late naturae, quantum in Dei regno esse potuerint: <lb/> ut
+					etiam ipsi summe unum sint in natura sua, quem­ <lb/> admodum Pater et Filius
+					summe unum sunt, quamvis <lb/> in excellentiore atque incomparabiliter meliore
+					na­ <lb/> tura sua. Dixit ergo ad Patrem Filius : <hi rend="italic">Pater
+						sancte, <lb/> serva eos</hi> in <hi rend="italic">nomine</hi> tuo, <hi
+						rend="italic">quos dedisti mihi ;</hi> ut <hi rend="italic">ant unum, <lb/>
+						sicut et nos.</hi> Non dixit, Ut sint unum nobiscum; <lb/> aut, Ut simus
+					unum ipsi et nos. Item pauk) post : <lb/>
+					<hi rend="italic">Non</hi> pro <hi rend="italic">Itis autem rogo tantum,</hi>
+					sed <hi rend="italic">et pro</hi> eia <hi rend="italic">qui cre.</hi>
+					<lb/> dituri <hi rend="italic">sunt</hi> per verbum ipsorum in <hi rend="italic"
+						>me;</hi> ut <hi rend="italic">omnes</hi> unum <hi rend="italic">sint,<lb/>
+						sicut</hi> tu <hi rend="italic">Pater in me, et ego</hi> in te, ut <hi
+						rend="italic">et</hi> ipsi in nobis unum <lb/>
+					<hi rend="italic">sint.</hi> Neque hic dixit, Ut ipsi et nos unum simus, sed, <lb/>
+					<hi rend="italic">unum sint in nobis.</hi> Quoniam homines qni natura unum <lb/>
+					suni, summe atque perfecte secundum suum modum <lb/> unum esse non possunt
+					justitiae plenitudine , nisi in <lb/> Deo perficiantur, ut unum sint in Patre et
+					Filio; id <lb/> est, in ipsis unum, non cum ipsis unum. Adhuc se­ <lb/> quitur,
+					et adjungit : <hi rend="italic">Ut mundus credat</hi> quia <hi rend="italic">tu
+						me mi- <lb/> sisti, et ego</hi> claritatem quam mihi <hi rend="italic"
+						>dedisti, dedi illis</hi> , ut <lb/> sint unum, sicut nos unum sumus: <hi
+						rend="italic">ego</hi> in <hi rend="italic">eis,</hi> et tu <hi
+						rend="italic">in</hi>
+					<lb/> me, <hi rend="italic">ut sint consummati</hi> in unum. Neque hie dixit, Ut
+					<lb/> nobiscum sint unum, ant, Ut ipsi et nos simus unum. <lb/> Deinde cum
+					addidisset, <hi rend="italic">Ut cognoscat mundus quia tu</hi>
+					<lb/> me <hi rend="italic">misisti, et</hi> dilexisti <hi rend="italic">eos</hi>
+					sicut <hi rend="italic">et</hi> me <hi rend="italic">dilexisti;</hi> seculus
+					<lb/> adjunxit, <hi rend="italic">Pater, volo</hi> ut <hi rend="italic">ubi
+						ego</hi> sum, <hi rend="italic">et</hi> ipsi <hi rend="italic">sint</hi> me­
+					<lb/> cum (Joan. XVII, 11-24).<hi rend="italic">Ubi</hi> sum,inquit, <hi
+						rend="italic">mecum</hi> sint : <lb/> non ait, Unum mecum sint 1. Hoc ergo
+					voluit, ut cum <lb/> illo essent, non ut illi et ipse unum essent. Quid est
+					<lb/> quod dicere voluisti 4 <hi rend="italic">Dilectionis fecit mentionem,</hi>
+					et <lb/> non substantiae ? Quamvis tu non eo loco ista Domini <lb/> verba
+					posueris, quo ab ipso sunt posita. Sed qnid <lb/> ad Hos ? quandoquidem non
+					ipsos et se, vel ipsos et <lb/> Patrem dixit aut voluit unam esse; sed ipsos
+					unum <lb/> esse voluit, quos noverat unius esse substantiae. Sic­ <lb/> ut <hi
+						rend="italic">ei nos</hi> , inquit unum sumus : quos identidem no­ <lb/>
+					verat unius essp substantia.</p>
+				<p>2. Tu si vis aliquid respondere, ostende secundum <lb/> Scripturam sanctam de
+					aliquibus rebus dici, Unum <lb/> sunt, quarum est diversa substantia. Hoc enim
+					Chri­ <lb/> stus non dixit, quod tamen tu ausus es dicere, id est, <lb/>
+					<hi rend="italic">Apostolos</hi> unum esse <hi rend="italic">cum Patre et</hi>
+					Filio , <hi rend="italic">in eo quod</hi> in <lb/> amnilus <hi rend="italic">ad
+						voluntatem</hi> Dei <hi rend="italic">Patris respicientes, ad</hi> imi­ <lb/>
+					<hi rend="italic">tationem Filii subditi uni Deo Patri et ipsi</hi> inveniun­ <lb/>
+					<hi rend="italic">tur</hi> (a). Haec dicens, Deum et homines sanctos unum <lb/>
+					esse fecisti. Potest ergo quisquam sanctorum dicere , <lb/> Ego et Dens unum
+					sumus? Absit hoc a cordibus et <lb/> oribus sanctis. Puto autem qnod et vos a
+					quocumque <lb/> hoc audiatis, horrescilis , nec fertis quemquam ho­ <lb/> minem,
+					quantolibet munere sanctitatis excellat, di­ <lb/> contem , Ego et Deus unum
+					sumus. Sed forte arro- <note type="footnote">4 I.ov. etquidain Mss. omitlunt,
+							<hi rend="italic">yon ait, vnum mecum sint</hi>
+					</note>
+					<note type="footnote"> !aj vide serm. i tO, n. ł, tom </note>
+					<lb/> gantiae videatur, si hoc de seipso aliquis dicat. Itane <lb/> vcro
+					quisquam vestrum etsi non audet dicere, Ego et <lb/> Deus unum sumus; saltem
+					audet dicere, Paulus et <lb/> Deus unum sunt; sicut incunctanter dicimus, Paulus
+					<lb/> et Apollo unum sunt; Deus Pater et Deus Filius <lb/> unum sunt? Porro, si
+					non audetis dicere , Quilihet <lb/> hono sanctus, quilibet propheta , quilibet
+					apostolus, <lb/> et Deus, unum sunt; quis te urgebal, quis te impin­ <lb/>
+					gebat, quis te praecipitabat 1, ut diceres, <hi rend="italic">Apostoli<lb/> unum
+						sunt cum Patre et Filio? Unum sunt,</hi> inquis, <lb/>
+					<hi rend="italic">Pater et Filius, non tamen</hi> unus : continuoque sub <lb/>
+					jungis, <hi rend="italic">Unum ad concordiam pertinet; Unus, ad</hi> nu­ <lb/>
+					<hi rend="italic">merum singularitatis.</hi> Volebas autem dicere , Unum <lb/>
+					sunt, ad concordiam pertinet; Unus est, ad numerum <lb/> singularitatis : sed te
+					a consideratione verborum tuo­ <lb/> rum impetus disputationis avertit. Nam et
+					Unum et <lb/> Unus utique ad numerum pertinet singularem. Scd <lb/> quod verum I
+					est; Unum sunt, propter id quod ad­ <lb/> dilum est, Sunt, pluralem indicat
+					numerum , qua­ <lb/> dam singularitate connexum : Unus est autem , aper­ <lb/>
+					tissime est numerus singularis. Sed numquid Aposto­ <lb/> lus diceret, Qui antem
+					adhaeret Domino, unum sunt? <lb/> Quid enim aliud diccret, si hoc diceret, nisi,
+					Homo <lb/> sanctus, et Deus, unum sunt? Sed ahsit, absit ab illa <lb/> sapientia
+					ista sententia : et tamen dixit, Qui <hi rend="italic">autem<lb/> adhœret
+						Domno,</hi> unus <hi rend="italic">spiritus</hi> eat (I <hi rend="italic"
+						>Cor.</hi> VI, 47); ut <lb/> noveris de his dici, Unum sunt, qaae unius sunt
+					ejus­ <lb/> demque substantiae : sient quibusdam bominibus di­ <lb/> etum est,
+						<hi rend="italic">Omnes enim</hi> vos <hi rend="italic">unum estis in
+						Christo</hi> Jesu <lb/>
+					<hi rend="italic">(Galat.</hi> III, 28); et sicut. ait Ipse Christus, <hi
+						rend="italic">Ego et Pa­ <lb/> ter</hi> unum sumus <hi rend="italic"
+						>(Joan.</hi> x, 30). Cum autem unns dici­ <lb/> tur, et qmd unus dicitur 3 :
+					et de diversis substantiis <lb/> dici potest, sicut dictum est, Qui adhaeret
+					Domino % <lb/>
+					<hi rend="italic">unus</hi> spiritus <hi rend="italic">est;</hi> et de rebus
+					unius substantiae, sient, <lb/> dictum est, <hi rend="italic">Erat eis anima et
+						cor unum (Act.</hi> IV, 32). <lb/>
+					<hi rend="italic">Erat,</hi> dixit; non dixit, Erant: quoniam dixit et quid
+					<lb/> crat; id est, <hi rend="italic">anima et cor.</hi> Sic etiam de Patre et
+					Filio, <lb/> et, Unum sunt, dicimus, quia unius substantiae duo <lb/> sunt : et,
+					Unus est, dicimus, sed addimus quid unus; <lb/> id est, unusDeus, unus Dominus ,
+					unus Omnipotens, <lb/> et si quid hujusmodi, Satis me vobis duarum istarum <lb/>
+					locutionum arbitror inculcasse distantiam. Scrutare <lb/> itaque Scripturas
+					canonicas veteres et novas, et in­ <lb/> vcni, si potes, ubi dicta sunt aliqua,
+					Unum sunt, quae <lb/> sunt diversae paturae atque substantiae.</p>
+				<p>3. Sane falli te nolo in Epistola Joannis apostoli, <lb/> ubi ait: <hi
+						rend="italic">Tres sunt testes; spiritus, et aqua, et sanguis;<lb/> et tres
+						unum sunt</hi> (I <hi rend="italic">Joan.</hi> v, 8). Ne forte dicas spiri­
+					<lb/> tum et aquam et sanguinem diversas esse substantias, <lb/> et tamen dictum
+					esse , <hi rend="italic">tres unum sunt :</hi> propter hoc <lb/> admonui ne
+					fallaris. Haec enim sacramenta sunt, in <lb/> quibus non quid sint, sed quid
+					ostendant semper at<lb/>tenditur : quoniam signa sunt rerum , alind existen
+					<lb/>tia, et aliud significanlia. Si ergo illa quae bis signifi <lb/> canlur,
+					intelligantur, ipsa inveniuntur unius esse sub- <note type="footnote">1 Apud Er.
+						Lugd. et ven., <hi rend="italic">quis te wgebat, quis</hi> pr(r' <lb/>
+						<hi rend="italic">cipitahat ?</hi> M. </note><note type="footnote"> ' Apud
+						Lov. et quosdam Mss., <hi rend="italic">verbum.</hi>
+					</note><note type="footnote"> a sic Mss. Kdili auicm, <hi rend="italic">ct quid
+							unus naturaj ct quid</hi> :&lt;&lt; <lb/>
+						<hi rend="italic">ndjicitur.</hi>
+					</note>
+					<lb/>
+					<pb n="795"/> stantiae ; tanquam si dicamus , Petra et aqua unum <lb/> sunt,
+					volentes per petram significare Christum ; per <lb/> aquam, Spiritum sanctum :
+					quis dubitat petram et <lb/> aquam diversas esse naturas ? Sed quia Christus et
+					<lb/> Spiritus sanctus unius sunt ejusdemque naturae ; idco <lb/> cum dicitur
+					Petra et aqua unum sunt; ex ea parte <lb/> recie accipi potest , qua istae duae
+					res quarum est di­ <lb/> versa natura, aliarum quoque signa sunt rerum qua­ <unclear/>
+					<lb/> rumest una natura. Tria itaque novimus de corpor- <lb/> Domini exisse, cum
+					penderet in ligno : primo, spiri­ <lb/> tum ; unde scriptum est, <hi
+						rend="italic">Et inclinato capite tradidit</hi>
+					<lb/> spiritum ; deinde , quando latus ejus lancca perfora­ <lb/> tum est,
+					sanguinem et aquom <hi rend="italic">(Joan.</hi> XIX, 50, 34). <lb/> Quae tria
+					si per se ipsa intueamur , diversas habent <lb/> singula quaeque substantias; ac
+					per hoc non sunt <lb/> unum. Si vero ea, quae his significata sunt, velimus
+					<lb/> inquirere , non absurde occurrit ipsa Trinitas , qui <lb/> unus, solus ,
+					verus, summus est Deus, Pater et Fi­ <lb/> lius et Spiritus sanctus, de quibus
+					verissime dici. po­ <lb/> tuit, <hi rend="italic">Tres</hi> sunt testes , <hi
+						rend="italic">et tres</hi> unum <hi rend="italic">sunt</hi> : ut nomine
+					<lb/> spiritus significatum accipiamus Deum Patrem : de <lb/> ipso quippe
+					adorando loquebamur Dominus, ubi ait, <lb/> Spiritus <hi rend="italic">eat Deus
+						(Id.</hi> IV, 24). Nomine autem sangui­ <lb/> nis, Filium : quia, <hi
+						rend="italic">Verbum caro factum est (Id.</hi> I, 14). <lb/> Et nomine aquae
+					Spiritum sanctum : cum enim de <lb/> aqua loqueretur Jesus, quam daturus erat
+					sitientibus, <lb/> ait evangelista, <hi rend="italic">Hoc autem dixit de
+						Spiritu, quem ac­</hi>
+					<lb/> cepturi <hi rend="italic">erant credentes</hi> in <hi rend="italic">eum
+						(Id.</hi> VII, 39). Tesles <lb/> vero esse Patrem et Filium et Spiritum
+					sanctum , <lb/> quis Evangelio credit, et dubitat, dicente Filio, <hi
+						rend="italic">Ego</hi>
+					<lb/> sum <hi rend="italic">qui testimonium perhibeo de me: et testimonium <lb/>
+						perhibet de</hi> me, <hi rend="italic">qui misit me, Pater (Jd.</hi> VIII,
+					18)? Ubi <lb/> etsi non est commemoratus Spiritus sanctus, non ta­ <lb/> men
+					intelligitur separatus. Sed nec de ipso alihi ta­ <lb/> cua, eumque testem satis
+					aperteque monstravit. Nam <lb/> curi illum promitteret, ait : <hi rend="italic"
+						>Ipse testimonium perhibebit <lb/> de me.</hi> Hi <hi rend="italic">sunt
+						tres testes: et tres unum sunt (Id.</hi> xv, <lb/> 26), quia unius
+					substantiae sunt. Quod antemi signa <lb/> quibus significati sunt, de corpore
+					Domini exierunt, <lb/> figuraverunt Ecclesiam praedicantem Trinitatis unam <lb/>
+					eamdemque naturam : quoniam hi tres qui trino mo* <lb/> do significati sunt,
+					unum sunt; Ecclesia vero eos <lb/> praedicans, corpus est Christi. Si ergo. Ires
+					res quibus <lb/> significati sunt, ex corpore Domini exierunt : sicut <lb/> ex
+					corpore Domini sonuit, ut baptizarentur gentes <hi rend="italic">in <lb/> nomine
+						Patris et Filii et Spiritus sancti (Matth.</hi> XXVIII, <lb/> 19). <hi
+						rend="italic">In</hi> nomine; non, In nominibus : hi enim tres <lb/> unum
+					sunt, et hi tres unus est Deus. Si quo autem <lb/> ano modo tanti sacramenti
+					ista profunditas , quae in <lb/> Epistola Joannis legitur, exponi et intelligi
+					potest <lb/> secundum catholicam fidem, quae nec confundit nec <lb/> separat Ti
+					iuitatem , nec abnuit tres personas , nec <lb/> diversas credit esse
+					substantias, nulla ratione respu­ <lb/> endum est. Quod enim ad exercendas
+					mentes fide­ <lb/> lium in Scripturis sanctis obscure ponitur,gratulan­ <lb/>
+					dum cst, si multis modis, non tamen insipienter ex­ <lb/> punitur.</p>
+				<p>CAPUT XXIII. — 1. Quid est autem quod po<lb/>Mis ut astruam , <hi
+						rend="italic">Si pater et Filias et Spiritus san­<lb/> ctus</hi> unus <hi
+						rend="italic">est Deus</hi> ; cum hoe astruat voce clarissima <lb/>
+					Scriptura divina dicens , <hi rend="italic">Audi, Israel; Dominus Deus</hi>
+					<lb/> tuus, <hi rend="italic">Dominus</hi> unus <hi rend="italic">est (
+						Deut,</hi> VI, 4)? Quod et vos <lb/> uiiquc audiretis, si Israel esse
+					velletis, non carnali­ <lb/> ter ut Judaeri, sed spiritualiter ut Christiani.
+					Qui enim <lb/> non vult fideliter audire quod dictum est, <hi rend="italic"
+						>Audi, Israel; <lb/> Dominus Deus tuus, Dominus unus est;</hi> superest ut
+					<lb/> eum qui hoc dixit, credat esse mendacem. Si autem <lb/> mendax ille non
+					est, vox ista vera est : si vox ista <lb/> vera est, quaestio ista finita est.
+					Procul dubio quippe <lb/> vos veritascogit Patrem aL Filium et Spiritum sanctum
+					<lb/> confiteri unum Dominum Deum. Sed Spiritum san­ <lb/> ctum, cujus templum
+					non manufactum, sed corpus <lb/> est nostrum , cujus templum non ligna et
+					lapides, sed <lb/> membra sunt Christi, negatis Deum : de ipso Christo <lb/>
+					quid dicturi estis, quem Deum et Dominum confite­ <lb/> mini? Respondete itaque
+					nobis, utrum Pater et Filius <lb/> unus sit Dominus Deus. Si cnim non est
+						<unclear>mius</unclear>, duo <lb/> sunt : si duo sunt, mentitur qui dicit,
+						<hi rend="italic">Audi , Israel; <lb/> Dominus Deus tuus, Dominus unus est
+						;</hi> mentitur qui <lb/> dicit, <hi rend="italic">Videte quoniam ego sum
+						Deus , et non cst</hi>
+					<unclear>otius</unclear>
+					<lb/>
+					<hi rend="italic">praeter me (Id.</hi> XXIII, 39). Sed quia illum
+						<unclear>menten­</unclear>
+					<lb/> tem dicere non audetis, quare vos corrigere dubita­ <lb/> tis, et venire
+					vel redire ad catholicam fidem , quae <lb/> Patrem et Filium et Spiritum sanctum
+					non tres do­ <lb/> minos deos, sed unum Dominum Dcum credit et <lb/> audit
+					clamantem populo suo, <hi rend="italic">Audi, Israel; Dominus, <lb/> Deus</hi>
+					tuus, Dominus <hi rend="italic">unus est;</hi> et, <hi rend="italic">Videte
+						quoniam egu</hi>
+					<lb/> sum <hi rend="italic">Dominus, et non est alius praeter me ?</hi> Si te
+					dicam <lb/> surdum et caecum, qui nec audis ista, nec vides, con­ <lb/>
+					tumeliosum sine dubio me putabis. Ecce non dico : <lb/> expone nobis quomodo
+					accipias, <hi rend="italic">Audi, Israel ; Do­ <lb/> minus Deus</hi> tuus , <hi
+						rend="italic">Dominus</hi> unus <hi rend="italic">est :</hi> utrum ibi sit
+					<lb/> intelligendus et Christus, an non sit. Si enim dixeris, <lb/> Ibi est;
+					confiteberis mecum Patrem et Filium unum <lb/> esse Dominum Deum. Si autem
+					responderis, Christum <lb/> non esse ibi intelligendum , duos contra vocem divi­
+					<lb/> nam introducturus es dominos deos, quoniam non <lb/> nogas etiam Christum
+					esse Dominum Deum. Similiter <lb/> abs te quaero quomodo accipias, <hi
+						rend="italic">Videte quoniam ego<lb/> sum Dominus, et non est alius
+						pr</hi>ae<hi rend="italic">ter</hi> me. Ibi est et <lb/> Christus, an non
+					est? Si ibi est, profecto Pater ct <lb/> Filius unus est Dominus : si autem ibi
+					non est, et <lb/> tamen Dominus est; mentitur qui dicit, <hi rend="italic">Non
+						est alius <lb/> praeter me.</hi> Est enim alius Dominus Filius, si non <lb/>
+					unus est Domninus Pater et Filius. Quantumlibet enim <lb/> excellentius laudes
+					Patrem, et infra cum deprimas <lb/> Filium, id agis , ut aequales non sint, non
+					ut duo non <lb/> sint. Clama , quantum vis, Pater est major, Filius <lb/> minor
+					: respondetur tibi, Duo sunt tamen major ct <lb/> minor. Nec dictum cst, Dominus
+					Dens tuus major, <lb/> Dominus unus est : sed dictum est , <hi rend="italic"
+						>Dominus</hi> Deus <lb/>
+					<hi rend="italic">tuus, Dominus unus est.</hi> Neque dictum est, Non est <lb/>
+					alius aequalis mihi : sed diclum est, <hi rend="italic">Non est alius <lb/>
+						Dominus praeter me.</hi> Aut ergo confitere Patrem et <lb/> Filium unum esse
+					Dominum Dcum , aut apene nega <lb/> Dominum Deum esse Christum , sicut aperte
+					negas <lb/> Dominum Deum esse Spiritum sanctum. Quod si <lb/> . leceris , istis
+					quidem te divinis vocibus non urgebo, <lb/>
+					<pb n="797"/> sedalia testimonia divina proferam, quibus te et iii <lb/> isto
+					errore detestabiliorem convincam 1. Nunc autem <lb/> et si negas Dominum Deum e
+					se Spiritum sancium, <lb/> tamen ut istis Dei vocibus conteraris, satis est quod
+					<lb/> Christum Dominum Deum confiteris : qui si non est <lb/> cum Patre unus
+					Dominus Ocus, duo domini dii nostri <lb/> erunt, et falsae illae Dei voces
+					erunt, <hi rend="italic">Dominus Deus <lb/> tuus, Dominus unus est ;</hi> et,
+						<hi rend="italic">Non eat alius</hi> praeter <hi rend="italic">me.</hi>
+					<lb/> Scd quanto melius erunt vestra verba emendata, quam <lb/> pei verba
+					mendacia ?</p>
+				<p>i. Quaeris a me utrum , <hi rend="italic">Judaico modo te horter</hi> pro­ <lb/>
+					<hi rend="italic">fiteri</hi> unum <hi rend="italic">Denm; an de subjectione
+						Filii potius secun­<lb/> dum quod fides habet</hi> Christiana , <hi
+						rend="italic">ostendatur unus esse<lb/> Deus, cujus Filius noster est
+						Deus.</hi> Ita hoc dicis, quasi <lb/> Judaeorum sil vox, <hi rend="italic"
+						>Audi, Israel; Dominus Deus</hi> tuus, <lb/>
+					<hi rend="italic">Dominus unus est ;</hi> aut, <hi rend="italic">Ego sum
+						Dominus, et non eat <lb/> alius prœter me.</hi> Ipse Deus hoc dixit:
+					agnosce, et <lb/> tace ; vel potius edissere quomodo ,'crum dixerit, <lb/> quem
+					nullus nostrum andet affirmare mentitum. <lb/> Edissere, inquam, quomodo verum
+					st, <hi rend="italic">Dominus Deus</hi>
+					<lb/> tuus, <hi rend="italic">Dominus unus est ;</hi> si domini dii nostri, nt
+					di­ <lb/> citis, duo sunt, unus major , alius minor : edissere <lb/> quomodo
+					verum sit, <hi rend="italic">Ego sum Dominus, et non est</hi>
+					<lb/> alius <hi rend="italic">prœter me.</hi> Quis enim hoc dixcril qu;cro,
+					utrum <lb/> pater, an Filius. Si Pater dixit, <hi rend="italic">Ego</hi> sum
+					Dominus, <lb/> et <hi rend="italic">non est alius praeter me;</hi> non verum
+					dixit, quia <lb/> est alius Dominus Filius. Si Filius hoc dixit: nee ipse <lb/>
+					verum dixit, quia est alius Dominus Pater. Si autem <lb/> hoc dixit Trinitas ;
+					profecto et verum dixit, et vos <lb/> falsum diccre ostendit. Trinitas quippe
+					secundum <lb/> rectam fidcm , id cst, Pater et Filius et Spiritus san­ <lb/>
+					ctus, in cujus nomine baptizamur, et unus Dominus <lb/> Deus noster est, ct
+					praeter ipsum alius non est. Ipse <lb/> est enim Deus de quo dicit Apostolus :
+						<hi rend="italic">Nullus</hi><hi rend="italic">est<lb/> Deus,</hi> nisi unus
+					(I <hi rend="italic">Cor.</hi> VIII , 4). Nam si hoc de Patre <lb/> acceperis
+					dictum , non tibi ent Deus Christus , quia <lb/> nun potest solvi Scriptura ,
+					dicens, <hi rend="italic">Nullus Deus, nisi</hi>
+					<lb/> unus : ut lic vobis taceam de Spiritu sancto , quem <lb/> superius Dominum
+					Deum ostendimus, vobis neganti­ <lb/> bus. Quapropter si Macedoniani haeretici
+					essetis, qui <lb/> de solo Spiritu sancto catholicae fidei consentire de­ <lb/>
+					trectant, Patrem vero et Filium duos quidem esse, <lb/> id est, illum Patrem ,
+					illum Filium , et aequales esse, <lb/> atque unius ejusdemque substantiae, nec
+					tamen duos <lb/> dominos deos, sed ambos simul unum Dominum <lb/> Deum essc
+					consentiunt : si ergo et vos saltem harte­ <lb/> nus erraretis, noh utique his
+					divinis vocibus urgerc­ <lb/> mini. Patrem quippe et Filium assereretis unum Do­
+					<lb/> minum Deum dixisse , <hi rend="italic">Non est alius prœter me.</hi> Uti­
+					<lb/> nam non restaret agere vobiscum, nisi ut adjungere­ <lb/> tis Spiritum
+					sanctum, et non dualitatem , sed Trini <lb/> tatem diceretis unum Dominum Deum.
+					Nunc vcro <lb/> cum sic asseritis Patrem Dominum Deum , et Filium <lb/> Dominum
+					Deum , ut simul ambos non dicatis unum <lb/> Dominum Deum, sed duos, majorem
+					unum,minorem <lb/> alterum ;prorsus confodimini gladio veritatis dicentis, <lb/>
+					<hi rend="italic">Audi, Israel ;</hi>Dominus <hi rend="italic">Deus tuus,
+						Dominus unus est:</hi>
+					<lb/> qui clamat, <hi rend="italic">Ego</hi> sum <hi rend="italic">Dominus, et
+						non est alius</hi> praeter <note type="footnote">I f.r. Usyl. v en., <hi
+							rend="italic">destestabiliorem</hi><hi rend="italic">comincam.</hi> M. </note>
+					<lb/> me. Neque enim Dom Pater sic rellet Israelitas a <lb/> cultu deorum
+					revocare multorum atque falsorum , ut <lb/> eis de uno Deo ac Domino mentiretur,
+					et diceret non <lb/> esse praeter se alium Dominum, cnm sciret Deum et <lb/>
+					Dominum esse suum Filium. Absit ut veritas et veri­ <lb/> tatis Pater mendacio
+					deciperet populum suum : hae­ <lb/> reticorum sit haec , uon catholicorum tam
+					horrenda <lb/> et detestanda blasphemia. Prorsus Deus verum dicit, <lb/> cum
+					dicit, <hi rend="italic">Audi, Israel; Dominus Dcus tuus, Dominus<lb/> unus
+						est:</hi> quia Patcr ct Filius et Sp ritus sanctus, non <lb/> tres dii, sed
+					unus Deus ; nec tres domini, sed unus <lb/> Dominus est. Prorsus verum dicit,
+						<hi rend="italic">Ego sum Dominus, <lb/> et non estalius prœter me ;</hi>
+					quia non hoc Pater tan­ <lb/> lum, sed ipsa Trinitas dicit : hic est Dominus
+					unus, <lb/> ct non alius praeter ipsum, Nam si Pater diceret, <hi rend="italic"
+						>Ego <lb/> sum Dominus, et non ert alius prœter me;</hi> negaretuti­ <lb/>
+					que Dominum esse unigenitum Filium. Et quis no­ <lb/> strum auderet eum Dominum
+					confiteri, contradicente <lb/> Patre atquc dicente, <hi rend="italic">Ego sum
+						Dominus, et non eat alius <lb/> prater me?</hi> Ac per boc secundumrectam
+					fidem , non <lb/> Patris, sed T riniiatis haec vox cst: et Patris ergo, et
+					Filii, <lb/> et Spiritus sancti. Obticescant igitur linguae ignoran­ <lb/> tium
+					vcritatcm : haec Trinitas Deus unus est. De hoc <lb/> uno Deo dicitur, Audi, <hi
+						rend="italic">Israel; Dominus Deus tuus,</hi>
+					<lb/> Dominus unus <hi rend="italic">est.</hi> llic Deus unus dicit, <hi
+						rend="italic">Ego</hi> sum <hi rend="italic">Do­ <lb/> minus, et non est
+						alius praeter me.</hi> Subjectus est quidem <lb/> Patri filius
+					secundumformam hominis : non tamen <lb/> sunt duo dii ct duo domini secundum
+					formam De!; <lb/> sed ambo cum Spirilu suo unus cst Dominus.</p>
+				<p>3. Testimonia quae de Paulo apostolo protulisti, <lb/> contra te loquuntur, ct
+					nescis. Dicit enim ille : <hi rend="italic">Gra­<lb/> tia vobis et pax a Deu
+						Patre nostro et Domino</hi> Jesu <lb/>
+					<hi rend="italic">Christo (Rom.</hi> I, 7; I <hi rend="italic">Cor.</hi> I, 3;
+					II <hi rend="italic">Cor.</hi> I, 2; <hi rend="italic">Gulat.</hi> i, <lb/> 3,
+						<hi rend="italic">et Ephes.</hi> I, 2). Quomodo est autem Dominus Je<lb/>sus Christus, si Pater dicit, <hi rend="italic">Ego sum Dominus,</hi> et non <lb/>
+					<hi rend="italic">eat</hi> alius <hi rend="italic">praeter me?</hi> Non ergo
+					solius Patris, ut dixi, <lb/> sed Trinitatis haec vox est. Adhibes alterurn
+					testimo­ <lb/> nium, et ipsum contra te ipsum, ubi ait Apostolus, <lb/>
+					<hi rend="italic">Unus Deus</hi> Puter , <hi rend="italic">ex quo omnia, et noa
+						in ipso ;</hi> et <lb/>
+					<hi rend="italic">unus Dominus</hi> Jesus <hi rend="italic">Christus, per quem
+						omnia, et <lb/> noa in ipso,</hi> sicut tu loculus es : Apostolus autem, <hi
+						rend="italic">a</hi>
+					<lb/> noa <hi rend="italic">per ipsum</hi> ait; non ait, in <hi rend="italic"
+						>ipso.</hi> Sed hoc quid ad <lb/> causam ? Solent ista contingere ex memoria
+					proferen <lb/> tibus testimonia, non ex codice illa legentibus : quod <lb/> ad
+					rem pertinet potius intuere. Ecce, dixit Aposto­ <lb/> lus, <hi rend="italic"
+						>Unus Deus Pater, ex quo omnia, et nos in</hi> ipso, <lb/>
+					<hi rend="italic">et unus Dominus Jesus Christus,</hi><hi rend="italic">per quem
+						omnia, et</hi>
+					<lb/> noa <hi rend="italic">per</hi> ipsum <hi rend="italic">Cor.</hi> VIII, 6).
+					Omnino duas personas, <lb/> unam Patris, alteram Filii, sine ulla confusione et
+					<lb/> sine ullo errore distinxit. Neque enim duo sunt dii <lb/> patres, sed unus
+					Deus Pater : nec duo sunt domini <lb/> Jesu Christi, sed unus Dominus Jesus
+					Christus. In <lb/> illa quippe Trinitate quaeDeus cst, unus est Pater, <lb/> non
+					duo vel tres; et unus Filius, non duo vel tres; <lb/> et unus amborum Spiritus,
+					non duo vel tres : ct ipse <lb/> unus Pater utique Deus est, et ipse unus Filius
+					etiam <lb/> vobis fatentibus Deus cst, et ipse amborum Spiritus <lb/> etiam
+					vobis negantibus Deus cst. Sic et Dominiun s <lb/> quaeras, singulum quemque
+					respondeo ; sed simu! <lb/>
+					<pb n="799"/> omnes non Ires dominos tlcos, sud unum Domiuum <lb/> Deum dico.
+					Haec est fides nostra, qnoniam haec fides <lb/> est recta, quae fides etiam
+					catholica nuncupatur. Tu <lb/> antem qui huic fidei contradicis, quaeso te,
+					expone <lb/> nobis, eliam Josus Christus quomodo sit Dominus, <lb/> qui non
+					Trinitatis, sed solius Patris esse asseris vo­ <lb/> cem, <hi rend="italic">Ego
+						sum Dominus, et non est alius praeter me.</hi>
+					<lb/> Nempe turbaris ; nempe quid respondeas non invenis, <lb/> nisi quia
+					tacere, quando convinceris, non vis. Si enim <lb/> non Deus Trinitas, sed Pater
+					tantum dixit, <hi rend="italic">Ego sum <lb/> Dominus, et non est alius prœter
+						me :</hi> procul dubio ne­ <lb/> gavit esse Dominum Filium; quoniam si
+					Dominus est <lb/> pt Filius, falso dictum est, <hi rend="italic">Non eat alius
+						Dominus<lb/> prœter me.</hi> Non enim agitur de Domino, quales sunt <lb/>
+					homines domini hominum servorum, quos Apostolus <lb/> secundum carnem dominos
+					esse dicit <hi rend="italic">(Ephes.</hi> VI, 5 ): <lb/> sed de Domino agitur,
+					cui servitus illa debetur, quae <lb/> graece <foreign xml:lang="grc"
+						>λατρεία</foreign> dicitur, secundum quam dictum est, <lb/>
+					<hi rend="italic">Dominum Deum</hi> tuum <hi rend="italic">adorabis, et illi
+						soli servies (Deut,</hi>
+					<lb/> VI, 13). Qui Dominus Deus si non Trinitas, sed solus <lb/> est Pater :
+					prohibemur utique Domino Cbristo tali <lb/> servitude servire, in <hi
+						rend="italic">eo</hi> quod audimus, <hi rend="italic">Illi soli aer­</hi>
+					<lb/> vies ; si ita dictum est, ac si diccrelur, Deo Patri soli <lb/> servies.
+					Qui profecto si solus, et non ipsa Trinitas <lb/> dixit, <hi rend="italic"
+						>Ego</hi> sum DorMiMus, <hi rend="italic">et</hi> non <hi rend="italic">eat
+						alius</hi> prœter <hi rend="italic">me;</hi>
+					<lb/> negavit csse Filium Dominum talem, quali domino <lb/> servitus illa
+					debetur, qua nonnisi Deo cum vera ret!­ <lb/> gione servitur. Non enim dixit,
+					Ego sum Dominus <lb/> majoraut melior*et non est tantus aut talis praeter <lb/>
+					ine : sed volens sibi soli ea quae Domino Deo debetur <lb/> servitute serviri,
+						<hi rend="italic">Ego sum,</hi> inquit, <hi rend="italic">Dominus, et non
+						est<lb/> alius</hi> praeter <hi rend="italic">me.</hi> Porro si vox ista,
+					sicut catholica fi­ <lb/> des dicit, unius Dei est, quod est ipsa Trinitas; sine
+					<lb/> ulla dubitatione huic soli serviendam est ea servitute, <lb/> quae nonnisi
+					Domino Deo debetur, quia ipse est Do­ <lb/> minus, et non est alius praeter
+					ipsum.</p>
+				<p>4. Deinde quaero quomodo accipias quod dictum <lb/> est, Unus <hi rend="italic"
+						>Deus Pater, ex quo omnia, et nos</hi> in <hi rend="italic">ipso; <lb/>
+						et</hi> unus <hi rend="italic">Dominus Jesus</hi> Christ: s, <hi
+						rend="italic">per quem omnia, et noa <lb/> per</hi> ipsum. Numquid non et ex
+					Filio sunt omnia : <lb/> quandoquidem ipse dicit, <hi rend="italic">Quœcumque
+						Pater facit, haec<lb/> et</hi> Filius <hi rend="italic">similiter facit
+						(Joan.</hi> v, 19)? Si autem ita dis­ <lb/> linguis, ut non sint per Patrem
+					omnia, sed ex Patre; <lb/> nec omnia sint ex Filio, sed per Filium : quis eorum
+					<lb/> tihi vidctur esse illc de quo idem apostolus dicit, 0 <lb/>
+					<hi rend="italic">altitudo diritiarum</hi><hi rend="italic">sapientiœ et
+						scientiœ Dei ! quam in­ <lb/> scrutabilia sunt judicia ejus, et
+						investigabiles viœ ejus ! <lb/> Quis enim cognovit sensum</hi> Domini ? <hi
+						rend="italic">Aut quis consilia­</hi>
+					<lb/> rius <hi rend="italic">ejus</hi> fuit ? <hi rend="italic">Aut quis prior
+						dcdit illi, et retribuetur ei? <lb/> Quoniam ex</hi> ipso, <hi rend="italic"
+						>et per ipsum, et in ipso</hi> sunt <hi rend="italic">omnia : <lb/> ip1i
+						gloria in sœcula</hi> sœculorum. Amen <hi rend="italic">(Rom.</hi>XI,
+					33-36). <lb/> Utrum Pater eat intelligondus, an Filius? Deum nam­ <lb/> que
+					prius nominavit, dicens : 0 <hi rend="italic">allitudo divitiarum sa­</hi>
+					<lb/> pientiae <hi rend="italic">et scientia Dei!</hi> Postea vcro eum Dominum
+					ap­ <lb/> pellait. ubi ait: <hi rend="italic">Quis enim</hi> cognovit sensum <hi
+						rend="italic">Domini?</hi> Sed <lb/> hocnon habet controversiam :utrumque
+					eniin nomen <lb/> etiam vos et Patri assigNatis et Filio. Neque enim sic <lb/>
+					dicitis DeumPatrem, ut negetis esse Deum Filium; <lb/> tut sic dicitis Deum
+					Filium, ut negetis esse Dcum Pa­ <lb/> trem. Quatnvis in hoc ap ostolico
+					testimonio quod ad­ <lb/> hibuisti, Deus dicatur Pater, Do t imis Filius, id
+					est, <lb/>
+					<hi rend="italic">Unus Deus</hi> Pater, <hi rend="italic">ex quo omnia; et</hi>
+					unus Dominus <hi rend="italic">Je­ <lb/> sus Christus, per quem omnia.</hi> Sed
+					illud attende abi di­ <lb/> ctum est. <hi rend="italic">0 altitudo
+						divitiarum</hi><hi rend="italic">sapientiae et</hi> scientiae <lb/>
+					<hi rend="italic">Dei!</hi> Nam sive Pater sit iste, sive Filius, <hi
+						rend="italic">ex ipso, et <lb/> per</hi> ipsum, <hi rend="italic">et</hi> in
+						<hi rend="italic">ipso sunt omnia.</hi> Quomodo ergo ex <lb/> Patre omnia,
+					non ex Filio; et per Filium omnia, non <lb/> per Patrem : quandoquidem quemlibet
+					eorum Apo­ <lb/> stolus voluerit hoc loco intelligi, <hi rend="italic">Ex</hi>
+					ipso , inquit, <hi rend="italic">et</hi>
+					<lb/> per ipsum, <hi rend="italic">et</hi> in <hi rend="italic">ipso sunt
+						omnia?</hi> Si ergo sive de Pa­ <lb/> tre sive de Filio, verissime tamen
+					dicitur, quod ex <lb/> ipso <hi rend="italic">et per ipsum, et in ipso sunt</hi>
+					omnia; sine dubio <lb/> Patris et Filii demonstratur aequalitas. Si autem quo­
+					<lb/> niam non nominavit Patrem et Filium et Spiritum <lb/> sanctum, sed Dcum et
+					Dominum, quod et ipsa Trini­ <lb/> tas dici potest, singula horum trium referri
+					ad singu­ <lb/> los voluit : <hi rend="italic">ex ipso</hi> dicens, propter
+					Patrem; <hi rend="italic">et per <lb/> ipsum,</hi> propter <hi rend="italic"
+						>Filium ; in ipso,</hi> propter Spiritum san­ <lb/> ctum : cur hanc
+					Trinitatem unum DominumDeum <lb/> non vultis agnoscere? Quandoquidem non ait, Ex
+					<lb/> ipsis, et per ipsos, et in ipsis; sed ait, <hi rend="italic">ex ipso; et
+						per</hi>
+					<lb/> ipsum, <hi rend="italic">et in ipso sunt</hi> omnia : nec ait, Ipsis
+					gloria; sed, <lb/>
+					<hi rend="italic">ipsi gloria</hi> in saecula sPeculorum. <hi rend="italic"
+						>Amen.</hi>
+				</p>
+				<p>5. Falleris sane, qui putas de Patre solo esse di­ <lb/> ctum, <hi rend="italic"
+						>Nemo bonus, nisi unus Deus.</hi> Si enim dixisset, <lb/> Nemo bonus, nisi
+					unus Patcr; nee sic exclusum Fi­ <lb/> lium et Spiritum sanctum ab ista unitate
+					bonitatis vo­ <lb/> luisset intelligi : quia et illud quod simili locutiono
+					<lb/> dictum est, quam supra commemoravi, <hi rend="italic">Ea quœ</hi><hi
+						rend="italic">Dei <lb/> sunt, nemo scit, nisi Spiritus Dei (I Cor.</hi> n,
+					41): non <lb/> excludit ab hac scientia Filium Dei. Quanto ergo no­ <lb/> bis
+					latitudo intelligentiae magis patet, quia non dixit, <lb/> Nemo bonus, nisi unus
+					Pater; sed, <hi rend="italic">Nemo bonus,</hi> nisi <lb/> unus <hi rend="italic"
+						>Deus;</hi> quod est ipsa Trinitas. Quaerebat quippe <lb/> ille cui hoc
+					respondit Jesus, non bonum qualecumque, <lb/> sed bonum quo fieret beatus; imo
+					ipsam beatitudinem <lb/> veram, id est, vitam desiderabat aeternam : et inter­
+					<lb/> pellaverat tanquam hominem Christum, nescicns eum <lb/> esse etiam Deum.
+					Dixerat enim : <hi rend="italic">Magister bone, quid <lb/> faciam, ut vitam</hi>
+					aeternam consequar ? Tunc ait ille: <lb/>
+					<hi rend="italic">Quid me dicis bonum? Nemo bonus,</hi> nisi unus <hi
+						rend="italic">Deus <lb/> (Marc.</hi> x, 17, 18). Vel, sicut legitur apud
+					alium evan­ <lb/> gelistam, qnod tantumdem valet, <hi rend="italic">Nemo
+						bonus,</hi> nisi <lb/>
+					<hi rend="italic">solus Deus (Luc.</hi> XVIII, 19). Tanquam diceret : Recte
+					<lb/> mc appellabis bonum, si me noveris Deum. Nam <lb/> qnando me nihil aliud
+					quam hominem putas, quid me <lb/> dicis bonum ?Non te facit bonum nec bcatum,
+					nisi <lb/> bonum immutabile quod solus est Deus. Nam bonus <lb/> angelus, bonus
+					homo, bona caetera creatura : haec <lb/> non ita bona sunt, ut ea quisquis
+					adeptus fuerit, sit <lb/> beatus; nec ulla est beata vita, si non sit aeterna.
+					<lb/> Quomodo autem non est tale bonum Dei Filius ve­ <lb/> rus, cumsit verus
+					Deus et vita aeterna, ad quam cu­ <lb/> piebat ille qui interrogaverat pervenire
+					?</p>
+				<p>6. Proinde cum ego asseram, <hi rend="italic">Nemo bonus,</hi> nisi unus <lb/> et
+						<hi rend="italic">solus Deus,</hi> de ipsa Trinitate dictum esse, qui Deus
+					<lb/> unus et solus est; tu autcm asseras de solo Dco Pa­ <lb/> tre dictum esse,
+					quia ipse de nullo alio Deus, de nullo <lb/>
+					<pb n="801"/> alio honus est ; Filius autem de Patre Dcus, de Patre <lb/> magnus
+					et bonus est diligenter attende quis nostrum <lb/> bene sentiat de Deo Patre et
+					de Deo Filio; utrum <lb/> ego qui dico, Dens quidem Pater, non de alio Dco <lb/>
+					Deus est, Deus autem Filius de Patre Deo Deus est, <lb/> sed tantus iste de
+					illo, quantus ille de nullo ; et bo­ <lb/> nus Pater non de alio bono bonus est,
+					Filius vero de <lb/> Pairc buno bonus est, sed tam bonus hic de illo, <lb/> quam
+					bonus ille de nullo : an tu qui propterea dicis <lb/> solum esse Patrem Deum
+					bonum, quia nec Deus est <lb/> de alio Dco,nec bonus de alio bono; Filium vero
+					<lb/> idco Patri non esse cocequandum, quia de illo Deus <lb/> est, de illo
+					bonus est? In qua sententia utrumque <lb/> blasphemas : et Patrem scilicet, quia
+					non tantum ge­ <lb/> nuit quantus cet ipse, nec talem qualis est ipse; et <lb/>
+					Filium, quia talis tantusque nasci non meruit, qualis <lb/> quantusque est ille
+					qui genuit. Denique ista ipsa duo <lb/> de quibus agimus, hoc cst, dcitas et
+					bonitas, quoniam <lb/> dictum est, <hi rend="italic">Nemo</hi> bonus, nisi <hi
+						rend="italic">unus Deus,</hi> in hac tua <lb/> opinione deficiunt. Tantum
+					enim quantus est ipse, et <lb/> talem qualis est ipse, si non potuit gignere,
+					quomodo <lb/> Dens est? si noluit, quomodo bonus cst?</p>
+				<p>7. <hi rend="italic">Pater,</hi> inquis, <hi rend="italic">fons</hi> bonitatis
+						<hi rend="italic">est, qui quod est</hi> bo­ <lb/> nIs <hi rend="italic">a
+						nemine accepit.</hi> Numquid ideo minus bonus est <lb/> Filius, quoniam quod
+					bonus est, ab eo Patrc accepit, <lb/> qui naseenli Filio tantam bonitatem
+					quantacumque <lb/> illi est, quia Deus est, dare potuit; et dedit, quia bo­
+					<lb/> nus invidere non potuit ? Nam si minus bonitatis, <lb/> quam quod ipse
+					habet unico dedit, minus bonus est <lb/> et ipse quam debuit : quod sentire
+					dementiae est. Er­ <lb/> go quantum ipse habet bonitatis, tantum F:lio de­ <lb/>
+					dit *. Et quia natura est, non gratia Filius, na­ <lb/> scenti, non indigenti
+					dedit; et plenus plenum, fons <lb/> bonitatis fontem genuit bonitatis. Ac per
+					boc nec <lb/> auxit in se hic quod accepit, nec minuit in se ille qui <lb/>
+					dedit 2: quia non habet immutabilitas unde defi­ <lb/> ciat, non habet plenitudo
+					quo crescat. Quid est <lb/> autem ipsa bonitas , nisi vita vivificans ? Proin­
+					<lb/> de quia fons fontem genuit, <hi rend="italic">sicut Pater suscitat mor­
+						<lb/> tuos et vivificat, sic et Filius quos vult vivificat</hi> (Joan. <lb/>
+					v , 21). Hoc ipse Filius dixit, non ego. Unde merito <lb/> Deo Patri dicitur,
+						<hi rend="italic">Quoniam apud te eat fons vitae.</hi> Quis <lb/> est autem
+					iste fons vitae apud Patrem, nisi de quo di­ <lb/> citur, In <hi rend="italic"
+						>principio erat</hi> Verbum, <hi rend="italic">et</hi> Verbum <hi
+						rend="italic">erat apud <lb/> Deum, et Deus erat Verbum; hoc erat</hi> in
+						<hi rend="italic">principio apud <lb/> Deum</hi> : de quo etiam paulo post
+					dictum est, <hi rend="italic">Et tila<lb/> erat lux</hi> hominum <hi
+						rend="italic">(Id.</hi> i, 1, 2, 4)? Haec vita fons vitae <lb/> est, et lux
+					ista lux lucis est. Unde cum dictum esset, <lb/>
+					<hi rend="italic">Apud te est fons vitae;</hi> continuo subjunctum est, <hi
+						rend="italic">In <lb/> lumine tuo videbimus lumen</hi> (Psal. XXXV, 10), hoc
+					est, <lb/> in Filio luo Spiritum sanctum ; quem tu quoque esse <lb/>
+					illuminatorem in Collationis nostrae priina parte nrm <lb/> fessus es. Fons ergo
+					de fonte, Filius de Patra, et si­ <lb/> mul ambo fons unus: lux de luce, Filius
+					de Patre, et <lb/> simul ambo lux una : sicut Dcus de Dco, et simul <lb/> ambo
+					utique Deus unus: et hoc totum non sine Spi­ <lb/> ritu amborum. Ex hoc fonte
+					bonitatis, ex hoc fonte <note type="footnote">* ouxlam Mss., <hi rend="italic"
+							>tantfui Vmco dedit.</hi>
+					</note><note type="footnote"> 'sic Myg. Editi vcro, <hi rend="italic">quod
+							dedit.</hi>
+					</note>
+					<lb/> vitae, ex hoc immutabili lumine, ex hac indeficiente <lb/> plenitudine, id
+					est, Patre, et Filio, et Spiritu sancto, <lb/> uno Domino Dco solo, sccundum
+					mensuram fidei su:e <lb/> quicumque veraciter credunt, sumentes boni fiunt, vi­
+					<lb/> vificantur, illuminantur, implentur. Quibus tu unige <lb/> nilum Filium,
+					pace tua dixcrim, nescio qua incredi­ <lb/> bili temeritate junxisti. Tua quippe
+					ista sunl verba : <lb/>
+					<hi rend="italic">Sive,</hi> inquis, <hi rend="italic">Filius, sive qui per
+						Filium sunt facti, de <lb/> illo uno fonte bonitatis unusquisque secundum
+						mensu­ <lb/> ram fidei suae assumpserunt ut essent boni.</hi> Ubi est ergo
+					<lb/> quod fueras ante confessus, illum natura Filium esse, <lb/> non gratia 1?
+					Ecce contra sententiam luam venis: ecce <lb/> jam prodis nefarium secretum
+					haeresis vestrae, quia <lb/> unigenitum verum Dei Filium, verum Dcum, non na­
+					<lb/> tura Filium, sed gratia profitemini. Si enim et ipse, <lb/> sicut verba
+					tua clamant, secundum mensuram fidei <lb/> SUm, ut bonus esset, assumpsit;
+					gratia est ergo Fi­ <lb/> lius, non natura : cL fuit aliquando non bonus, et
+					cre­ <lb/> dendo factus est bonus; quia ut esset bonus, quemad­ <lb/> modum
+					dicis, secundum mensuram fidei suae de illo <lb/> qui Pater est, fonte bonitatis
+					assumpsit. Legimus qui­ <lb/> dcm quod <hi rend="italic">Jesus</hi> proficiebat
+					aetate et <hi rend="italic">sapientia, et gratia <lb/> Dei erat</hi> in <hi
+						rend="italic">illo (Luc.</hi> II, 52) : sed secundum formaro <lb/> hominis
+					quam pro nobis accepit ex nobis, non secun­ <lb/> dum formam Dei, in qua non
+					alienam arbitratus est <lb/> esse aequalis Deo <hi rend="italic">(Philipp.</hi>
+					II, 6). Verumtamen etiam <lb/> in ipsa forma hominis legimus eum aetate et
+					sapientia <lb/> profccissc, non tamen ut ex non bono bonus fieret <lb/> credendo
+					meruisse. Neque nunc inter nos quaestio <lb/> vertitur de natura filii hominis,
+					in qua Dei Filius mi­ <lb/> nor cst Patre: sed de natura Filii Dei, in qua, ut
+					nos <lb/> dicimus, vos negatis, aequalis es. Patri : quia Filius <lb/> verus,
+					Filius unicus, Filius de vero Deo verus Dcus, <lb/> in nullo degeneravit a
+					Patre. Proinde incomparabi­ <lb/> lem Patrem Filio, nec in Scripturis sanctis
+					alicubi <lb/> legere potuisti. Nec sana fide ipse dixisti immensum <lb/> etiam
+					Patrem; quoniam propterea dicis, ut Filium <lb/> non pariter immensum, sed
+					mensura existimes ter­ <lb/> minatum. Tecum habeto mensuram tuam, qua <lb/> tuum
+					falsum dominum metiaris, et de vero Domino <lb/> mentiaris.</p>
+				<p>CAPUT XXIV. — Bene confiteris quod et Pater <lb/> diligat Filium, et Filius
+					diligat Patrem : sed si et hoc <lb/> confitcaris, quia non est major dilectio in
+					Patre quam <lb/> in Filio. Quia cnim natura divinitatis a quales sunt, <lb/>
+					aequaliter se invicem diligunt. Facit autem Filius sic­ <lb/> ut homo mandatum
+					Patris. Nani sicut Deus, ipse Fr- <lb/>
+					<lb/> lius est mandatum Patris, quia ipse est Verbum Pa­ <lb/> tris. Unde alio
+					loco de mandato Patris, hoc est, de se <lb/> ipso dicit : <hi rend="italic">Scio
+						quia mandatum ejus vita aeterna est <lb/> (Joan.</hi> XII, 50). Quod autem
+					ipse Dei Filius sit vin <lb/> aeterna, Scriptura divina testatur. Ubi autem ait,
+						<hi rend="italic">Qni <lb/> me vidit, vidit et Patrem (Id.</hi> XIV, 9);
+					quis nesciat ideo <lb/> dictum, quoniam quisquis per intelligentiam videt Fi­
+					<lb/> lium, Patri utique videt aequalem? Quod vos ideo non <lb/> vultis, quia
+					per oculos cordis, quantum ia bac <unclear>vita­</unclear>
+					<lb/> viden potest, Filium non videtis. <note type="footnote">* Plores Mss., <hi
+							rend="italic">nvs gratia.</hi>
+					</note></p>
+				<pb n="803"/>
 
-					<p>CAPUT XXV. — Putas non recte a me dictum esse, <lb/> qnod propter formam servi quam
-						suscepit Filius (Phi­ <lb/>
-						<hi rend="italic">lipp.</hi> II, 7), major sil Palcr. Tu enim secundum hæ­ <lb/> resim
-						vestram, in ipsa Dei forma Patrem Filio vis esse <lb/> majorem : cui paternam sic
-						invides formam, ut ideo <lb/> perfectum velis natum esse Filium æterna perfectio­ <lb/>
-						ne, ne ad paternam formam saltem crescendo valcai <lb/> pervenire. Sed inaniter invidet
-						homo paternam for­ <lb/> mam Dei Filio, cui Pater eam non invidit, quia æqua­ <lb/> lem
-						sibi unicum genuit. Sed dicis non esse Patris <lb/> . magnam gloriam, si ea forma servi
-						major est, qua <lb/> forma sunt majores et Angeli. Vide si aliud conaris, <lb/> nisi ad
-						unius Patris gloriam, per unici Filii contume­ <lb/> liam pervenire, ut sciliccl non
-						augeatur Pater in glo. <lb/> ria, nisi minuatur Filius in natura. Cohibe te: nescis
-						<lb/> et Patri et Filio te ingerere contumeliam, si nec ille <lb/> potuit aut noluit
-						gignere æqualem sibi, nec iste nasci <lb/> æqualis Puni? Non sc vult Deus ita laudari
-						Patrem, <lb/> ut Filimn dicatur de se ipso generasse degenerem. <lb/> Non vult bonus
-						Filii dilector iia prædicari formam <lb/> suam, ut eam non polucril unicus (jus vcl
-						nascendo <lb/> sumere, vel crescendo comprehendere. Quod autem <lb/> libi videtur nihil
-						magnum de Dco Patrc dici, si forma <lb/> servi major est; qua majores videntur et
-						Angeli: non <lb/> recte cogitas quem locum in rebus habeat humana <lb/> natura, quae
-						condita esi ad imaginem Dei. Majores <lb/> Angeli dici possunt homine, quia majores sunt
-						homi­ <lb/> nis corpore: majores sunt et animo, sed in forma <lb/> quam peccati
-						originalis merito <unclear>curruptihile</unclear> aggravat <lb/> corpus. Natura vero
-						humana, qualem naturam Chri­ <lb/> stus humanæ mentis assumpsit, quæ nullo peccato <lb/>
-						potuit depravari, solus major est Deus. Denique pro­ <lb/> pler quid dictum sit, <hi rend="italic">Minorasti eum modico</hi> minus <hi rend="italic">quam</hi>
-						<lb/> angelos <hi rend="italic">(Psal.</hi> VIII, 6); apcruit Scriptura, ubi legitur, <lb/>
-						<hi rend="italic">Eum</hi> autem modico minus <hi rend="italic">quam angelos</hi>
-						minoratum <hi rend="italic">vi­ <lb/> dimus</hi> Jesum <hi rend="italic">propter
-							passionem</hi> mortis <hi rend="italic">(llebr.</hi> II, 9). <lb/> Non ergo propter
-						naturam hominis; sed, <hi rend="italic">propter pas­<lb/> sionem mortis.</hi> Natura
-						vero hominis, quæ mente ra­ <lb/> tionali et intellectuali creaturas cæteras antecedit,
-						<lb/> Deus solus est niajor: cui utique injuria facta non <lb/> est, ubi scriptum est,
-							<hi rend="italic">Major est Deus corde</hi> nostro <lb/> (I <hi rend="italic">Joan.</hi> III, 20). Filius ergo Dci susceptum hominem <lb/> levaturus ad Patrem
-						quando dicebat, <hi rend="italic">Si diligeretis me,</hi>
-						<lb/> I gauderetis <hi rend="italic">utique, quia t'ado ad Patrem; quia Pater</hi>
-						<lb/> major <hi rend="italic">me eat (Joan.</hi> xiv, 28); non carni suæ solum, sed
-						<lb/> eliam menti, quam gerebat, humanæ Deum Patrem <lb/> utique præferebat : quæ tota
-						sine dubio forma agno­ <lb/> scitur servi, quoniam tota servit creatura Creatori.</p>
-					<p>CAPUT XXVI. — i. Postrema tibi disputatio fuit, <lb/> quomodo sit Deus patribus visus,
-						quando corpus <lb/> humanum in quo videretur, nondum acceperat Chri­ <lb/> stus, cam
-						invisibilis sit per se ipsa divina natura. <lb/> Quod cum eliam tu ila confessus fueris
-						ut inter c;c- <lb/> tera non solum Patrem, sed nec ipsum Filium in <lb/> substantia
-						divinitatis suae diccres esse visibilem, non <lb/> solum hominibus, sed nee ipsis
-						coelestibus potestati­ <lb/> bus : postea, mutata sententia, dicis eum et ante in­ <lb/>
-						carnationem suam conspectibus apparuisse morta­ <lb/> lium, asserens illud quod ait
-						Apostolus , <hi rend="italic">Quem nemo <lb/> hominum vidit, nec videre potest</hi> (I
-							<hi rend="italic">Tim.</hi> VI, 16), do <lb/> solo Deo Patre dictum esse; Filium vero
-						ex initic <lb/> generis humani videri solitum esse ab hominibus. <lb/> Quod cum probare
-						voluisses, nulia de Scripturis san­ <lb/> ctis testimonia protulisti, quæ te nihil
-						adjuvare po­ <lb/> luerunt. Non cnim legis alicubi scripsisse Moyse , <lb/> sicut dicis,
-						quod ab illo primo homine Adam usque <lb/> ad ipsam incarnationem semper Filius visus
-						est. Hoc <lb/> enim cum describere pronuntias in Geneseos libro, <lb/> quod ita falsum
-						est, ut etiam ridiculum sit. Numquid <lb/> eniin liber Geneseos , ab Adam usque ad
-						incarnatio­ <lb/> nem Christi, ea quae gesta sunt continet? aut ipsg <lb/> Moyses usque
-						ad tempora incarnationis Christi, vel in <lb/> carne vixit, vel ea quæ facta sunt
-						scripsit? Hæc <lb/> dicis, et putas te aliquid dicere, vcl putaris ab cis <lb/> qui nee
-						ista possunt, quae tam manifeste falsa sunt ; <lb/> cernere.</p>
-					<p>2. Deinde quod commemoras Patrem ad Filium di­ <lb/> centem, <hi rend="italic">Faciamus</hi> hominem <hi rend="italic">ad imaginem</hi> et similitudi­ <lb/>
-						<hi rend="italic">nem</hi> nostram ; quid hoc ad rem pertinet, rogo te? quid <lb/> ad
-						rem pertinet? Tantumne tibi vajabat loqui, ut non <lb/> attendens quid probare
-						susceperas , memoritcr nobis <lb/> et inaniter Scripturam Geneseos ventilares? Num­
-						<lb/> quid hinc probatur ante carnem susceptam visus ab <lb/> hominibus Christus, quia
-						dixit Pater ad Filium, Fa <lb/> ciamus <hi rend="italic">hominem ad imaginem et
-							similitudinem nostram ?</hi>
-						<lb/> Deinde adjungis, ac dicis, <hi rend="italic">Et fecit Deus hominem (Gen.</hi>
-						<lb/> I. 26, 27) : atque addis, <hi rend="italic">Quis Dens, nisi Filius ?</hi> Et <lb/>
-						ut mihi de opere quasi præscribas meo, <hi rend="italic">Hoc</hi> utique, <lb/> inquis,
-							<hi rend="italic">et</hi> tu <hi rend="italic">in tuis tractatibus exposuisti.</hi>
-						Ubi nolo <lb/> quærere quam verum loquaris, quando video nibil <lb/> ad causam pertinere
-						quod loqueris. Agitur quippe in­ <lb/> ter nos, utrum per suæ divinitatis. substantiam
-						<lb/> Christus visibus apparuisset humanis. Et tu dicis, <lb/>
-						<hi rend="italic">Fecit Deus hominem :</hi> et addis, <hi rend="italic">Quis Deus,
-							nisi</hi>
-						<lb/> Filius ? quasi propterea necesse fuerit ut homo <lb/> Deum opificem suum videret
-						oculis carneis. Hoc si <lb/> ita esset, omnes homines viderent Deum : quit <lb/> enim
-						alius eos facit in uteris matrum ? Adhuc ad­ <lb/> jicis talia, et dicis : <hi rend="italic">Iste ergo Filius qui est propheta</hi>
-						<lb/> sui genitoris, <hi rend="italic">dicebut</hi> : « Non est <hi rend="italic">bonum
-							solum esse <lb/> hominem, faciamus</hi> ei adjutorium <hi rend="italic">secundum
-							se</hi> &gt; <hi rend="italic">(Id.</hi>
-						<lb/> II, 18). Si quæram , quis tibi indicaverit quia Filius <lb/> hoc dicebat, in
-						quibus angustiis te videbis? Scriptura <lb/> enim qua; dixit, <hi rend="italic">In
-							principio fecit Deus caelum et ter­</hi>
-						<lb/> ram, non exprimens utrum Pater, an Filius, an Spi­ <lb/> ritus sanctus, an ipsa
-						Trinitas fecerit, qui unus est <lb/> Deus; per cætera eliam ita commemorat Deum, nt
-						<lb/> dicat, Et <hi rend="italic">fecit Deus, Et</hi> dixit <hi rend="italic">Deus,</hi>
-						per quæque opera <lb/> ejus, quorum illum asserit conditorem. Simili ergo <lb/>
-						locutione ait, <hi rend="italic">lit Dixit Deus, Faciamus hominem ud <lb/> imaginem</hi>
-						et similitudinem <hi rend="italic">nostram. Et fecit</hi> Deus homi­ <lb/> nem : nec
-						aliter locuta est, ubi nit, <hi rend="italic">Non eat bonum</hi> esse <lb/>
-						<hi rend="italic">hominem solum; faciamus</hi> ei <hi rend="italic">adjutorium
-							secundum</hi> st. <lb/> Unde igitur tibi persuasum est, caetera suj eriora Pa­ <lb/>
-						trem dixisse, hoc autem Filium? Unde, quæso, dis­ <lb/> tinguis, unde discernis Patrem
-						dixisse, <hi rend="italic">Fiat lux (Id.</hi>
-						<lb/> I, 1-27), ct cætera ; Patrem denique dixisse, <hi rend="italic">Faciamus <lb/>
-							hominem;</hi> ct Filium dixisse, <hi rend="italic">Faciamus ei adjutorium:</hi>
-						<lb/>
-						<pb n="805"/> rum tibi Scriptura Ubique nob dicat nisi, <hi rend="italic">Dixit Deus
-							?</hi>
-						<lb/> Quæ est ista temeritas ? quae praesumptio ? Dcinde cum <lb/> idco Patrem majorem
-						soleatis asserere, quia dixit, <lb/> Fiat hoc, aut illud, tanquam jubens Filio; Filium
-						<lb/> vero ideo minorem , quia jussa perfecit : quid dicturi <lb/> estis, ubi scriptum
-						est, <hi rend="italic">Faciamus</hi> hominem ? Non enim <lb/> ait sicut in superioribus,
-						Fiat homo, tanquam id jus <lb/> serit Filio : sed, <hi rend="italic">Faciamus,</hi>
-						inquit, <hi rend="italic">hominem.</hi> Quod noa <lb/> quaero quem dixisse arbitreris :
-						jam enim verba tua <lb/> tenemus, quod Pater hoc dixerit Filio. Cur ergo non <lb/> ait,
-						Fiat, vel, Fac; sed ait, <hi rend="italic">Faciamus?</hi> An cætera <lb/> Deus
-						imperavit, et Filius fecit; bominem vero ambo <lb/> fecerunt, sed Patre et jubente, et
-						cooperante, Filio <lb/> autem non jubente I, sed tantum jussa faciente ? Sed <lb/> si
-						propterea Patrem jubentem intelligis, quia scriptum <lb/> est, <hi rend="italic">Dixit
-							Deut, Faciamus</hi> hominem : ergo jussit et <lb/> Filius; quia tu ipse non Patrem
-						accipis dixisse, sed <lb/> Filium, <hi rend="italic">Faciamus ei adjulorium.</hi> Et
-						sicut illud uhi di­ <lb/> ctum est, <hi rend="italic">Et fecit Dcus hominem ;</hi>
-						obedisse jubenti l'a- <lb/> tri Filium vis videri, quia Pater dixerat, <hi rend="italic">Faciamus <lb/> hominem</hi> : ita eliam ubi legimus, <hi rend="italic">Ei immisit
-							Dominus <lb/> soporem in Adam, et sumpsit unam de costis ejus (Gen.</hi>
-						<lb/> n, 21) , et caetera , quibus oslendilur factum homini <lb/> esse adjutorium,
-						obedisse P.trein jubenti Filio, te <lb/> auctore, intelligamus ; quia non Patrem, sed
-						Filium <lb/> dixisse asseris, <hi rend="italic">Faciamus ei adjutorium.</hi>
-					</p>
-					<p>5. Sed hæc ila loquor, quasi ad causam quoe a nobis <lb/> agitur, quidquam pertineat,
-						quodlibet hinc volueris <lb/> credere aut suspicari. Prorsus, sicut dicis, Pater jus­
-						<lb/> serit, ubi dictum est, <hi rend="italic">Faciamus hominem;</hi> et Filius <lb/>
-						obedierit, ubi dictum est, <hi rend="italic">Et fecit Deus hominem :</hi>
-						<lb/> prorsus sicut te delectat, Filius dixerit, <hi rend="italic">Non est bonum <lb/>
-							solum esse hominem; faciamus</hi> ei <hi rend="italic">adjutorium;</hi> sed talia
-						<lb/> dicens ipse non jusserit, quia hoc vultis : quomodo <lb/> ostendis Filium qui
-						hominem fecerit, ab homine vi­ <lb/> sum ? Quomodo ostendis Filium qui dixit, Non <hi rend="italic">est bo­ <lb/> num hominem esse solum; faciamus ei adjutorium,</hi> ab
-						<lb/> homine visum, vel ab ipsa muliere, si eam factam <lb/> non vis a Patre, ne Filio
-						Pater obedisse videatur; <lb/> scd ipse eam Filius, tanquain sibi jubens sibique obe­
-						<lb/> diens, et faciendam dixit et fecit? Demonstra Filium <lb/> visum esse a viro,
-						visum esse a mulicre. Demonstra- <lb/> turum te quippe promiseras, et antequam
-						incarnare­ <lb/> tur visum fuisse humanis aspeotibus Filium. Ostende <lb/> promissa.
-						Quid pergis in vacua? Quid deludis exspe­ <lb/> ctationem nostram, nec cxhihes
-						pollicitationem tuam? <lb/> Multiplicas verba non necessaria, ut necessaria occu­ <lb/>
-						pes tempora. Si propterea visus est a viro Filius quia <lb/> fecit cum, et propterea
-						visus ab ejus muliere quia te­ <lb/> cit eam ; defini, si audes, non posse Dcum Filium
-						et <lb/> operari videntia, et a suis operibus, quamvis alia yi­ <lb/> dentibus, non
-						videri. Si autein huc j olest Dcus Filius; <lb/> ipse quippe usque nunc operatur cuncta
-						videntia, et <lb/> tamen eorum a se ipso crcatis oculis non videtur; <lb/> quid cst quod
-						dixisti ? Cur ista de libro Geneseos in <lb/> tuo sermone posuisti ? cur nobis
-						necessaria tempo­ <lb/> rum spatia superflua loquacitate finisti? <note type="footnote">1 Editi, <hi rend="italic">et cooperante</hi> ttiio, <hi rend="italic">rilio
-								autcm</hi> uon <hi rend="italic">jubente, etc.</hi>
-							<lb/> Costigantur ex vss. </note>
-					</p>
-					<p>4. <hi rend="italic">Sed iste,</hi> inquli, <hi rend="italic">Filius</hi> visus <hi rend="italic">tit Adæ,</hi> secundum <lb/>
-						<hi rend="italic">quod legimus, Adam dicentem,</hi> «<hi rend="italic">Vocem</hi> tuam
-						audivi <lb/>
-						<hi rend="italic">deambulantis in paradiso; et abscondi</hi> me, <hi rend="italic">quia
-							nudus <lb/> tum</hi> » <hi rend="italic">( Gen.</hi> III, 10). Hoc orgo prius diceres,
-						hom <lb/> bone. inde inciperes promissa nonstrare. Quanivis et <lb/> hic Adam, <hi rend="italic">Vocem tuam,</hi> inquit, <hi rend="italic">audivi</hi> ; non ait, F'a .
-						<lb/> ciei vel speciem luam vidi. Et quod ait, <hi rend="italic">Abscondi</hi> me, <lb/>
-						<hi rend="italic">quia nudus sum;</hi> videri se a Deo timuit, non a se Deum <lb/> visum
-						esse monstravit. Nam si vox quando auditur, <lb/> sequitur visio; visus est et Deus
-						Pater quoties voce <lb/> attestatus est Filio. Novimus quippe in Evangelio ver. <lb/> ba
-						Patris sonantis, atque dicentis, <hi rend="italic">Tu es Filius</hi> meus <lb/>
-						<hi rend="italic">dilectus,</hi> etc. <hi rend="italic">(Marc.</hi> i, 11), ubi auditus
-						ab hominibus, <lb/> non tamen visus est. Ac per hoc et in illis verbis qua; ł <lb/>
-						adjungis, ubi dicit, <hi rend="italic">Quis nuntiavit tibi quia nudus</hi> es? <lb/> et
-						sequentia ; potuit audiri, et non videri Deus. Non­ <lb/> dum itaque aliquid ex eo quod
-						promiseras dixisse tu <lb/> vide : et dic tandem aliquid quod discutere debeamus, <lb/>
-						aut quod pro tua causa esse fateamur.</p>
-					<p>5. <hi rend="italic">Hic Deus,</hi> inquis, <hi rend="italic">et Abrahæ</hi> visus <hi rend="italic">est.</hi> Visum esse <lb/> Deum Abi ahæ negare non possumus. Scriptura
-						quip­ <lb/> pe fidelissima apertissime hoc loquitur, dicens : <hi rend="italic">Visus
-							<lb/> eat</hi> autem <hi rend="italic">illi Deus ad quercum Mambre.</hi> Sed neque h:c
-						<lb/> expressum est, utrum Pater an Filius. Cum autem <lb/> narraret Scriptura , quomodo
-						ci visus sit Deus, tres <lb/> viros illi apparuisse declarat, in quibus magis ipsa <lb/>
-						Trinitas, qui unus est Deus, recte intelligi potest. De­ <lb/> nique Ires videt , el non
-						dominos, sed Dominum ap­ <lb/> pellat, quoniam Trinitas tres quidem personae sunt, <lb/>
-						sed unus Dominus Deus. Sic autem narratur quod vi­ <lb/> dit Abraham : <hi rend="italic">Respiciens,</hi> inquit, <hi rend="italic">oculis</hi> suis <hi rend="italic">vidit,
-							et<lb/> ecce tres viri stabant super eum; et videns</hi> procurrit in <lb/>
-						<hi rend="italic">obviam</hi> illis <hi rend="italic">ab ostio tabernaculi</hi> sui, <hi rend="italic">et</hi> adoravit super <lb/>
-						<hi rend="italic">terram, et dixit: Domine,</hi> si <hi rend="italic">inveni gratiam
-							ante</hi> te, ne <lb/>
-						<hi rend="italic">prætereas servum tuum.</hi> Hic videmus tres viros appa­ <lb/> ruisse,
-						et unum Dominum dici, unumque Dominum <lb/> rogari ne prætereat servum suum , quoniam
-						congruit <lb/> Deo visitare famulos suos. Dcinde tres personas plu­ <lb/> raliter
-						alloquitur, dicens : <hi rend="italic">Sumatur nunc aqua, et</hi> la­ <lb/>
-						<hi rend="italic">vem pedes vestros, et refrigerate sub arbore, et sumam<lb/> panem , et
-							manducate, et postea transibitis</hi> in <hi rend="italic">viam</hi> ve­ <lb/>
-						<hi rend="italic">stram, propter quod declinastis ad servum</hi> vestrum. Ma­ <lb/>
-						nifestum est eos tanquam homines invitari : non enim <lb/> tale illis praberetur
-						obsequium, quo indigentia refi­ <lb/> cereut corpora,nisi homines putarentur. Et
-						Scriptura <lb/> pluraliter eos respondisse commemorat : ait enim, Et <lb/>
-						<hi rend="italic">dixerunt, Sic fac quemadmodum dixisti.</hi> Noa ait, Et <lb/> dixit;
-						sed, <hi rend="italic">dixerunt.</hi> Deinde cam esset parata rcfectio, <lb/> dicit
-						Scriptura : <hi rend="italic">Et apposuit ante illos, et ederunt.</hi> Non <lb/> ait,
-						Apposuit anle ilium, et edit. Sed ubi ad id ven­ <lb/> tum est, ut Abrahæ filius
-						promitteretur ex Sara, quia <lb/> dirinum offerebatur beneficium, non ut hominibus <lb/>
-						humanum exhibebatur obsequium, unum narrat Scri­ <lb/> ptura dicentem, <hi rend="italic">Ubi eat Sara</hi> uxor <hi rend="italic">tua ?</hi> Non euim ait, <lb/> Dixerunt
-						autem ad illum : sed ait, <hi rend="italic">Dixit autem ad il­ <lb/> tum : Ubi est Sara
-							uxor tua?</hi> Quis autcm hoc dixcril , <lb/> postea manifestat ; ubi cum risisset
-						Sara, ait eadem <lb/> Scriptura : <hi rend="italic">Et dixit Dominus ad</hi> Abraham :
-						Quare <hi rend="italic">risit <lb/> Sara in semetipsa?</hi> et cætera usque ad finem,
-						tanquam <lb/>
-						<pb n="807"/> unus Dominus singulariter loquitur. Ac post hæc, ut <lb/> homines
-						pluraliter ahirc narrantur, et dicitur : E:c- <lb/>
-						<hi rend="italic">surgentes autem inde</hi> vin, <hi rend="italic">conspexerunt</hi> in
-						faciem Sodo­ <lb/>
-						<hi rend="italic">morum et</hi> Gomorrhæ ; <hi rend="italic">Abraham vero ambulabat</hi>
-						cum <lb/> illis,<hi rend="italic">deducens.</hi> Rursus autem redit Scriptura ad sin­
-						<lb/> gularem numerum, ac dicit : <hi rend="italic">Dominus autem</hi> dixit <hi rend="italic">: <lb/> Numquid celabo ego puero meo Abraham quæ ego</hi> facio ? <lb/>
-						Deinde promittitur Abrahae praeclara et copiosa poste. <lb/> ritas, et Sodomorum
-						denuntiatur iuleritus. Sequens <lb/> autem Scriptura dicit : <hi rend="italic">Et
-							conversi inde</hi> viri, <hi rend="italic">venerunt<lb/> in Sodoma ; Abraham autem
-							erat adhuc stans</hi> ante <hi rend="italic">Do­</hi>
-						<lb/> minum. <hi rend="italic">Et appropians Abraham dixit: Ne simul perdas <lb/> justum
-							cum impio; et erit justus tanquam</hi> impius ? Et <lb/> post collocutionem Domini
-						atque Abrahæ, sequitur <lb/> Scriptura, et dicit: <hi rend="italic">Abiit autem Dominus,
-							utdesiit loqui <lb/> ad Abraham,</hi> et <hi rend="italic">Abraham regressus eat in
-							locum</hi> suum. <lb/>
-						<hi rend="italic">Venerunt autem duo angeli in Sodoma ad vesperam.</hi> Hi <lb/> sunt de
-						quibus paulo ante dixerat : <hi rend="italic">Conversi inde viri<lb/> venerunt</hi> in
-							<hi rend="italic">Sodoma.</hi> Sed duos esse non expresserat, <lb/> cum ab initio tres
-						viros dixisset apparuisse Abrahæ, <lb/> et hospitaliter ab iRo esse susceptos, quos et
-						abeuntes <lb/> deduXit, ambubns cum eis.</p>
-					<p>6. Fortassis ergo jam pronuntiare festinas, unum <lb/> fuisse in eis Dominum Christum,
-						qui singulariter pro­ <lb/> mittebat et respondebat Abrahft; duos vero illos, an­ <lb/>
-						gelos ejus, qui venerunt in Sodoma tanquam missi <lb/> angeli a Domino suo. Sed exspecta
-						: quid properas? <lb/> Consideremus omnia diligenter, ac prius intueamur <lb/> verba
-						Domini loquentis Abrahae : <hi rend="italic">Clamor Sodomorum,</hi>
-						<lb/> tnquit, <hi rend="italic">et Gomorrhæ multiplicatus est, et peccata eorum <lb/>
-							magna valde. Descendens ergo videbo,</hi> si <hi rend="italic">secundum cla­</hi>
-						<lb/> morem ipsorum <hi rend="italic">vanientem ad me</hi> consummant. Hic se <lb/>
-						ipsum descensorum dixit in Sodoma, quo tamen neu <lb/> ipse descendit, sed angeli duo.
-						Ipse quippe <hi rend="italic">abiit, ut</hi>
-						<lb/> desiit <hi rend="italic">loqui ad Abraham; Abraham autem regressus est</hi>
-						<lb/> in <hi rend="italic">locum</hi> suum. <hi rend="italic">Venerunt</hi> autem, sicut
-						dictum est, <hi rend="italic">duo <lb/> angeli ad vesperam in Sodoma.</hi> Quid, si et
-						in illis duo­ <lb/> bus angelis unus Dominus invenitur, qui secundum <lb/> verbum suum
-						in ipsis angelis descendit in Sodoma ? <lb/> Nonne manifestum erit in tribus illis viris
-						unum Do­ <lb/> minum visum fuisse, ubi quid aliud quam ipsa Trini­ <lb/> tas figurata
-						est? Sed videamus utrum nobis sancta <lb/> Scriptura demonstret, etiam in illis duobus
-						angelis, <lb/> ut dixi, unum Dominum inventum, ne forte hæc ex <lb/> nostro corde
-						affirmasse videamur. <hi rend="italic">Venerunt</hi> ergo <hi rend="italic">duo <lb/>
-							angeli in</hi> Sodoma <hi rend="italic">ad</hi> vesperam; <hi rend="italic">Loth vero
-							sedebat,</hi> ut <lb/> scriptum est, <hi rend="italic">juxta portam</hi> Sodomorum.
-							<hi rend="italic">Videns autem<lb/> Loth,</hi> surrexit in <hi rend="italic">obviam
-							illis, et adoravit in faciem in <lb/> terram.</hi> Vides nempe hic a justo viro
-						angelos adoratos, <lb/> et tu non vis adorari Spiritum sanctum, quem vos quo­ <lb/> que
-						omnibus angelis I sine ambiguitate præponiłis ? <lb/> Sed dicturus es Homines esse
-						credebat, nam et in <lb/> Hospitium tanquam homines invitavit. Hoc magis est <lb/>
-						contra te, qui dicis non adorari Spiritum sanctum, <lb/> omnibus Angelis præfendum ;
-						cOrn videas et ho­ <lb/> mines inferiores Angelis a justis hominibus adorari. <lb/> Scd
-						adhuc dicturus es, Dominum adoravit : cum <lb/> quippe in duobus illis, quos putabat
-						esse homines, <note type="footnote">1 m t-dilione Lov. deest, angelis. </note>
-						<lb/> tanquam in prophetis esse cognovit. Jam ergo pro­ <lb/> batum est, quod me per
-						Scripturam sanctam de- <lb/> monstraturum esse promiseram, eumdem Dominum <lb/> qui
-						dictus fuerat abiisse ut cessavit loqui ad Abra­ <lb/> bam, in illis duobus ange! s
-						descendisse in Sodoma, <lb/> sicut dixerat, et in cis ab homine justo agnitum <lb/>
-						fuisse. Exhibuit itaque hospitalitatem quomodo san­ <lb/> ctis hominibus Dei, in quibus
-						Deum esse cognovit, <lb/> cum eos, sicut etiam ipse Abraham, angelos esse <lb/>
-						nesciret. Hi enim Patriarchae sunt significati in Epi­ <lb/> stola ad Hebraeos, ubi de
-						hospitalitate loquens ait: <lb/>
-						<hi rend="italic">Per hanc quidam</hi> nescientes, <hi rend="italic">hospitio receperunt
-							an­<lb/> gelos (Hebr.</hi> XIII, 2). Receptis ergo eis Loth, nesciens <lb/> quod
-						angeli essent, cognoscens tamen sicut ipo Do­ <lb/> nrino demonstrante cognoscere
-						potuit, quis in eis <lb/> esset, ut ea quae interca facta sunt taceam, exii', cnm <lb/>
-						eis de Sodomis: qnod antequam fierct, sicut Scri­ <lb/> plura loquitur, <hi rend="italic">dixerunt</hi> viri <hi rend="italic">ad Loth : Sunt tibi hic</hi>
-						<lb/> generi, <hi rend="italic">aut filii, aut</hi> filiæ ? <hi rend="italic">aut</hi>
-						si <hi rend="italic">quis</hi> tibi <hi rend="italic">alius eat</hi> in <lb/>
-						<hi rend="italic">civitate, educ de loco</hi> hoc : quoniam perdimus' <hi rend="italic">noa <lb/> locum hunc ; quia exaltatus ese clamor eorum ante Do­ <lb/> minum, et
-							misit</hi> noa <hi rend="italic">Dominus conterere eum.</hi> Ecce ubi <lb/> apparet
-						illud incendium Sodomorum per angelos fa­ <lb/> ctum, quos misit Dominus; in quibus
-						tamen et ipse <lb/> erat : neque enim sic mittit suos, ut recedat ab eis. <lb/> In eis
-						ergo descendit in Sodoma, quod se facturum <lb/> esse praedixerat, quando cum Abraham
-						loqucbatur: <lb/> quod posteaquam fecit, abiisse ipse dictus est, et an­ <lb/> geli
-						venisse in Sodoma ad vesperam. Deinde paulo <lb/> post, mox ut cduxerunt illum foras, et
-						dixerum, <lb/> sicut eadem Scriptura narrat, <hi rend="italic">Salvam</hi> fac animan <lb/>
-						<hi rend="italic">tuam; ne respexeris retro, nec steteris in tota regione;</hi> in <lb/>
-						<hi rend="italic">monte salvum te fac, nequando comprehendaris</hi> : dixit <lb/> Loth
-						ad illos, <hi rend="italic">Oro, Domine, quia</hi> invenit <hi rend="italic">puer</hi>
-						tuus <lb/>
-						<hi rend="italic">misericordiam ante te,</hi> etc. Quæ cum finisset loquendo, <lb/> et
-						elegisset sibi civitatem pusillam in qua salvaretur, <lb/> seqnitur Scriptura, ct ei
-						dicit esse responsum : <hi rend="italic">Ecce<lb/> miratus</hi> sum2 <hi rend="italic">faciem tuam et super verbum hoc, ne<lb/> everterem civitatem de qua</hi> locutus ea.
-							<hi rend="italic">Festina ergo ut<lb/> salvus sis ibi : non enim potero facere verbum,
-							donec <lb/> tu illo introeas (Gen.</hi> XVIII <hi rend="italic">et</hi> XIX). Quis hoc
-						ei re­ <lb/> spondit, nisi ille cui dixcrat, Oro, <hi rend="italic">Domine?</hi> Hoc an­
-						<lb/> tem ad ambos dixerat, non ad unum, sicut apertis­ <lb/> sime scriptum est, <hi rend="italic">Dixit autem Loth ad</hi> illos, Ora, <lb/>
-						<hi rend="italic">Domine.</hi> Agnovit ergo a Loth unum Dominum in an­ <lb/> gelis
-						duobus, sicut Abraham unum agnovit in tribus.</p>
-					<p>7. Non est cur dicatur : Ille abierat qui Dominus <lb/> erat et cum Abraham locutus
-						erat; duo vero angeli <lb/> ejus erant qui in Sodoma, illo abeunte 4, venerunt. <lb/>
-						Omnes enim tres viridiclisunl . qui apparuerunt Abra­ <lb/> hae, sicut Scriptura solet
-						viros etiain angelos nuncu­ <lb/> pare. Nee eoruin alicui uni promptius et humilius
-						<lb/> Abraham obsecutus est quam duobus, sed æqualiter <lb/> omnibus pedes lavit,
-						æqualiter omnibus epulas In i- <note type="footnote"> * sic Mss. Editi vero, <hi rend="italic">perdemus.</hi>
-						</note><note type="footnote"> I Editi, <hi rend="italic">miseratus</hi> sum. At Mss.,
-								<hi rend="italic">miratus</hi> sum : <unclear>hirc</unclear>
-							<lb/> 16 de civitate Dei, cap. 29, juxta græcum LXX, <hi rend="italic">ethaumasa,</hi>
-							<lb/> quod dici POtest, <hi rend="italic">reveritus sunt, suipexi.</hi>
-						</note><note type="footnote"> I In Mss., <hi rend="italic">jgnovisti ergo.</hi>
-						</note><note type="footnote"> * Sola fere edi lio Lov., <hi rend="italic">jnbente.</hi>
-						</note>
-						<lb/>
-						<pb n="809"/> nistravit. Ergo in omnibus Deum vidit. Propter quod <lb/> Scriptura
-						prædixerat, quod visus fuerat Deus Abrahæ <lb/> ad quercum Mambre, sub cujns umbra
-						arboris tres <lb/> viros pavit, quos oculis corporis vidit: in cis vero <lb/> Deum, non
-						corporis, sed cordis oculis vidit, id est, <lb/> intellexit atque cognovit; sicut Loth
-						in duobus, cum <lb/> quo non pluraliter, sed singulariter loquebatur, eique <lb/>
-						respondebat etiam ipse tanquam unus. Primo quippe <lb/> Abraham per tres viros illum
-						audivit, postea per <lb/> unum, qui duobus in Sodoma euntibus manens lo­ <lb/> cuius est
-						cum eo; Loth autem per duos, tamen et <lb/> ipse unum Dominum, quein pro liberatione sua
-						ro­ <lb/> gabat, et qui ei respondebat, audivit : cum ambo, id <lb/> est, et Abraham ct
-						Loth, homines putarent eos qui <lb/> angeli erant; Deum vero in eis intelligerent qui
-						erat, <lb/> non putarent esse qui non erat. Quid sibi ergo vult <lb/> ista visibilis
-						Trinitas et intelligibilis unitas, nisi ut <lb/> nobis insinuaretur quod ita tres essent
-						Pater et Fi­ <lb/> lius ct Spiritus sanctus, ut tamen simul non tres dii <lb/> et domini
-						essent, sed unus Dominus Deus ? Tu autem <lb/> dixisti, <hi rend="italic">Hic Deus visus
-							eat Abrahæ :</hi> sciens te legisse <lb/> quod scriptum cst, visum esse Deum Abrahæ ad
-						quer­ <lb/> cuin Mambre : et volens quasi probare Dominum <lb/> Filium visum esse illi
-						patriarchæ, declinasti ab illis <lb/> tribus viris, ct cos omnino tacuisti, in quibus
-						narrat <lb/> Scriptura Deum visum fuisse Abrahae; ne tu ipse nos <lb/> admoneres unius
-						esse substantiæ Trinitatem Deum, <lb/> sicut unius erant substantiæ tres viri quos vidit
-						Abra­ <lb/> ham : cum prædixisset Scriptura, <hi rend="italic">Visus est Deus <lb/>
-							Abrahce,</hi> nec tamen tres deos esse, quia et, <hi rend="italic">Visus eat<lb/>
-							Deus,</hi> dictum est; non, visi sunt dii : et ipse Abra-<lb/> ham tres vidit, et unum
-						adoravit : a quo praeteriri <lb/> noluit; ab uno responsa divinitatis accepit. Nec ali­
-						<lb/> quos duos eorum duos esse dcos sensit, sed unum in <lb/> omnibus : quia et Loth
-						duos vidit, et tamen unum <lb/> Dominum agnovit. Ubi mihi videntur per angelos si­ <lb/>
-						gnificari Filius et Spiritus sanctus : quoniam se illi <lb/> angeli missos esse dixerunt
-						; et de Trinitate quæ Deus <lb/> est, solus Pater non legitur missus; leguntur autem
-						<lb/> missi et Filius et Spiritus sanctus ; quorum non ideo <lb/> est diversa natura :
-						nam et illi viri per quos signifi­ <lb/> cati sunt, unius erant ejusdemque naturae. Hanc
-						ergo <lb/> Scripturam qua convinci posses, astuto silentio devi­ <lb/> tasti. Et cum
-						dixisses, <hi rend="italic">Hic Deus visus</hi> eat <hi rend="italic">Abrahæ :</hi>
-						<lb/> volens Filium solum visum putari in eo quod in Ge­ <lb/> nesi legitur, visum esse
-						Deum Abrah;e, quomodo sit <lb/> visus, dicere noluisti, ne ibi non solus Filius, sed
-						<lb/> Trinitas agnosceretur Deus.</p>
-					<p>8. Dixisti autem : <hi rend="italic">Si vis credere, quia Filius vi,,,. <lb/> est
-							Abrahæ, utique ipse Unigenitus</hi> in <hi rend="italic">sancto affirmavit <lb/>
-							Evangelio sic :</hi> « <hi rend="italic">Abraham pater vester exsultavit ut</hi> vi-­ <lb/>
-						<hi rend="italic">deret diem</hi> meum; <hi rend="italic">et vidit, et gavisus est. &gt;
-							(Joan.</hi> VIII, <lb/> 56). 0 disputare, o probare promissa I quasi dixerit <lb/> Dei
-						Filius, Abraham pater vester concupivit me vi­ <lb/> dere; et vidit, et gavisus est.
-						Quamvis et hoc sic ad­ <lb/> huc posset intelligi, quod sanctus Patriarcha oculis <lb/>
-						cordis viderit Dei Filium, non oculis carnis, unde <lb/> inter nos vertitur quæstio. Sed
-						cum dixerit Christus, <lb/> Abraham concupivit <hi rend="italic">videre diem</hi> meum ;
-						et <hi rend="italic">vidit, et</hi>
-						<lb/> gavisus <hi rend="italic">est ;</hi> cur non diem Christi intelligimus tem­ <lb/>
-						pus Christi, quo erat venturus in carne, quod Abra­ <lb/> ham sicut et alii Prophetæ in
-						spiritu potuit vidcre <lb/> atque gaudere? Neque hie igitur quod proposueras <lb/> et
-						pollicitus fueras, probare potuisti.</p>
-					<p>9. Post hæc venisti ad Jacob, qui luctatus est cum <lb/> Angelo, quem scriptura ipsa
-						Geneseos et hominem <lb/> dicit et Deum. Nam ita legitur : <hi rend="italic">Remansit
-							autem</hi> Ja­ <lb/>
-						<hi rend="italic">cob</hi> solus, <hi rend="italic">et luctabatur hamo cum illo
-							usque</hi> in <hi rend="italic">mane. <lb/> Vidit autem quod non potest ad eum, et
-							tetigit latitudi­</hi>
-						<lb/> nem <hi rend="italic">femoris ejus, et</hi> obstupuit' latitudo <hi rend="italic">femoris Jacob, <lb/> dum luctaretur cum eo; et dixit illi : Dimitte me;</hi> f <lb/>
-						<hi rend="italic">ascendit enim aurora. Ille autem dixit: Non te dimit- <lb/> tam,</hi>
-						nisi <hi rend="italic">me benedixeris. Dixit autem</hi> ei: <hi rend="italic">Quod eat
-							no­ <lb/> men</hi> tuum ? <hi rend="italic">llle autem dixit: Jacob. Et dixit ei:
-							Nan<lb/> vocabitur amplius nomen tuum Jacob; sed Israel erit <lb/> nomen tuum, quia
-							valuisti cum Deo, et cum</hi> hominibus <lb/>
-						<hi rend="italic">potens es. Rogavit autem eum Jacob dicens : Enuntia <lb/> mihi
-							nomen</hi> tuum. <hi rend="italic">Et dixit : Quare hoc interrogas</hi> tu <lb/>
-						<hi rend="italic">nomen meum? Et benedixit eum illic. Et appellavit <lb/> Jacob nomen
-							loci illius, Aspectus Dei : Vtdi</hi> enim <hi rend="italic">Deum <lb/> facie ad</hi>
-						faciem, <hi rend="italic">et salva facta est anima mea</hi> (Gen. <lb/> XXXII, 24-30).
-						Ex ista lectione unicum Dei Filium et <lb/> antequam venisset in carne visibiliter
-						apparuisse co­ <lb/> naris ostendere : ubi etsi non absurde Christus intel­ <lb/>
-						ligitur figuratus, propter prophetiam futura nuntian­ <lb/> tem, quia futurum erat ut
-						Jacob in filiis suis qui cru. <lb/> cifixerunt Christum, prævaluisse Christo videretur;
-						<lb/> et in filiis suis videret Christum facie ad faciem, ct <lb/> salva Geret anima
-						Israelitarum qui fideliter hoc vide­ <lb/> runt: tamen hunc hominem quI luctatus est cum
-						<lb/> Jacob, Osee propheta evidenter angelum dicit. Sic <lb/> enim apud eum scriptum est
-						de Jacob : <hi rend="italic">In utero</hi> sup­ <lb/>
-						<hi rend="italic">plantavit fratrem</hi> suum, <hi rend="italic">et in. labore
-							prævaluit</hi> Deo, et <lb/>
-						<hi rend="italic">confortatus eat cum angelo,</hi> et potuit <hi rend="italic">(Osee</hi> XII, 3, 4). <lb/> Sicut ergo in Genesi ille qui luctatus est cnm Jacob,
-						<lb/> ct homo et Deus dicitur 2 ; ita et ab hoc propheta et <lb/> Deus et. angelus. Ac
-						per hoc ita qui erat angelus, <lb/> dictus est humo, quomodo illi dicti suut viri qui
-						ap­ <lb/> paruerunt Abrahæ, qnando nescientes* et ipse et <lb/> Loth hospitio receperunt
-						angelos. Deus ergo erat <lb/> in angelo, sicut est Deus in homine, maxime quan­ <lb/> do
-						pcr hominem loquitur. Ita vero per hunc an. <lb/> gelum figuratus est Christus, sicut
-						per hominem. <lb/> Nam et Isaac filius Abrahæ,quid crat in figura, <lb/> nisi Christus,
-						quando sicut ovis ad immolandum <lb/> ductus est <hi rend="italic">( Isai.</hi> LIII,
-						7), et quando sicut Do­ <lb/> minus erucem suam, ita et ipse sibi quibus fuerct <lb/>
-						imponendus ligna portabat? Postremo, quid nri­ <lb/> ramur per angelum figuratum esse
-						Jcsum, si non <lb/> solum per hominem, verum etiam per pecudem figu­ <lb/> ratus est?
-						Nam quis alius erat ille aries qui cornibus <lb/> tenebatur in vepre, nisi Christus
-						crucifixus, vel spinis <lb/> etiam coronatus. Hunc autem arietem pro filio, cui <lb/>
-						parcere jussus est, immolavit Abraham <hi rend="italic">( Gen.</hi> xxJ, <lb/> 6-13).
-						Ita cnim homini parci Deus jussit, ut tanMn IX <note type="footnote"> 1 ID MSS., <hi rend="italic">obit..</hi> ' </note><note type="footnote"> * Mss., et Deus <hi rend="italic">scitur.</hi>
-						</note><note type="footnote"> * MM., <hi rend="italic">quando</hi> tidentes. </note>
-						<note type="footnote"> PATROL. XLII. </note>
-						<note type="footnote">
-							<hi rend="italic">(Vinyl-siahJ</hi>
-						</note>
-						<lb/>
-						<pb n="811"/> pecore, propter passionem Christi, qua? illo modo <lb/> prænuntiabatur,
-						mysterium sacri sanguinis implore­ <lb/> tur. Si ergo putas proprietate, non figura,
-						Christum <lb/> fuisse angelum, qni luctatus est cum Jacob; potes di­ <lb/> cere
-						proprietate, non figura, Christum fuisse arietem, <lb/> quom patriarcha immolavit
-						Abraham : potes postre­ <lb/> o dicere proprictate, non figura, Christuin fuisse <lb/>
-						petram, quæ percussa ligno, sifienli populo potum <lb/> largissimum fudit ( Exod. XVII,
-						G ). Sic enim dicit <lb/> Apostolus : <hi rend="italic">Bibebant enim de spirituali</hi>
-						sequente petra ; <lb/>
-						<hi rend="italic">petra autem erat</hi> Christus ( I <hi rend="italic">Cor.</hi> x, 4 ).
-						Figure istæ <lb/> non res ipsæ fuerunt, quibus figuris præcedentibus <lb/> tes
-						significabantur esse ventura;: quæ figuræ per <lb/> suhjectam Deo creaturam, et maxime
-						per Angelorum <lb/> ministerium, mortalium cxhibebantur aspectibus, Dei <lb/> quidem
-						agente potentia, sed tamen latente natura, <lb/> sive Patris, sive Filii, sive Spiritus
-						sancti.</p>
-					<p>40. Frustra itaque asseris Filium Dei risum fuisse <lb/> ah hominibus, Patrem autem non
-						fuisse visum : cum <lb/> pcr subjectam sibi creaturam et Pater videri potuerit, <lb/> et
-						Filius, et Spiritus sanctus; per suam vero substan- <lb/> Ham nullus illurum visus cst.
-						Ergo Deus, sicut infir­ <lb/> mis hominum sensibus, magis significatus quam de­ <lb/>
-						monstratus est. Non itaque visus cst sicut est : hoc <lb/> quippe in futura vita
-						promittitur sanctis. Unde dicit <lb/> apostolus Joannes : <hi rend="italic">Dilectissimi, nunc filii Dei</hi> sumus, <lb/> et <hi rend="italic">nondum apparuit
-							quid erimus : scimus autem</hi> quia <lb/> cum apparuerit, <hi rend="italic">similes</hi> ei <hi rend="italic">erimus, quoniam videbimus <lb/> eum sicuti eat</hi>
-						(I <hi rend="italic">Joan.</hi> III, 2). Videruut ergo et in hoc <lb/> sæculo Apostoli
-						Dominum; viderunt, sed non sicut <lb/> est. Denique Moyses eum sibi cupiebat ostendi,
-						quam­ <lb/> vis cum eo facie ad faciem Scriptura indice loquero­ <lb/> tur (Exod.
-						XXXIII, 13, 11). Quod cum in mea superius <lb/> prosecutione dixissem, quasi non
-						audieris præteristi, <lb/> cnm tibi ejusdem meso prosecutionis recitari ex tabu­ <lb/>
-						lis universa voluissem. Non autem discernens quid <lb/> sit videri Dcum per substantiam
-						suam, et quid sit <lb/> videri Deum per subjectam creaturam, in tantam <lb/> blasphemiam
-						decidisti, ut unigenitum Dei Filium per <lb/> hoe ipsum quod Deus est mutabilem diceres
-						: quando­ <lb/> quidamsoli Patri putasti esse tribuendum quod scri­ <lb/> pturO osse
-						dixisti, <hi rend="italic">Ego sum qui</hi> sum , <hi rend="italic">et non</hi> sum <hi rend="italic">mu­ <lb/> tatus;</hi> quasi Filius vel Spiritus sanctus sit mutatus
-						<lb/> quando visibiliter apparuit, vel ille quod constat natus <lb/> ex fcmina , vel
-						iste in specie columbæ aut igneis lin­ <lb/> guis se humanis aspectibus monstrans. Unde
-						jam re­ <lb/> spondi tibi in eo sermone, ubi ostendi non te rcfel­ <lb/> lisse quæ dili.
-						Nunc vero ut intelligas quomodo <lb/> dixerit Deus,<hi rend="italic">Ego</hi> sum <hi rend="italic">qui sum, et non sum mutatus,</hi>
-						<lb/> vel quod scriptum magis invenitur, <hi rend="italic">Ego</hi> enim <hi rend="italic">Dom­</hi>
-						<lb/> nus, <hi rend="italic">et</hi> non <hi rend="italic">mutor (Id.</hi> 3, 14, <hi rend="italic">et Malach.</hi> 3, 6); quo­ <lb/> niam non solus Pater, sed Deos unus
-						hoc dixit, quod <lb/> est ipsa Trinitas ; Psalmum attende ubi legitur : Tu <lb/> in <hi rend="italic">principio, Domine, terram</hi> fundasti, <hi rend="italic">et opera</hi>
-						manuum <lb/> tuarum sunt <hi rend="italic">cæli : ipsi peribunt; tu autem permanebis :
-							<lb/> et omnes sicut vestimentum veterascent, et velut tegu­ <lb/> mentum mutabis eos,
-							ct</hi> mutabuntur ; <hi rend="italic">tu autem idem</hi>
-						<unclear/>
-						<lb/> spse es, et anni <hi rend="italic">tui non deficient (Psal.</hi> CI, 25-28). Hoc
-						<lb/> autem ad Filium Dei dictum es n in Epistola qua est <lb/> ad Hebræos sancta
-						Scriptura .testatur <hi rend="italic">(Hebr.</hi> I, 10- <lb/> 42). Quis vero non
-						intelligat, uhi dicitur, <hi rend="italic">Cæli muta­ <lb/> buntur; tu autem idem ipse
-							es;</hi> nihil dici animI, nisi, <lb/> TII non mutaris? Ac per hoc etiam Deo Filio
-						convenit <lb/> dicere, <hi rend="italic">Ego sum qui sum, et</hi> non <hi rend="italic">sum mutatus;</hi> vel <lb/>
-						<hi rend="italic">Ego enim Dominus, et non mutor.</hi> Quod tu idco soli <lb/> Patri
-						assignasti, ut in sua substantia crederetur esse <lb/> mutabilis Filius ; tanquam ita
-						susceperit hominem, ut <lb/> in hominem verteretur. iianc tantam blasphamiam <lb/> non
-						emendabis, nisi credideris, in assumpti mehomi <lb/> nis accessisse Filio quud non erat,
-						non autem reces­ <lb/> sisse vcl defecisse quod crat.</p>
-					<p>11. Deinde quæro, quis apparuerit Moysi in igne <lb/> quando rubus iullammabatur, ct
-						non urebatur Quan­ <lb/> quain et illic angelum apparuisse Scriptura ipsa de­ <lb/>
-						clarat , dicens : <hi rend="italic">Apparuit antem illi angelus Domini in<lb/> flamma
-							ignis de rubo.</hi> In angelo autem Deum fuisse , <lb/> quis dubitet? Sed quis
-						Deuserat ? utrum Pater, an <lb/> Filius? Dicturus es, Filius : non vis enim Patrem <lb/>
-						ullo modo, vel pcr subjectam crcaturam, visibus ap­ <lb/> paruisse mortalium. Sed
-						quodlibet horum eligas, ad <lb/> utrumque respondeo. Si Paler crat, apparuit ct Pater
-						<lb/> hominibus : si Filius erat, non inutatur et Filius. Ibi <lb/> enim cum quæsisset
-						Moyscs, quis esset qui eum mit­ <lb/> tere!; ille respondit : <hi rend="italic">Ego sum
-							qui</hi> sum. Quod quid <lb/> est aliud, nisi, Mutabilis non sum : sicut propheticum
-						<lb/> testimonium ipse posuisti, <hi rend="italic">Ego</hi> sum <hi rend="italic">qui
-							sum, et non <lb/> sum</hi> mutatus ? Dixit etiam rursus ad Moyscn : <hi rend="italic">Ego</hi>
-						<lb/> sum <hi rend="italic">Deus Abraham, et Deus Isaac, et Deus Jacob (Exod.</hi>
-						<lb/> III, 2, 14, 6, 15). Aude, si potes, negare Dcum Patrem <lb/> Dcum esse Abraham, et
-						Isaac, et Jacob; si non i;se <lb/> de ruho, sed Filius loquebatur. Si autem Pater, con­
-						<lb/> fitere eliam Patrem Deum hominibus visum. Si vero <lb/> uterque est Deus Abraham,
-						et Deus Isaac, et Deus <lb/> Jacob, quod esse annuis ;-quid ambigis utrumque <lb/> unum
-						Deum? Jacob quippe ipse est Israel, cujus filiis <lb/> dicitur : <hi rend="italic">Audi,
-							Israel; Dominus Deus tuus, Dominus <lb/> unus est (Deut.</hi> VI, 4).</p>
-					<p>12. Quapropter verum esse agnosce qnod dixi, di­ <lb/> vinitatem non per substantiam
-						suam, in qua invisi­ <lb/> bilis ct immutabilis est, ped per creaturam sibi subjo- <lb/>
-						Clam mortalium oculis apparuisse cum voluit. Non <lb/> itaque sicut accipere vel accipi
-						mea verba voluisti, <lb/> ego divinitatem sic patribus 1 ostendisse se dixi, tan­ <lb/>
-						quan eam voluerim credi visibilem, quati prius <lb/> invisibilem dixeram esse : sed
-						dixi, quando se patri­ <lb/> bus divinitas ostendebat, per subjectam creaturam se <lb/>
-						visibilem demonstrabat. Nam per ipsam suam natu­ <lb/> . ram usque adeo invisibilis est,
-						ut ipse Moyscs ei cum <lb/> quo facie ad faciem loquebatur diceret: <hi rend="italic">Si
-							inveni gra. <lb/> tiam ante te, ostende mihi temetipsum manifeste (Exod.</hi>
-						<lb/> XXXIII, 11, 15). Ecce quod dixi : relege, et invenies <lb/> me verum dicere ; te
-						autem non intelligere voluisse, <lb/> vcl non potuisse, quod dixi. Audi ergo idipsum me
-						<lb/> aliquanto planius disserentem. Ego divinitatem Patris <lb/> et Filii et Spiritus
-						sancti in sua natura atque substan­ <lb/> tia mortalibus oculis invisibilem dico. Eam
-						vcro se tu <note type="footnote"> I riure* 'w:SS. J <hi rend="italic">ratru.</hi>
-						</note>
-						<lb/>
-						<pb n="813"/> formas visibiles vertere, absit ut dicam, quia et im­ <lb/> mutabilem
-						dico. Restat ergo ut aspcetibus humanis <lb/> quando se ostendit ut voluit, per
-						subjectam intelliga­ <lb/> tur hoc fecisse creaturam, quæ potest oculis apparere <lb/>
-						mortilihus.</p>
-					<p>13. Quid est autem quod eum -de Patre dixisses, <lb/>
-						<hi rend="italic">Unus est</hi> invisibilis, unde jam salis est disputatum; ad­ <lb/>
-						didisti, Unus <hi rend="italic">etiam incapubilis atque immensus?</hi> Inca­ <lb/>
-						pabilem quidem non legimus Deum. Cur sane dicas <lb/> incapabilem, nescio. Si cnim capi
-						non potest, quo­ <lb/> modo non solum Filius, verum eLiam Pater veniunt <lb/> ad
-						hominem, sicut dicit ipse Filius, et mansionem <lb/> apud eum faciunt <hi rend="italic">(Joan.</hi> xiv, 23) ? Puto quod capiat <lb/> eos apud quem faciunt mansionem. An
-						forte dicis, <lb/> Non ex toto, sed ex parte capiuntur? Dic quod vis : <lb/> respondetur
-						enim tibi, Non sunt ergo incapabiles, qui <lb/> sunt xel ex parte capabiles. An ideo
-						tibi non sufficit <lb/> incapabilem dicere, sed addidisti, et immensum, ut <lb/>
-						exponeres quatenus incapabilem dixeris ? id cst, quia <lb/> totius capax non est humana
-						natura; immensus est <lb/> enim ? Verum hoc et de Filio dici potest. Neque enim <lb/>
-						quisquam sic capit unigenitum Verbum, ut ejus ca­ <lb/> pacem se omni modo audeat
-						profiteri. Prorsus etiam <lb/> ipsum non esse dubitamus immensum. Nam quaero <lb/> abs
-						te, de quo accipias quod scriptum est : <hi rend="italic">Magnus <lb/> est, et non
-							habet</hi> finem; <hi rend="italic">excelsus et</hi> immensus. De ipso <lb/> quippc
-						paulo post dicitur : <hi rend="italic">Hic Deus noster,</hi> non <hi rend="italic">æsti­
-							<lb/> mabitur alius ad eum ; hic</hi> invenit <hi rend="italic">omnem viam disci­
-							<lb/> plinæ et dedit eam Jacob puero suo, et Israel dilecto <lb/> suo : post hæc super
-							terram</hi> visus <hi rend="italic">eat, ei inter homines<lb/> conversatus eat
-							(Baruch</hi> III, 26, 56, 37, 58) ? Quis est <lb/> iste, responde? Quis est, inquam,
-							<hi rend="italic">Magnus, et non <lb/> habens finem ; excelsus et immensus; qui super
-							terram</hi>
-						<lb/> visus <hi rend="italic">est, et inter homines conversatus est</hi> ? Yidco quos
-						<lb/> æstus, quas patiaris angustias. Times dicere, Pater <lb/> est ; ubi audis, <hi rend="italic">super terram</hi> visus <hi rend="italic">est, et inter homines <lb/>
-							conversatus est.</hi> Tu enim Patrem por suam substan­ <lb/> tiam revera invisihilem,
-						nec per subjectam creaturam <lb/> vis esse ab hominibus visum. Times dicere, Filius
-						<lb/> est ; ubi audis, non <hi rend="italic">habet finem, excelsus et immensus.</hi>
-						<lb/> Tii enim Patrem tantummodo esse contendis immen­ <lb/> sum. Times dicere, Spiritus
-						sanctus est; ubi audis , <lb/>
-						<hi rend="italic">hic Deus noster.</hi> Tu enim nec Deum vis esse Spiritum <lb/>
-						sanctum. Quid es acturus, quid responsurus, homo <lb/> qui non vis esse catholicus, ut
-						Christum sic accipias <lb/> in forma servi super terram visum, et inter homines <lb/>
-						conversatum, ut tamen in forma Dei in qua invisibilis <lb/> mansit, confitearis immensum
-						? <hi rend="italic">Hic Deus noster, non <lb/> æstimabitur alius ad eum.</hi> Quis
-						alius, nisi Antichristus, <lb/> quem veram Christum fides vera non æstimat, sed <lb/>
-						enim pro vero Christo exsecrabilis Judxorum error <lb/> exspectat ?</p>
-					<p>14. Si oras, et petis, ut dicis, discipulus esse divi­ <lb/> narum Scripturarum. ad rem
-						pertinentia testimonia <lb/> divina considera. Noli per multa quæ te nihil adju­ <lb/>
-						vene, evagari: elige prudenter tacere quam inaniter <lb/> loqui, quando non invenis quid
-						respondcas manife­ <lb/> stissimæ veritati. Timere te ostendis , nc te nudcm <lb/>
-						discipulis tuis. Utinam tu Chrsio sic induaris, at di­ <lb/> scipulos tuos magis ipsius
-						velis discipulos esse quant <lb/> tuos. Nam me non pœnitet, quantum Dominus donat. <lb/>
-						operam dare ut tu et discipuli tui sub uno magistro <lb/> sitis condiscipuli mei.
-						Tractatui autcm men, cui post <lb/> tantum tempus adhuc te responsurum esse promittis,
-						<lb/> si ita responsurus es, ut modo respondisti vel inter­ <lb/> rogationibus, vel
-						prosecutionibus meis, non plana <lb/> aliquid respondebis: sed ut homines non
-						intelligentes <lb/> quomodocumque dccipias , non tacebis. Ex his ergo <lb/> omnibus, quæ
-						sicut potui disputavi, satis apparet <lb/> Patris ct Filii et Spiritus sancti unam esse
-						virtutem, <lb/> unam esse suBstantiam, unam deitatem, unam majo­ <lb/> statcm, unam
-						gloriam; quia ipsa Trinitas est unus <lb/> Dominus Deus noster, de quo dictum ea, <hi rend="italic">Audi, Israel; <lb/> Dominus Deus tuus, Dominus unus eat (Deut.</hi> VI ,
-						4). <lb/> Tunc autem dictum est, quando Dominu; solus dedu­ <lb/> cebat eos, et non fuit
-						in eis deus alienus. Neque cnim <lb/> non cos deducebat et Christus, cum dicat
-						Apostolus, <lb/>
-						<hi rend="italic">Neque tentemus Christum, sicut quidam illorum tenta­ <lb/> verunt</hi>
-						(I <hi rend="italic">Cor.</hi> x, 9); aut Christus1 non cst Deus, aut <lb/> Christus
-						Deus est alienus. Hic est ergo Deus Pater <lb/> et Filius et Spiritus sanctus, Trinitas
-						unus Deus : cul <lb/> uni jubemur ea quæ non nisi Deo debetur servitute <lb/> servire,
-						cum audimus , Dominum <hi rend="italic">Deum tuum</hi> adora­ <lb/>
-						<hi rend="italic">bis, et illi soli servies (Deut,</hi> VI, 43). Neque enim hac <lb/>
-						servitute non servimus Christo, cUjus membra su­ <lb/> mus; aut Spiritui sancto, cujus
-						templuuf sumus. Hæc <lb/> Trinitas unus Deus <hi rend="italic">dicit: Ego 4um Dominus,
-							et non<lb/> est alius</hi> præter <hi rend="italic">me ( Id.</hi> XXXII, 59). Neque
-						enim nun <lb/> est Dominus Christo!, quem vos quoque Deum et Do­ <lb/> minum
-						confitcmini; aut Spiritus sanctus uon est Do­ <lb/> minus domus suae, hoc est templi
-						sui. Ipse est quippe <lb/> Spiritus Domini de quo dicitur: <hi rend="italic">Dominus
-							autem spiri­ <lb/> tua</hi> eat ; <hi rend="italic">ubi autem spiritus Domini, ibi
-							libertas</hi> (II <hi rend="italic">Cor.</hi>
-						<lb/> iiT, 17). Haec est Trinitas unus Deus, de. quo dicit <lb/> Apostolus : <hi rend="italic">Nullus Deus, nisi unus</hi> (I <hi rend="italic">Cor.</hi> VIII , 4).
-						<lb/> Non enim cum hæc ,tuditis, Deum negare unigeuitum <lb/> audetis. Hic Deus Trinitas
-						dicit; <hi rend="italic">Ego</hi> sum <hi rend="italic">qui</hi> sum, et <lb/> non <hi rend="italic">sum mutatus (Exod.</hi> III, 14, <hi rend="italic">et Malach.</hi> III,
-						6). Non <lb/> enim mutatus est Christus, cui dicitur : <hi rend="italic">Mutabis</hi>
-						cæ­ <lb/> los, <hi rend="italic">et mutabuntur; tu autem idem ipse es</hi> ( <hi rend="italic">Psat.</hi> CI. <lb/> 27, 28): aut mutabitur Spiritus veritatis, cum sit
-						<lb/> immutabilis vcritas, cui tantum honorem dat ipse <lb/> Christus, ut dicat, <hi rend="italic">Expedit tobis ut ego eam;</hi> nisi <lb/>
-						<hi rend="italic">enim ego</hi>
-						<unclear>abiers</unclear>, <hi rend="italic">Paracletus non veniet ad</hi> vos <hi rend="italic">(Joan.</hi>
-						<lb/> xvi, 7): et, <hi rend="italic">Quicumque dixerit blasphemiam</hi> in <hi rend="italic">Filium <lb/> hominis, dimittetur ei; qui autem dixerit in Spiritum <lb/>
-							sanctum, noM dimittetur ei (Matth.</hi> XII. 52 ). Et cum d&lt;: <lb/> se ipso
-						dixerit, <hi rend="italic">Ecce ego vobiscum sum usque ad con­<lb/> summationem sæculi
-							(Id.</hi> XXVIII , 20); de illo dixit <lb/>
-						<hi rend="italic">Ut vobiscum sit</hi> in <hi rend="italic">æternum (Joan.</hi> XIV,
-						16). Hisatque <lb/> hujusmodi testimoniis, quæ omnia quærere et colli­ <lb/> gere longum
-						est, si pacifice acquiescas , eris, quod <lb/> orare et optare te dicis, divinarum
-						Scripturarum di­ <lb/> scipulus, ut de tua fraternitate gaudeamus. <note type="footnote"> 1 Kdili, <hi rend="italic">qitibus</hi> c fr::tus. Vclius Mss., <hi rend="italic">ntd</hi> (Christus. </note></p>
-				</div>
-				</body>
-  </text>
+				<p>CAPUT XXV. — Putas non recte a me dictum esse, <lb/> qnod propter formam servi
+					quam suscepit Filius (Phi­ <lb/>
+					<hi rend="italic">lipp.</hi> II, 7), major sil Palcr. Tu enim secundum hae­
+					<lb/> resim vestram, in ipsa Dei forma Patrem Filio vis esse <lb/> majorem : cui
+					paternam sic invides formam, ut ideo <lb/> perfectum velis natum esse Filium
+					aeterna perfectio­ <lb/> ne, ne ad paternam formam saltem crescendo valcai <lb/>
+					pervenire. Sed inaniter invidet homo paternam for­ <lb/> mam Dei Filio, cui
+					Pater eam non invidit, quia aequa­ <lb/> lem sibi unicum genuit. Sed dicis non
+					esse Patris <lb/> . magnam gloriam, si ea forma servi major est, qua <lb/> forma
+					sunt majores et Angeli. Vide si aliud conaris, <lb/> nisi ad unius Patris
+					gloriam, per unici Filii contume­ <lb/> liam pervenire, ut sciliccl non augeatur
+					Pater in glo. <lb/> ria, nisi minuatur Filius in natura. Cohibe te: nescis <lb/>
+					et Patri et Filio te ingerere contumeliam, si nec ille <lb/> potuit aut noluit
+					gignere aequalem sibi, nec iste nasci <lb/> aequalis Puni? Non sc vult Deus ita
+					laudari Patrem, <lb/> ut Filimn dicatur de se ipso generasse degenerem. <lb/>
+					Non vult bonus Filii dilector iia praedicari formam <lb/> suam, ut eam non
+					polucril unicus (jus vcl nascendo <lb/> sumere, vel crescendo comprehendere.
+					Quod autem <lb/> libi videtur nihil magnum de Dco Patrc dici, si forma <lb/>
+					servi major est; qua majores videntur et Angeli: non <lb/> recte cogitas quem
+					locum in rebus habeat humana <lb/> natura, quae condita esi ad imaginem Dei.
+					Majores <lb/> Angeli dici possunt homine, quia majores sunt homi­ <lb/> nis
+					corpore: majores sunt et animo, sed in forma <lb/> quam peccati originalis
+					merito <unclear>curruptihile</unclear> aggravat <lb/> corpus. Natura vero
+					humana, qualem naturam Chri­ <lb/> stus humanae mentis assumpsit, quae nullo
+					peccato <lb/> potuit depravari, solus major est Deus. Denique pro­ <lb/> pler
+					quid dictum sit, <hi rend="italic">Minorasti eum modico</hi> minus <hi
+						rend="italic">quam</hi>
+					<lb/> angelos <hi rend="italic">(Psal.</hi> VIII, 6); apcruit Scriptura, ubi
+					legitur, <lb/>
+					<hi rend="italic">Eum</hi> autem modico minus <hi rend="italic">quam
+						angelos</hi> minoratum <hi rend="italic">vi­ <lb/> dimus</hi> Jesum <hi
+						rend="italic">propter passionem</hi> mortis <hi rend="italic">(llebr.</hi>
+					II, 9). <lb/> Non ergo propter naturam hominis; sed, <hi rend="italic">propter
+						pas­<lb/> sionem mortis.</hi> Natura vero hominis, quae mente ra­ <lb/>
+					tionali et intellectuali creaturas caeteras antecedit, <lb/> Deus solus est
+					niajor: cui utique injuria facta non <lb/> est, ubi scriptum est, <hi
+						rend="italic">Major est Deus corde</hi> nostro <lb/> (I <hi rend="italic"
+						>Joan.</hi> III, 20). Filius ergo Dci susceptum hominem <lb/> levaturus ad
+					Patrem quando dicebat, <hi rend="italic">Si diligeretis me,</hi>
+					<lb/> I gauderetis <hi rend="italic">utique, quia t'ado ad Patrem; quia
+						Pater</hi>
+					<lb/> major <hi rend="italic">me eat (Joan.</hi> xiv, 28); non carni suae solum,
+					sed <lb/> eliam menti, quam gerebat, humanae Deum Patrem <lb/> utique
+					praeferebat : quae tota sine dubio forma agno­ <lb/> scitur servi, quoniam tota
+					servit creatura Creatori.</p>
+				<p>CAPUT XXVI. — i. Postrema tibi disputatio fuit, <lb/> quomodo sit Deus patribus
+					visus, quando corpus <lb/> humanum in quo videretur, nondum acceperat Chri­
+					<lb/> stus, cam invisibilis sit per se ipsa divina natura. <lb/> Quod cum eliam
+					tu ila confessus fueris ut inter c;c- <lb/> tera non solum Patrem, sed nec ipsum
+					Filium in <lb/> substantia divinitatis suae diccres esse visibilem, non <lb/>
+					solum hominibus, sed nee ipsis coelestibus potestati­ <lb/> bus : postea, mutata
+					sententia, dicis eum et ante in­ <lb/> carnationem suam conspectibus apparuisse
+					morta­ <lb/> lium, asserens illud quod ait Apostolus , <hi rend="italic">Quem
+						nemo <lb/> hominum vidit, nec videre potest</hi> (I <hi rend="italic"
+						>Tim.</hi> VI, 16), do <lb/> solo Deo Patre dictum esse; Filium vero ex
+					initic <lb/> generis humani videri solitum esse ab hominibus. <lb/> Quod cum
+					probare voluisses, nulia de Scripturis san­ <lb/> ctis testimonia protulisti,
+					quae te nihil adjuvare po­ <lb/> luerunt. Non cnim legis alicubi scripsisse
+					Moyse , <lb/> sicut dicis, quod ab illo primo homine Adam usque <lb/> ad ipsam
+					incarnationem semper Filius visus est. Hoc <lb/> enim cum describere pronuntias
+					in Geneseos libro, <lb/> quod ita falsum est, ut etiam ridiculum sit. Numquid
+					<lb/> eniin liber Geneseos , ab Adam usque ad incarnatio­ <lb/> nem Christi, ea
+					quae gesta sunt continet? aut ipsg <lb/> Moyses usque ad tempora incarnationis
+					Christi, vel in <lb/> carne vixit, vel ea quae facta sunt scripsit? Haec <lb/>
+					dicis, et putas te aliquid dicere, vcl putaris ab cis <lb/> qui nee ista
+					possunt, quae tam manifeste falsa sunt ; <lb/> cernere.</p>
+				<p>2. Deinde quod commemoras Patrem ad Filium di­ <lb/> centem, <hi rend="italic"
+						>Faciamus</hi> hominem <hi rend="italic">ad imaginem</hi> et similitudi­ <lb/>
+					<hi rend="italic">nem</hi> nostram ; quid hoc ad rem pertinet, rogo te? quid
+					<lb/> ad rem pertinet? Tantumne tibi vajabat loqui, ut non <lb/> attendens quid
+					probare susceperas , memoritcr nobis <lb/> et inaniter Scripturam Geneseos
+					ventilares? Num­ <lb/> quid hinc probatur ante carnem susceptam visus ab <lb/>
+					hominibus Christus, quia dixit Pater ad Filium, Fa <lb/> ciamus <hi
+						rend="italic">hominem ad imaginem et similitudinem nostram ?</hi>
+					<lb/> Deinde adjungis, ac dicis, <hi rend="italic">Et fecit Deus hominem
+						(Gen.</hi>
+					<lb/> I. 26, 27) : atque addis, <hi rend="italic">Quis Dens, nisi Filius ?</hi>
+					Et <lb/> ut mihi de opere quasi praescribas meo, <hi rend="italic">Hoc</hi>
+					utique, <lb/> inquis, <hi rend="italic">et</hi> tu <hi rend="italic">in tuis
+						tractatibus exposuisti.</hi> Ubi nolo <lb/> quaerere quam verum loquaris,
+					quando video nibil <lb/> ad causam pertinere quod loqueris. Agitur quippe in­
+					<lb/> ter nos, utrum per suae divinitatis. substantiam <lb/> Christus visibus
+					apparuisset humanis. Et tu dicis, <lb/>
+					<hi rend="italic">Fecit Deus hominem :</hi> et addis, <hi rend="italic">Quis
+						Deus, nisi</hi>
+					<lb/> Filius ? quasi propterea necesse fuerit ut homo <lb/> Deum opificem suum
+					videret oculis carneis. Hoc si <lb/> ita esset, omnes homines viderent Deum :
+					quit <lb/> enim alius eos facit in uteris matrum ? Adhuc ad­ <lb/> jicis talia,
+					et dicis : <hi rend="italic">Iste ergo Filius qui est propheta</hi>
+					<lb/> sui genitoris, <hi rend="italic">dicebut</hi> : « Non est <hi
+						rend="italic">bonum solum esse <lb/> hominem, faciamus</hi> ei adjutorium
+						<hi rend="italic">secundum se</hi> &gt; <hi rend="italic">(Id.</hi>
+					<lb/> II, 18). Si quaeram , quis tibi indicaverit quia Filius <lb/> hoc dicebat,
+					in quibus angustiis te videbis? Scriptura <lb/> enim qua; dixit, <hi
+						rend="italic">In principio fecit Deus caelum et ter­</hi>
+					<lb/> ram, non exprimens utrum Pater, an Filius, an Spi­ <lb/> ritus sanctus, an
+					ipsa Trinitas fecerit, qui unus est <lb/> Deus; per caetera eliam ita commemorat
+					Deum, nt <lb/> dicat, Et <hi rend="italic">fecit Deus, Et</hi> dixit <hi
+						rend="italic">Deus,</hi> per quaeque opera <lb/> ejus, quorum illum asserit
+					conditorem. Simili ergo <lb/> locutione ait, <hi rend="italic">lit Dixit Deus,
+						Faciamus hominem ud <lb/> imaginem</hi> et similitudinem <hi rend="italic"
+						>nostram. Et fecit</hi> Deus homi­ <lb/> nem : nec aliter locuta est, ubi
+					nit, <hi rend="italic">Non eat bonum</hi> esse <lb/>
+					<hi rend="italic">hominem solum; faciamus</hi> ei <hi rend="italic">adjutorium
+						secundum</hi> st. <lb/> Unde igitur tibi persuasum est, caetera suj eriora
+					Pa­ <lb/> trem dixisse, hoc autem Filium? Unde, quaeso, dis­ <lb/> tinguis, unde
+					discernis Patrem dixisse, <hi rend="italic">Fiat lux (Id.</hi>
+					<lb/> I, 1-27), ct caetera ; Patrem denique dixisse, <hi rend="italic">Faciamus
+						<lb/> hominem;</hi> ct Filium dixisse, <hi rend="italic">Faciamus ei
+						adjutorium:</hi>
+					<lb/>
+					<pb n="805"/> rum tibi Scriptura Ubique nob dicat nisi, <hi rend="italic">Dixit
+						Deus ?</hi>
+					<lb/> Quae est ista temeritas ? quae praesumptio ? Dcinde cum <lb/> idco Patrem
+					majorem soleatis asserere, quia dixit, <lb/> Fiat hoc, aut illud, tanquam jubens
+					Filio; Filium <lb/> vero ideo minorem , quia jussa perfecit : quid dicturi <lb/>
+					estis, ubi scriptum est, <hi rend="italic">Faciamus</hi> hominem ? Non enim
+					<lb/> ait sicut in superioribus, Fiat homo, tanquam id jus <lb/> serit Filio :
+					sed, <hi rend="italic">Faciamus,</hi> inquit, <hi rend="italic">hominem.</hi>
+					Quod noa <lb/> quaero quem dixisse arbitreris : jam enim verba tua <lb/>
+					tenemus, quod Pater hoc dixerit Filio. Cur ergo non <lb/> ait, Fiat, vel, Fac;
+					sed ait, <hi rend="italic">Faciamus?</hi> An caetera <lb/> Deus imperavit, et
+					Filius fecit; bominem vero ambo <lb/> fecerunt, sed Patre et jubente, et
+					cooperante, Filio <lb/> autem non jubente I, sed tantum jussa faciente ? Sed
+					<lb/> si propterea Patrem jubentem intelligis, quia scriptum <lb/> est, <hi
+						rend="italic">Dixit Deut, Faciamus</hi> hominem : ergo jussit et <lb/>
+					Filius; quia tu ipse non Patrem accipis dixisse, sed <lb/> Filium, <hi
+						rend="italic">Faciamus ei adjulorium.</hi> Et sicut illud uhi di­ <lb/> ctum
+					est, <hi rend="italic">Et fecit Dcus hominem ;</hi> obedisse jubenti l'a<lb/>ri Filium vis videri, quia Pater dixerat, <hi rend="italic">Faciamus <lb/>
+						hominem</hi> : ita eliam ubi legimus, <hi rend="italic">Ei immisit Dominus
+						<lb/> soporem in Adam, et sumpsit unam de costis ejus (Gen.</hi>
+					<lb/> n, 21) , et caetera , quibus oslendilur factum homini <lb/> esse
+					adjutorium, obedisse P.trein jubenti Filio, te <lb/> auctore, intelligamus ;
+					quia non Patrem, sed Filium <lb/> dixisse asseris, <hi rend="italic">Faciamus ei
+						adjutorium.</hi>
+				</p>
+				<p>5. Sed haec ila loquor, quasi ad causam quoe a nobis <lb/> agitur, quidquam
+					pertineat, quodlibet hinc volueris <lb/> credere aut suspicari. Prorsus, sicut
+					dicis, Pater jus­ <lb/> serit, ubi dictum est, <hi rend="italic">Faciamus
+						hominem;</hi> et Filius <lb/> obedierit, ubi dictum est, <hi rend="italic"
+						>Et fecit Deus hominem :</hi>
+					<lb/> prorsus sicut te delectat, Filius dixerit, <hi rend="italic">Non est bonum
+						<lb/> solum esse hominem; faciamus</hi> ei <hi rend="italic"
+						>adjutorium;</hi> sed talia <lb/> dicens ipse non jusserit, quia hoc vultis
+					: quomodo <lb/> ostendis Filium qui hominem fecerit, ab homine vi­ <lb/> sum ?
+					Quomodo ostendis Filium qui dixit, Non <hi rend="italic">est bo­ <lb/> num
+						hominem esse solum; faciamus ei adjutorium,</hi> ab <lb/> homine visum, vel
+					ab ipsa muliere, si eam factam <lb/> non vis a Patre, ne Filio Pater obedisse
+					videatur; <lb/> scd ipse eam Filius, tanquain sibi jubens sibique obe­ <lb/>
+					diens, et faciendam dixit et fecit? Demonstra Filium <lb/> visum esse a viro,
+					visum esse a mulicre. Demonstra<lb/>turum te quippe promiseras, et antequam
+					incarnare­ <lb/> tur visum fuisse humanis aspeotibus Filium. Ostende <lb/>
+					promissa. Quid pergis in vacua? Quid deludis exspe­ <lb/> ctationem nostram, nec
+					cxhihes pollicitationem tuam? <lb/> Multiplicas verba non necessaria, ut
+					necessaria occu­ <lb/> pes tempora. Si propterea visus est a viro Filius quia
+					<lb/> fecit cum, et propterea visus ab ejus muliere quia te­ <lb/> cit eam ;
+					defini, si audes, non posse Dcum Filium et <lb/> operari videntia, et a suis
+					operibus, quamvis alia yi­ <lb/> dentibus, non videri. Si autein huc j olest
+					Dcus Filius; <lb/> ipse quippe usque nunc operatur cuncta videntia, et <lb/>
+					tamen eorum a se ipso crcatis oculis non videtur; <lb/> quid cst quod dixisti ?
+					Cur ista de libro Geneseos in <lb/> tuo sermone posuisti ? cur nobis necessaria
+					tempo­ <lb/> rum spatia superflua loquacitate finisti? <note type="footnote">1
+						Editi, <hi rend="italic">et cooperante</hi> ttiio, <hi rend="italic">rilio
+							autcm</hi> uon <hi rend="italic">jubente, etc.</hi>
+						<lb/> Costigantur ex vss. </note>
+				</p>
+				<p>4. <hi rend="italic">Sed iste,</hi> inquli, <hi rend="italic">Filius</hi> visus
+						<hi rend="italic">tit Adae,</hi> secundum <lb/>
+					<hi rend="italic">quod legimus, Adam dicentem,</hi> «<hi rend="italic"
+						>Vocem</hi> tuam audivi <lb/>
+					<hi rend="italic">deambulantis in paradiso; et abscondi</hi> me, <hi
+						rend="italic">quia nudus <lb/> tum</hi> » <hi rend="italic">( Gen.</hi> III,
+					10). Hoc orgo prius diceres, hom <lb/> bone. inde inciperes promissa nonstrare.
+					Quanivis et <lb/> hic Adam, <hi rend="italic">Vocem tuam,</hi> inquit, <hi
+						rend="italic">audivi</hi> ; non ait, F'a . <lb/> ciei vel speciem luam vidi.
+					Et quod ait, <hi rend="italic">Abscondi</hi> me, <lb/>
+					<hi rend="italic">quia nudus sum;</hi> videri se a Deo timuit, non a se Deum
+					<lb/> visum esse monstravit. Nam si vox quando auditur, <lb/> sequitur visio;
+					visus est et Deus Pater quoties voce <lb/> attestatus est Filio. Novimus quippe
+					in Evangelio ver. <lb/> ba Patris sonantis, atque dicentis, <hi rend="italic">Tu
+						es Filius</hi> meus <lb/>
+					<hi rend="italic">dilectus,</hi> etc. <hi rend="italic">(Marc.</hi> i, 11), ubi
+					auditus ab hominibus, <lb/> non tamen visus est. Ac per hoc et in illis verbis
+					qua; ł <lb/> adjungis, ubi dicit, <hi rend="italic">Quis nuntiavit tibi quia
+						nudus</hi> es? <lb/> et sequentia ; potuit audiri, et non videri Deus. Non­
+					<lb/> dum itaque aliquid ex eo quod promiseras dixisse tu <lb/> vide : et dic
+					tandem aliquid quod discutere debeamus, <lb/> aut quod pro tua causa esse
+					fateamur.</p>
+				<p>5. <hi rend="italic">Hic Deus,</hi> inquis, <hi rend="italic">et Abrahae</hi>
+					visus <hi rend="italic">est.</hi> Visum esse <lb/> Deum Abi ahae negare non
+					possumus. Scriptura quip­ <lb/> pe fidelissima apertissime hoc loquitur, dicens
+					: <hi rend="italic">Visus <lb/> eat</hi> autem <hi rend="italic">illi Deus ad
+						quercum Mambre.</hi> Sed neque h:c <lb/> expressum est, utrum Pater an
+					Filius. Cum autem <lb/> narraret Scriptura , quomodo ci visus sit Deus, tres
+					<lb/> viros illi apparuisse declarat, in quibus magis ipsa <lb/> Trinitas, qui
+					unus est Deus, recte intelligi potest. De­ <lb/> nique Ires videt , el non
+					dominos, sed Dominum ap­ <lb/> pellat, quoniam Trinitas tres quidem personae
+					sunt, <lb/> sed unus Dominus Deus. Sic autem narratur quod vi­ <lb/> dit Abraham
+					: <hi rend="italic">Respiciens,</hi> inquit, <hi rend="italic">oculis</hi> suis
+						<hi rend="italic">vidit, et<lb/> ecce tres viri stabant super eum; et
+						videns</hi> procurrit in <lb/>
+					<hi rend="italic">obviam</hi> illis <hi rend="italic">ab ostio tabernaculi</hi>
+					sui, <hi rend="italic">et</hi> adoravit super <lb/>
+					<hi rend="italic">terram, et dixit: Domine,</hi> si <hi rend="italic">inveni
+						gratiam ante</hi> te, ne <lb/>
+					<hi rend="italic">praetereas servum tuum.</hi> Hic videmus tres viros appa­
+					<lb/> ruisse, et unum Dominum dici, unumque Dominum <lb/> rogari ne praetereat
+					servum suum , quoniam congruit <lb/> Deo visitare famulos suos. Dcinde tres
+					personas plu­ <lb/> raliter alloquitur, dicens : <hi rend="italic">Sumatur nunc
+						aqua, et</hi> la­ <lb/>
+					<hi rend="italic">vem pedes vestros, et refrigerate sub arbore, et sumam<lb/>
+						panem , et manducate, et postea transibitis</hi> in <hi rend="italic"
+						>viam</hi> ve­ <lb/>
+					<hi rend="italic">stram, propter quod declinastis ad servum</hi> vestrum. Ma­
+					<lb/> nifestum est eos tanquam homines invitari : non enim <lb/> tale illis
+					praberetur obsequium, quo indigentia refi­ <lb/> cereut corpora,nisi homines
+					putarentur. Et Scriptura <lb/> pluraliter eos respondisse commemorat : ait enim,
+					Et <lb/>
+					<hi rend="italic">dixerunt, Sic fac quemadmodum dixisti.</hi> Noa ait, Et <lb/>
+					dixit; sed, <hi rend="italic">dixerunt.</hi> Deinde cam esset parata rcfectio,
+					<lb/> dicit Scriptura : <hi rend="italic">Et apposuit ante illos, et
+						ederunt.</hi> Non <lb/> ait, Apposuit anle ilium, et edit. Sed ubi ad id
+					ven­ <lb/> tum est, ut Abrahae filius promitteretur ex Sara, quia <lb/> dirinum
+					offerebatur beneficium, non ut hominibus <lb/> humanum exhibebatur obsequium,
+					unum narrat Scri­ <lb/> ptura dicentem, <hi rend="italic">Ubi eat Sara</hi> uxor
+						<hi rend="italic">tua ?</hi> Non euim ait, <lb/> Dixerunt autem ad illum :
+					sed ait, <hi rend="italic">Dixit autem ad il­ <lb/> tum : Ubi est Sara uxor
+						tua?</hi> Quis autcm hoc dixcril , <lb/> postea manifestat ; ubi cum
+					risisset Sara, ait eadem <lb/> Scriptura : <hi rend="italic">Et dixit Dominus
+						ad</hi> Abraham : Quare <hi rend="italic">risit <lb/> Sara in
+						semetipsa?</hi> et caetera usque ad finem, tanquam <lb/>
+					<pb n="807"/> unus Dominus singulariter loquitur. Ac post haec, ut <lb/> homines
+					pluraliter ahirc narrantur, et dicitur : E:c<lb/>
+					<hi rend="italic">surgentes autem inde</hi> vin, <hi rend="italic"
+						>conspexerunt</hi> in faciem Sodo­ <lb/>
+					<hi rend="italic">morum et</hi> Gomorrhae ; <hi rend="italic">Abraham vero
+						ambulabat</hi> cum <lb/> illis,<hi rend="italic">deducens.</hi> Rursus autem
+					redit Scriptura ad sin­ <lb/> gularem numerum, ac dicit : <hi rend="italic"
+						>Dominus autem</hi> dixit <hi rend="italic">: <lb/> Numquid celabo ego puero
+						meo Abraham quae ego</hi> facio ? <lb/> Deinde promittitur Abrahae praeclara
+					et copiosa poste. <lb/> ritas, et Sodomorum denuntiatur iuleritus. Sequens <lb/>
+					autem Scriptura dicit : <hi rend="italic">Et conversi inde</hi> viri, <hi
+						rend="italic">venerunt<lb/> in Sodoma ; Abraham autem erat adhuc stans</hi>
+					ante <hi rend="italic">Do­</hi>
+					<lb/> minum. <hi rend="italic">Et appropians Abraham dixit: Ne simul perdas
+						<lb/> justum cum impio; et erit justus tanquam</hi> impius ? Et <lb/> post
+					collocutionem Domini atque Abrahae, sequitur <lb/> Scriptura, et dicit: <hi
+						rend="italic">Abiit autem Dominus, utdesiit loqui <lb/> ad Abraham,</hi> et
+						<hi rend="italic">Abraham regressus eat in locum</hi> suum. <lb/>
+					<hi rend="italic">Venerunt autem duo angeli in Sodoma ad vesperam.</hi> Hi <lb/>
+					sunt de quibus paulo ante dixerat : <hi rend="italic">Conversi inde viri<lb/>
+						venerunt</hi> in <hi rend="italic">Sodoma.</hi> Sed duos esse non
+					expresserat, <lb/> cum ab initio tres viros dixisset apparuisse Abrahae, <lb/>
+					et hospitaliter ab iRo esse susceptos, quos et abeuntes <lb/> deduXit, ambubns
+					cum eis.</p>
+				<p>6. Fortassis ergo jam pronuntiare festinas, unum <lb/> fuisse in eis Dominum
+					Christum, qui singulariter pro­ <lb/> mittebat et respondebat Abrahft; duos vero
+					illos, an­ <lb/> gelos ejus, qui venerunt in Sodoma tanquam missi <lb/> angeli a
+					Domino suo. Sed exspecta : quid properas? <lb/> Consideremus omnia diligenter,
+					ac prius intueamur <lb/> verba Domini loquentis Abrahae : <hi rend="italic"
+						>Clamor Sodomorum,</hi>
+					<lb/> tnquit, <hi rend="italic">et Gomorrhae multiplicatus est, et peccata eorum
+						<lb/> magna valde. Descendens ergo videbo,</hi> si <hi rend="italic"
+						>secundum cla­</hi>
+					<lb/> morem ipsorum <hi rend="italic">vanientem ad me</hi> consummant. Hic se
+					<lb/> ipsum descensorum dixit in Sodoma, quo tamen neu <lb/> ipse descendit, sed
+					angeli duo. Ipse quippe <hi rend="italic">abiit, ut</hi>
+					<lb/> desiit <hi rend="italic">loqui ad Abraham; Abraham autem regressus
+						est</hi>
+					<lb/> in <hi rend="italic">locum</hi> suum. <hi rend="italic">Venerunt</hi>
+					autem, sicut dictum est, <hi rend="italic">duo <lb/> angeli ad vesperam in
+						Sodoma.</hi> Quid, si et in illis duo­ <lb/> bus angelis unus Dominus
+					invenitur, qui secundum <lb/> verbum suum in ipsis angelis descendit in Sodoma ?
+					<lb/> Nonne manifestum erit in tribus illis viris unum Do­ <lb/> minum visum
+					fuisse, ubi quid aliud quam ipsa Trini­ <lb/> tas figurata est? Sed videamus
+					utrum nobis sancta <lb/> Scriptura demonstret, etiam in illis duobus angelis,
+					<lb/> ut dixi, unum Dominum inventum, ne forte haec ex <lb/> nostro corde
+					affirmasse videamur. <hi rend="italic">Venerunt</hi> ergo <hi rend="italic">duo
+						<lb/> angeli in</hi> Sodoma <hi rend="italic">ad</hi> vesperam; <hi
+						rend="italic">Loth vero sedebat,</hi> ut <lb/> scriptum est, <hi
+						rend="italic">juxta portam</hi> Sodomorum. <hi rend="italic">Videns
+						autem<lb/> Loth,</hi> surrexit in <hi rend="italic">obviam illis, et
+						adoravit in faciem in <lb/> terram.</hi> Vides nempe hic a justo viro
+					angelos adoratos, <lb/> et tu non vis adorari Spiritum sanctum, quem vos quo­
+					<lb/> que omnibus angelis I sine ambiguitate praeponiłis ? <lb/> Sed dicturus es
+					Homines esse credebat, nam et in <lb/> Hospitium tanquam homines invitavit. Hoc
+					magis est <lb/> contra te, qui dicis non adorari Spiritum sanctum, <lb/> omnibus
+					Angelis praefendum ; cOrn videas et ho­ <lb/> mines inferiores Angelis a justis
+					hominibus adorari. <lb/> Scd adhuc dicturus es, Dominum adoravit : cum <lb/>
+					quippe in duobus illis, quos putabat esse homines, <note type="footnote">1 m
+						t-dilione Lov. deest, angelis. </note>
+					<lb/> tanquam in prophetis esse cognovit. Jam ergo pro­ <lb/> batum est, quod me
+					per Scripturam sanctam de<lb/>monstraturum esse promiseram, eumdem Dominum
+					<lb/> qui dictus fuerat abiisse ut cessavit loqui ad Abra­ <lb/> bam, in illis
+					duobus ange! s descendisse in Sodoma, <lb/> sicut dixerat, et in cis ab homine
+					justo agnitum <lb/> fuisse. Exhibuit itaque hospitalitatem quomodo san­ <lb/>
+					ctis hominibus Dei, in quibus Deum esse cognovit, <lb/> cum eos, sicut etiam
+					ipse Abraham, angelos esse <lb/> nesciret. Hi enim Patriarchae sunt significati
+					in Epi­ <lb/> stola ad Hebraeos, ubi de hospitalitate loquens ait: <lb/>
+					<hi rend="italic">Per hanc quidam</hi> nescientes, <hi rend="italic">hospitio
+						receperunt an­<lb/> gelos (Hebr.</hi> XIII, 2). Receptis ergo eis Loth,
+					nesciens <lb/> quod angeli essent, cognoscens tamen sicut ipo Do­ <lb/> nrino
+					demonstrante cognoscere potuit, quis in eis <lb/> esset, ut ea quae interca
+					facta sunt taceam, exii', cnm <lb/> eis de Sodomis: qnod antequam fierct, sicut
+					Scri­ <lb/> plura loquitur, <hi rend="italic">dixerunt</hi> viri <hi
+						rend="italic">ad Loth : Sunt tibi hic</hi>
+					<lb/> generi, <hi rend="italic">aut filii, aut</hi> filiae ? <hi rend="italic"
+						>aut</hi> si <hi rend="italic">quis</hi> tibi <hi rend="italic">alius
+						eat</hi> in <lb/>
+					<hi rend="italic">civitate, educ de loco</hi> hoc : quoniam perdimus' <hi
+						rend="italic">noa <lb/> locum hunc ; quia exaltatus ese clamor eorum ante
+						Do­ <lb/> minum, et misit</hi> noa <hi rend="italic">Dominus conterere
+						eum.</hi> Ecce ubi <lb/> apparet illud incendium Sodomorum per angelos fa­
+					<lb/> ctum, quos misit Dominus; in quibus tamen et ipse <lb/> erat : neque enim
+					sic mittit suos, ut recedat ab eis. <lb/> In eis ergo descendit in Sodoma, quod
+					se facturum <lb/> esse praedixerat, quando cum Abraham loqucbatur: <lb/> quod
+					posteaquam fecit, abiisse ipse dictus est, et an­ <lb/> geli venisse in Sodoma
+					ad vesperam. Deinde paulo <lb/> post, mox ut cduxerunt illum foras, et dixerum,
+					<lb/> sicut eadem Scriptura narrat, <hi rend="italic">Salvam</hi> fac animan <lb/>
+					<hi rend="italic">tuam; ne respexeris retro, nec steteris in tota regione;</hi>
+					in <lb/>
+					<hi rend="italic">monte salvum te fac, nequando comprehendaris</hi> : dixit
+					<lb/> Loth ad illos, <hi rend="italic">Oro, Domine, quia</hi> invenit <hi
+						rend="italic">puer</hi> tuus <lb/>
+					<hi rend="italic">misericordiam ante te,</hi> etc. Quae cum finisset loquendo,
+					<lb/> et elegisset sibi civitatem pusillam in qua salvaretur, <lb/> seqnitur
+					Scriptura, ct ei dicit esse responsum : <hi rend="italic">Ecce<lb/> miratus</hi>
+					sum2 <hi rend="italic">faciem tuam et super verbum hoc, ne<lb/> everterem
+						civitatem de qua</hi> locutus ea. <hi rend="italic">Festina ergo ut<lb/>
+						salvus sis ibi : non enim potero facere verbum, donec <lb/> tu illo introeas
+						(Gen.</hi> XVIII <hi rend="italic">et</hi> XIX). Quis hoc ei re­ <lb/>
+					spondit, nisi ille cui dixcrat, Oro, <hi rend="italic">Domine?</hi> Hoc an­
+					<lb/> tem ad ambos dixerat, non ad unum, sicut apertis­ <lb/> sime scriptum est,
+						<hi rend="italic">Dixit autem Loth ad</hi> illos, Ora, <lb/>
+					<hi rend="italic">Domine.</hi> Agnovit ergo a Loth unum Dominum in an­ <lb/>
+					gelis duobus, sicut Abraham unum agnovit in tribus.</p>
+				<p>7. Non est cur dicatur : Ille abierat qui Dominus <lb/> erat et cum Abraham
+					locutus erat; duo vero angeli <lb/> ejus erant qui in Sodoma, illo abeunte 4,
+					venerunt. <lb/> Omnes enim tres viridiclisunl . qui apparuerunt Abra­ <lb/> hae,
+					sicut Scriptura solet viros etiain angelos nuncu­ <lb/> pare. Nee eoruin alicui
+					uni promptius et humilius <lb/> Abraham obsecutus est quam duobus, sed
+					aequaliter <lb/> omnibus pedes lavit, aequaliter omnibus epulas In i- <note
+						type="footnote"> * sic Mss. Editi vero, <hi rend="italic">perdemus.</hi>
+					</note><note type="footnote"> I Editi, <hi rend="italic">miseratus</hi> sum. At
+						Mss., <hi rend="italic">miratus</hi> sum : <unclear>hirc</unclear>
+						<lb/> 16 de civitate Dei, cap. 29, juxta graecum LXX, <hi rend="italic"
+							>ethaumasa,</hi>
+						<lb/> quod dici POtest, <hi rend="italic">reveritus sunt, suipexi.</hi>
+					</note><note type="footnote"> I In Mss., <hi rend="italic">jgnovisti ergo.</hi>
+					</note><note type="footnote"> * Sola fere edi lio Lov., <hi rend="italic"
+							>jnbente.</hi>
+					</note>
+					<lb/>
+					<pb n="809"/> nistravit. Ergo in omnibus Deum vidit. Propter quod <lb/>
+					Scriptura praedixerat, quod visus fuerat Deus Abrahae <lb/> ad quercum Mambre,
+					sub cujns umbra arboris tres <lb/> viros pavit, quos oculis corporis vidit: in
+					cis vero <lb/> Deum, non corporis, sed cordis oculis vidit, id est, <lb/>
+					intellexit atque cognovit; sicut Loth in duobus, cum <lb/> quo non pluraliter,
+					sed singulariter loquebatur, eique <lb/> respondebat etiam ipse tanquam unus.
+					Primo quippe <lb/> Abraham per tres viros illum audivit, postea per <lb/> unum,
+					qui duobus in Sodoma euntibus manens lo­ <lb/> cuius est cum eo; Loth autem per
+					duos, tamen et <lb/> ipse unum Dominum, quein pro liberatione sua ro­ <lb/>
+					gabat, et qui ei respondebat, audivit : cum ambo, id <lb/> est, et Abraham ct
+					Loth, homines putarent eos qui <lb/> angeli erant; Deum vero in eis
+					intelligerent qui erat, <lb/> non putarent esse qui non erat. Quid sibi ergo
+					vult <lb/> ista visibilis Trinitas et intelligibilis unitas, nisi ut <lb/> nobis
+					insinuaretur quod ita tres essent Pater et Fi­ <lb/> lius ct Spiritus sanctus,
+					ut tamen simul non tres dii <lb/> et domini essent, sed unus Dominus Deus ? Tu
+					autem <lb/> dixisti, <hi rend="italic">Hic Deus visus eat Abrahae :</hi> sciens
+					te legisse <lb/> quod scriptum cst, visum esse Deum Abrahae ad quer­ <lb/> cuin
+					Mambre : et volens quasi probare Dominum <lb/> Filium visum esse illi
+					patriarchae, declinasti ab illis <lb/> tribus viris, ct cos omnino tacuisti, in
+					quibus narrat <lb/> Scriptura Deum visum fuisse Abrahae; ne tu ipse nos <lb/>
+					admoneres unius esse substantiae Trinitatem Deum, <lb/> sicut unius erant
+					substantiae tres viri quos vidit Abra­ <lb/> ham : cum praedixisset Scriptura,
+						<hi rend="italic">Visus est Deus <lb/> Abrahce,</hi> nec tamen tres deos
+					esse, quia et, <hi rend="italic">Visus eat<lb/> Deus,</hi> dictum est; non, visi
+					sunt dii : et ipse Abra-<lb/> ham tres vidit, et unum adoravit : a quo
+					praeteriri <lb/> noluit; ab uno responsa divinitatis accepit. Nec ali­ <lb/>
+					quos duos eorum duos esse dcos sensit, sed unum in <lb/> omnibus : quia et Loth
+					duos vidit, et tamen unum <lb/> Dominum agnovit. Ubi mihi videntur per angelos
+					si­ <lb/> gnificari Filius et Spiritus sanctus : quoniam se illi <lb/> angeli
+					missos esse dixerunt ; et de Trinitate quae Deus <lb/> est, solus Pater non
+					legitur missus; leguntur autem <lb/> missi et Filius et Spiritus sanctus ;
+					quorum non ideo <lb/> est diversa natura : nam et illi viri per quos signifi­
+					<lb/> cati sunt, unius erant ejusdemque naturae. Hanc ergo <lb/> Scripturam qua
+					convinci posses, astuto silentio devi­ <lb/> tasti. Et cum dixisses, <hi
+						rend="italic">Hic Deus visus</hi> eat <hi rend="italic">Abrahae :</hi>
+					<lb/> volens Filium solum visum putari in eo quod in Ge­ <lb/> nesi legitur,
+					visum esse Deum Abrah;e, quomodo sit <lb/> visus, dicere noluisti, ne ibi non
+					solus Filius, sed <lb/> Trinitas agnosceretur Deus.</p>
+				<p>8. Dixisti autem : <hi rend="italic">Si vis credere, quia Filius vi,,,. <lb/> est
+						Abrahae, utique ipse Unigenitus</hi> in <hi rend="italic">sancto affirmavit
+						<lb/> Evangelio sic :</hi> « <hi rend="italic">Abraham pater vester
+						exsultavit ut</hi> vi-­ <lb/>
+					<hi rend="italic">deret diem</hi> meum; <hi rend="italic">et vidit, et gavisus
+						est. &gt; (Joan.</hi> VIII, <lb/> 56). 0 disputare, o probare promissa I
+					quasi dixerit <lb/> Dei Filius, Abraham pater vester concupivit me vi­ <lb/>
+					dere; et vidit, et gavisus est. Quamvis et hoc sic ad­ <lb/> huc posset
+					intelligi, quod sanctus Patriarcha oculis <lb/> cordis viderit Dei Filium, non
+					oculis carnis, unde <lb/> inter nos vertitur quaestio. Sed cum dixerit Christus,
+					<lb/> Abraham concupivit <hi rend="italic">videre diem</hi> meum ; et <hi
+						rend="italic">vidit, et</hi>
+					<lb/> gavisus <hi rend="italic">est ;</hi> cur non diem Christi intelligimus
+					tem­ <lb/> pus Christi, quo erat venturus in carne, quod Abra­ <lb/> ham sicut
+					et alii Prophetae in spiritu potuit vidcre <lb/> atque gaudere? Neque hie igitur
+					quod proposueras <lb/> et pollicitus fueras, probare potuisti.</p>
+				<p>9. Post haec venisti ad Jacob, qui luctatus est cum <lb/> Angelo, quem scriptura
+					ipsa Geneseos et hominem <lb/> dicit et Deum. Nam ita legitur : <hi
+						rend="italic">Remansit autem</hi> Ja­ <lb/>
+					<hi rend="italic">cob</hi> solus, <hi rend="italic">et luctabatur hamo cum illo
+						usque</hi> in <hi rend="italic">mane. <lb/> Vidit autem quod non potest ad
+						eum, et tetigit latitudi­</hi>
+					<lb/> nem <hi rend="italic">femoris ejus, et</hi> obstupuit' latitudo <hi
+						rend="italic">femoris Jacob, <lb/> dum luctaretur cum eo; et dixit illi :
+						Dimitte me;</hi> f <lb/>
+					<hi rend="italic">ascendit enim aurora. Ille autem dixit: Non te dimit- <lb/>
+						tam,</hi> nisi <hi rend="italic">me benedixeris. Dixit autem</hi> ei: <hi
+						rend="italic">Quod eat no­ <lb/> men</hi> tuum ? <hi rend="italic">llle
+						autem dixit: Jacob. Et dixit ei: Nan<lb/> vocabitur amplius nomen tuum
+						Jacob; sed Israel erit <lb/> nomen tuum, quia valuisti cum Deo, et cum</hi>
+					hominibus <lb/>
+					<hi rend="italic">potens es. Rogavit autem eum Jacob dicens : Enuntia <lb/> mihi
+						nomen</hi> tuum. <hi rend="italic">Et dixit : Quare hoc interrogas</hi> tu <lb/>
+					<hi rend="italic">nomen meum? Et benedixit eum illic. Et appellavit <lb/> Jacob
+						nomen loci illius, Aspectus Dei : Vtdi</hi> enim <hi rend="italic">Deum
+						<lb/> facie ad</hi> faciem, <hi rend="italic">et salva facta est anima
+						mea</hi> (Gen. <lb/> XXXII, 24-30). Ex ista lectione unicum Dei Filium et
+					<lb/> antequam venisset in carne visibiliter apparuisse co­ <lb/> naris
+					ostendere : ubi etsi non absurde Christus intel­ <lb/> ligitur figuratus,
+					propter prophetiam futura nuntian­ <lb/> tem, quia futurum erat ut Jacob in
+					filiis suis qui cru. <lb/> cifixerunt Christum, praevaluisse Christo videretur;
+					<lb/> et in filiis suis videret Christum facie ad faciem, ct <lb/> salva Geret
+					anima Israelitarum qui fideliter hoc vide­ <lb/> runt: tamen hunc hominem quI
+					luctatus est cum <lb/> Jacob, Osee propheta evidenter angelum dicit. Sic <lb/>
+					enim apud eum scriptum est de Jacob : <hi rend="italic">In utero</hi> sup­ <lb/>
+					<hi rend="italic">plantavit fratrem</hi> suum, <hi rend="italic">et in. labore
+						praevaluit</hi> Deo, et <lb/>
+					<hi rend="italic">confortatus eat cum angelo,</hi> et potuit <hi rend="italic"
+						>(Osee</hi> XII, 3, 4). <lb/> Sicut ergo in Genesi ille qui luctatus est cnm
+					Jacob, <lb/> ct homo et Deus dicitur 2 ; ita et ab hoc propheta et <lb/> Deus
+					et. angelus. Ac per hoc ita qui erat angelus, <lb/> dictus est humo, quomodo
+					illi dicti suut viri qui ap­ <lb/> paruerunt Abrahae, qnando nescientes* et ipse
+					et <lb/> Loth hospitio receperunt angelos. Deus ergo erat <lb/> in angelo, sicut
+					est Deus in homine, maxime quan­ <lb/> do pcr hominem loquitur. Ita vero per
+					hunc an. <lb/> gelum figuratus est Christus, sicut per hominem. <lb/> Nam et
+					Isaac filius Abrahae,quid crat in figura, <lb/> nisi Christus, quando sicut ovis
+					ad immolandum <lb/> ductus est <hi rend="italic">( Isai.</hi> LIII, 7), et
+					quando sicut Do­ <lb/> minus erucem suam, ita et ipse sibi quibus fuerct <lb/>
+					imponendus ligna portabat? Postremo, quid nri­ <lb/> ramur per angelum figuratum
+					esse Jcsum, si non <lb/> solum per hominem, verum etiam per pecudem figu­ <lb/>
+					ratus est? Nam quis alius erat ille aries qui cornibus <lb/> tenebatur in vepre,
+					nisi Christus crucifixus, vel spinis <lb/> etiam coronatus. Hunc autem arietem
+					pro filio, cui <lb/> parcere jussus est, immolavit Abraham <hi rend="italic">(
+						Gen.</hi> xxJ, <lb/> 6-13). Ita cnim homini parci Deus jussit, ut tanMn IX
+						<note type="footnote"> 1 ID MSS., <hi rend="italic">obit..</hi> '
+						</note><note type="footnote"> * Mss., et Deus <hi rend="italic">scitur.</hi>
+					</note><note type="footnote"> * MM., <hi rend="italic">quando</hi> tidentes. </note>
+					<note type="footnote"> PATROL. XLII. </note>
+					<note type="footnote">
+						<hi rend="italic">(Vinyl-siahJ</hi>
+					</note>
+					<lb/>
+					<pb n="811"/> pecore, propter passionem Christi, qua? illo modo <lb/>
+					praenuntiabatur, mysterium sacri sanguinis implore­ <lb/> tur. Si ergo putas
+					proprietate, non figura, Christum <lb/> fuisse angelum, qni luctatus est cum
+					Jacob; potes di­ <lb/> cere proprietate, non figura, Christum fuisse arietem,
+					<lb/> quom patriarcha immolavit Abraham : potes postre­ <lb/> o dicere
+					proprictate, non figura, Christuin fuisse <lb/> petram, quae percussa ligno,
+					sifienli populo potum <lb/> largissimum fudit ( Exod. XVII, G ). Sic enim dicit
+					<lb/> Apostolus : <hi rend="italic">Bibebant enim de spirituali</hi> sequente
+					petra ; <lb/>
+					<hi rend="italic">petra autem erat</hi> Christus ( I <hi rend="italic">Cor.</hi>
+					x, 4 ). Figure istae <lb/> non res ipsae fuerunt, quibus figuris praecedentibus
+					<lb/> tes significabantur esse ventura;: quae figurae per <lb/> suhjectam Deo
+					creaturam, et maxime per Angelorum <lb/> ministerium, mortalium cxhibebantur
+					aspectibus, Dei <lb/> quidem agente potentia, sed tamen latente natura, <lb/>
+					sive Patris, sive Filii, sive Spiritus sancti.</p>
+				<p>40. Frustra itaque asseris Filium Dei risum fuisse <lb/> ah hominibus, Patrem
+					autem non fuisse visum : cum <lb/> pcr subjectam sibi creaturam et Pater videri
+					potuerit, <lb/> et Filius, et Spiritus sanctus; per suam vero substan<lb/> Ham
+					nullus illurum visus cst. Ergo Deus, sicut infir­ <lb/> mis hominum sensibus,
+					magis significatus quam de­ <lb/> monstratus est. Non itaque visus cst sicut est
+					: hoc <lb/> quippe in futura vita promittitur sanctis. Unde dicit <lb/>
+					apostolus Joannes : <hi rend="italic">Dilectissimi, nunc filii Dei</hi> sumus,
+					<lb/> et <hi rend="italic">nondum apparuit quid erimus : scimus autem</hi> quia
+					<lb/> cum apparuerit, <hi rend="italic">similes</hi> ei <hi rend="italic"
+						>erimus, quoniam videbimus <lb/> eum sicuti eat</hi> (I <hi rend="italic"
+						>Joan.</hi> III, 2). Videruut ergo et in hoc <lb/> saeculo Apostoli Dominum;
+					viderunt, sed non sicut <lb/> est. Denique Moyses eum sibi cupiebat ostendi,
+					quam­ <lb/> vis cum eo facie ad faciem Scriptura indice loquero­ <lb/> tur
+					(Exod. XXXIII, 13, 11). Quod cum in mea superius <lb/> prosecutione dixissem,
+					quasi non audieris praeteristi, <lb/> cnm tibi ejusdem meso prosecutionis
+					recitari ex tabu­ <lb/> lis universa voluissem. Non autem discernens quid <lb/>
+					sit videri Dcum per substantiam suam, et quid sit <lb/> videri Deum per
+					subjectam creaturam, in tantam <lb/> blasphemiam decidisti, ut unigenitum Dei
+					Filium per <lb/> hoe ipsum quod Deus est mutabilem diceres : quando­ <lb/>
+					quidamsoli Patri putasti esse tribuendum quod scri­ <lb/> pturO osse dixisti,
+						<hi rend="italic">Ego sum qui</hi> sum , <hi rend="italic">et non</hi> sum
+						<hi rend="italic">mu­ <lb/> tatus;</hi> quasi Filius vel Spiritus sanctus
+					sit mutatus <lb/> quando visibiliter apparuit, vel ille quod constat natus <lb/>
+					ex fcmina , vel iste in specie columbae aut igneis lin­ <lb/> guis se humanis
+					aspectibus monstrans. Unde jam re­ <lb/> spondi tibi in eo sermone, ubi ostendi
+					non te rcfel­ <lb/> lisse quae dili. Nunc vero ut intelligas quomodo <lb/>
+					dixerit Deus,<hi rend="italic">Ego</hi> sum <hi rend="italic">qui sum, et non
+						sum mutatus,</hi>
+					<lb/> vel quod scriptum magis invenitur, <hi rend="italic">Ego</hi> enim <hi
+						rend="italic">Dom­</hi>
+					<lb/> nus, <hi rend="italic">et</hi> non <hi rend="italic">mutor (Id.</hi> 3,
+					14, <hi rend="italic">et Malach.</hi> 3, 6); quo­ <lb/> niam non solus Pater,
+					sed Deos unus hoc dixit, quod <lb/> est ipsa Trinitas ; Psalmum attende ubi
+					legitur : Tu <lb/> in <hi rend="italic">principio, Domine, terram</hi> fundasti,
+						<hi rend="italic">et opera</hi> manuum <lb/> tuarum sunt <hi rend="italic"
+						>caeli : ipsi peribunt; tu autem permanebis : <lb/> et omnes sicut
+						vestimentum veterascent, et velut tegu­ <lb/> mentum mutabis eos, ct</hi>
+					mutabuntur ; <hi rend="italic">tu autem idem</hi>
+					<unclear/>
+					<lb/> spse es, et anni <hi rend="italic">tui non deficient (Psal.</hi> CI,
+					25-28). Hoc <lb/> autem ad Filium Dei dictum es n in Epistola qua est <lb/> ad
+					Hebraeos sancta Scriptura .testatur <hi rend="italic">(Hebr.</hi> I, 10- <lb/>
+					42). Quis vero non intelligat, uhi dicitur, <hi rend="italic">Caeli muta­ <lb/>
+						buntur; tu autem idem ipse es;</hi> nihil dici animI, nisi, <lb/> TII non
+					mutaris? Ac per hoc etiam Deo Filio convenit <lb/> dicere, <hi rend="italic">Ego
+						sum qui sum, et</hi> non <hi rend="italic">sum mutatus;</hi> vel <lb/>
+					<hi rend="italic">Ego enim Dominus, et non mutor.</hi> Quod tu idco soli <lb/>
+					Patri assignasti, ut in sua substantia crederetur esse <lb/> mutabilis Filius ;
+					tanquam ita susceperit hominem, ut <lb/> in hominem verteretur. iianc tantam
+					blasphamiam <lb/> non emendabis, nisi credideris, in assumpti mehomi <lb/> nis
+					accessisse Filio quud non erat, non autem reces­ <lb/> sisse vcl defecisse quod
+					crat.</p>
+				<p>11. Deinde quaero, quis apparuerit Moysi in igne <lb/> quando rubus
+					iullammabatur, ct non urebatur Quan­ <lb/> quain et illic angelum apparuisse
+					Scriptura ipsa de­ <lb/> clarat , dicens : <hi rend="italic">Apparuit antem illi
+						angelus Domini in<lb/> flamma ignis de rubo.</hi> In angelo autem Deum
+					fuisse , <lb/> quis dubitet? Sed quis Deuserat ? utrum Pater, an <lb/> Filius?
+					Dicturus es, Filius : non vis enim Patrem <lb/> ullo modo, vel pcr subjectam
+					crcaturam, visibus ap­ <lb/> paruisse mortalium. Sed quodlibet horum eligas, ad
+					<lb/> utrumque respondeo. Si Paler crat, apparuit ct Pater <lb/> hominibus : si
+					Filius erat, non inutatur et Filius. Ibi <lb/> enim cum quaesisset Moyscs, quis
+					esset qui eum mit­ <lb/> tere!; ille respondit : <hi rend="italic">Ego sum
+						qui</hi> sum. Quod quid <lb/> est aliud, nisi, Mutabilis non sum : sicut
+					propheticum <lb/> testimonium ipse posuisti, <hi rend="italic">Ego</hi> sum <hi
+						rend="italic">qui sum, et non <lb/> sum</hi> mutatus ? Dixit etiam rursus ad
+					Moyscn : <hi rend="italic">Ego</hi>
+					<lb/> sum <hi rend="italic">Deus Abraham, et Deus Isaac, et Deus Jacob
+						(Exod.</hi>
+					<lb/> III, 2, 14, 6, 15). Aude, si potes, negare Dcum Patrem <lb/> Dcum esse
+					Abraham, et Isaac, et Jacob; si non i;se <lb/> de ruho, sed Filius loquebatur.
+					Si autem Pater, con­ <lb/> fitere eliam Patrem Deum hominibus visum. Si vero
+					<lb/> uterque est Deus Abraham, et Deus Isaac, et Deus <lb/> Jacob, quod esse
+					annuis ;-quid ambigis utrumque <lb/> unum Deum? Jacob quippe ipse est Israel,
+					cujus filiis <lb/> dicitur : <hi rend="italic">Audi, Israel; Dominus Deus tuus,
+						Dominus <lb/> unus est (Deut.</hi> VI, 4).</p>
+				<p>12. Quapropter verum esse agnosce qnod dixi, di­ <lb/> vinitatem non per
+					substantiam suam, in qua invisi­ <lb/> bilis ct immutabilis est, ped per
+					creaturam sibi subjo<lb/>Clam mortalium oculis apparuisse cum voluit. Non
+					<lb/> itaque sicut accipere vel accipi mea verba voluisti, <lb/> ego divinitatem
+					sic patribus 1 ostendisse se dixi, tan­ <lb/> quan eam voluerim credi visibilem,
+					quati prius <lb/> invisibilem dixeram esse : sed dixi, quando se patri­ <lb/>
+					bus divinitas ostendebat, per subjectam creaturam se <lb/> visibilem
+					demonstrabat. Nam per ipsam suam natu­ <lb/> . ram usque adeo invisibilis est,
+					ut ipse Moyscs ei cum <lb/> quo facie ad faciem loquebatur diceret: <hi
+						rend="italic">Si inveni gra. <lb/> tiam ante te, ostende mihi temetipsum
+						manifeste (Exod.</hi>
+					<lb/> XXXIII, 11, 15). Ecce quod dixi : relege, et invenies <lb/> me verum
+					dicere ; te autem non intelligere voluisse, <lb/> vcl non potuisse, quod dixi.
+					Audi ergo idipsum me <lb/> aliquanto planius disserentem. Ego divinitatem Patris
+					<lb/> et Filii et Spiritus sancti in sua natura atque substan­ <lb/> tia
+					mortalibus oculis invisibilem dico. Eam vcro se tu <note type="footnote"> I
+						riure* 'w:SS. J <hi rend="italic">ratru.</hi>
+					</note>
+					<lb/>
+					<pb n="813"/> formas visibiles vertere, absit ut dicam, quia et im­ <lb/>
+					mutabilem dico. Restat ergo ut aspcetibus humanis <lb/> quando se ostendit ut
+					voluit, per subjectam intelliga­ <lb/> tur hoc fecisse creaturam, quae potest
+					oculis apparere <lb/> mortilihus.</p>
+				<p>13. Quid est autem quod eumde Patre dixisses, <lb/>
+					<hi rend="italic">Unus est</hi> invisibilis, unde jam salis est disputatum; ad­
+					<lb/> didisti, Unus <hi rend="italic">etiam incapubilis atque immensus?</hi>
+					Inca­ <lb/> pabilem quidem non legimus Deum. Cur sane dicas <lb/> incapabilem,
+					nescio. Si cnim capi non potest, quo­ <lb/> modo non solum Filius, verum eLiam
+					Pater veniunt <lb/> ad hominem, sicut dicit ipse Filius, et mansionem <lb/> apud
+					eum faciunt <hi rend="italic">(Joan.</hi> xiv, 23) ? Puto quod capiat <lb/> eos
+					apud quem faciunt mansionem. An forte dicis, <lb/> Non ex toto, sed ex parte
+					capiuntur? Dic quod vis : <lb/> respondetur enim tibi, Non sunt ergo
+					incapabiles, qui <lb/> sunt xel ex parte capabiles. An ideo tibi non sufficit
+					<lb/> incapabilem dicere, sed addidisti, et immensum, ut <lb/> exponeres
+					quatenus incapabilem dixeris ? id cst, quia <lb/> totius capax non est humana
+					natura; immensus est <lb/> enim ? Verum hoc et de Filio dici potest. Neque enim
+					<lb/> quisquam sic capit unigenitum Verbum, ut ejus ca­ <lb/> pacem se omni modo
+					audeat profiteri. Prorsus etiam <lb/> ipsum non esse dubitamus immensum. Nam
+					quaero <lb/> abs te, de quo accipias quod scriptum est : <hi rend="italic"
+						>Magnus <lb/> est, et non habet</hi> finem; <hi rend="italic">excelsus
+						et</hi> immensus. De ipso <lb/> quippc paulo post dicitur : <hi
+						rend="italic">Hic Deus noster,</hi> non <hi rend="italic">aesti­ <lb/>
+						mabitur alius ad eum ; hic</hi> invenit <hi rend="italic">omnem viam disci­
+						<lb/> plinae et dedit eam Jacob puero suo, et Israel dilecto <lb/> suo :
+						post haec super terram</hi> visus <hi rend="italic">eat, ei inter
+						homines<lb/> conversatus eat (Baruch</hi> III, 26, 56, 37, 58) ? Quis est
+					<lb/> iste, responde? Quis est, inquam, <hi rend="italic">Magnus, et non <lb/>
+						habens finem ; excelsus et immensus; qui super terram</hi>
+					<lb/> visus <hi rend="italic">est, et inter homines conversatus est</hi> ? Yidco
+					quos <lb/> aestus, quas patiaris angustias. Times dicere, Pater <lb/> est ; ubi
+					audis, <hi rend="italic">super terram</hi> visus <hi rend="italic">est, et inter
+						homines <lb/> conversatus est.</hi> Tu enim Patrem por suam substan­ <lb/>
+					tiam revera invisihilem, nec per subjectam creaturam <lb/> vis esse ab hominibus
+					visum. Times dicere, Filius <lb/> est ; ubi audis, non <hi rend="italic">habet
+						finem, excelsus et immensus.</hi>
+					<lb/> Tii enim Patrem tantummodo esse contendis immen­ <lb/> sum. Times dicere,
+					Spiritus sanctus est; ubi audis , <lb/>
+					<hi rend="italic">hic Deus noster.</hi> Tu enim nec Deum vis esse Spiritum <lb/>
+					sanctum. Quid es acturus, quid responsurus, homo <lb/> qui non vis esse
+					catholicus, ut Christum sic accipias <lb/> in forma servi super terram visum, et
+					inter homines <lb/> conversatum, ut tamen in forma Dei in qua invisibilis <lb/>
+					mansit, confitearis immensum ? <hi rend="italic">Hic Deus noster, non <lb/>
+						aestimabitur alius ad eum.</hi> Quis alius, nisi Antichristus, <lb/> quem
+					veram Christum fides vera non aestimat, sed <lb/> enim pro vero Christo
+					exsecrabilis Judxorum error <lb/> exspectat ?</p>
+				<p>14. Si oras, et petis, ut dicis, discipulus esse divi­ <lb/> narum Scripturarum.
+					ad rem pertinentia testimonia <lb/> divina considera. Noli per multa quae te
+					nihil adju­ <lb/> vene, evagari: elige prudenter tacere quam inaniter <lb/>
+					loqui, quando non invenis quid respondcas manife­ <lb/> stissimae veritati.
+					Timere te ostendis , nc te nudcm <lb/> discipulis tuis. Utinam tu Chrsio sic
+					induaris, at di­ <lb/> scipulos tuos magis ipsius velis discipulos esse quant
+					<lb/> tuos. Nam me non pœnitet, quantum Dominus donat. <lb/> operam dare ut tu
+					et discipuli tui sub uno magistro <lb/> sitis condiscipuli mei. Tractatui autcm
+					men, cui post <lb/> tantum tempus adhuc te responsurum esse promittis, <lb/> si
+					ita responsurus es, ut modo respondisti vel inter­ <lb/> rogationibus, vel
+					prosecutionibus meis, non plana <lb/> aliquid respondebis: sed ut homines non
+					intelligentes <lb/> quomodocumque dccipias , non tacebis. Ex his ergo <lb/>
+					omnibus, quae sicut potui disputavi, satis apparet <lb/> Patris ct Filii et
+					Spiritus sancti unam esse virtutem, <lb/> unam esse suBstantiam, unam deitatem,
+					unam majo­ <lb/> statcm, unam gloriam; quia ipsa Trinitas est unus <lb/> Dominus
+					Deus noster, de quo dictum ea, <hi rend="italic">Audi, Israel; <lb/> Dominus
+						Deus tuus, Dominus unus eat (Deut.</hi> VI , 4). <lb/> Tunc autem dictum
+					est, quando Dominu; solus dedu­ <lb/> cebat eos, et non fuit in eis deus
+					alienus. Neque cnim <lb/> non cos deducebat et Christus, cum dicat Apostolus, <lb/>
+					<hi rend="italic">Neque tentemus Christum, sicut quidam illorum tenta­ <lb/>
+						verunt</hi> (I <hi rend="italic">Cor.</hi> x, 9); aut Christus1 non cst
+					Deus, aut <lb/> Christus Deus est alienus. Hic est ergo Deus Pater <lb/> et
+					Filius et Spiritus sanctus, Trinitas unus Deus : cul <lb/> uni jubemur ea quae
+					non nisi Deo debetur servitute <lb/> servire, cum audimus , Dominum <hi
+						rend="italic">Deum tuum</hi> adora­ <lb/>
+					<hi rend="italic">bis, et illi soli servies (Deut,</hi> VI, 43). Neque enim hac
+					<lb/> servitute non servimus Christo, cUjus membra su­ <lb/> mus; aut Spiritui
+					sancto, cujus templuuf sumus. Haec <lb/> Trinitas unus Deus <hi rend="italic"
+						>dicit: Ego 4um Dominus, et non<lb/> est alius</hi> praeter <hi
+						rend="italic">me ( Id.</hi> XXXII, 59). Neque enim nun <lb/> est Dominus
+					Christo!, quem vos quoque Deum et Do­ <lb/> minum confitcmini; aut Spiritus
+					sanctus uon est Do­ <lb/> minus domus suae, hoc est templi sui. Ipse est quippe
+					<lb/> Spiritus Domini de quo dicitur: <hi rend="italic">Dominus autem spiri­
+						<lb/> tua</hi> eat ; <hi rend="italic">ubi autem spiritus Domini, ibi
+						libertas</hi> (II <hi rend="italic">Cor.</hi>
+					<lb/> iiT, 17). Haec est Trinitas unus Deus, de. quo dicit <lb/> Apostolus : <hi
+						rend="italic">Nullus Deus, nisi unus</hi> (I <hi rend="italic">Cor.</hi>
+					VIII , 4). <lb/> Non enim cum haec ,tuditis, Deum negare unigeuitum <lb/>
+					audetis. Hic Deus Trinitas dicit; <hi rend="italic">Ego</hi> sum <hi
+						rend="italic">qui</hi> sum, et <lb/> non <hi rend="italic">sum mutatus
+						(Exod.</hi> III, 14, <hi rend="italic">et Malach.</hi> III, 6). Non <lb/>
+					enim mutatus est Christus, cui dicitur : <hi rend="italic">Mutabis</hi> cae­
+					<lb/> los, <hi rend="italic">et mutabuntur; tu autem idem ipse es</hi> ( <hi
+						rend="italic">Psat.</hi> CI. <lb/> 27, 28): aut mutabitur Spiritus
+					veritatis, cum sit <lb/> immutabilis vcritas, cui tantum honorem dat ipse <lb/>
+					Christus, ut dicat, <hi rend="italic">Expedit tobis ut ego eam;</hi> nisi <lb/>
+					<hi rend="italic">enim ego</hi>
+					<unclear>abiers</unclear>, <hi rend="italic">Paracletus non veniet ad</hi> vos
+						<hi rend="italic">(Joan.</hi>
+					<lb/> xvi, 7): et, <hi rend="italic">Quicumque dixerit blasphemiam</hi> in <hi
+						rend="italic">Filium <lb/> hominis, dimittetur ei; qui autem dixerit in
+						Spiritum <lb/> sanctum, noM dimittetur ei (Matth.</hi> XII. 52 ). Et cum
+					d&lt;: <lb/> se ipso dixerit, <hi rend="italic">Ecce ego vobiscum sum usque ad
+						con­<lb/> summationem saeculi (Id.</hi> XXVIII , 20); de illo dixit <lb/>
+					<hi rend="italic">Ut vobiscum sit</hi> in <hi rend="italic">aeternum (Joan.</hi>
+					XIV, 16). Hisatque <lb/> hujusmodi testimoniis, quae omnia quaerere et colli­
+					<lb/> gere longum est, si pacifice acquiescas , eris, quod <lb/> orare et optare
+					te dicis, divinarum Scripturarum di­ <lb/> scipulus, ut de tua fraternitate
+					gaudeamus. <note type="footnote"> 1 Kdili, <hi rend="italic">qitibus</hi> c
+						fr::tus. Vclius Mss., <hi rend="italic">ntd</hi> (Christus. </note></p>
+			</div>
+		</body>
+	</text>
 </TEI>

--- a/data/stoa0040/stoa028/stoa0040.stoa028.opp-lat1.xml
+++ b/data/stoa0040/stoa028/stoa0040.stoa028.opp-lat1.xml
@@ -151,4017 +151,4471 @@
 					<title type="main">S. AURELII AUGUSTINI HIPPONENSIS EPISCOPI CONTRA MAXIMINUM
 						HaeRETICUM Arianorum Episcopum LIBRI DUO (a).</title>
 				</head>
-				<ab>
-					<title type="sub">
-						<hi rend="italic">LIBER PRIMUS (b).</hi>
-					</title>
-				</ab>
-				<p>Ostendit Augustinus, ea quae in Collalione ipse dixit, Maximinum non poluisse
-					refellere.</p>
-				<p>Disputationi Miximini Arianorum episcopi , cujus <lb/> prolixitate spatium diei,
-					quo praesentes conferebamus, <lb/> absumpsit, responsionem debitam reddens, ad
-					ipsum <lb/> loqui utique debeo : sive adhuc existimet contradi­ <lb/> cendum
-					esse cum legerit, sive Domino in ejus corde <lb/> mirabiliter operante
-					manifestatae consentiat veritati. <lb/> Quid tibi visum est, homo ariane, tam
-					multa dicere, <lb/> ct pro causa quae inter nos agitur nihil dicere, quasi <lb/>
-					hoc sit n spondete posse, quod est tacere non posse? <lb/> Prius itaque ostendam
-					refellere te non potuisse quae <lb/> dixi : deinde, quantum nccessarium
-					videbitur, ego <lb/> refellam qu:c ipse dixisti.</p>
-				<div type="textpart" subtype="chapter" n="1">
-					<p>CAPUT PIUMUM. — <hi rend="italic">De duobus diis.</hi> De duobus <lb/> diis quae
-					ipse dixisti, ego certe respondens verbis <lb/> tuis, ubi aisti a vobis unum
-					Deum colatis : <hi rend="italic">Consequens <lb/> est,</hi> inquam, <hi
-						rend="italic">ut aut</hi> non <hi rend="italic">colatis</hi> Christum, <hi
-						rend="italic">aut non unum <lb/> Deum colatis, sed duos.</hi> Ad hoc tu
-					respondere cona­ <lb/> tus, mullum quidem locutus es, asserens quod et <lb/>
-					Christum Deum colatis : sed duos deos a vobis coli <lb/> quamvis non negaveris,
-					tamen non ausus es confiteri. <lb/> Sensisti enim, duos esse deos colendos,
-					christianas au­ <lb/> res ferre non posse. O quam de proximo te corrigeres ,
-					<lb/> si timeres credere quod dicere timuisli! Cum enim <lb/> clamet I
-					Apostolus, <hi rend="italic">Corde creditur ad justitiam,</hi> ore <lb/>
-					<hi rend="italic">confessio fit ad salutem (Rom.</hi> x, 10); si ad justitiam
-					<lb/> putas pertinere quod credis, cur hoc ad salutem etiam <lb/> orc non
-					confiteris ? Si autem duos dens colendos ad <lb/> salutem non pertinet
-					confiteri, sine dubio nec ad ju­ <lb/> stitiam pertinet credere. Qui ergo non
-					vis tali con­ <lb/> fessione . cum teneri os tuum , quare non mundas a <lb/>
-					tali credulitate cor tuum ? Tene cum Catholica fidem <lb/> rectam , non te pudeat
-					emendare perversam. Tene <lb/> cum Catholica, Patrem quidem non esse qui Filius
-					<lb/> est, et Filium non esse qui Pater est; et Deum esse <lb/> Patrem, Deum
-					esse Filium : verumtamen ambos si­ <lb/> mul non duos deos esse, sed unum. Isto
-					modo solo <lb/> fiet ut et Patrem colas et Filium , nee tamen duos <lb/> deos
-					esse colendos dicas, sed unum, ne reatu impie- <note type="footnote"> I E.r.
-						Lugd. ven. et Lov.. <hi rend="italic">mamfesice. II.</hi>
-					</note><note type="footnote"> I Er. Lugd. ven. Lov. clamal. M. </note>
-					<note type="footnote"> &lt;a) scrillli circiter annum -1m. </note><note
-						type="footnote">
-						<hi rend="italic">(b)</hi> AliJtf, secundus. </note>
-					<lb/> tatis tua conscientia compungatur , quando sonuerint <lb/> in auribus tuis
-					dicta divina , quia Nullus <hi rend="italic">Deus,</hi> nisi <lb/> unus (I <hi
-						rend="italic">Cor.</hi> VIII, 4); ct, <hi rend="italic">Audi Israel; Dominus
-						Deus</hi>
-					<lb/> tuus, <hi rend="italic">Dominus unas est:</hi> et quando audis , <hi
-						rend="italic">Dominum</hi>
-					<lb/> Deum tuum <hi rend="italic">adorabis et</hi> illi <hi rend="italic">soli
-						servies (Deut.</hi> VI, 4,13); <lb/> securus possis, non soli Patri, sed
-					etiam Filio ea quae <lb/> uni Deo debetur servitute servire. Memento ergo te
-					<lb/> non respondisse ad illud quod objeceram , non a vo­ <lb/> bis coli unum
-					Dcum, sed duos.</p>
+				<div type="textpart" subtype="book" n="1">
+					<ab>
+						<title type="sub">
+							<hi rend="italic">LIBER PRIMUS (b).</hi>
+						</title>
+					</ab>
+					<p>Ostendit Augustinus, ea quae in Collalione ipse dixit, Maximinum non poluisse
+						refellere.</p>
+					<p>Disputationi Miximini Arianorum episcopi , cujus <lb/> prolixitate spatium
+						diei, quo praesentes conferebamus, <lb/> absumpsit, responsionem debitam
+						reddens, ad ipsum <lb/> loqui utique debeo : sive adhuc existimet contradi­
+						<lb/> cendum esse cum legerit, sive Domino in ejus corde <lb/> mirabiliter
+						operante manifestatae consentiat veritati. <lb/> Quid tibi visum est, homo
+						ariane, tam multa dicere, <lb/> ct pro causa quae inter nos agitur nihil
+						dicere, quasi <lb/> hoc sit n spondete posse, quod est tacere non posse?
+						<lb/> Prius itaque ostendam refellere te non potuisse quae <lb/> dixi :
+						deinde, quantum nccessarium videbitur, ego <lb/> refellam qu:c ipse
+						dixisti.</p>
+					<div type="textpart" subtype="chapter" n="1">
+						<p>CAPUT PIUMUM. — <hi rend="italic">De duobus diis.</hi> De duobus <lb/>
+							diis quae ipse dixisti, ego certe respondens verbis <lb/> tuis, ubi
+							aisti a vobis unum Deum colatis : <hi rend="italic">Consequens <lb/>
+								est,</hi> inquam, <hi rend="italic">ut aut</hi> non <hi
+								rend="italic">colatis</hi> Christum, <hi rend="italic">aut non unum
+								<lb/> Deum colatis, sed duos.</hi> Ad hoc tu respondere cona­ <lb/>
+							tus, mullum quidem locutus es, asserens quod et <lb/> Christum Deum
+							colatis : sed duos deos a vobis coli <lb/> quamvis non negaveris, tamen
+							non ausus es confiteri. <lb/> Sensisti enim, duos esse deos colendos,
+							christianas au­ <lb/> res ferre non posse. O quam de proximo te
+							corrigeres , <lb/> si timeres credere quod dicere timuisli! Cum enim
+							<lb/> clamet I Apostolus, <hi rend="italic">Corde creditur ad
+								justitiam,</hi> ore <lb/>
+							<hi rend="italic">confessio fit ad salutem (Rom.</hi> x, 10); si ad
+							justitiam <lb/> putas pertinere quod credis, cur hoc ad salutem etiam
+							<lb/> orc non confiteris ? Si autem duos dens colendos ad <lb/> salutem
+							non pertinet confiteri, sine dubio nec ad ju­ <lb/> stitiam pertinet
+							credere. Qui ergo non vis tali con­ <lb/> fessione . cum teneri os tuum
+							, quare non mundas a <lb/> tali credulitate cor tuum ? Tene cum
+							Catholica fidem <lb/> rectam , non te pudeat emendare perversam. Tene
+							<lb/> cum Catholica, Patrem quidem non esse qui Filius <lb/> est, et
+							Filium non esse qui Pater est; et Deum esse <lb/> Patrem, Deum esse
+							Filium : verumtamen ambos si­ <lb/> mul non duos deos esse, sed unum.
+							Isto modo solo <lb/> fiet ut et Patrem colas et Filium , nee tamen duos
+							<lb/> deos esse colendos dicas, sed unum, ne reatu impie- <note
+								type="footnote"> I E.r. Lugd. ven. et Lov.. <hi rend="italic"
+									>mamfesice. II.</hi>
+							</note><note type="footnote"> I Er. Lugd. ven. Lov. clamal. M. </note>
+							<note type="footnote"> &lt;a) scrillli circiter annum -1m. </note><note
+								type="footnote">
+								<hi rend="italic">(b)</hi> AliJtf, secundus. </note>
+							<lb/> tatis tua conscientia compungatur , quando sonuerint <lb/> in
+							auribus tuis dicta divina , quia Nullus <hi rend="italic">Deus,</hi>
+							nisi <lb/> unus (I <hi rend="italic">Cor.</hi> VIII, 4); ct, <hi
+								rend="italic">Audi Israel; Dominus Deus</hi>
+							<lb/> tuus, <hi rend="italic">Dominus unas est:</hi> et quando audis ,
+								<hi rend="italic">Dominum</hi>
+							<lb/> Deum tuum <hi rend="italic">adorabis et</hi> illi <hi
+								rend="italic">soli servies (Deut.</hi> VI, 4,13); <lb/> securus
+							possis, non soli Patri, sed etiam Filio ea quae <lb/> uni Deo debetur
+							servitute servire. Memento ergo te <lb/> non respondisse ad illud quod
+							objeceram , non a vo­ <lb/> bis coli unum Dcum, sed duos.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="2">
+						<p>CAPUT II. — <hi rend="italic">De humanis contagiis.</hi> Secundo loco
+							<lb/> egi tecum de verbis tuis, ubi dixeras, <hi rend="italic">Deum
+								Patrem</hi>
+							<lb/> ad <hi rend="italic">humana</hi> non <hi rend="italic">descendisse
+								contagia;</hi> quasi Christus <lb/> illa in carne perpessus sit : et
+							admonui, quomodo <lb/> contagium intelligi soleat, non utique nisi in
+							aliquo <lb/> vitio, a quibus omnibus immunem novimus Christum. <lb/> Nec
+							ad hoc quidquam respondere potuisti. Testimo­ <lb/> nia quippe divina,
+							quae abs te commemorata sunt, <lb/> nihil te adjuvare potuerunt : non
+							enim eis probare <lb/> potuisti humano Christum attaminatum esse conta­
+							<lb/> gio. Quod enim Apostolum dixisse commemoras, <lb/>
+							<hi rend="italic">Quoniam Christus cum peccator non esset, peccatum</hi>
+							<lb/> pro <hi rend="italic">nobis fecit:</hi> lege diligentius &gt; et
+							ne forte mendo­ <lb/> sum incurreris codicem, aut latinus interpres
+							errave­ <lb/> rit, graecum inspice; et invenies non Christum pro <lb/>
+							nobis fecisse peccatum, sed a Patre Deo ipsum Chri» <lb/> stum factum
+							esse peccatum, id est, sacrificium pro <lb/> peccato. Ait enim
+							Apostolus: <hi rend="italic">Obsecramus pro Christo, <lb/>
+								reconciliamini Deo 1:</hi> tum <hi rend="italic">qui non noverat
+								peccatum, <lb/> pro nobis peccatum fecit</hi> (II Cor. v, 20, 21).
+							Non ergo <lb/> fecit ipse peccatum, sed eum Deus pro nobis pecca­ <lb/>
+							tum fecit, hoc est, ut dixi, sacrificium pro peccato. <lb/> Si enim
+							recolas vel relegas, invenies in libris Veteris <lb/> Testamenti peccata
+							appellari sacrificia pro peccatis. <lb/> Similitudo etiam carnis
+							peccati, in qua venit ad nos, <lb/> dicta est et ipsa peccatum : Misit,
+							inquit, <hi rend="italic">Deus Filium</hi>
+							<lb/> suum <hi rend="italic">in similitudine carnis peccati, et de
+								peccato da­ <lb/> mnavit peccatum</hi> in <hi rend="italic">carne
+								(Rom.</hi> VIII, 5): hoc est, de <lb/> similitudine carnis peccati,
+							quae ipsius erat, <unclear>damnavit</unclear>
+							<note type="footnote"> 1 AIt'.. Er. et Uss.v <unclear/><hi rend="italic"
+									>reconciliari</hi> ret* </note>
+							<lb/>
+							<pb n="745"/> percatum in carne peccati, quae nostra est. Propter <lb/>
+							hoc etiam de illo dicitur : <hi rend="italic">Quod enim mortuus est pec­
+								<lb/> calo, mortuus est semel; quod autem vivit, vivit Deo</hi>
+							(Rom. <lb/> VI, 10). Peccato enim mortuus est semel. quia simili­ <lb/>
+							tudini 1 carnis peccati mortuus est, quando moriendo <lb/> exutus est
+							carne: ut per hoc mysterium significaret, <lb/> eos qui in morte ipsius
+							baptizantur, mori peccato, ut <lb/> vivant Deo, Sic etiam per crucem <hi
+								rend="italic">factus</hi> est <hi rend="italic">pro nobis<lb/>
+								maledictum (Galat.</hi> III, 15). Pendens quippe in ligno, <lb/>
+							mortem quae de maledicto Dei venerat , suspendit in <lb/> ligno, atque
+							ita <hi rend="italic">vetus homo noster simul confixus</hi> eat <lb/>
+							<hi rend="italic">cruci</hi> (Rom. VI. 6): ut non mendaciter dictum
+							intelliga­ <lb/> tur in Lege , <hi rend="italic">Maledictus omnis qui
+								pendet in ligno <lb/> (Deut.</hi> xxi, 25). Quid est, <hi
+								rend="italic">maledictus</hi> , nisi, <hi rend="italic">Terra
+								es,<lb/> et</hi> in <hi rend="italic">terram ibis (Gen.</hi> m , 19)
+							? Et quid est, <hi rend="italic">omnis ;</hi>
+							<lb/> n'si quia et ipse Christus, qui cum esset vita , mor­ <lb/> tuus
+							est tamen vera morte , non ficta ? Si intelligas <lb/> ista mysteria ,
+							simul intelliges non esse contagia. Sed <lb/> quid ad nos , si more tuo
+							loquens, contactum forte <lb/> mortalium voluisti appellare contagium;
+							cum tamen <lb/> nobiscum sentias, Dominum Jesum, nec in spiritu, <lb/>
+							nec in carne ullum habuisse peccatum?</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="3">
+						<p>CAPUT III. — <hi rend="italic">De invisibili Deo.</hi> Tertio loco de in­
+							<lb/> visibili Deo cum agerem, admonui ul crederes invisi­ <lb/> bilem ,
+							non solum Patrem, sed etiam Filium secun­ <lb/> dun. divinit item, non
+							secundum carnem, in qua eum <lb/> visibilem mortalibus apparuisse quis
+							negat? undeot <lb/> alio loco postea disputavi. Tu antem cedens manife­
+							<lb/> stissimae veritati, consensisti esse invisibilem Filium : <lb/> ac
+							per hoc destruxisti quod dixeras, <hi rend="italic">unum invisibilem
+								<lb/> Patrem.</hi> Sed rursus tua consensione conturbatus, <lb/>
+							quia invisibilem etiam Filium esse consenseras, au­ <lb/> sus es dicere,
+							min tra videri a majurihus, majora vero <lb/> a minoribus non posse
+							videri; dicens Angelos videri <lb/> ab Archangelis , animas ab Angelis,
+							Angelos vero ab <lb/> animabus non videri : unde eliam Christum secun­
+							<lb/> dum divinitatis suae substantiam, non solum ab ho­ <lb/> minibus,
+							sed nec a Virtulibus coelestibus videri asse­ <lb/> rens, ideo Patrem
+							solum invisibilem esse dixisti, quia <lb/> superiorem non habet a quo
+							circuminspiciatur. Dic <lb/> nobis, rogo te, quando libi indicaverunt
+							Archangeli , <lb/> quod ipsi vidcant Angelos, non autem videantur ab
+							<lb/> Augelis! Quibus narrantibus Angelis cognovisti, quod <lb/> ipsi
+							videam animas, animae illos non vidcant? A quo <lb/> haec audisti? unde
+							didicisti? ubi legisti ? Nonne me­ <lb/> lius divinis Libris animum
+							intenderes, ubi legimus et <lb/> ab hominibus Angelos visos,quando
+							voluerunt, cet <lb/> quomodo voluerunt videri, jubente vel sinente <lb/>
+							omnium Creature? Verumtamen qui dixeras, ideo <lb/>
+							<hi rend="italic">solum</hi> dicendum <hi rend="italic">in visibilem
+								Patrem, quia non habet <lb/> superiorem a quo
+								circuminspiciatur;</hi> confessus es po­ <lb/> sica, Filio esse
+							visibilem , contra te ipsum proferens <lb/> evangelicum testimonium, uhi
+							dicit ipse Filius, <hi rend="italic">Non <lb/> quia Patrem vidit
+								quisquam, sed qui eat a Deo, hic vi­ <lb/> dit Patrem (Joan.</hi>
+							VI, 46). Ubi te quidem veritas apcr­ <lb/> tissime vicit: sed tu nolens
+							ab errore liberari, nolui- <note type="footnote"> 1 sola edllio I.oV.,
+									<hi rend="italic">q1ria in siiwliludine.</hi> quidam Mss., <hi
+									rend="italic">quia <lb/> fiudiUttdinc.</hi>
+							</note>
+							<lb/> sti salubriter vinci. Cum enim contra te commemo­ <lb/> rasses
+							evangelicum testimonium, quo claruit a Filio <lb/> videri Patrem,
+							dicente ipso Filio, <hi rend="italic">Sed qui est</hi> a <hi
+								rend="italic">Deo,<lb/> hic vidit Patrem;</hi> mox addidisti de tuo,
+								<hi rend="italic">Sed vidit in - <lb/> capabilem.</hi> Interim quod
+							dixeras perdidisti, solum <lb/> esse invisibilem Patrem, quia non habet
+							superiorem : <lb/> quandoquidem veritate victus, cum vidcri ab inferiore
+							<lb/> confessus es. l'os enim dicitis inferiorem Filium a <lb/> quo
+							tamen Patrem videri, teste Filio cogente I, dixi­ <lb/> sti. De
+							incapabili postea videbimus, ut etiam te illic <lb/> veritas vincat. Non
+							enim de capabili et incapabili, sed <lb/> de visibili et invisibili
+							inter nos quaestio versabatur : <lb/> in qua quaestione si libi ipsi tu
+							ip e visibilis es, vi. <lb/> ctum te esse vides.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="4">
+						<p>CAPUT IV. — <hi rend="italic">De immortali</hi>
+							<unclear/><hi rend="italic">Deo.</hi> Quarto loco egi <lb/> tecum de
+							immortali Den etiam Filio. Quoniam tu il­ <lb/> lud quod ait Apostolus ,
+								<hi rend="italic">Qui solus habet immortalita­<lb/> tem</hi> (I <hi
+								rend="italic">Tim.</hi> VI, 16) ; sic intelligi voluibti, tanquam
+							<lb/> de solo Patre sit dictum : cum ille hoc non de Patre <lb/>
+							dixerit, sed de Deo , quod est Pa er et Filius et Spirit <lb/> Ius
+							sanctus. Ostend! ergo ct Filium habere immorta­ <lb/> litatem secundum
+							substantiam divinitatis suae. Nam <lb/> secundum carnem quis negat eum
+							fuisse mortalem ? <lb/> Tu autem cum mihi respondere ad hunc locum vel­
+							<lb/> les, perspicua veritate conclusus, etiam Deum Filium <lb/>
+							immortalitatem habere confessus es. Victus es igitur <lb/> in eo quod
+							dicebas de Patre tantum dixisse Aposto­ <lb/> lam, quod solus habeat
+							immortalitatem. Ncque enim <lb/> propterea vinculis veritatis elaberis ,
+							quoniam dicis, <lb/>
+							<hi rend="italic">Habet quidem Filius immortalitatem, sed accipiens</hi>
+							a <lb/>
+							<hi rend="italic">Patre.</hi> Non quaeritur uude habcat, sed utrum
+							habeat. <lb/> Tu enim de Patre solo vis intelligi quod scriptum esi, <lb/>
+							<hi rend="italic">Solus habet immortalitatem.</hi> Prorsus a nullo
+							acceptam <lb/> Pater habet immortalitatem, et a Patre acceptam Fi <lb/>
+							lius habet immortalitatem : tamen et Pater ct Filius <lb/> habet
+							immortalitatem. Alioquin si eam non habet <lb/> Filius ; Pater eam non
+							dedit Filio, aut acceptam per­ <lb/> didit Filius. Dedit autem Pater
+							Filio, nec perdidit Fi­ <lb/> lius : nec Pater dando perdidit quod
+							generando dedi!. <lb/> Habet ergo immorlalitalem et Pater et Filius, non
+							<lb/> Pater solus. Cogeris itaque confiteri non de solo Patre <lb/>
+							dictum esse, <hi rend="italic">Qui solus habet immortalitatem:</hi> quia
+							jam <lb/> coactus es confiteri quod et Filius habeat immorta­ <lb/>
+							litatem. Habet autem hanc <hi rend="italic">solus,</hi> sed Deus: quod
+							<lb/> non solus est Pater; quia hoc est et Filius, et uter­ <lb/> que
+							adjuncto Spiritu sancto unus est Deus. Sed quaro <lb/> solus Deus dictus
+							sit habere immortalitatem, cum et <lb/> anima pro suo modo sit
+							immortalis, et alia <unclear>spiritun­</unclear>
+							<lb/> lis coelestisque creatura, postea videbimus : nunc au­ <lb/> tem
+							sufficit nobis, quod ad ea quae dixi, nihii respon­ <lb/> dere potuisti,
+							ct non solum Patrem ; sed quamvis ab <lb/> ipso, habere tamen ,
+							immortalitatem etiam Filium <lb/> coactus es confiteri.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="5">
+						<p>CAPUT V. — <hi rend="italic">Unde major sit Pater.</hi> Quinto loco <lb/>
+							ostendi, unde major sit Pater Filio : quia nou Den <lb/> major est, unde
+							illi coaeternus est Filius; sed homine <lb/> major est, quod ex tempore
+							,factus est Filius. Ibi <lb/> commemoravi apostolicum testimonium : <hi
+								rend="italic">Quia</hi> cum <hi rend="italic">in</hi>
+							<note type="footnote"> t Hic apud l.ov. additur, <hi rend="italic"
+									>veritate.</hi>
+							</note>
+							<note type="footnote"> PATROL. XLII. </note>
+							<note type="footnote">
+								<hi rend="italic">(Yingl-quatrl.)</hi>
+							</note>
+							<lb/>
+							<pb n="747"/>
+							<hi rend="italic">forma</hi> £Dei esset, <hi rend="italic">non rapinam
+								arbitratus esl esse aequa­</hi>
+							<lb/> lis Dec. Natura quippe illi fuerat Dei aequalitas , non <lb/>
+							rapina. Ad quod tu respondens dixisti : <hi rend="italic">Quis enim<lb/>
+								vegat Filium esse in forma Dei ? Qnod enim sit Dens, <lb/> quod sit
+								Dominus , quod sit Rex, jam pulo latius</hi> expo­ <lb/> s
+								<unclear>uimus</unclear>.<hi rend="italic">Et</hi> &lt; <hi
+								rend="italic">quia non rapinam arbitratus cat esse aequa­<lb/> lis
+								Deo, » hoc nos beatus apostolus Paulus instruit, quod <lb/> ille non
+								rapuit, nee noa dicimus.</hi> Haec verba tua non <lb/> solum nihil
+							habent adversus nos ; sed magis apparent <lb/> esse pro nobis. Si enim
+							confiteris Dei formam , cur <lb/> non aperte Dei Filium Deo confiteris
+							aequalem ? Prae­ <lb/> sertim, quia de verbis Apostoli, ubi ait, <hi
+								rend="italic">Non rapinam <lb/> arbitratus eat esse aequalis
+								Deo;</hi> non poluisti pro tuis <lb/> partibus invenire quod
+							diceres. Et quia hoc dixisse <lb/> Apostolum non potuisti negare, idco
+							dixisti, <hi rend="italic">quod ille</hi>
+							<lb/> non <hi rend="italic">rapuit, nec nos dicimus</hi> : tanquam hoc
+							sit <hi rend="italic">non ra­</hi>
+							<lb/> puit, qnod csl non hahuit, id est, aequalitatem Dei : <lb/> atque
+							ita dictum sit, <hi rend="italic">Non rapinam arbitratus eat esse<lb/>
+								aequalis Deo;</hi> ac si diceretur, Non arbitratus est esse <lb/>
+							rapiendam aequalitatem Dei, co quod ab illo fuerit <lb/> alicua. Raptor
+							enim rei alienae usurpator est: tan­ <lb/> quam hoc Filius, cum posset,
+							rapcre noluisset. Quod <lb/> vides quanta insipientia sentiatur. Ergo
+							intellige Apo­ <lb/> siolum ideo dixisse , <hi rend="italic">Non rapinam
+								arbitratus eat esse</hi>
+							<lb/> aequalis <hi rend="italic">Deo;</hi> quia non alienum arbitratus
+							est esse <lb/> quod natus est: sed tamen quamvis aequalitatem Dui <lb/>
+							non fuerit arbitratus alienam, sed suam, <hi rend="italic"
+								>semetipsum<lb/> exinanivit,</hi> non quaerens quae sua sunt, sed
+							quae no­ <lb/> sira sunt. Quod ut noveris ita esse , attende unde ad
+							<lb/> hoc Apostolus venerit. Cum enim Christianis humili­ <lb/> tatem
+							praeciperet charitatis : <hi rend="italic">Alter alterum,</hi> inquit,
+							<lb/> existimantes superiorem <hi rend="italic">sibi, non quae sua sunt
+								unusquis­ <lb/> que intendentes, sed et quae aliorumf.</hi> Deinde
+							til exem­ <lb/> plo Christi hortaretur non sua quaerere vel intendere,
+							<lb/> sed et quae aliorum sunt: <hi rend="italic">Singuli quique,</hi>
+							inquit, <hi rend="italic">hoc<lb/> sentite</hi> in <hi rend="italic"
+								>vobis quod et in Christo Jesu : qui cum in forma<lb/> Dei
+								esset,</hi> quae illi crat sua, non <hi rend="italic">rapinam
+								arbitratus est,</hi>
+							<lb/> hoc cst, non alienum arbitratus est, <hi rend="italic">esse
+								aequali, Deo ;</hi>
+							<lb/> sed tamen quaerens nostra, non sua , <hi rend="italic">semetipsum
+								ex­</hi>
+							<lb/> inanivit, non formam Dci amittens, sed fOrmam <hi rend="italic"
+								>servi ac.</hi>
+							<lb/> cipiens. Non enim est mutabilis illa natura ut se ex­ <lb/>
+							inaniret perdendo quod erat, sed accipiendo quod non <lb/> crat : nec
+							consumendo quae sua sunt, sed assumendo <lb/> quae nostra sunt; ac
+							deinde in forma servi obediendo <lb/> sicut homo <hi rend="italic">usque
+								ad mortem crucis. Propter quod et <lb/> Deus</hi> eum <hi
+								rend="italic">exaltavit,</hi> et donarit ei <hi rend="italic"
+								>nomen</hi> qnod <hi rend="italic">eat super<lb/> omne nomen
+								(Philipp.</hi> 11, 6-9) : et caetera. Homini ergo <lb/> donavit
+							ista, non Deo. Neque enim tum in forma ici <lb/> esset non excelsus
+							crat, aut non ei genua flectebant <lb/> « cœlestia, terrena et inferna.
+							Sed cum dicitur, <hi rend="italic">Propter<lb/> quod eum exaltavit;</hi>
+							satis apparet propter quid exalta­ <lb/> verit, id est, propter
+							ohedicntiam <hi rend="italic">usque ad mortem cru­</hi>
+							<lb/> cis. ITI qua ergo forma crucifixos est, ipsa exaltata <lb/>
+							&lt;at, ipsi donatum est <hi rend="italic">nomen quod eat super omne
+								no­</hi>
+							<lb/> men; ut cum ipsa forma servi nominetur Filius Uni­ <lb/> genitus
+							Dei 2. Non itaque facias imparem Dco formam <note type="footnote"> *
+								tor,, <hi rend="italic">aed ea quae</hi><hi rend="italic"
+									>atiorum.</hi> At sas., <hi rend="italic">sed et qua aliorum
+									:</hi>
+								<lb/> jux ui gJ":9CUlD, <hi rend="italic">atla kilL.</hi> .
+								</note><note type="footnote"> ' I iiic cdili addiuit, <hi
+									rend="italic">intelligetur.</hi> et reluctantibus <lb/> Mss.
+								<lb/> , </note>
+							<lb/> Dei : quod nee in ipsis hominibus did potest. Nam <lb/> cum dictum
+							fuerit, Iste homo in forma est illius ho­ <lb/> minis, nemo intelligit
+							nisi aequales 1. An forte non <lb/> vis sic accipere quod dictum est,
+								<hi rend="italic">Cum</hi> in <hi rend="italic">forma Dci<lb/>
+								esset,</hi> ut in forpia Dci Patris intelligas Filium, ubi <lb/>
+							nihil aliud quam aequalitas apparet amborum ; sed, <hi rend="italic">in
+								<lb/> forma Dei,</hi> putas intelligendum in forma sua, quia et
+							<lb/> ipse utique Deus est ? Non multum curo si etiam sic <lb/>
+							intelligas. Ubi enim plenitudinem formae aetatis in­ <lb/> crementa non
+							faciunt, sed Deo gignente perfectus <lb/> natus est Filius; procul dubio
+							si forma Filii formae <lb/> Patris non cst aequalis, non verus cst
+							Filius. Scriptum <lb/> est autem : Ut simus in <hi rend="italic">vero
+								Filio ejus Jesu Christo</hi>
+							<lb/> (I <hi rend="italic">Joan.</hi> v , 20). Forma igitur vcri Filii,
+							formae Dei <lb/> Patris esse non potest inaequalis. Proinde nee hu'c
+							<lb/> loco prosecutionis meae, ubi de verbis Apostoli aequa­ <lb/> lem
+							Patri Filium comptobavi, respondere aliquid pro <lb/> vestra intentione
+							potuisti.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="6">
+						<p>CAPUT VI. — <hi rend="italic">De veris filiis animalium.</hi> Sexto loco
+							<lb/> ut ejusdem naturae cujus ct Pater est, ostenderem <lb/> Filium,
+							etiam mortalium fctus animalium immanitati <lb/> vestri crroris objeci,
+							increpans cor vestrum, qui ejus­ <lb/> dem nature cujus est Pater,
+							negatis esse Deum Fi­ <lb/> lium, quamvis verum esse Filium non negetis;
+							cunt <lb/> Deus ipse dederit animalibus hoc generare quod ipsa <lb/>
+							sunt : ubi non solum hominis homincm, verum etiam <lb/> canis canem
+							filium nominavi; non ad similitudinem <lb/> Dei, sed ad confusionem
+							detrahentium Filio Dci : qui <lb/> cum videant corruptibiles mortalesque
+							naturas, habere <lb/> tamen naturae de suis parentibus unitatem, Filio
+							Dei <lb/> vero nolunt concedere communionem naturae unius <lb/> habere
+							de Patre; cum sit inseparabilis a Patre, ct in­ <lb/> corruptibilis
+							aeternusque cum Patre. Unde etiam dixi, <lb/> quod melior sit secundum
+							vos humana conditio , ubi <lb/> conceditur crescere, ut ad robnr
+							parentum vcl cre­ <lb/> scendo possint filii pervenire: Filius autem Dci
+							, sicut <lb/> dicitis et docetis, minor Patre genitus sic remansit,
+							<lb/> atque ut ad Patris formam non posset pervenire, nec <lb/> crevit.
+							Hic tu, ut appareret quam magna veritatis mole <lb/> premereris, omnino
+							ad rem non respondisti : sed <lb/> tanquam deficienti flatu I anhelarcs,
+							reprehendendum <lb/> me putasti, dicens quod tam foeda comparatio, de
+							filio <lb/> scilicet hominis sive canis, in illam tantam immen­ <lb/>
+							sitatem produci non debuit. lloc respondere est , an <lb/> potius
+							inopiam responsionis ostendere ? Quasi ego <lb/> propterca terrenarum
+							naturarum ista exempla produ­ <lb/> xcrim, ut incorruptioni
+							corruptionem, immortalitati <lb/> mortalitatem , invisibilibus
+							visihilia, aeternis tempo­ <lb/> ralia coaequarem : ac non potius ut vos
+							in magnis ct <lb/> summis rebus errantes , de rebus parvulis infimisque
+							<lb/> convincerem, qui non videtis bonum quod Creator <lb/> summe bonus
+							dedit etiam extremis vilibusque creatu­ <lb/> ris, ut cnm longe aliud
+							sint quam est ipse, hoc tamen <lb/> gcnerent quod sunt ipsae. Nee
+							attenditis quid niali di­ <lb/> catis, ut cum homines et canes, et
+							caetera hujusmodi <lb/> habeant filios veruS, quos illis gignentibus
+							creat vcri­ <lb/> tas, nOli sit vcrus Dei Filius ipsa vcritas. Aut si
+							san­ <note type="footnote"> * Am. F.r. et va,r., <hi rend="italic">rtiri
+									fcquatis.</hi>
+							</note><note type="footnote"> t .to., <hi rend="italic">deficinlis</hi>
+								<unclear>fatus</unclear>. -, </note>
+							<lb/>
+							<pb n="749"/> cta Scriptura cogente permittitis ut verus Filius sit,
+							<lb/> rogamus permittite ut dcgener non sit. Et degener <lb/> quomodo?
+							Andiant catholici, unde erubescant haere­ <lb/> tici. Filius viri fortis
+							si non habeat fortitudinem , de­ <lb/> gener dicitur : tamen homo est,
+							quod ct patcr est; <lb/> atque in dissimili vita , non est tamen aliena
+							substan­ <lb/> tia. Vos unigenitum Dei Filium ita degenerem vullis,
+							<lb/> ut ipsam Patris ei substantiam denegetis : minorem <lb/> natum,
+							minorem remansisse jactatis ; non ullam datis <lb/> aetatem qua possit
+							augeri, non datis eamdem formam <lb/> qua possit
+								<unclear>aequari</unclear>. Cujus naturae tanta subtrahitis, <lb/>
+							miror verum Filium qua fronte dicatis : nisi quia in­ <lb/> fclicissimo
+							errore non vos putatis ad unius Patris glo­ <lb/> riam, nisi per unici
+							Filii contumeliam pervenire (a).</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="7">
+						<p>CAPUT VII. — <hi rend="italic">De magnitudine Filii.</hi> Septimo loco
+							<lb/> dixi : <hi rend="italic">Usque adeo autem Filium agnoscimus magnum
+								<lb/> Deum , ut Patri dicamus aequalem. Itaque</hi> sine <hi
+								rend="italic">causa,</hi>
+							<lb/> inquam, nobis <hi rend="italic">quod valde profitemur,
+								testimoniis, et <lb/> multiloquio</hi> probas voluisti. Et his
+							verbis meis addidi <lb/> disputationem, in qua rationem redilidi, quare
+							Filius <lb/> cum sit Patri aequalis, dicat cum tamcn Deum suum, <lb/>
+							ubi nil : <hi rend="italic">Ascendo ad Patrem meum et ad Patrem ve­</hi>
+							<lb/> strum , Deum meum <hi rend="italic">et Deum</hi> restrum <hi
+								rend="italic">(Joan.</hi> xx, 17). <lb/> Quoniam tu commemoraveras
+							hoc evangelicum testi­ <lb/> monium , quo te probarc existimasti quod
+							Patri Filius <lb/> non esset aequalis. Ego itaque tibi ad ista
+							respondens, <lb/> dixi Patrem propterea etiam Deum esse unigeniti Filii,
+							<lb/> quoniam factus est homo et natus ex femina : ct hoc <lb/> esse
+							quod dicit in Psalmo, ubi quod futurum fucrat <lb/> praenuntiavit, <hi
+								rend="italic">De ventre matris meae Deus meus es tu<lb/> (Psal.</hi>
+							xxi, 11) ; ut ostenderet Patrem hinc esse Deum <lb/> suum , quia homo
+							factus est. Homo enim de ventre <lb/> matris est natus, et secundum
+							hominem de virgine <lb/> natus est Deus : ut non solum Pater illi esset
+							qui cum <lb/> de se ipso genuil, verum etiam Deus ejus esset quem <lb/>
+							de ventre matris hominem creavit. Ad hacc tu cum <lb/> respondere
+							voluisses, mu!ta dixisti, ct multa testimo­ <lb/> nia quae te nihil
+							adjuvant, protulisti. Quomodo ta­ <lb/> men dictum sit. <hi
+								rend="italic">De ventre matris meae Deus meus es tu;</hi>
+							<lb/> quamvis eadem Scripturae sanct e verba memorasses, <lb/> nullo
+							modo invenire potuiti. Cur autcm in eo loco <lb/> posueris psalmi
+							alterius testimonium, ubi scriptum <lb/> est, <hi rend="italic">Tecum
+								principium in die virtutis tuae, in splendo­ <lb/> ribus sanctorum,
+								ex utero ante luciferum genui te (Psal.</hi>
+							<lb/> CIX, 5); omnino non video. Non enim Filii persona <lb/> est
+							dicentis, Ex utero tuo, aut, De ventre tuo, Deus <lb/> meus es tu. Illa
+							ineffabilis generatio cHam si ex utcro <lb/> Patris accipitur, hoc
+							significatum cst, quia de 83 <lb/> ipso, hoc cst, de substantia sua Deus
+							Deum genuit, <lb/> sicuit ex utero matris quando natus est, homo homi­
+							<lb/> nem genuit: ut intelligeremus in utraque generatione <lb/> non
+							diversas ejus qui cst natus, et eorum de quibus <lb/> est natus, esse
+							substantias. Diversa quidem substantia <lb/> cst, Deus Pater, et homo
+							mater: non tamen diversa <lb/> substantia est, Deus Pater, ct Deus
+							'ilius ; sicut non <lb/> est diversa substantia, homo mater, ct homo
+							filius. <lb/> Sed audi quid dicat in prophetia iste Filius : <hi
+								rend="italic">De</hi> ven­ <lb/> Ire, inquit, <hi rend="italic"
+								>matris</hi>
+							<unclear/><hi rend="italic">meae Deus</hi> meuses <hi rend="italic"
+								>tu.</hi> Noli multis <note type="footnote"> (r) vide scrin. 130,
+								no. 4 et 3, tom, 5. </note>
+							<lb/> vetbis ad rem non necessariis conari operire res cla<lb/>ras. Qui
+							est Pater Filio ex utero suo, de vontre ma­ <lb/> tris Deus ejus est,
+							non de suo. Ad hoc ergo prorsus <lb/> nihil respondere po:uisti.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="8">
+						<p>CAPUT VIII. — <hi rend="italic">De subjectione Filii</hi> Octavo loco de
+							<lb/> subjectione qua subjectus est Patri Filius, respondi <lb/> libi :
+							quoniam dixeras, <hi rend="italic">De sua subjectione unum sta­<lb/>
+								tuit Deum.</hi> Respondi ergo ellam hoc secundum homi­ <lb/> nen
+							recte accipi, quod Filius subditus est Patri. Nc­ <lb/> que hoc esse
+							mirandum , cum legatur utique secun­ <lb/> dum ipsam servi formam etiam
+							parentibus subdimus <lb/>
+							<hi rend="italic">(Luc.</hi> n , 51) : et de illo sit scriptum, <hi
+								rend="italic">Minorasti eum <lb/> paulo</hi> minus <hi rend="italic"
+								>ab Angelis (Psal.</hi> VIII, 6). Ad quod tu <lb/> quasi respondens
+							dixisti me optime prosecutum, quo­ <lb/> niam ct parentibus propter
+							formam Servi esset subjg­ <lb/> ctus. Dcinde volens velut pro te esse
+							ostendere, quod <lb/> contra te esse cernebas; ac sic incautis
+								<unclear>minusquo</unclear>
+							<lb/> attentis hominibus, quicumque essent ista lecturi, <lb/> tanquam
+							respondentem te facere, ubi quod diceres <lb/> non habebas; adjungis et
+							dicis : Si eni, t <hi rend="italic">parentibus <lb/> subjectus invenitur
+								quos ipse creavit, qnia omnia pet <lb/> ipsunt facta sunt : nec enim
+								post tempora, sed ante tem­ <lb/> pora novimus Filium genitum a
+								Patre : si ergo parenti­</hi>
+							<lb/> bus , inquis , <hi rend="italic">subditus etat, ut</hi>
+							<unclear/><hi rend="italic">divinarum Scripturarum<lb/> auctoritas luce
+								clarius prat'dicat : quanto magis utique illl <lb/> suo genitori est
+								subditus, qui tantum ac tatem</hi> eum <hi rend="italic">ge­<lb/>
+								nuit;</hi> secundum <hi rend="italic">quod ait Paulus, Cum omnia
+								fuerint <lb/> Filio</hi> subjecta, <hi rend="italic">tunc et ipse
+								Filius subjectus erit illi</hi> qui <lb/>
+							<hi rend="italic">sibi subjecit omnia</hi> (I <hi rend="italic"
+								>Cor.</hi> xv, 28) ? Haec verba tua pos<lb/>sevit a me putari dicta
+							esse, et omnino mca esse, nisi <lb/> tc audientibus cum dicerentur, et
+							postea haec cuncti <lb/> legentibus, evidenter appareret tc illa
+							dixisse. Quis <lb/> enim crederet, consentire posse vos nobis, secundum
+							<lb/> formam servi, ac per hoc non secundum formam Det <lb/> Christum
+							esse subjectum ?</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="9">
+						<p>CAPUT IX. — <hi rend="italic">Utrum adoret Patrem Spiritus san­<lb/>
+								ctus.</hi> Nono loco abs te quaesivimus, ut per Scripturas <lb/>
+							divinas ostenderes, si valeres, utrum adoret Patrem <lb/> Spiritus
+							sanctus. Iloc cniin dixeras : sed sicut ipsi <lb/> tua prosccutio, cui
+							respondi, satis indicat, non pro­ <lb/> baveras. Ad hanc ergo
+							inquisitionem mcam vide quid <lb/> posteriore prosccutione responderis.
+							Cum enim divis<lb/>ses quantum voluisti de judicio Filii, quod et nos
+							fide­ <lb/> lissime credimus; ct de subjectione, quam secundum <lb/>
+							formam servi Filium Patri reddere non negamus : <lb/> ubi venisti ut
+							probares a sancto Spiritu adorari Pa­ <lb/> trem, rediiti ad illos
+							gemitus, de quibus tibi jam ante <lb/> responderam, secundum morem
+							sanctarum Scriptu­ <lb/> rarum, qna locutione sil dictum, <hi
+								rend="italic">Et</hi> ipse Spiritus <hi rend="italic">in­<lb/>
+								terpellat gemitibus inenarrabilibus (Rom.</hi> VIII, 26) : no <lb/>
+							credamus Spiritum sanctum nunquam esse esine gc­ <lb/> mitibus posse,
+							quomam nulus dies, nulla hora, nul­ <lb/> lum momentum temporis
+							invenitur, quo non a sanctis <lb/> orationes Dco ubicumque fundamur, ab
+							aliis hic, ab <lb/> aliis alibi. Cum tamen ab orationibus sanctorum nul­
+							<lb/> lum sit tempus immune, quandoquidem dicbus et <lb/> noctibus, cum
+							alii cibo ac potu reficiuntur, alli quod­ <lb/> libet aliud agunt, alii
+							dormiunt, non utique desunt <unclear/><lb/> quos desiderium sancium
+							orare compellat; ita fit ut <lb/>
+							<pb n="751"/> Spiritus sanctus, qui ubique omnibus adest, aliquan­ <lb/>
+							tulum cessare a gemitibus nun sinatur, quod est ex­ <lb/> tremae
+							miseriae, cum pro quibuscumque orantibus <lb/> cogitur gemere : nisi
+							gemitibus inenarrabilibus in­ <lb/> terpellare sic intelligatur, ut
+							dixi, id cst, quia gemi­ <lb/> tibus sanctorum desideriorum interpellare
+							sanctos <lb/> facit, quibus affectum pium gratiae spiritualis infundit.
+							<lb/> Sed cum similes locutionum modos, quando per ef­ <lb/> ficientem
+							significamur id quod efficitur; sicut frigus <lb/> pigruin dicimus, quia
+							pigros facit; et dicm tristem <lb/> vel laetum, quia tristes vel laetos
+							facit; etiam de Scri­ <lb/> puris sanctis commemoraverim, ubi Deus dicit
+							ad <lb/> Abraham , <hi rend="italic">Nunc cognovi (Gen.</hi> XXII, 12);
+							quod nihil <lb/> est aliud quam , Nunc ut cognosceres feci : non enim
+							<lb/> tunc Deus dicendus est cognovisse, quod antequam <lb/> fieret
+							nunquam potuit ignorare: quos locutionis modos <lb/> de divinis eloquiis
+							a me prolatos, quomodo aliter <lb/> interpretareris non invenisti; nullo
+							modo utique ad <lb/> itos gemimus redire debuisti. Nemo crum sic de
+							<lb/> Spiritu sancto sapit, nisi qui secundum carnem , non <lb/>
+							secundum spiritum sapit. Quamvis et si libi concede­ <lb/> rctur,
+							quomodo tu sentis, sic Spiritum sanctum in­ <lb/> terpellare pro
+							sanctis; aliud cst interpellare vel orare, <lb/> aliud adorare. Omnis
+							qui orat, rogal: non omuis <lb/> qui adorat, rogat; nec omnis qui rogat,
+							adorat. Re­ <lb/> cole consuctudincm regum, qni plerumque adorantur,
+							<lb/> ct non rogantur ; aliquando rogantur, et non adora n<lb/>tur. Ac
+							pcr hoc a Spiritu sancto adorari Patrem <lb/> nullo modo demonstrarc
+							potuisti.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="10">
+						<p>CAPUTX.— <hi rend="italic">Quomodo sit unus Deus Pater et Filius <lb/>
+								et</hi> Spiritus <hi rend="italic">sanctus.</hi> Decimo loco egi
+							lecum ut intelli­ <lb/> geres, quomodo per ineffabilem copulationem sit
+							unus <lb/> Deus ipsa Trinitas,quam dicimusunius esse substan­ <lb/> tiae
+							: quandoquidem ctiam diversas substantias inve­ <lb/> nimus , hoc est,
+							spiritum hominis et Spiritum Domini, <lb/> per copulationem qua homo
+							adhaeret Domino, unum <lb/> spiritum dictum, ubi ait Apostolus , Qui <hi
+								rend="italic">autem adhae­<lb/> ret Domino,</hi> unus <hi
+								rend="italic">spiritus est</hi> ( I <hi rend="italic">Cor.</hi> VI,
+							17). Ad quod <lb/> tu respondens, vcl potius non tacens, conatus es
+							<lb/> ostendere quomodo Patcr et Filius unum sint, non <lb/> unitate
+							naturae, sed voluntatis. Hoc quidem dicere <lb/> soletis : sed tunc
+							soletis, cum vobis objicitur quod <lb/> ait Dominus, <hi rend="italic"
+								>Ego et Pater unum</hi> sumus <hi rend="italic">(Jonn.</hi> x, 50).
+							<lb/> Ego autem hoc loco non boc volui probare, quod <lb/> Pater et
+							Filius ct Spiritus sanctus unum sint, quod <lb/> quidem propter unitatem
+							substantiae fidelissime certe <lb/> creilimus; sed qnod cadem Trinitas
+							unus est Deus. <lb/> Aliud est quippc, unum sunt; aliud, unus est Deus.
+							<lb/> Discerne, Est, ct Sunt. Nec ait Apostolus, Qui adhae­ <lb/> rent
+							Domino, unum sunt; quoniam diversa substantia <lb/> cst : sed ait : <hi
+								rend="italic">Qui</hi> adhaeret <hi rend="italic">Domino,</hi> unus
+							spiritus <hi rend="italic">est.</hi>
+							<lb/> Si autem vos, cum de duobus dicitur, Unus est, et di­ <lb/> citur
+							quid unus, sicut dicit Apostolus, <hi rend="italic">unus spiritus<lb/>
+								est;</hi> hoc idem putatis esse , quod est cum de duobus <lb/>
+							dicitur, Unum sunt, nee dicitur quid unum ; sicut <lb/> ait Salvator,
+								<hi rend="italic">Ego ct Pater</hi> unum sumus : cur non dici­ <lb/>
+							tis, Palcr et Filius uuus cst Deus? Quare quando an­ <lb/> ditis. <hi
+								rend="italic">Audi, Israel; Dominus Deus tuus, Dominus unus <lb/>
+								est (Deut.</hi> v!. 4); de Patre tantum vultis intelligi ? <lb/>
+							Nempe Pater Dominus Deus est, ct Fillus Dominus <lb/> Heus cst : cur non
+							apud vos uterque unus Dominus <lb/> Deus csl, sicut apud beatum
+							Apostolum, spiritus ho­ <lb/> minis et Spiritus Domini 1 <hi
+								rend="italic">unus spiritus est ?</hi> Quid art­ <lb/> tem prodest
+							causae vestre, quia per consensionem <lb/> voluntatis hoc dicitis fieri
+							? Quod quidem fit, sed ubi <lb/> est diversa natnra, sicut diversa
+							natura est hominis <lb/> et Domini : et tamen <hi rend="italic">qui</hi>
+							adhaeret <hi rend="italic">Domino,</hi> per con­ <lb/> sensionem utique
+							voluntatis, <hi rend="italic">unus spiritus est.</hi> Si ergo <lb/> non
+							vultis per unilatem substantiae; certe per consea­ <lb/> sionem
+							voluntatis dicite, tamen aliquando dicite , <lb/> quoquo modo dicite,
+							Pater ct Filius unus Deus cst. <lb/> Sed non dicitis, ne quod nunquam
+							voluistis, cogamini <lb/> confiteri de utroque dictum esse, non dc Patre
+							solo , <lb/>
+							<hi rend="italic">Audi, Israel; Dominus Deus tuus, Dominus</hi> unus <hi
+								rend="italic">cst:</hi>
+							<lb/> quoniam sanctum Spiritum non vultis Dcum, non <lb/> vultis Dominum
+							confitcri. Dicite, irnjuam , ratione <lb/> qua vultis , Patcr et Filius
+							unus Dominus Deus cst: <lb/> ut Patri et Filio servientes, non duobus
+							diis ct duo­ <lb/> bus dominis contra praeceptum Dei, sed Domino uni
+							<lb/> serviatis I. Sed nunc de hac re satis dictum sit. Puto, <lb/> cum
+							ista legeris, nihil te respondere potuisse ad id quod <lb/> de Apostolo
+							commemoravi, <hi rend="italic">qui</hi> adhaeret <hi rend="italic"
+								>Domino,</hi> unus <lb/>
+							<hi rend="italic">spiritus</hi> est : si contentionem deposueris, non
+							negabis.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="11">
+						<p>CAPUT XI. — <hi rend="italic">De templo Spiritus sancti.</hi> Undecimo
+							<lb/> loco, Deum esse Spiritum sanctum, de templo ejus <lb/> quod nos
+							ipsi sumus, teste Apostolo, ostendi , ubi <lb/> ait, <hi rend="italic"
+								>Nescitis quia templum Dei estis, et</hi> Spiritus <hi rend="italic"
+								>Dei <lb/> habitat</hi> in <hi rend="italic">vobis</hi> (I <hi
+								rend="italic">Cor.</hi> III, 16) ? et iterum , <hi rend="italic"
+								>Nescitis<lb/> qnia corpora vestra templum in vobis est
+								Spiritus</hi> sancti, <lb/>
+							<hi rend="italic">quem habetis a Deo (Id.</hi> vi, 19) ? Tu aulem ad
+							isto re­ <lb/> spondisti nihil. Aisti enim : <hi rend="italic">Suscipio
+								quae protulisti :</hi>
+							<lb/> i <hi rend="italic">Nescitis quia templum Dei estis, ci Spiritus
+								Dei habi­<lb/> tat</hi> in <hi rend="italic">vobis?</hi> &gt; <hi
+								rend="italic">Neque enim Deus,</hi> inquis , <hi rend="italic"
+								>inhabitat in <lb/> homine, quem non ante Spiritus sanctificaverit
+								atque <lb/> purgaverit.</hi> Atque isto modo intelligi voluisti, non
+							Spi­ <lb/> ritum sanctum esse dictum Deum, nec templum <lb/> Spiritus
+							sancti nos a esse, sed Dci : et hoc esse cii­ <lb/> ctum, <hi
+								rend="italic">Templum Dei estis.</hi> Sed ideo additum, <hi
+								rend="italic">Spiritus<lb/> Dei habitat in vobis</hi> : quia purgat
+							Spiritus sancius <lb/> templum Dei, non suum ; ut cum ipse purgaverit,
+							<lb/> tunc illic inhabitet Deus. Quem sensum tuum quanta <lb/> sequatur
+							absurditas, nolo nunc dicere. Illud enirn <lb/> nunc ostendere debeo,
+							quomodo multa dicendo, nihil <lb/> quod ad rcm pertinet, dixeris.
+							Dimisisti enim cau­ <lb/> sam, et perrexisti in laudem Spiritus sancti,
+							camque <lb/> copiose contra te ipsum exsecutus es. Centra te ipsum <lb/>
+							ideo dixi, quoniam non vis eum dicere Deum, cujus <lb/> tantam
+							divinitatem per laudem coactus es confiteri; <lb/> ut cum sit unus,
+							ubique sit praesens, et nemini sancti­ <lb/> ficando desit, ubicumque
+							quisquc christianus esse et <lb/> Deum orare voluerit, simul se omnibus
+							exhibendo, <lb/> sive in oriente, sive in occidente baptizentur in Chri­
+							<lb/> sto : hoc ct nos dicimus. Sed qucm dicimus talcm ac <lb/> tantum,
+							absit a nohis ut eum negemus Dcum : quod <lb/> etiam per suum templum,
+							quod nos ipsi sumus, ci- <note type="footnote"> * Quidam vss., <hi
+									rend="italic">Dommm.</hi>
+							</note><note type="footnote"> * Ain. Er. ct Mss., <hi rend="italic">ct
+									Domini 'om1nå &lt;U!&lt;M&lt; serviahs.</hi>
+							</note><note type="footnote"> I Abcst, nos, a '!ss. </note>
+							<lb/>
+							<pb n="753"/> tissime et facile ostenditur. Neque enim nisi Deus <lb/>
+							noster esset, templum nos ipsos habere potuisset: <lb/> quod tu ut
+							occultares, et in sermone tuo mentes <lb/> hominum a luce veritatis
+							averteres, de templo Dei <lb/> quodeumque dixisti, quem noluisti
+							intelligi Spiritum <lb/> sanctum; de templo autem Spiritus sancti, quod
+							aper­ <lb/> tissimc demonstratum est, omnino tacuisti. Cum enim <lb/>
+							tibi duo testimonia Pauli apostoli proposuerim; <lb/> unnm ubi ait, <hi
+								rend="italic">Nescitis</hi> quia <hi rend="italic">templum Dei
+								estis, et Spi­<lb/> ritus Dei habitat in</hi> vobis ? alterum ubi
+							ait, <hi rend="italic">Nescitis <lb/> quia corpora</hi> vestra <hi
+								rend="italic">templum</hi> in <hi rend="italic">vobis Spiritus
+								sancti</hi> est ? <lb/> quare tam fraudulenter egisti, ut unum horum
+							com­ <lb/> memorares, quod dictum cst, <hi rend="italic">Templum Dei
+								estis;</hi> et <lb/> alterum taceres, quod dictum est, <hi
+								rend="italic">Corpora vestra <lb/> templum in</hi> vobis <hi
+								rend="italic">est Spiritus</hi> sancti ? Cur hoc fccisti, <lb/> rogo
+							te ; nisi quia nullo pacto posses argumentari <lb/> quomodo Deus noster
+							non esset, qui templtum nos <lb/> ipsos haberet: quem sine dubio Deam
+							cognoscere­ <lb/> mus, si ei templum de lignis et lapidibus per divinam
+							<lb/> Scripturam faccre juberemur?</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="12">
+						<p>CAPUT XII. — <hi rend="italic">De eo quod Pater et Filius unum<lb/>
+								sint.</hi> Duodecimo loco admonui te, ut proferres, si <lb/> posses,
+							qua divina auctorilate sit dictum, quod unum <lb/> sint, ubi substantiae
+							sunt diversae. Tu autem respon­ <lb/> dcre ad hoc volens, nihil tale
+							proferre potuisti; sed <lb/> magnis coarctatus angustiis affirmare ausus
+							es, quod <lb/> Apostoli unum siut cum Patre et Filio. Quod Christus
+							<lb/> omnino non dixit: sic enim abs te dictum est, tan­ <lb/> quam
+							Pater et Filius et Apostoli unum sint. Christus <lb/> autem non ait, Ut
+							ipsi ct nos unum simus ; sed ait, <lb/>
+							<hi rend="italic">Ut sint</hi> unum, <hi rend="italic">sicut et</hi> nos
+							unum sumus. Nam, ut verba <lb/> ipsa evangelica ponam : <hi
+								rend="italic">Pater sancte,</hi> inquit, <hi rend="italic">serva
+								eos</hi>
+							<lb/> in <hi rend="italic">nomine luo quos dedisti mihi,</hi> ut <hi
+								rend="italic">sint unum,</hi> sicut <hi rend="italic">el <lb/> nos
+								unum.</hi> Numquid dixit, Ut nobiscum sint unum; <lb/> aut, Ipsi et
+							nos simus unum ? Item post aliquantum : <lb/>
+							<hi rend="italic">Non,</hi> inquit, <hi rend="italic">pro</hi> eia <hi
+								rend="italic">rogo tantum; sed et pro eis qui cre­</hi>
+							<lb/> dituri <hi rend="italic">sunt per verbum eorum in</hi> me, <hi
+								rend="italic">ut omnes unum sint.</hi>
+							<lb/> Neque hic dixit, Ut nobiscum unum sint. Deinde se­ <lb/> quitur :
+								<hi rend="italic">Sicut tu, Pater, in me et ego in te, et ipsi in
+								<lb/> nobis unum sint.</hi> Et hic non dixit, Unum simus ; aut,
+							<lb/> Unum nobiscum sint: sed; <hi rend="italic">Unum sint in
+								nobis;</hi> ut qui <lb/> natura unum sunt, quia homincs sunt, etiam
+							in Pa­ <lb/> tre et Filio sint unum; non cum ipsis unum, id est, <lb/>
+							non ut ipsi et isti sint unum. Adhuc adjungit, et dicit: <lb/>
+							<hi rend="italic">Ut mundus credat quia tu me</hi> misisti, <hi
+								rend="italic">et ego claritatem<lb/> quam dedisti mihi, dedi illis,
+								ut sint unum, sicut nos</hi>
+							<lb/> unum <hi rend="italic">sumus: ego in eia et tu in me,</hi> ut sint
+								<hi rend="italic">consummati <lb/> in</hi> unum <hi rend="italic"
+								>(Joan.</hi> XVII, 11-23). Cum ergo toties dixerit, <lb/>
+							<hi rend="italic">Ut sint</hi> unum ; non tamen alicubi dixit, Ut ipsi
+							et nos <lb/> simus unum, hoc est, ut nobiscum sint unum : sed <lb/> aut,
+								<hi rend="italic">in nobis</hi> dixit; aut, <hi rend="italic">sicut
+								nos;</hi> id est, ipsi secun­ <lb/> dum naturam suam, nos secundum
+							nostram. Volebat <lb/> enim eos qui natura unum erant, in hoc ipso quod
+							<lb/> unum erant, esse perfectos. Non enim quia dicit , <lb/>
+							<hi rend="italic">Estote ergo et vos perfecti</hi> sicut <hi
+								rend="italic">Puter vester</hi> caelestis <hi rend="italic">per­
+								<lb/> fectus eit (Matth.</hi> v, 48); vult illos Deo natura unitate
+							<lb/> conjungere, tanquam illorum et illius una eademque <lb/> oatura
+							sit : sed perfectos vult esse in natura Sua, Sic­ <lb/> ut est Deus
+							perfectus in sua , quamvis diversa, non <lb/> una ; quod nisi in ipso
+							simus, omnino esse non possu­ <lb/> mus. Non sicut in illo sunt omnes,
+							quia ipse continet <lb/> omnia quae creavit; propter quod dictus est <hi
+								rend="italic">non longe <lb/> positus ab unoquoque</hi> nostrum,
+							quia <hi rend="italic">in illo vivimus, et <lb/> movemur, et sumus
+								(Act.</hi> XVII, 27, 28): sed sicut in illo <lb/> sunt tales
+							qualibus dictum est, <hi rend="italic">Fuistis enim aliquando</hi>
+							<lb/> tenebrae, <hi rend="italic">nunc autem lux</hi> in <hi
+								rend="italic">Domino (Ephes. V,</hi> 8). Unde <lb/> et illud est,
+								<hi rend="italic">Cui</hi> vult <hi rend="italic">nubat, tantum</hi>
+							in <hi rend="italic">Domino</hi> (I <hi rend="italic">Cor.</hi>
+							<lb/> VII, 59). Non igitur proferre potuisti ubi dictum sit, <lb/> Unum
+							sunt, quorum est non una, sed diversa sub­ <lb/> stantia : et tamen 1 in
+							obscuro loco nobis subrepere <lb/> voluisti , ut diceres Apostolos unum
+							esse cum Patre <lb/> et Filio , tanquam unum essent Apos!oli et Pater et
+							<lb/> Filius; cum Apostolorum substantiam manifestum sit <lb/> a Patre
+							et Filio esse diversam. Sed quoniam, Ut ipsi <lb/> et nos unum simus,
+							aut, Nobiscum sint unum, nus­ <lb/> quam Christum dixisse manifestum
+							est; te quoque <lb/> nobis respondere non potuisse, et fraudern facere
+							vo­ <lb/> luisse manifestum sit.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="13">
+						<p>CAPUT XIII. — <hi rend="italic">De testimonio quod Pater perhibuit<lb/>
+								Filio.</hi> Tertio decimo loco te commonui, non ideo Pa­ <lb/> irem
+							Filio esse majorem, quia testimonium perhibuit <lb/> Pater Filio. Nam et
+							Propbetas ei testimonium perhi­ <lb/> buisse memoravi, quos majores illo
+							esse non potes <lb/> dicere. Dixeras enim quod Pater Filio perhibuerit
+							te­ <lb/> stimonium ; quod sic accepi, tanquam hinc ipse pro­ <lb/> bare
+							volueris, illo cui testimonium perhibuit, eum <lb/> esse majorem : sed
+							quoniam posteriore prosecutione <lb/> hinc omnino tacuisti,
+							taciturnitatem tuam in locum <lb/> consensionis accepi ; etsi fieri
+							polost. ut ideo comme. <lb/> moraveris Patrem Filio perhibuisse
+							testimonium, ut <lb/> hinc illum esse alium , istum autem alium, non ut
+							<lb/> illum isto probares esse majorem. Alium vero esse <lb/> Patrem,
+							aliutn esse Filium, quoniam non est Pater <lb/> ipse qui Filius, et
+							vobis et nobis contra Sabellianos <lb/> est dogma commune. Illi enim
+							dicunt, nonalium, sed <lb/> eumdem Filium esse qui est Pater : nos autem
+							alium <lb/> quidem esse Patrem, et alium Filium; sed tamen <lb/> quod
+							Pater est, hoc esse dicimus Filium.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="14">
+						<p>CAPUT XIV. — <hi rend="italic">De dilectione Patris et Filii.</hi> Quarto
+							<lb/> decimo loco ad illud quod dixeras, <hi rend="italic">Dilectum
+								lego, et <lb/> credo quod Pater eat qui diligit , et Filius qui
+								diligitur;</hi>
+							<lb/> respondens dixi : <hi rend="italic">Sic autem dicis hinc inter
+								Patrem et <lb/> Filium esse diversitatem, quia Pater diligit, et
+								Filius <lb/> diligitur; quasi negare possis quod et Filius diligat
+								Pa­<lb/> trem.</hi> Deinde addidi: <hi rend="italic">Si ambo se
+								invicem diligunt, cur<lb/> negatis eoa</hi> unius <hi rend="italic"
+								>esse naturae</hi> ? Quod utique ideo dixi, <lb/> ne hinc unam
+							naturam negaretis amborum, quia iI­ <lb/> lum diligere, hunc diligi ipse
+							dixisti. Ad hoc tu re­ <lb/> spondens consensisti quidem, quod et Filius
+							diligat <lb/> Patrem , sed unius esse naturae consentire noluisti :
+							<lb/> tanquam Filius ita diligat Patrem, sicut creatura <lb/> Crratorcm
+							, non sicut unigenitus geuitorcm, quem <lb/> diversitate substantiae
+							vultis esse degenerem.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="15">
+						<p>CAPUT XV. — <hi rend="italic">De invisibilitate Trinitatis.</hi> Quinto
+							<lb/> decimo loco dixi pariter esse invisibilem Trinitatem, <note
+								type="footnote"> * ALD, fcr. et Mas., <hi rend="italic"
+									>tanquam.</hi>
+							</note>
+							<lb/>
+							<pb n="755"/> nun solum Patrem : sed apparuisse tamen visibilem <lb/>
+							:'ilium in forma servi, propter quam dixit, <hi rend="italic">Pater
+								ma­</hi>
+							<lb/> jor <hi rend="italic">me eat (Joan.</hi> xiv, 23). Sed quoniam
+							patribus se di­ <lb/> vinilas demostrabat , dixi per subjectum
+							crealurain <lb/> id osse factum, non per naturam suam, qua est invi­
+							<lb/> sibilis Trinitas. Atque ut hoc probarem, Moysen com­ <lb/>
+							memoravi ci dicentem, cum quo facie ad faciem lo­ <lb/> quebatur, Si <hi
+								rend="italic">inveni</hi> gratiam <hi rend="italic">ante te, ostende
+								mihi temet­<lb/> ipsum</hi> manifeste <hi rend="italic">(Exod.</hi>
+							XXXIII, 11, 13) : ut intelligeres <lb/> quomodo cum vidcbat, quem sibi
+							cupiebat ostendi ; <lb/> quia utique si Deum in substantia qua Deus cst
+							vide­ <lb/> rpt, profecto ut se illi ostenderet non rogaret. Dixi <lb/>
+							etiam esse Christum visibilium ct invisibilium creato­ <lb/> rem , ut
+							ipsum probarem per substantiam suam non <lb/> esse visibilem , a quo
+							preari non solum visibilia, <lb/> veram etiam invisibilia potuerunt. Ad
+							haec tu respon­ <lb/> dere conatus, quam multa quae ad rem non pertinent
+							<lb/> dixeris , intueantur qui legunt : et tamen de Moyse, <lb/> cur
+							sibi Deum cum quo loquebatur, vellet ostendi , si <lb/> cnus naturam
+							substantiamque cernebat, prorsus nibil <lb/> ausus es dicere: ct adhuc
+							affirmare non destitisti, Dei <lb/> Filium invisibilium crcatorem , et
+							antequam formam <lb/> servi acciperet, in forma Dei fuisse visihilcm;
+							quem <lb/> tupcrius in formi servi viden potuisse , in substantia <lb/>
+							vero suie divinitatis esse invisibilem, jam fueras et <lb/> ipse
+							confessus.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="16">
+						<p>CAPUT XVI. — <hi rend="italic">De solo sapiente Deo.</hi> Sexto de­ <lb/>
+							cimo loco; quia de Patre tantum dixissc Apostolum <lb/> dixeras, <hi
+								rend="italic">Soli sapienti Deo (Rom.</hi> xvi, 27); ego dixi : <lb/>
+							<hi rend="italic">Ergo solus Pater est Deus sapiens, et non est
+								sapiens<lb/> ipsa Dei sapientia, quod est</hi> Christus; <hi
+								rend="italic">de quo ait Aposto­</hi>
+							<lb/> lus : « <hi rend="italic">Christum Dei Virtutem et Dei</hi>
+							Sapientiam <hi rend="italic">» (I Cor.</hi>
+							<lb/> I, 24) ! Deinde addidi : <hi rend="italic">Superest ut dicatis
+								(quid enim <lb/> non audetis? ) insipientem esse sapientiam
+								Dei.</hi> Ad h:rc <lb/> tu : <hi rend="italic">Sapientem solum,</hi>
+							inquis, <hi rend="italic">Patrem praedicat Paulus <lb/> beatus
+								apostolus, dicens sic:</hi> « <hi rend="italic">Soli sapienti
+								Dco.</hi> i <hi rend="italic">Sed <lb/> requirenda est ,</hi>
+							inquis, <hi rend="italic">ratio quemadmodum solus sapiens,</hi>
+							<lb/> non <hi rend="italic">quod Christus non sit sapiens.</hi> Scqucris
+							dcinceps , <lb/> et adjungis quomodo sapientem confitearis et Chri­
+							<lb/> stum : nam post nonnulla , quae ad rem non perii.. <lb/> nentia
+							texuisti , ut sermonem tempusque produceres, <lb/> eliam hoc inseruisti
+							verbis tuis ut diceres, <hi rend="italic">Sed vere <lb/> solus
+								sapiens</hi> Pater ; quasi Apostolus dixerit, Soli <lb/> sapienti
+							Patri. Sed dixit, <hi rend="italic">Soli sapienti Dco</hi> : quia Deus
+							<lb/> est et Filius, quod et vos vultis; Dcus est ct Spiritus <lb/>
+							sanctus, etsi non vultis : ct ista Trinitas cst solus sa­ <lb/> piens
+							Deus, qui nec potuit unquam esse insipicns <lb/> omnino, nec poterit;
+							non per gratiam particeps sa­ <lb/> pientiae, sed sapiens immobilitate
+							atque immuta­ <lb/> bilitate naturae. Nam si tibi dicam, itane vero, o
+							<lb/> homo qui christiano nomine gloriaris, Christus sic est <lb/>
+							sapiens , ut non sit vere sapiens ? ergone Christus qui <lb/> osi verus
+							Deus, non est verb sapicns? nonne ita sub <lb/> hac interrogatione
+							turbaberis, ut continuo respon­ <lb/> deas , Christum vere esse
+							sapientem ? Quid est ergo <lb/> quod dixisti, <hi rend="italic">Sed</hi>
+							vere <hi rend="italic">solus sapiens</hi> Pater ? Nempe <lb/> quo per
+							veneris , et a quanta blasphemia te debeas re­ <lb/> yovare, jam
+							sentis.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="17">
+						<p>CAPUT XVII. — <hi rend="italic">De infecto Deo.</hi> Septimo decimo <lb/>
+							loco egi tecum, quod etiam Filius , non solus Pater, <lb/> infectus sit,
+							hoc est, factus non sit. Dixeras enim ideo <lb/> a vobis unum Deum
+							pronuntiari, quia <hi rend="italic">unus est super<lb/> omnia
+								innatus,</hi> infectus. Respondens crgo huic aula. <lb/> ci:c tu:c :
+								<hi rend="italic">Sic antem</hi> , inquam, <hi rend="italic">dicis
+								Patrem infectum,<lb/> quasi Filius factus sit , per quem facta sunt
+								omnia.</hi>
+							<lb/> Deinde addidi : <hi rend="italic">Scito factum esse Filium, sed
+								in</hi> forma <lb/>
+							<hi rend="italic">servi.</hi> Nam in <hi rend="italic">forma Dei
+								usque</hi> adeo <hi rend="italic">non est factus,</hi> ut <lb/>
+							<hi rend="italic">per illum facta sint omnia.</hi> Si <hi rend="italic"
+								>enim ipse factus</hi> eat, in­ <lb/> quam, <hi rend="italic">non
+								per illum facta sunt omnia, aed</hi> caetera. Ad <lb/> haec tu cum
+							tota hii prolixitate sermonis, ita nihil <lb/> quod diceres invenisti ,
+							ut hinc omnino, tanquam id <lb/> non audieris, conticesceres.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="18">
+						<p>CAPUT XVIII. <hi rend="italic">- De ingenito Patre.</hi> Octavo decimo
+							<lb/> loco etiam de innato Patre , id est ingenito , quia ct <lb/> hoc
+							dixcras, tccum agendum putavi, et dixi: <hi rend="italic">Non <lb/>
+								itoque dico Filium ingenitum; aed Patrem genitorem, <lb/> Filium
+								genitum. Hoc tamen genuit Puter quod est : <lb/> alioquin non est
+								verus Filius ,</hi> si <hi rend="italic">qnod est Pater non est
+								<lb/> Filius ; sicut de partubus animalium supra jam diximus.</hi>
+							<lb/> Eliam ad hoc In nee verum nec falsum ali quid protulisti.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="19">
+						<p>CAPUT XIX. — <hi rend="italic">De aequalitate Spiritus sancti cum
+								Pa.<lb/> tre.</hi> Nonodccimo loco, quia poposceras a mc, ut osten­
+							<lb/> derem aequalem esse I'atri i Spiritum sanctum ; respondi <lb/>
+							tibi dicens: <hi rend="italic">Quid est autem quod</hi> poscis, <hi
+								rend="italic">ut ostendam tibi</hi>
+							<lb/> aqualem Patri <hi rend="italic">esse Spiritum sanctum, quasi tu
+								Patrem <lb/> ostenderis majorem esse Spiritu sancto; sicut potuisti
+								<lb/> ostendere de Filio, propter formam servi? Scimus enim,</hi>
+							<lb/> inquam, <hi rend="italic">dictum esse Patrem Filio majorem,
+								quia</hi> in <lb/>
+							<hi rend="italic">forma servi erat Filius ; ct adhuc in forma eat
+								humana<lb/> Filius, quam levavit in coelum : propterea de illo</hi>
+							di­ <lb/> ctum <hi rend="italic">eat quod et nunc</hi> a interpellat <hi
+								rend="italic">pro</hi> nobis i <hi rend="italic">(Rom.</hi>
+							<lb/> VIII, 54). <hi rend="italic">Et sempiterna erit in regno haec
+								eadem forma <lb/> immortalis : propter quod dictum</hi> eat « <hi
+								rend="italic">Tunc et ipsa</hi> Fi­ <lb/> « <hi rend="italic">lius
+								subjectus erit ei qui illi subjecit omnia</hi> » ( I <hi
+								rend="italic">Cor.</hi>
+							<lb/> xv, 28). <hi rend="italic">Nam de Spiritu sancto qui nullam
+								suscepit <lb/> creaturam ad unitatem personae suae, quamvis se per
+								<lb/> subjectam creaturam visibiliter et ipse.. sive per</hi>
+							columbae <lb/>
+							<hi rend="italic">speciem, sive per linguas igneas sit demonstrare
+								digna­ <lb/> tua (Matth</hi> III, 16 <hi rend="italic">, et
+								Act.</hi> II, 3), <hi rend="italic">nunquam dictus est <lb/> eo
+								major Pater; nunquam dictus cst</hi> Spiiitus <hi rend="italic"
+								>adorasse <lb/> Patrem; nunquam dictus est minor Patre.</hi> Ad haec
+							tu <lb/> quasi respondens, non tamen respandisti. Non enim <lb/>
+							potuisti ostendere Spiritu sancto alicubi Patrem dictum <lb/> fuissc
+							majorem, sicuti Filius propter formam servi di­ <lb/> xit, <hi
+								rend="italic">Pater major me est (Joan.</hi> XIV, 28). Et cum ego
+							<lb/> dixerim, Spiritum sanctum non ad unitatem personae <lb/> suae
+							ullam suscepisse creaturam; tu ita Spiritum san­ <lb/> ctum in columba
+							ct igne apparuisse dixisti, sicut ap­ <lb/> paruit Christus in homine :
+							quasi columba el Spiritus, <lb/> vel ignis et Spiritus una persona sit,
+							sicut Verbum et ' <lb/> homo una persona est. Ad horam quippe
+							apparuerunt <lb/> illa, quae Spiritum sanctum significando monstrarent
+							<lb/> visibiliter invisibilem ; columba, propter amorem san­ <lb/> ctum
+							; ignis autem , propter charitatis lumcn atque <lb/> fervorem ; et
+							peracto significationis officio, corporales <lb/> illae species
+							transierunt, atque esse ulterius destite­ <lb/> runt; sicut columna
+							nubis. nebulosa per diem , lunii­ <lb/> nosa per noctem <hi
+								rend="italic">(Exod.</hi> XIII, 21-22). Denique ne puta­ <lb/>
+							<pb n="757"/> retur columba vel flamma ad substantiam pertinere <lb/>
+							Spiritus sancti, vel quod se in haec visibilia tantae ma­ <lb/> jestatis
+							natura converterit, aut in unitatem personae <lb/> suae ista susceperit,
+							nunquam postea sic apparuisse le­ <lb/> gitur Spiritus sancius. Cbristus
+							autem, qui humanam <lb/> non ad horam sumpsit effigiem, in qua hominibus
+							ap­ <lb/> pareret, ac deinde illa species praeteriret; sed in uni­ <lb/>
+							tatem personae suae, manente invisibili Dei forma I, <lb/> accepit
+							visibilem hominis formam; non solum, natus <lb/> cst in ea de homine
+							matre, verum etiam crevit in ea, et <lb/> manducavit, et bibit, et
+							dormivit in ea, et occisus est <lb/> in ea, et resurrexit in ea, et
+							ascendit in coelum, et <lb/> scdet ad dexteram Patris in ea, ad
+							judicandos vivos <lb/> et mortuos est venturus in ea, et in regno suo,
+							ci qui <lb/> illi subjecit omnia, erit subjectus in ea. Ilac tu in <lb/>
+							mea responsione breviter dicta, quae nunc aliquanto <lb/> latius, ut vel
+							sic intelligcres, explicavi, attendere et <lb/> considcrare noluisti,
+							irruens in tantam blasphemiam, <lb/> . ut naturam divinam Dei et
+							Spiritus sancli converti-, <lb/> bilem, proh nefas! et mutabilem
+							diccres. Tua nam­ <lb/> que ista sunt verba : <hi rend="italic">Ea,</hi>
+							inquis, <hi rend="italic">quae; de invisibilitate <lb/> &gt;
+								omnipotentis</hi> 2 <hi rend="italic">Dei prosecutus sum, eliam et
+								ipse, licet <lb/> alio</hi> proposito, attamen <hi rend="italic"
+								>tuis verbis affirmasti, quod Spi­</hi>
+							<lb/> . <lb/> ritus sanctus in <hi rend="italic">specie columbae sit
+								MMM, necnon et in<lb/> specie ignis : Filius sane,</hi> in forma
+							hominis: <hi rend="italic">Pater<lb/> autem, neque</hi> in <hi
+								rend="italic">specie columbx, nec</hi> in <hi rend="italic">forma
+								hominis;. <lb/> nec aliquando vertit se in formas, sed nec
+								aliquando</hi>
+							<lb/> vertetur : <hi rend="italic">de quo scriptum est, « Ego</hi> sum
+								<hi rend="italic">qui sum, et</hi>
+							<lb/> « <hi rend="italic">non sum mutatus.</hi> &gt; Deinde adjungis, et
+							dicis: Fi­ <lb/>
+							<hi rend="italic">lius sane</hi> in forma <hi rend="italic">Dei
+								constitutus jam,</hi> ut <hi rend="italic">ipse protu<lb/>li.,;,
+								formam servi accepit, quod non Pater: Spiritus <lb/> aeque sanctus
+								suscepit speciem columbae, quam</hi> nonsta­ <lb/>
+							<hi rend="italic">cepit Parer. Scito ergo,</hi> inquis, <hi
+								rend="italic">quia unus est, invisi­ <lb/> bilis, unus eliam
+								incapabilis atque immensus.</hi> Haec <lb/> numquid diceres, si
+							secundum spiritum, non secun­ <lb/> dum carnem, posses cogitare quid
+							diceres ? Homo <lb/> es enim, qui legis in Scripturis sanctis, <hi
+								rend="italic">Ego</hi> sum <hi rend="italic">qui <lb/> sum:, et non
+								sum mutatus (Exod.</hi> III, 14, <hi rend="italic">et Malach.</hi>
+							<lb/> III, 6). Et cum verba ista sint, non Patris solius, sed <lb/>
+							ipsius Trinitatis, quae unus est Deus; tu ea Patri <note type="footnote"
+								> I Editio Lov., <hi rend="italic">sed unitate personae manenle,
+									invisibUis <lb/> hei fortna accepit,</hi> etc. * </note><note
+								type="footnote"> I Am. ET. et Mss., <hi rend="italic"
+									>omnitenentis.</hi>
+							</note>
+							<lb/> tantummodo tribuens, Filium mutabilem credis! Uni­ <lb/> genitum
+							per quem facta sunt omnia mutabilem credis: <lb/> eum de quo dicit
+							Evangelium, <hi rend="italic">In principio erat Ver. <lb/> bum, et
+								Verbum erat apud Deum, et Deus erat Verbum;</hi>
+							<lb/> et, <hi rend="italic">Omnia per</hi> ipsum <hi rend="italic">facta
+								sunt (Joan.</hi> i, 1, 5), muta­ <lb/> bilem credis! Quid jam dicam
+							de Spiritu sancto, <lb/> quando illum quem verum Filium Dei et verum
+							con­ <lb/> fiteris Deum, mutahilem credis ? Quod ufiquc non <lb/>
+							crederes, si formam servi a forma Dei esse susce­ <lb/> ptam, non formam
+							Dci in formam servi esse muta. <lb/> tam, tanquam catholicus crederes;
+							et visibili homine <lb/> assumpto, permansisse invisibilem Deum, non
+							car­ <lb/> nalitcr, sed spiritualiter cogitares ; nee coptendend&gt;
+							<lb/> diffideres, sed intelligendo conspiceres : et Spiritum <lb/>
+							sanctum invisibili sua manente natura, nullo modo <lb/> in ignis aut
+							columbae speciem mutata atque conversa, <lb/> per subjectam creaturam
+							apparuisse, sicul voluit vi­ <lb/> sibiliter <hi rend="italic"
+								>(Act.</hi> n, 3, <hi rend="italic">et Matth.</hi> III, 16), tu
+							posses consi<lb/>derare fideliter. Memento tamen, nec majorem Pa<lb/>
+							Irem Spiritu sancto, nec adoratum Patrem ab Spiritu <lb/> sancto, ullis
+							divinis testimoniis contra propositionem <lb/> meam te demonstrare
+							potuisse.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="20">
+						<p>CAPUT XX. — <hi rend="italic">Licet ingenitus Pater,</hi> aequalis <hi
+								rend="italic">ta­<lb/> men Filius.</hi> Vigesimo loco, quoniam
+							dixeras de Filio, <lb/> Si <hi rend="italic">aequalis. Patri, utique
+								talis:</hi> si <hi rend="italic">talis, utique innatus;</hi>
+							<lb/> ego respondens tibi: Sed dicis, inquam, de Filio, Si <lb/>
+							<hi rend="italic">aequalis, utique talis;</hi> id est, ut <hi
+								rend="italic">quia non eat ingenitus.<lb/> non videatur talis.
+								Posses dtcere non esse hominem quem<lb/> genuit Adam, quia ipse Adam
+								non eat genitus, sed factus<lb/> a Deo.</hi> Si <hi rend="italic"
+								>autem potuit Adam et non esse genitus,</hi> et <lb/> tamen <hi
+								rend="italic">hoc generare quod erat ipse; non vis ut potue­<lb/>
+								rit Deus Deum aquatem</hi> sibi ? Ad haec non miror <lb/> nullum te
+							invenisse responsum : sed plane laudo nec <lb/> respondere conatum.
+							Atque utinam hoc ubique fe­ <lb/> cisses! nusquam enim in sermonibus
+							nostris quid <lb/> recte responderes invenire potuisti, et tamen pene
+							<lb/> ubique tacere noluisti. Sed cum in aliis tam multa <lb/> dixeris,
+							causae quoe inter nos agitur non necessaria , <lb/> et tempus loquendo
+							consumpseris; gratiae tibi agendae <lb/> sunt, ubi nonnulla sic vidisti
+							te refutare non posse, ut <lb/> ea malles summo silentio praeterire.
+								<note type="footnote"> I Apud Lov., <hi rend="italic">plene.</hi>
+							</note>
+						</p>
+					</div>
 				</div>
-				<div type="textpart" subtype="chapter" n="2">
-					<p>CAPUT II. — <hi rend="italic">De humanis contagiis.</hi> Secundo loco <lb/> egi
-					tecum de verbis tuis, ubi dixeras, <hi rend="italic">Deum Patrem</hi>
-					<lb/> ad <hi rend="italic">humana</hi> non <hi rend="italic">descendisse
-						contagia;</hi> quasi Christus <lb/> illa in carne perpessus sit : et
-					admonui, quomodo <lb/> contagium intelligi soleat, non utique nisi in aliquo
-					<lb/> vitio, a quibus omnibus immunem novimus Christum. <lb/> Nec ad hoc
-					quidquam respondere potuisti. Testimo­ <lb/> nia quippe divina, quae abs te
-					commemorata sunt, <lb/> nihil te adjuvare potuerunt : non enim eis probare <lb/>
-					potuisti humano Christum attaminatum esse conta­ <lb/> gio. Quod enim Apostolum
-					dixisse commemoras, <lb/>
-					<hi rend="italic">Quoniam Christus cum peccator non esset, peccatum</hi>
-					<lb/> pro <hi rend="italic">nobis fecit:</hi> lege diligentius &gt; et ne forte
-					mendo­ <lb/> sum incurreris codicem, aut latinus interpres errave­ <lb/> rit,
-					graecum inspice; et invenies non Christum pro <lb/> nobis fecisse peccatum, sed
-					a Patre Deo ipsum Chri» <lb/> stum factum esse peccatum, id est, sacrificium pro
-					<lb/> peccato. Ait enim Apostolus: <hi rend="italic">Obsecramus pro Christo,
-						<lb/> reconciliamini Deo 1:</hi> tum <hi rend="italic">qui non noverat
-						peccatum, <lb/> pro nobis peccatum fecit</hi> (II Cor. v, 20, 21). Non ergo
-					<lb/> fecit ipse peccatum, sed eum Deus pro nobis pecca­ <lb/> tum fecit, hoc
-					est, ut dixi, sacrificium pro peccato. <lb/> Si enim recolas vel relegas,
-					invenies in libris Veteris <lb/> Testamenti peccata appellari sacrificia pro
-					peccatis. <lb/> Similitudo etiam carnis peccati, in qua venit ad nos, <lb/>
-					dicta est et ipsa peccatum : Misit, inquit, <hi rend="italic">Deus Filium</hi>
-					<lb/> suum <hi rend="italic">in similitudine carnis peccati, et de peccato da­
-						<lb/> mnavit peccatum</hi> in <hi rend="italic">carne (Rom.</hi> VIII, 5):
-					hoc est, de <lb/> similitudine carnis peccati, quae ipsius erat,
-						<unclear>damnavit</unclear>
-					<note type="footnote"> 1 AIt'.. Er. et Uss.v <unclear/><hi rend="italic"
-							>reconciliari</hi> ret* </note>
-					<lb/>
-					<pb n="745"/> percatum in carne peccati, quae nostra est. Propter <lb/> hoc
-					etiam de illo dicitur : <hi rend="italic">Quod enim mortuus est pec­ <lb/> calo,
-						mortuus est semel; quod autem vivit, vivit Deo</hi> (Rom. <lb/> VI, 10).
-					Peccato enim mortuus est semel. quia simili­ <lb/> tudini 1 carnis peccati
-					mortuus est, quando moriendo <lb/> exutus est carne: ut per hoc mysterium
-					significaret, <lb/> eos qui in morte ipsius baptizantur, mori peccato, ut <lb/>
-					vivant Deo, Sic etiam per crucem <hi rend="italic">factus</hi> est <hi
-						rend="italic">pro nobis<lb/> maledictum (Galat.</hi> III, 15). Pendens
-					quippe in ligno, <lb/> mortem quae de maledicto Dei venerat , suspendit in <lb/>
-					ligno, atque ita <hi rend="italic">vetus homo noster simul confixus</hi> eat <lb/>
-					<hi rend="italic">cruci</hi> (Rom. VI. 6): ut non mendaciter dictum intelliga­
-					<lb/> tur in Lege , <hi rend="italic">Maledictus omnis qui pendet in ligno <lb/>
-						(Deut.</hi> xxi, 25). Quid est, <hi rend="italic">maledictus</hi> , nisi,
-						<hi rend="italic">Terra es,<lb/> et</hi> in <hi rend="italic">terram ibis
-						(Gen.</hi> m , 19) ? Et quid est, <hi rend="italic">omnis ;</hi>
-					<lb/> n'si quia et ipse Christus, qui cum esset vita , mor­ <lb/> tuus est tamen
-					vera morte , non ficta ? Si intelligas <lb/> ista mysteria , simul intelliges
-					non esse contagia. Sed <lb/> quid ad nos , si more tuo loquens, contactum forte
-					<lb/> mortalium voluisti appellare contagium; cum tamen <lb/> nobiscum sentias,
-					Dominum Jesum, nec in spiritu, <lb/> nec in carne ullum habuisse peccatum?</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="3">
-					<p>CAPUT III. — <hi rend="italic">De invisibili Deo.</hi> Tertio loco de in­ <lb/>
-					visibili Deo cum agerem, admonui ul crederes invisi­ <lb/> bilem , non solum
-					Patrem, sed etiam Filium secun­ <lb/> dun. divinit item, non secundum carnem, in
-					qua eum <lb/> visibilem mortalibus apparuisse quis negat? undeot <lb/> alio loco
-					postea disputavi. Tu antem cedens manife­ <lb/> stissimae veritati, consensisti
-					esse invisibilem Filium : <lb/> ac per hoc destruxisti quod dixeras, <hi
-						rend="italic">unum invisibilem <lb/> Patrem.</hi> Sed rursus tua consensione
-					conturbatus, <lb/> quia invisibilem etiam Filium esse consenseras, au­ <lb/> sus
-					es dicere, min tra videri a majurihus, majora vero <lb/> a minoribus non posse
-					videri; dicens Angelos videri <lb/> ab Archangelis , animas ab Angelis, Angelos
-					vero ab <lb/> animabus non videri : unde eliam Christum secun­ <lb/> dum
-					divinitatis suae substantiam, non solum ab ho­ <lb/> minibus, sed nec a
-					Virtulibus coelestibus videri asse­ <lb/> rens, ideo Patrem solum invisibilem
-					esse dixisti, quia <lb/> superiorem non habet a quo circuminspiciatur. Dic <lb/>
-					nobis, rogo te, quando libi indicaverunt Archangeli , <lb/> quod ipsi vidcant
-					Angelos, non autem videantur ab <lb/> Augelis! Quibus narrantibus Angelis
-					cognovisti, quod <lb/> ipsi videam animas, animae illos non vidcant? A quo <lb/>
-					haec audisti? unde didicisti? ubi legisti ? Nonne me­ <lb/> lius divinis Libris
-					animum intenderes, ubi legimus et <lb/> ab hominibus Angelos visos,quando
-					voluerunt, cet <lb/> quomodo voluerunt videri, jubente vel sinente <lb/> omnium
-					Creature? Verumtamen qui dixeras, ideo <lb/>
-					<hi rend="italic">solum</hi> dicendum <hi rend="italic">in visibilem Patrem,
-						quia non habet <lb/> superiorem a quo circuminspiciatur;</hi> confessus es
-					po­ <lb/> sica, Filio esse visibilem , contra te ipsum proferens <lb/>
-					evangelicum testimonium, uhi dicit ipse Filius, <hi rend="italic">Non <lb/> quia
-						Patrem vidit quisquam, sed qui eat a Deo, hic vi­ <lb/> dit Patrem
-						(Joan.</hi> VI, 46). Ubi te quidem veritas apcr­ <lb/> tissime vicit: sed tu
-					nolens ab errore liberari, nolui- <note type="footnote"> 1 sola edllio I.oV.,
-							<hi rend="italic">q1ria in siiwliludine.</hi> quidam Mss., <hi
-							rend="italic">quia <lb/> fiudiUttdinc.</hi>
-					</note>
-					<lb/> sti salubriter vinci. Cum enim contra te commemo­ <lb/> rasses evangelicum
-					testimonium, quo claruit a Filio <lb/> videri Patrem, dicente ipso Filio, <hi
-						rend="italic">Sed qui est</hi> a <hi rend="italic">Deo,<lb/> hic vidit
-						Patrem;</hi> mox addidisti de tuo, <hi rend="italic">Sed vidit in - <lb/>
-						capabilem.</hi> Interim quod dixeras perdidisti, solum <lb/> esse
-					invisibilem Patrem, quia non habet superiorem : <lb/> quandoquidem veritate
-					victus, cum vidcri ab inferiore <lb/> confessus es. l'os enim dicitis inferiorem
-					Filium a <lb/> quo tamen Patrem videri, teste Filio cogente I, dixi­ <lb/> sti.
-					De incapabili postea videbimus, ut etiam te illic <lb/> veritas vincat. Non enim
-					de capabili et incapabili, sed <lb/> de visibili et invisibili inter nos
-					quaestio versabatur : <lb/> in qua quaestione si libi ipsi tu ip e visibilis es,
-					vi. <lb/> ctum te esse vides.</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="4">
-					<p>CAPUT IV. — <hi rend="italic">De immortali</hi>
-					<unclear/><hi rend="italic">Deo.</hi> Quarto loco egi <lb/> tecum de immortali
-					Den etiam Filio. Quoniam tu il­ <lb/> lud quod ait Apostolus , <hi rend="italic"
-						>Qui solus habet immortalita­<lb/> tem</hi> (I <hi rend="italic">Tim.</hi>
-					VI, 16) ; sic intelligi voluibti, tanquam <lb/> de solo Patre sit dictum : cum
-					ille hoc non de Patre <lb/> dixerit, sed de Deo , quod est Pa er et Filius et
-					Spirit <lb/> Ius sanctus. Ostend! ergo ct Filium habere immorta­ <lb/> litatem
-					secundum substantiam divinitatis suae. Nam <lb/> secundum carnem quis negat eum
-					fuisse mortalem ? <lb/> Tu autem cum mihi respondere ad hunc locum vel­ <lb/>
-					les, perspicua veritate conclusus, etiam Deum Filium <lb/> immortalitatem habere
-					confessus es. Victus es igitur <lb/> in eo quod dicebas de Patre tantum dixisse
-					Aposto­ <lb/> lam, quod solus habeat immortalitatem. Ncque enim <lb/> propterea
-					vinculis veritatis elaberis , quoniam dicis, <lb/>
-					<hi rend="italic">Habet quidem Filius immortalitatem, sed accipiens</hi> a <lb/>
-					<hi rend="italic">Patre.</hi> Non quaeritur uude habcat, sed utrum habeat. <lb/>
-					Tu enim de Patre solo vis intelligi quod scriptum esi, <lb/>
-					<hi rend="italic">Solus habet immortalitatem.</hi> Prorsus a nullo acceptam
-					<lb/> Pater habet immortalitatem, et a Patre acceptam Fi <lb/> lius habet
-					immortalitatem : tamen et Pater ct Filius <lb/> habet immortalitatem. Alioquin
-					si eam non habet <lb/> Filius ; Pater eam non dedit Filio, aut acceptam per­
-					<lb/> didit Filius. Dedit autem Pater Filio, nec perdidit Fi­ <lb/> lius : nec
-					Pater dando perdidit quod generando dedi!. <lb/> Habet ergo immorlalitalem et
-					Pater et Filius, non <lb/> Pater solus. Cogeris itaque confiteri non de solo
-					Patre <lb/> dictum esse, <hi rend="italic">Qui solus habet immortalitatem:</hi>
-					quia jam <lb/> coactus es confiteri quod et Filius habeat immorta­ <lb/>
-					litatem. Habet autem hanc <hi rend="italic">solus,</hi> sed Deus: quod <lb/> non
-					solus est Pater; quia hoc est et Filius, et uter­ <lb/> que adjuncto Spiritu
-					sancto unus est Deus. Sed quaro <lb/> solus Deus dictus sit habere
-					immortalitatem, cum et <lb/> anima pro suo modo sit immortalis, et alia
-						<unclear>spiritun­</unclear>
-					<lb/> lis coelestisque creatura, postea videbimus : nunc au­ <lb/> tem sufficit
-					nobis, quod ad ea quae dixi, nihii respon­ <lb/> dere potuisti, ct non solum
-					Patrem ; sed quamvis ab <lb/> ipso, habere tamen , immortalitatem etiam Filium
-					<lb/> coactus es confiteri.</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="5">
-					<p>CAPUT V. — <hi rend="italic">Unde major sit Pater.</hi> Quinto loco <lb/>
-					ostendi, unde major sit Pater Filio : quia nou Den <lb/> major est, unde illi
-					coaeternus est Filius; sed homine <lb/> major est, quod ex tempore ,factus est
-					Filius. Ibi <lb/> commemoravi apostolicum testimonium : <hi rend="italic"
-						>Quia</hi> cum <hi rend="italic">in</hi>
-					<note type="footnote"> t Hic apud l.ov. additur, <hi rend="italic"
-							>veritate.</hi>
-					</note>
-					<note type="footnote"> PATROL. XLII. </note>
-					<note type="footnote">
-						<hi rend="italic">(Yingl-quatrl.)</hi>
-					</note>
-					<lb/>
-					<pb n="747"/>
-					<hi rend="italic">forma</hi> £Dei esset, <hi rend="italic">non rapinam
-						arbitratus esl esse aequa­</hi>
-					<lb/> lis Dec. Natura quippe illi fuerat Dei aequalitas , non <lb/> rapina. Ad
-					quod tu respondens dixisti : <hi rend="italic">Quis enim<lb/> vegat Filium esse
-						in forma Dei ? Qnod enim sit Dens, <lb/> quod sit Dominus , quod sit Rex,
-						jam pulo latius</hi> expo­ <lb/> s <unclear>uimus</unclear>.<hi
-						rend="italic">Et</hi> &lt; <hi rend="italic">quia non rapinam arbitratus cat
-						esse aequa­<lb/> lis Deo, » hoc nos beatus apostolus Paulus instruit, quod
-						<lb/> ille non rapuit, nee noa dicimus.</hi> Haec verba tua non <lb/> solum
-					nihil habent adversus nos ; sed magis apparent <lb/> esse pro nobis. Si enim
-					confiteris Dei formam , cur <lb/> non aperte Dei Filium Deo confiteris aequalem
-					? Prae­ <lb/> sertim, quia de verbis Apostoli, ubi ait, <hi rend="italic">Non
-						rapinam <lb/> arbitratus eat esse aequalis Deo;</hi> non poluisti pro tuis
-					<lb/> partibus invenire quod diceres. Et quia hoc dixisse <lb/> Apostolum non
-					potuisti negare, idco dixisti, <hi rend="italic">quod ille</hi>
-					<lb/> non <hi rend="italic">rapuit, nec nos dicimus</hi> : tanquam hoc sit <hi
-						rend="italic">non ra­</hi>
-					<lb/> puit, qnod csl non hahuit, id est, aequalitatem Dei : <lb/> atque ita
-					dictum sit, <hi rend="italic">Non rapinam arbitratus eat esse<lb/> aequalis
-						Deo;</hi> ac si diceretur, Non arbitratus est esse <lb/> rapiendam
-					aequalitatem Dei, co quod ab illo fuerit <lb/> alicua. Raptor enim rei alienae
-					usurpator est: tan­ <lb/> quam hoc Filius, cum posset, rapcre noluisset. Quod
-					<lb/> vides quanta insipientia sentiatur. Ergo intellige Apo­ <lb/> siolum ideo
-					dixisse , <hi rend="italic">Non rapinam arbitratus eat esse</hi>
-					<lb/> aequalis <hi rend="italic">Deo;</hi> quia non alienum arbitratus est esse
-					<lb/> quod natus est: sed tamen quamvis aequalitatem Dui <lb/> non fuerit
-					arbitratus alienam, sed suam, <hi rend="italic">semetipsum<lb/> exinanivit,</hi>
-					non quaerens quae sua sunt, sed quae no­ <lb/> sira sunt. Quod ut noveris ita
-					esse , attende unde ad <lb/> hoc Apostolus venerit. Cum enim Christianis humili­
-					<lb/> tatem praeciperet charitatis : <hi rend="italic">Alter alterum,</hi>
-					inquit, <lb/> existimantes superiorem <hi rend="italic">sibi, non quae sua sunt
-						unusquis­ <lb/> que intendentes, sed et quae aliorumf.</hi> Deinde til exem­
-					<lb/> plo Christi hortaretur non sua quaerere vel intendere, <lb/> sed et quae
-					aliorum sunt: <hi rend="italic">Singuli quique,</hi> inquit, <hi rend="italic"
-						>hoc<lb/> sentite</hi> in <hi rend="italic">vobis quod et in Christo Jesu :
-						qui cum in forma<lb/> Dei esset,</hi> quae illi crat sua, non <hi
-						rend="italic">rapinam arbitratus est,</hi>
-					<lb/> hoc cst, non alienum arbitratus est, <hi rend="italic">esse aequali, Deo
-						;</hi>
-					<lb/> sed tamen quaerens nostra, non sua , <hi rend="italic">semetipsum ex­</hi>
-					<lb/> inanivit, non formam Dci amittens, sed fOrmam <hi rend="italic">servi
-						ac.</hi>
-					<lb/> cipiens. Non enim est mutabilis illa natura ut se ex­ <lb/> inaniret
-					perdendo quod erat, sed accipiendo quod non <lb/> crat : nec consumendo quae sua
-					sunt, sed assumendo <lb/> quae nostra sunt; ac deinde in forma servi obediendo
-					<lb/> sicut homo <hi rend="italic">usque ad mortem crucis. Propter quod et <lb/>
-						Deus</hi> eum <hi rend="italic">exaltavit,</hi> et donarit ei <hi
-						rend="italic">nomen</hi> qnod <hi rend="italic">eat super<lb/> omne nomen
-						(Philipp.</hi> 11, 6-9) : et caetera. Homini ergo <lb/> donavit ista, non
-					Deo. Neque enim tum in forma ici <lb/> esset non excelsus crat, aut non ei genua
-					flectebant <lb/> « cœlestia, terrena et inferna. Sed cum dicitur, <hi
-						rend="italic">Propter<lb/> quod eum exaltavit;</hi> satis apparet propter
-					quid exalta­ <lb/> verit, id est, propter ohedicntiam <hi rend="italic">usque ad
-						mortem cru­</hi>
-					<lb/> cis. ITI qua ergo forma crucifixos est, ipsa exaltata <lb/> &lt;at, ipsi
-					donatum est <hi rend="italic">nomen quod eat super omne no­</hi>
-					<lb/> men; ut cum ipsa forma servi nominetur Filius Uni­ <lb/> genitus Dei 2.
-					Non itaque facias imparem Dco formam <note type="footnote"> * tor,, <hi
-							rend="italic">aed ea quae</hi><hi rend="italic">atiorum.</hi> At sas.,
-							<hi rend="italic">sed et qua aliorum :</hi>
-						<lb/> jux ui gJ":9CUlD, <hi rend="italic">atla kilL.</hi> . </note><note
-						type="footnote"> ' I iiic cdili addiuit, <hi rend="italic"
-							>intelligetur.</hi> et reluctantibus <lb/> Mss. <lb/> , </note>
-					<lb/> Dei : quod nee in ipsis hominibus did potest. Nam <lb/> cum dictum fuerit,
-					Iste homo in forma est illius ho­ <lb/> minis, nemo intelligit nisi aequales 1.
-					An forte non <lb/> vis sic accipere quod dictum est, <hi rend="italic">Cum</hi>
-					in <hi rend="italic">forma Dci<lb/> esset,</hi> ut in forpia Dci Patris
-					intelligas Filium, ubi <lb/> nihil aliud quam aequalitas apparet amborum ; sed,
-						<hi rend="italic">in <lb/> forma Dei,</hi> putas intelligendum in forma sua,
-					quia et <lb/> ipse utique Deus est ? Non multum curo si etiam sic <lb/>
-					intelligas. Ubi enim plenitudinem formae aetatis in­ <lb/> crementa non faciunt,
-					sed Deo gignente perfectus <lb/> natus est Filius; procul dubio si forma Filii
-					formae <lb/> Patris non cst aequalis, non verus cst Filius. Scriptum <lb/> est
-					autem : Ut simus in <hi rend="italic">vero Filio ejus Jesu Christo</hi>
-					<lb/> (I <hi rend="italic">Joan.</hi> v , 20). Forma igitur vcri Filii, formae
-					Dei <lb/> Patris esse non potest inaequalis. Proinde nee hu'c <lb/> loco
-					prosecutionis meae, ubi de verbis Apostoli aequa­ <lb/> lem Patri Filium
-					comptobavi, respondere aliquid pro <lb/> vestra intentione potuisti.</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="6">
-					<p>CAPUT VI. — <hi rend="italic">De veris filiis animalium.</hi> Sexto loco <lb/> ut
-					ejusdem naturae cujus ct Pater est, ostenderem <lb/> Filium, etiam mortalium
-					fctus animalium immanitati <lb/> vestri crroris objeci, increpans cor vestrum,
-					qui ejus­ <lb/> dem nature cujus est Pater, negatis esse Deum Fi­ <lb/> lium,
-					quamvis verum esse Filium non negetis; cunt <lb/> Deus ipse dederit animalibus
-					hoc generare quod ipsa <lb/> sunt : ubi non solum hominis homincm, verum etiam
-					<lb/> canis canem filium nominavi; non ad similitudinem <lb/> Dei, sed ad
-					confusionem detrahentium Filio Dci : qui <lb/> cum videant corruptibiles
-					mortalesque naturas, habere <lb/> tamen naturae de suis parentibus unitatem,
-					Filio Dei <lb/> vero nolunt concedere communionem naturae unius <lb/> habere de
-					Patre; cum sit inseparabilis a Patre, ct in­ <lb/> corruptibilis aeternusque cum
-					Patre. Unde etiam dixi, <lb/> quod melior sit secundum vos humana conditio , ubi
-					<lb/> conceditur crescere, ut ad robnr parentum vcl cre­ <lb/> scendo possint
-					filii pervenire: Filius autem Dci , sicut <lb/> dicitis et docetis, minor Patre
-					genitus sic remansit, <lb/> atque ut ad Patris formam non posset pervenire, nec
-					<lb/> crevit. Hic tu, ut appareret quam magna veritatis mole <lb/> premereris,
-					omnino ad rem non respondisti : sed <lb/> tanquam deficienti flatu I anhelarcs,
-					reprehendendum <lb/> me putasti, dicens quod tam foeda comparatio, de filio
-					<lb/> scilicet hominis sive canis, in illam tantam immen­ <lb/> sitatem produci
-					non debuit. lloc respondere est , an <lb/> potius inopiam responsionis ostendere
-					? Quasi ego <lb/> propterca terrenarum naturarum ista exempla produ­ <lb/>
-					xcrim, ut incorruptioni corruptionem, immortalitati <lb/> mortalitatem ,
-					invisibilibus visihilia, aeternis tempo­ <lb/> ralia coaequarem : ac non potius
-					ut vos in magnis ct <lb/> summis rebus errantes , de rebus parvulis infimisque
-					<lb/> convincerem, qui non videtis bonum quod Creator <lb/> summe bonus dedit
-					etiam extremis vilibusque creatu­ <lb/> ris, ut cnm longe aliud sint quam est
-					ipse, hoc tamen <lb/> gcnerent quod sunt ipsae. Nee attenditis quid niali di­
-					<lb/> catis, ut cum homines et canes, et caetera hujusmodi <lb/> habeant filios
-					veruS, quos illis gignentibus creat vcri­ <lb/> tas, nOli sit vcrus Dei Filius
-					ipsa vcritas. Aut si san­ <note type="footnote"> * Am. F.r. et va,r., <hi
-							rend="italic">rtiri fcquatis.</hi>
-					</note><note type="footnote"> t .to., <hi rend="italic">deficinlis</hi>
-						<unclear>fatus</unclear>. -, </note>
-					<lb/>
-					<pb n="749"/> cta Scriptura cogente permittitis ut verus Filius sit, <lb/>
-					rogamus permittite ut dcgener non sit. Et degener <lb/> quomodo? Andiant
-					catholici, unde erubescant haere­ <lb/> tici. Filius viri fortis si non habeat
-					fortitudinem , de­ <lb/> gener dicitur : tamen homo est, quod ct patcr est;
-					<lb/> atque in dissimili vita , non est tamen aliena substan­ <lb/> tia. Vos
-					unigenitum Dei Filium ita degenerem vullis, <lb/> ut ipsam Patris ei substantiam
-					denegetis : minorem <lb/> natum, minorem remansisse jactatis ; non ullam datis
-					<lb/> aetatem qua possit augeri, non datis eamdem formam <lb/> qua possit
-						<unclear>aequari</unclear>. Cujus naturae tanta subtrahitis, <lb/> miror
-					verum Filium qua fronte dicatis : nisi quia in­ <lb/> fclicissimo errore non vos
-					putatis ad unius Patris glo­ <lb/> riam, nisi per unici Filii contumeliam
-					pervenire (a).</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="7">
-					<p>CAPUT VII. — <hi rend="italic">De magnitudine Filii.</hi> Septimo loco <lb/> dixi
-					: <hi rend="italic">Usque adeo autem Filium agnoscimus magnum <lb/> Deum , ut
-						Patri dicamus aequalem. Itaque</hi> sine <hi rend="italic">causa,</hi>
-					<lb/> inquam, nobis <hi rend="italic">quod valde profitemur, testimoniis, et
-						<lb/> multiloquio</hi> probas voluisti. Et his verbis meis addidi <lb/>
-					disputationem, in qua rationem redilidi, quare Filius <lb/> cum sit Patri
-					aequalis, dicat cum tamcn Deum suum, <lb/> ubi nil : <hi rend="italic">Ascendo
-						ad Patrem meum et ad Patrem ve­</hi>
-					<lb/> strum , Deum meum <hi rend="italic">et Deum</hi> restrum <hi rend="italic"
-						>(Joan.</hi> xx, 17). <lb/> Quoniam tu commemoraveras hoc evangelicum testi­
-					<lb/> monium , quo te probarc existimasti quod Patri Filius <lb/> non esset
-					aequalis. Ego itaque tibi ad ista respondens, <lb/> dixi Patrem propterea etiam
-					Deum esse unigeniti Filii, <lb/> quoniam factus est homo et natus ex femina : ct
-					hoc <lb/> esse quod dicit in Psalmo, ubi quod futurum fucrat <lb/>
-					praenuntiavit, <hi rend="italic">De ventre matris meae Deus meus es tu<lb/>
-						(Psal.</hi> xxi, 11) ; ut ostenderet Patrem hinc esse Deum <lb/> suum , quia
-					homo factus est. Homo enim de ventre <lb/> matris est natus, et secundum hominem
-					de virgine <lb/> natus est Deus : ut non solum Pater illi esset qui cum <lb/> de
-					se ipso genuil, verum etiam Deus ejus esset quem <lb/> de ventre matris hominem
-					creavit. Ad hacc tu cum <lb/> respondere voluisses, mu!ta dixisti, ct multa
-					testimo­ <lb/> nia quae te nihil adjuvant, protulisti. Quomodo ta­ <lb/> men
-					dictum sit. <hi rend="italic">De ventre matris meae Deus meus es tu;</hi>
-					<lb/> quamvis eadem Scripturae sanct e verba memorasses, <lb/> nullo modo
-					invenire potuiti. Cur autcm in eo loco <lb/> posueris psalmi alterius
-					testimonium, ubi scriptum <lb/> est, <hi rend="italic">Tecum principium in die
-						virtutis tuae, in splendo­ <lb/> ribus sanctorum, ex utero ante luciferum
-						genui te (Psal.</hi>
-					<lb/> CIX, 5); omnino non video. Non enim Filii persona <lb/> est dicentis, Ex
-					utero tuo, aut, De ventre tuo, Deus <lb/> meus es tu. Illa ineffabilis generatio
-					cHam si ex utcro <lb/> Patris accipitur, hoc significatum cst, quia de 83 <lb/>
-					ipso, hoc cst, de substantia sua Deus Deum genuit, <lb/> sicuit ex utero matris
-					quando natus est, homo homi­ <lb/> nem genuit: ut intelligeremus in utraque
-					generatione <lb/> non diversas ejus qui cst natus, et eorum de quibus <lb/> est
-					natus, esse substantias. Diversa quidem substantia <lb/> cst, Deus Pater, et
-					homo mater: non tamen diversa <lb/> substantia est, Deus Pater, ct Deus 'ilius ;
-					sicut non <lb/> est diversa substantia, homo mater, ct homo filius. <lb/> Sed
-					audi quid dicat in prophetia iste Filius : <hi rend="italic">De</hi> ven­ <lb/>
-					Ire, inquit, <hi rend="italic">matris</hi>
-					<unclear/><hi rend="italic">meae Deus</hi> meuses <hi rend="italic">tu.</hi>
-					Noli multis <note type="footnote"> (r) vide scrin. 130, no. 4 et 3, tom, 5. </note>
-					<lb/> vetbis ad rem non necessariis conari operire res cla<lb/>ras. Qui est
-					Pater Filio ex utero suo, de vontre ma­ <lb/> tris Deus ejus est, non de suo. Ad
-					hoc ergo prorsus <lb/> nihil respondere po:uisti.</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="8">
-					<p>CAPUT VIII. — <hi rend="italic">De subjectione Filii</hi> Octavo loco de <lb/>
-					subjectione qua subjectus est Patri Filius, respondi <lb/> libi : quoniam
-					dixeras, <hi rend="italic">De sua subjectione unum sta­<lb/> tuit Deum.</hi>
-					Respondi ergo ellam hoc secundum homi­ <lb/> nen recte accipi, quod Filius
-					subditus est Patri. Nc­ <lb/> que hoc esse mirandum , cum legatur utique secun­
-					<lb/> dum ipsam servi formam etiam parentibus subdimus <lb/>
-					<hi rend="italic">(Luc.</hi> n , 51) : et de illo sit scriptum, <hi
-						rend="italic">Minorasti eum <lb/> paulo</hi> minus <hi rend="italic">ab
-						Angelis (Psal.</hi> VIII, 6). Ad quod tu <lb/> quasi respondens dixisti me
-					optime prosecutum, quo­ <lb/> niam ct parentibus propter formam Servi esset
-					subjg­ <lb/> ctus. Dcinde volens velut pro te esse ostendere, quod <lb/> contra
-					te esse cernebas; ac sic incautis <unclear>minusquo</unclear>
-					<lb/> attentis hominibus, quicumque essent ista lecturi, <lb/> tanquam
-					respondentem te facere, ubi quod diceres <lb/> non habebas; adjungis et dicis :
-					Si eni, t <hi rend="italic">parentibus <lb/> subjectus invenitur quos ipse
-						creavit, qnia omnia pet <lb/> ipsunt facta sunt : nec enim post tempora, sed
-						ante tem­ <lb/> pora novimus Filium genitum a Patre : si ergo parenti­</hi>
-					<lb/> bus , inquis , <hi rend="italic">subditus etat, ut</hi>
-					<unclear/><hi rend="italic">divinarum Scripturarum<lb/> auctoritas luce clarius
-						prat'dicat : quanto magis utique illl <lb/> suo genitori est subditus, qui
-						tantum ac tatem</hi> eum <hi rend="italic">ge­<lb/> nuit;</hi> secundum <hi
-						rend="italic">quod ait Paulus, Cum omnia fuerint <lb/> Filio</hi> subjecta,
-						<hi rend="italic">tunc et ipse Filius subjectus erit illi</hi> qui <lb/>
-					<hi rend="italic">sibi subjecit omnia</hi> (I <hi rend="italic">Cor.</hi> xv,
-					28) ? Haec verba tua pos<lb/>sevit a me putari dicta esse, et omnino mca
-					esse, nisi <lb/> tc audientibus cum dicerentur, et postea haec cuncti <lb/>
-					legentibus, evidenter appareret tc illa dixisse. Quis <lb/> enim crederet,
-					consentire posse vos nobis, secundum <lb/> formam servi, ac per hoc non secundum
-					formam Det <lb/> Christum esse subjectum ?</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="9">
-					<p>CAPUT IX. — <hi rend="italic">Utrum adoret Patrem Spiritus san­<lb/> ctus.</hi>
-					Nono loco abs te quaesivimus, ut per Scripturas <lb/> divinas ostenderes, si
-					valeres, utrum adoret Patrem <lb/> Spiritus sanctus. Iloc cniin dixeras : sed
-					sicut ipsi <lb/> tua prosccutio, cui respondi, satis indicat, non pro­ <lb/>
-					baveras. Ad hanc ergo inquisitionem mcam vide quid <lb/> posteriore prosccutione
-					responderis. Cum enim divis<lb/>ses quantum voluisti de judicio Filii, quod
-					et nos fide­ <lb/> lissime credimus; ct de subjectione, quam secundum <lb/>
-					formam servi Filium Patri reddere non negamus : <lb/> ubi venisti ut probares a
-					sancto Spiritu adorari Pa­ <lb/> trem, rediiti ad illos gemitus, de quibus tibi
-					jam ante <lb/> responderam, secundum morem sanctarum Scriptu­ <lb/> rarum, qna
-					locutione sil dictum, <hi rend="italic">Et</hi> ipse Spiritus <hi rend="italic"
-						>in­<lb/> terpellat gemitibus inenarrabilibus (Rom.</hi> VIII, 26) : no
-					<lb/> credamus Spiritum sanctum nunquam esse esine gc­ <lb/> mitibus posse,
-					quomam nulus dies, nulla hora, nul­ <lb/> lum momentum temporis invenitur, quo
-					non a sanctis <lb/> orationes Dco ubicumque fundamur, ab aliis hic, ab <lb/>
-					aliis alibi. Cum tamen ab orationibus sanctorum nul­ <lb/> lum sit tempus
-					immune, quandoquidem dicbus et <lb/> noctibus, cum alii cibo ac potu
-					reficiuntur, alli quod­ <lb/> libet aliud agunt, alii dormiunt, non utique
-					desunt <unclear/><lb/> quos desiderium sancium orare compellat; ita fit ut <lb/>
-					<pb n="751"/> Spiritus sanctus, qui ubique omnibus adest, aliquan­ <lb/> tulum
-					cessare a gemitibus nun sinatur, quod est ex­ <lb/> tremae miseriae, cum pro
-					quibuscumque orantibus <lb/> cogitur gemere : nisi gemitibus inenarrabilibus in­
-					<lb/> terpellare sic intelligatur, ut dixi, id cst, quia gemi­ <lb/> tibus
-					sanctorum desideriorum interpellare sanctos <lb/> facit, quibus affectum pium
-					gratiae spiritualis infundit. <lb/> Sed cum similes locutionum modos, quando per
-					ef­ <lb/> ficientem significamur id quod efficitur; sicut frigus <lb/> pigruin
-					dicimus, quia pigros facit; et dicm tristem <lb/> vel laetum, quia tristes vel
-					laetos facit; etiam de Scri­ <lb/> puris sanctis commemoraverim, ubi Deus dicit
-					ad <lb/> Abraham , <hi rend="italic">Nunc cognovi (Gen.</hi> XXII, 12); quod
-					nihil <lb/> est aliud quam , Nunc ut cognosceres feci : non enim <lb/> tunc Deus
-					dicendus est cognovisse, quod antequam <lb/> fieret nunquam potuit ignorare:
-					quos locutionis modos <lb/> de divinis eloquiis a me prolatos, quomodo aliter
-					<lb/> interpretareris non invenisti; nullo modo utique ad <lb/> itos gemimus
-					redire debuisti. Nemo crum sic de <lb/> Spiritu sancto sapit, nisi qui secundum
-					carnem , non <lb/> secundum spiritum sapit. Quamvis et si libi concede­ <lb/>
-					rctur, quomodo tu sentis, sic Spiritum sanctum in­ <lb/> terpellare pro sanctis;
-					aliud cst interpellare vel orare, <lb/> aliud adorare. Omnis qui orat, rogal:
-					non omuis <lb/> qui adorat, rogat; nec omnis qui rogat, adorat. Re­ <lb/> cole
-					consuctudincm regum, qni plerumque adorantur, <lb/> ct non rogantur ; aliquando
-					rogantur, et non adora n<lb/>tur. Ac pcr hoc a Spiritu sancto adorari Patrem
-					<lb/> nullo modo demonstrarc potuisti.</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="10">
-					<p>CAPUTX.— <hi rend="italic">Quomodo sit unus Deus Pater et Filius <lb/> et</hi>
-					Spiritus <hi rend="italic">sanctus.</hi> Decimo loco egi lecum ut intelli­ <lb/>
-					geres, quomodo per ineffabilem copulationem sit unus <lb/> Deus ipsa
-					Trinitas,quam dicimusunius esse substan­ <lb/> tiae : quandoquidem ctiam
-					diversas substantias inve­ <lb/> nimus , hoc est, spiritum hominis et Spiritum
-					Domini, <lb/> per copulationem qua homo adhaeret Domino, unum <lb/> spiritum
-					dictum, ubi ait Apostolus , Qui <hi rend="italic">autem adhae­<lb/> ret
-						Domino,</hi> unus <hi rend="italic">spiritus est</hi> ( I <hi rend="italic"
-						>Cor.</hi> VI, 17). Ad quod <lb/> tu respondens, vcl potius non tacens,
-					conatus es <lb/> ostendere quomodo Patcr et Filius unum sint, non <lb/> unitate
-					naturae, sed voluntatis. Hoc quidem dicere <lb/> soletis : sed tunc soletis, cum
-					vobis objicitur quod <lb/> ait Dominus, <hi rend="italic">Ego et Pater unum</hi>
-					sumus <hi rend="italic">(Jonn.</hi> x, 50). <lb/> Ego autem hoc loco non boc
-					volui probare, quod <lb/> Pater et Filius ct Spiritus sanctus unum sint, quod
-					<lb/> quidem propter unitatem substantiae fidelissime certe <lb/> creilimus; sed
-					qnod cadem Trinitas unus est Deus. <lb/> Aliud est quippc, unum sunt; aliud,
-					unus est Deus. <lb/> Discerne, Est, ct Sunt. Nec ait Apostolus, Qui adhae­ <lb/>
-					rent Domino, unum sunt; quoniam diversa substantia <lb/> cst : sed ait : <hi
-						rend="italic">Qui</hi> adhaeret <hi rend="italic">Domino,</hi> unus spiritus
-						<hi rend="italic">est.</hi>
-					<lb/> Si autem vos, cum de duobus dicitur, Unus est, et di­ <lb/> citur quid
-					unus, sicut dicit Apostolus, <hi rend="italic">unus spiritus<lb/> est;</hi> hoc
-					idem putatis esse , quod est cum de duobus <lb/> dicitur, Unum sunt, nee dicitur
-					quid unum ; sicut <lb/> ait Salvator, <hi rend="italic">Ego ct Pater</hi> unum
-					sumus : cur non dici­ <lb/> tis, Palcr et Filius uuus cst Deus? Quare quando an­
-					<lb/> ditis. <hi rend="italic">Audi, Israel; Dominus Deus tuus, Dominus unus
-						<lb/> est (Deut.</hi> v!. 4); de Patre tantum vultis intelligi ? <lb/> Nempe
-					Pater Dominus Deus est, ct Fillus Dominus <lb/> Heus cst : cur non apud vos
-					uterque unus Dominus <lb/> Deus csl, sicut apud beatum Apostolum, spiritus ho­
-					<lb/> minis et Spiritus Domini 1 <hi rend="italic">unus spiritus est ?</hi> Quid
-					art­ <lb/> tem prodest causae vestre, quia per consensionem <lb/> voluntatis hoc
-					dicitis fieri ? Quod quidem fit, sed ubi <lb/> est diversa natnra, sicut diversa
-					natura est hominis <lb/> et Domini : et tamen <hi rend="italic">qui</hi>
-					adhaeret <hi rend="italic">Domino,</hi> per con­ <lb/> sensionem utique
-					voluntatis, <hi rend="italic">unus spiritus est.</hi> Si ergo <lb/> non vultis
-					per unilatem substantiae; certe per consea­ <lb/> sionem voluntatis dicite,
-					tamen aliquando dicite , <lb/> quoquo modo dicite, Pater ct Filius unus Deus
-					cst. <lb/> Sed non dicitis, ne quod nunquam voluistis, cogamini <lb/> confiteri
-					de utroque dictum esse, non dc Patre solo , <lb/>
-					<hi rend="italic">Audi, Israel; Dominus Deus tuus, Dominus</hi> unus <hi
-						rend="italic">cst:</hi>
-					<lb/> quoniam sanctum Spiritum non vultis Dcum, non <lb/> vultis Dominum
-					confitcri. Dicite, irnjuam , ratione <lb/> qua vultis , Patcr et Filius unus
-					Dominus Deus cst: <lb/> ut Patri et Filio servientes, non duobus diis ct duo­
-					<lb/> bus dominis contra praeceptum Dei, sed Domino uni <lb/> serviatis I. Sed
-					nunc de hac re satis dictum sit. Puto, <lb/> cum ista legeris, nihil te
-					respondere potuisse ad id quod <lb/> de Apostolo commemoravi, <hi rend="italic"
-						>qui</hi> adhaeret <hi rend="italic">Domino,</hi> unus <lb/>
-					<hi rend="italic">spiritus</hi> est : si contentionem deposueris, non
-					negabis.</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="11">
-					<p>CAPUT XI. — <hi rend="italic">De templo Spiritus sancti.</hi> Undecimo <lb/>
-					loco, Deum esse Spiritum sanctum, de templo ejus <lb/> quod nos ipsi sumus,
-					teste Apostolo, ostendi , ubi <lb/> ait, <hi rend="italic">Nescitis quia templum
-						Dei estis, et</hi> Spiritus <hi rend="italic">Dei <lb/> habitat</hi> in <hi
-						rend="italic">vobis</hi> (I <hi rend="italic">Cor.</hi> III, 16) ? et iterum
-					, <hi rend="italic">Nescitis<lb/> qnia corpora vestra templum in vobis est
-						Spiritus</hi> sancti, <lb/>
-					<hi rend="italic">quem habetis a Deo (Id.</hi> vi, 19) ? Tu aulem ad isto re­
-					<lb/> spondisti nihil. Aisti enim : <hi rend="italic">Suscipio quae protulisti
-						:</hi>
-					<lb/> i <hi rend="italic">Nescitis quia templum Dei estis, ci Spiritus Dei
-						habi­<lb/> tat</hi> in <hi rend="italic">vobis?</hi> &gt; <hi rend="italic"
-						>Neque enim Deus,</hi> inquis , <hi rend="italic">inhabitat in <lb/> homine,
-						quem non ante Spiritus sanctificaverit atque <lb/> purgaverit.</hi> Atque
-					isto modo intelligi voluisti, non Spi­ <lb/> ritum sanctum esse dictum Deum, nec
-					templum <lb/> Spiritus sancti nos a esse, sed Dci : et hoc esse cii­ <lb/> ctum,
-						<hi rend="italic">Templum Dei estis.</hi> Sed ideo additum, <hi
-						rend="italic">Spiritus<lb/> Dei habitat in vobis</hi> : quia purgat Spiritus
-					sancius <lb/> templum Dei, non suum ; ut cum ipse purgaverit, <lb/> tunc illic
-					inhabitet Deus. Quem sensum tuum quanta <lb/> sequatur absurditas, nolo nunc
-					dicere. Illud enirn <lb/> nunc ostendere debeo, quomodo multa dicendo, nihil
-					<lb/> quod ad rcm pertinet, dixeris. Dimisisti enim cau­ <lb/> sam, et
-					perrexisti in laudem Spiritus sancti, camque <lb/> copiose contra te ipsum
-					exsecutus es. Centra te ipsum <lb/> ideo dixi, quoniam non vis eum dicere Deum,
-					cujus <lb/> tantam divinitatem per laudem coactus es confiteri; <lb/> ut cum sit
-					unus, ubique sit praesens, et nemini sancti­ <lb/> ficando desit, ubicumque
-					quisquc christianus esse et <lb/> Deum orare voluerit, simul se omnibus
-					exhibendo, <lb/> sive in oriente, sive in occidente baptizentur in Chri­ <lb/>
-					sto : hoc ct nos dicimus. Sed qucm dicimus talcm ac <lb/> tantum, absit a nohis
-					ut eum negemus Dcum : quod <lb/> etiam per suum templum, quod nos ipsi sumus,
-					ci- <note type="footnote"> * Quidam vss., <hi rend="italic">Dommm.</hi>
-					</note><note type="footnote"> * Ain. Er. ct Mss., <hi rend="italic">ct Domini
-							'om1nå &lt;U!&lt;M&lt; serviahs.</hi>
-					</note><note type="footnote"> I Abcst, nos, a '!ss. </note>
-					<lb/>
-					<pb n="753"/> tissime et facile ostenditur. Neque enim nisi Deus <lb/> noster
-					esset, templum nos ipsos habere potuisset: <lb/> quod tu ut occultares, et in
-					sermone tuo mentes <lb/> hominum a luce veritatis averteres, de templo Dei <lb/>
-					quodeumque dixisti, quem noluisti intelligi Spiritum <lb/> sanctum; de templo
-					autem Spiritus sancti, quod aper­ <lb/> tissimc demonstratum est, omnino
-					tacuisti. Cum enim <lb/> tibi duo testimonia Pauli apostoli proposuerim; <lb/>
-					unnm ubi ait, <hi rend="italic">Nescitis</hi> quia <hi rend="italic">templum Dei
-						estis, et Spi­<lb/> ritus Dei habitat in</hi> vobis ? alterum ubi ait, <hi
-						rend="italic">Nescitis <lb/> quia corpora</hi> vestra <hi rend="italic"
-						>templum</hi> in <hi rend="italic">vobis Spiritus sancti</hi> est ? <lb/>
-					quare tam fraudulenter egisti, ut unum horum com­ <lb/> memorares, quod dictum
-					cst, <hi rend="italic">Templum Dei estis;</hi> et <lb/> alterum taceres, quod
-					dictum est, <hi rend="italic">Corpora vestra <lb/> templum in</hi> vobis <hi
-						rend="italic">est Spiritus</hi> sancti ? Cur hoc fccisti, <lb/> rogo te ;
-					nisi quia nullo pacto posses argumentari <lb/> quomodo Deus noster non esset,
-					qui templtum nos <lb/> ipsos haberet: quem sine dubio Deam cognoscere­ <lb/>
-					mus, si ei templum de lignis et lapidibus per divinam <lb/> Scripturam faccre
-					juberemur?</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="12">
-					<p>CAPUT XII. — <hi rend="italic">De eo quod Pater et Filius unum<lb/> sint.</hi>
-					Duodecimo loco admonui te, ut proferres, si <lb/> posses, qua divina auctorilate
-					sit dictum, quod unum <lb/> sint, ubi substantiae sunt diversae. Tu autem
-					respon­ <lb/> dcre ad hoc volens, nihil tale proferre potuisti; sed <lb/> magnis
-					coarctatus angustiis affirmare ausus es, quod <lb/> Apostoli unum siut cum Patre
-					et Filio. Quod Christus <lb/> omnino non dixit: sic enim abs te dictum est, tan­
-					<lb/> quam Pater et Filius et Apostoli unum sint. Christus <lb/> autem non ait,
-					Ut ipsi ct nos unum simus ; sed ait, <lb/>
-					<hi rend="italic">Ut sint</hi> unum, <hi rend="italic">sicut et</hi> nos unum
-					sumus. Nam, ut verba <lb/> ipsa evangelica ponam : <hi rend="italic">Pater
-						sancte,</hi> inquit, <hi rend="italic">serva eos</hi>
-					<lb/> in <hi rend="italic">nomine luo quos dedisti mihi,</hi> ut <hi
-						rend="italic">sint unum,</hi> sicut <hi rend="italic">el <lb/> nos
-						unum.</hi> Numquid dixit, Ut nobiscum sint unum; <lb/> aut, Ipsi et nos
-					simus unum ? Item post aliquantum : <lb/>
-					<hi rend="italic">Non,</hi> inquit, <hi rend="italic">pro</hi> eia <hi
-						rend="italic">rogo tantum; sed et pro eis qui cre­</hi>
-					<lb/> dituri <hi rend="italic">sunt per verbum eorum in</hi> me, <hi
-						rend="italic">ut omnes unum sint.</hi>
-					<lb/> Neque hic dixit, Ut nobiscum unum sint. Deinde se­ <lb/> quitur : <hi
-						rend="italic">Sicut tu, Pater, in me et ego in te, et ipsi in <lb/> nobis
-						unum sint.</hi> Et hic non dixit, Unum simus ; aut, <lb/> Unum nobiscum
-					sint: sed; <hi rend="italic">Unum sint in nobis;</hi> ut qui <lb/> natura unum
-					sunt, quia homincs sunt, etiam in Pa­ <lb/> tre et Filio sint unum; non cum
-					ipsis unum, id est, <lb/> non ut ipsi et isti sint unum. Adhuc adjungit, et
-					dicit: <lb/>
-					<hi rend="italic">Ut mundus credat quia tu me</hi> misisti, <hi rend="italic">et
-						ego claritatem<lb/> quam dedisti mihi, dedi illis, ut sint unum, sicut
-						nos</hi>
-					<lb/> unum <hi rend="italic">sumus: ego in eia et tu in me,</hi> ut sint <hi
-						rend="italic">consummati <lb/> in</hi> unum <hi rend="italic">(Joan.</hi>
-					XVII, 11-23). Cum ergo toties dixerit, <lb/>
-					<hi rend="italic">Ut sint</hi> unum ; non tamen alicubi dixit, Ut ipsi et nos
-					<lb/> simus unum, hoc est, ut nobiscum sint unum : sed <lb/> aut, <hi
-						rend="italic">in nobis</hi> dixit; aut, <hi rend="italic">sicut nos;</hi> id
-					est, ipsi secun­ <lb/> dum naturam suam, nos secundum nostram. Volebat <lb/>
-					enim eos qui natura unum erant, in hoc ipso quod <lb/> unum erant, esse
-					perfectos. Non enim quia dicit , <lb/>
-					<hi rend="italic">Estote ergo et vos perfecti</hi> sicut <hi rend="italic">Puter
-						vester</hi> caelestis <hi rend="italic">per­ <lb/> fectus eit (Matth.</hi>
-					v, 48); vult illos Deo natura unitate <lb/> conjungere, tanquam illorum et
-					illius una eademque <lb/> oatura sit : sed perfectos vult esse in natura Sua,
-					Sic­ <lb/> ut est Deus perfectus in sua , quamvis diversa, non <lb/> una ; quod
-					nisi in ipso simus, omnino esse non possu­ <lb/> mus. Non sicut in illo sunt
-					omnes, quia ipse continet <lb/> omnia quae creavit; propter quod dictus est <hi
-						rend="italic">non longe <lb/> positus ab unoquoque</hi> nostrum, quia <hi
-						rend="italic">in illo vivimus, et <lb/> movemur, et sumus (Act.</hi> XVII,
-					27, 28): sed sicut in illo <lb/> sunt tales qualibus dictum est, <hi
-						rend="italic">Fuistis enim aliquando</hi>
-					<lb/> tenebrae, <hi rend="italic">nunc autem lux</hi> in <hi rend="italic"
-						>Domino (Ephes. V,</hi> 8). Unde <lb/> et illud est, <hi rend="italic"
-						>Cui</hi> vult <hi rend="italic">nubat, tantum</hi> in <hi rend="italic"
-						>Domino</hi> (I <hi rend="italic">Cor.</hi>
-					<lb/> VII, 59). Non igitur proferre potuisti ubi dictum sit, <lb/> Unum sunt,
-					quorum est non una, sed diversa sub­ <lb/> stantia : et tamen 1 in obscuro loco
-					nobis subrepere <lb/> voluisti , ut diceres Apostolos unum esse cum Patre <lb/>
-					et Filio , tanquam unum essent Apos!oli et Pater et <lb/> Filius; cum
-					Apostolorum substantiam manifestum sit <lb/> a Patre et Filio esse diversam. Sed
-					quoniam, Ut ipsi <lb/> et nos unum simus, aut, Nobiscum sint unum, nus­ <lb/>
-					quam Christum dixisse manifestum est; te quoque <lb/> nobis respondere non
-					potuisse, et fraudern facere vo­ <lb/> luisse manifestum sit.</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="13">
-					<p>CAPUT XIII. — <hi rend="italic">De testimonio quod Pater perhibuit<lb/>
-						Filio.</hi> Tertio decimo loco te commonui, non ideo Pa­ <lb/> irem Filio
-					esse majorem, quia testimonium perhibuit <lb/> Pater Filio. Nam et Propbetas ei
-					testimonium perhi­ <lb/> buisse memoravi, quos majores illo esse non potes <lb/>
-					dicere. Dixeras enim quod Pater Filio perhibuerit te­ <lb/> stimonium ; quod sic
-					accepi, tanquam hinc ipse pro­ <lb/> bare volueris, illo cui testimonium
-					perhibuit, eum <lb/> esse majorem : sed quoniam posteriore prosecutione <lb/>
-					hinc omnino tacuisti, taciturnitatem tuam in locum <lb/> consensionis accepi ;
-					etsi fieri polost. ut ideo comme. <lb/> moraveris Patrem Filio perhibuisse
-					testimonium, ut <lb/> hinc illum esse alium , istum autem alium, non ut <lb/>
-					illum isto probares esse majorem. Alium vero esse <lb/> Patrem, aliutn esse
-					Filium, quoniam non est Pater <lb/> ipse qui Filius, et vobis et nobis contra
-					Sabellianos <lb/> est dogma commune. Illi enim dicunt, nonalium, sed <lb/>
-					eumdem Filium esse qui est Pater : nos autem alium <lb/> quidem esse Patrem, et
-					alium Filium; sed tamen <lb/> quod Pater est, hoc esse dicimus Filium.</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="14">
-					<p>CAPUT XIV. — <hi rend="italic">De dilectione Patris et Filii.</hi> Quarto <lb/>
-					decimo loco ad illud quod dixeras, <hi rend="italic">Dilectum lego, et <lb/>
-						credo quod Pater eat qui diligit , et Filius qui diligitur;</hi>
-					<lb/> respondens dixi : <hi rend="italic">Sic autem dicis hinc inter Patrem et
-						<lb/> Filium esse diversitatem, quia Pater diligit, et Filius <lb/>
-						diligitur; quasi negare possis quod et Filius diligat Pa­<lb/> trem.</hi>
-					Deinde addidi: <hi rend="italic">Si ambo se invicem diligunt, cur<lb/> negatis
-						eoa</hi> unius <hi rend="italic">esse naturae</hi> ? Quod utique ideo dixi,
-					<lb/> ne hinc unam naturam negaretis amborum, quia iI­ <lb/> lum diligere, hunc
-					diligi ipse dixisti. Ad hoc tu re­ <lb/> spondens consensisti quidem, quod et
-					Filius diligat <lb/> Patrem , sed unius esse naturae consentire noluisti : <lb/>
-					tanquam Filius ita diligat Patrem, sicut creatura <lb/> Crratorcm , non sicut
-					unigenitus geuitorcm, quem <lb/> diversitate substantiae vultis esse
-					degenerem.</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="15">
-					<p>CAPUT XV. — <hi rend="italic">De invisibilitate Trinitatis.</hi> Quinto <lb/>
-					decimo loco dixi pariter esse invisibilem Trinitatem, <note type="footnote"> *
-						ALD, fcr. et Mas., <hi rend="italic">tanquam.</hi>
-					</note>
-					<lb/>
-					<pb n="755"/> nun solum Patrem : sed apparuisse tamen visibilem <lb/> :'ilium in
-					forma servi, propter quam dixit, <hi rend="italic">Pater ma­</hi>
-					<lb/> jor <hi rend="italic">me eat (Joan.</hi> xiv, 23). Sed quoniam patribus se
-					di­ <lb/> vinilas demostrabat , dixi per subjectum crealurain <lb/> id osse
-					factum, non per naturam suam, qua est invi­ <lb/> sibilis Trinitas. Atque ut hoc
-					probarem, Moysen com­ <lb/> memoravi ci dicentem, cum quo facie ad faciem lo­
-					<lb/> quebatur, Si <hi rend="italic">inveni</hi> gratiam <hi rend="italic">ante
-						te, ostende mihi temet­<lb/> ipsum</hi> manifeste <hi rend="italic"
-						>(Exod.</hi> XXXIII, 11, 13) : ut intelligeres <lb/> quomodo cum vidcbat,
-					quem sibi cupiebat ostendi ; <lb/> quia utique si Deum in substantia qua Deus
-					cst vide­ <lb/> rpt, profecto ut se illi ostenderet non rogaret. Dixi <lb/>
-					etiam esse Christum visibilium ct invisibilium creato­ <lb/> rem , ut ipsum
-					probarem per substantiam suam non <lb/> esse visibilem , a quo preari non solum
-					visibilia, <lb/> veram etiam invisibilia potuerunt. Ad haec tu respon­ <lb/>
-					dere conatus, quam multa quae ad rem non pertinent <lb/> dixeris , intueantur
-					qui legunt : et tamen de Moyse, <lb/> cur sibi Deum cum quo loquebatur, vellet
-					ostendi , si <lb/> cnus naturam substantiamque cernebat, prorsus nibil <lb/>
-					ausus es dicere: ct adhuc affirmare non destitisti, Dei <lb/> Filium
-					invisibilium crcatorem , et antequam formam <lb/> servi acciperet, in forma Dei
-					fuisse visihilcm; quem <lb/> tupcrius in formi servi viden potuisse , in
-					substantia <lb/> vero suie divinitatis esse invisibilem, jam fueras et <lb/>
-					ipse confessus.</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="16">
-					<p>CAPUT XVI. — <hi rend="italic">De solo sapiente Deo.</hi> Sexto de­ <lb/> cimo
-					loco; quia de Patre tantum dixissc Apostolum <lb/> dixeras, <hi rend="italic"
-						>Soli sapienti Deo (Rom.</hi> xvi, 27); ego dixi : <lb/>
-					<hi rend="italic">Ergo solus Pater est Deus sapiens, et non est sapiens<lb/>
-						ipsa Dei sapientia, quod est</hi> Christus; <hi rend="italic">de quo ait
-						Aposto­</hi>
-					<lb/> lus : « <hi rend="italic">Christum Dei Virtutem et Dei</hi> Sapientiam <hi
-						rend="italic">» (I Cor.</hi>
-					<lb/> I, 24) ! Deinde addidi : <hi rend="italic">Superest ut dicatis (quid enim
-						<lb/> non audetis? ) insipientem esse sapientiam Dei.</hi> Ad h:rc <lb/> tu
-					: <hi rend="italic">Sapientem solum,</hi> inquis, <hi rend="italic">Patrem
-						praedicat Paulus <lb/> beatus apostolus, dicens sic:</hi> « <hi
-						rend="italic">Soli sapienti Dco.</hi> i <hi rend="italic">Sed <lb/>
-						requirenda est ,</hi> inquis, <hi rend="italic">ratio quemadmodum solus
-						sapiens,</hi>
-					<lb/> non <hi rend="italic">quod Christus non sit sapiens.</hi> Scqucris
-					dcinceps , <lb/> et adjungis quomodo sapientem confitearis et Chri­ <lb/> stum :
-					nam post nonnulla , quae ad rem non perii.. <lb/> nentia texuisti , ut sermonem
-					tempusque produceres, <lb/> eliam hoc inseruisti verbis tuis ut diceres, <hi
-						rend="italic">Sed vere <lb/> solus sapiens</hi> Pater ; quasi Apostolus
-					dixerit, Soli <lb/> sapienti Patri. Sed dixit, <hi rend="italic">Soli sapienti
-						Dco</hi> : quia Deus <lb/> est et Filius, quod et vos vultis; Dcus est ct
-					Spiritus <lb/> sanctus, etsi non vultis : ct ista Trinitas cst solus sa­ <lb/>
-					piens Deus, qui nec potuit unquam esse insipicns <lb/> omnino, nec poterit; non
-					per gratiam particeps sa­ <lb/> pientiae, sed sapiens immobilitate atque immuta­
-					<lb/> bilitate naturae. Nam si tibi dicam, itane vero, o <lb/> homo qui
-					christiano nomine gloriaris, Christus sic est <lb/> sapiens , ut non sit vere
-					sapiens ? ergone Christus qui <lb/> osi verus Deus, non est verb sapicns? nonne
-					ita sub <lb/> hac interrogatione turbaberis, ut continuo respon­ <lb/> deas ,
-					Christum vere esse sapientem ? Quid est ergo <lb/> quod dixisti, <hi
-						rend="italic">Sed</hi> vere <hi rend="italic">solus sapiens</hi> Pater ?
-					Nempe <lb/> quo per veneris , et a quanta blasphemia te debeas re­ <lb/> yovare,
-					jam sentis.</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="17">
-					<p>CAPUT XVII. — <hi rend="italic">De infecto Deo.</hi> Septimo decimo <lb/> loco
-					egi tecum, quod etiam Filius , non solus Pater, <lb/> infectus sit, hoc est,
-					factus non sit. Dixeras enim ideo <lb/> a vobis unum Deum pronuntiari, quia <hi
-						rend="italic">unus est super<lb/> omnia innatus,</hi> infectus. Respondens
-					crgo huic aula. <lb/> ci:c tu:c : <hi rend="italic">Sic antem</hi> , inquam, <hi
-						rend="italic">dicis Patrem infectum,<lb/> quasi Filius factus sit , per quem
-						facta sunt omnia.</hi>
-					<lb/> Deinde addidi : <hi rend="italic">Scito factum esse Filium, sed in</hi>
-					forma <lb/>
-					<hi rend="italic">servi.</hi> Nam in <hi rend="italic">forma Dei usque</hi> adeo
-						<hi rend="italic">non est factus,</hi> ut <lb/>
-					<hi rend="italic">per illum facta sint omnia.</hi> Si <hi rend="italic">enim
-						ipse factus</hi> eat, in­ <lb/> quam, <hi rend="italic">non per illum facta
-						sunt omnia, aed</hi> caetera. Ad <lb/> haec tu cum tota hii prolixitate
-					sermonis, ita nihil <lb/> quod diceres invenisti , ut hinc omnino, tanquam id
-					<lb/> non audieris, conticesceres.</p></div>
-				<div type="textpart" subtype="chapter" n="18">
-					<p>CAPUT XVIII. <hi rend="italic">- De ingenito Patre.</hi> Octavo decimo <lb/> loco
-					etiam de innato Patre , id est ingenito , quia ct <lb/> hoc dixcras, tccum
-					agendum putavi, et dixi: <hi rend="italic">Non <lb/> itoque dico Filium
-						ingenitum; aed Patrem genitorem, <lb/> Filium genitum. Hoc tamen genuit
-						Puter quod est : <lb/> alioquin non est verus Filius ,</hi> si <hi
-						rend="italic">qnod est Pater non est <lb/> Filius ; sicut de partubus
-						animalium supra jam diximus.</hi>
-					<lb/> Eliam ad hoc In nee verum nec falsum ali quid protulisti.</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="19">
-					<p>CAPUT XIX. — <hi rend="italic">De aequalitate Spiritus sancti cum Pa.<lb/>
-						tre.</hi> Nonodccimo loco, quia poposceras a mc, ut osten­ <lb/> derem
-					aequalem esse I'atri i Spiritum sanctum ; respondi <lb/> tibi dicens: <hi
-						rend="italic">Quid est autem quod</hi> poscis, <hi rend="italic">ut ostendam
-						tibi</hi>
-					<lb/> aqualem Patri <hi rend="italic">esse Spiritum sanctum, quasi tu Patrem
-						<lb/> ostenderis majorem esse Spiritu sancto; sicut potuisti <lb/> ostendere
-						de Filio, propter formam servi? Scimus enim,</hi>
-					<lb/> inquam, <hi rend="italic">dictum esse Patrem Filio majorem, quia</hi> in <lb/>
-					<hi rend="italic">forma servi erat Filius ; ct adhuc in forma eat humana<lb/>
-						Filius, quam levavit in coelum : propterea de illo</hi> di­ <lb/> ctum <hi
-						rend="italic">eat quod et nunc</hi> a interpellat <hi rend="italic">pro</hi>
-					nobis i <hi rend="italic">(Rom.</hi>
-					<lb/> VIII, 54). <hi rend="italic">Et sempiterna erit in regno haec eadem forma
-						<lb/> immortalis : propter quod dictum</hi> eat « <hi rend="italic">Tunc et
-						ipsa</hi> Fi­ <lb/> « <hi rend="italic">lius subjectus erit ei qui illi
-						subjecit omnia</hi> » ( I <hi rend="italic">Cor.</hi>
-					<lb/> xv, 28). <hi rend="italic">Nam de Spiritu sancto qui nullam suscepit <lb/>
-						creaturam ad unitatem personae suae, quamvis se per <lb/> subjectam
-						creaturam visibiliter et ipse.. sive per</hi> columbae <lb/>
-					<hi rend="italic">speciem, sive per linguas igneas sit demonstrare digna­ <lb/>
-						tua (Matth</hi> III, 16 <hi rend="italic">, et Act.</hi> II, 3), <hi
-						rend="italic">nunquam dictus est <lb/> eo major Pater; nunquam dictus
-						cst</hi> Spiiitus <hi rend="italic">adorasse <lb/> Patrem; nunquam dictus
-						est minor Patre.</hi> Ad haec tu <lb/> quasi respondens, non tamen
-					respandisti. Non enim <lb/> potuisti ostendere Spiritu sancto alicubi Patrem
-					dictum <lb/> fuissc majorem, sicuti Filius propter formam servi di­ <lb/> xit,
-						<hi rend="italic">Pater major me est (Joan.</hi> XIV, 28). Et cum ego <lb/>
-					dixerim, Spiritum sanctum non ad unitatem personae <lb/> suae ullam suscepisse
-					creaturam; tu ita Spiritum san­ <lb/> ctum in columba ct igne apparuisse
-					dixisti, sicut ap­ <lb/> paruit Christus in homine : quasi columba el Spiritus,
-					<lb/> vel ignis et Spiritus una persona sit, sicut Verbum et ' <lb/> homo una
-					persona est. Ad horam quippe apparuerunt <lb/> illa, quae Spiritum sanctum
-					significando monstrarent <lb/> visibiliter invisibilem ; columba, propter amorem
-					san­ <lb/> ctum ; ignis autem , propter charitatis lumcn atque <lb/> fervorem ;
-					et peracto significationis officio, corporales <lb/> illae species transierunt,
-					atque esse ulterius destite­ <lb/> runt; sicut columna nubis. nebulosa per diem
-					, lunii­ <lb/> nosa per noctem <hi rend="italic">(Exod.</hi> XIII, 21-22).
-					Denique ne puta­ <lb/>
-					<pb n="757"/> retur columba vel flamma ad substantiam pertinere <lb/> Spiritus
-					sancti, vel quod se in haec visibilia tantae ma­ <lb/> jestatis natura
-					converterit, aut in unitatem personae <lb/> suae ista susceperit, nunquam postea
-					sic apparuisse le­ <lb/> gitur Spiritus sancius. Cbristus autem, qui humanam
-					<lb/> non ad horam sumpsit effigiem, in qua hominibus ap­ <lb/> pareret, ac
-					deinde illa species praeteriret; sed in uni­ <lb/> tatem personae suae, manente
-					invisibili Dei forma I, <lb/> accepit visibilem hominis formam; non solum, natus
-					<lb/> cst in ea de homine matre, verum etiam crevit in ea, et <lb/> manducavit,
-					et bibit, et dormivit in ea, et occisus est <lb/> in ea, et resurrexit in ea, et
-					ascendit in coelum, et <lb/> scdet ad dexteram Patris in ea, ad judicandos vivos
-					<lb/> et mortuos est venturus in ea, et in regno suo, ci qui <lb/> illi subjecit
-					omnia, erit subjectus in ea. Ilac tu in <lb/> mea responsione breviter dicta,
-					quae nunc aliquanto <lb/> latius, ut vel sic intelligcres, explicavi, attendere
-					et <lb/> considcrare noluisti, irruens in tantam blasphemiam, <lb/> . ut naturam
-					divinam Dei et Spiritus sancli converti-, <lb/> bilem, proh nefas! et mutabilem
-					diccres. Tua nam­ <lb/> que ista sunt verba : <hi rend="italic">Ea,</hi> inquis,
-						<hi rend="italic">quae; de invisibilitate <lb/> &gt; omnipotentis</hi> 2 <hi
-						rend="italic">Dei prosecutus sum, eliam et ipse, licet <lb/> alio</hi>
-					proposito, attamen <hi rend="italic">tuis verbis affirmasti, quod Spi­</hi>
-					<lb/> . <lb/> ritus sanctus in <hi rend="italic">specie columbae sit MMM, necnon
-						et in<lb/> specie ignis : Filius sane,</hi> in forma hominis: <hi
-						rend="italic">Pater<lb/> autem, neque</hi> in <hi rend="italic">specie
-						columbx, nec</hi> in <hi rend="italic">forma hominis;. <lb/> nec aliquando
-						vertit se in formas, sed nec aliquando</hi>
-					<lb/> vertetur : <hi rend="italic">de quo scriptum est, « Ego</hi> sum <hi
-						rend="italic">qui sum, et</hi>
-					<lb/> « <hi rend="italic">non sum mutatus.</hi> &gt; Deinde adjungis, et dicis:
-					Fi­ <lb/>
-					<hi rend="italic">lius sane</hi> in forma <hi rend="italic">Dei constitutus
-						jam,</hi> ut <hi rend="italic">ipse protu<lb/>li.,;, formam servi
-						accepit, quod non Pater: Spiritus <lb/> aeque sanctus suscepit speciem
-						columbae, quam</hi> nonsta­ <lb/>
-					<hi rend="italic">cepit Parer. Scito ergo,</hi> inquis, <hi rend="italic">quia
-						unus est, invisi­ <lb/> bilis, unus eliam incapabilis atque immensus.</hi>
-					Haec <lb/> numquid diceres, si secundum spiritum, non secun­ <lb/> dum carnem,
-					posses cogitare quid diceres ? Homo <lb/> es enim, qui legis in Scripturis
-					sanctis, <hi rend="italic">Ego</hi> sum <hi rend="italic">qui <lb/> sum:, et non
-						sum mutatus (Exod.</hi> III, 14, <hi rend="italic">et Malach.</hi>
-					<lb/> III, 6). Et cum verba ista sint, non Patris solius, sed <lb/> ipsius
-					Trinitatis, quae unus est Deus; tu ea Patri <note type="footnote"> I Editio
-						Lov., <hi rend="italic">sed unitate personae manenle, invisibUis <lb/> hei
-							fortna accepit,</hi> etc. * </note><note type="footnote"> I Am. ET. et
-						Mss., <hi rend="italic">omnitenentis.</hi>
-					</note>
-					<lb/> tantummodo tribuens, Filium mutabilem credis! Uni­ <lb/> genitum per quem
-					facta sunt omnia mutabilem credis: <lb/> eum de quo dicit Evangelium, <hi
-						rend="italic">In principio erat Ver. <lb/> bum, et Verbum erat apud Deum, et
-						Deus erat Verbum;</hi>
-					<lb/> et, <hi rend="italic">Omnia per</hi> ipsum <hi rend="italic">facta sunt
-						(Joan.</hi> i, 1, 5), muta­ <lb/> bilem credis! Quid jam dicam de Spiritu
-					sancto, <lb/> quando illum quem verum Filium Dei et verum con­ <lb/> fiteris
-					Deum, mutahilem credis ? Quod ufiquc non <lb/> crederes, si formam servi a forma
-					Dei esse susce­ <lb/> ptam, non formam Dci in formam servi esse muta. <lb/> tam,
-					tanquam catholicus crederes; et visibili homine <lb/> assumpto, permansisse
-					invisibilem Deum, non car­ <lb/> nalitcr, sed spiritualiter cogitares ; nee
-					coptendend&gt; <lb/> diffideres, sed intelligendo conspiceres : et Spiritum
-					<lb/> sanctum invisibili sua manente natura, nullo modo <lb/> in ignis aut
-					columbae speciem mutata atque conversa, <lb/> per subjectam creaturam
-					apparuisse, sicul voluit vi­ <lb/> sibiliter <hi rend="italic">(Act.</hi> n, 3,
-						<hi rend="italic">et Matth.</hi> III, 16), tu posses consi<lb/>derare
-					fideliter. Memento tamen, nec majorem Pa<lb/> Irem Spiritu sancto, nec
-					adoratum Patrem ab Spiritu <lb/> sancto, ullis divinis testimoniis contra
-					propositionem <lb/> meam te demonstrare potuisse.</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="20">
-					<p>CAPUT XX. — <hi rend="italic">Licet ingenitus Pater,</hi> aequalis <hi
-						rend="italic">ta­<lb/> men Filius.</hi> Vigesimo loco, quoniam dixeras de
-					Filio, <lb/> Si <hi rend="italic">aequalis. Patri, utique talis:</hi> si <hi
-						rend="italic">talis, utique innatus;</hi>
-					<lb/> ego respondens tibi: Sed dicis, inquam, de Filio, Si <lb/>
-					<hi rend="italic">aequalis, utique talis;</hi> id est, ut <hi rend="italic">quia
-						non eat ingenitus.<lb/> non videatur talis. Posses dtcere non esse hominem
-						quem<lb/> genuit Adam, quia ipse Adam non eat genitus, sed factus<lb/> a
-						Deo.</hi> Si <hi rend="italic">autem potuit Adam et non esse genitus,</hi>
-					et <lb/> tamen <hi rend="italic">hoc generare quod erat ipse; non vis ut
-						potue­<lb/> rit Deus Deum aquatem</hi> sibi ? Ad haec non miror <lb/> nullum
-					te invenisse responsum : sed plane laudo nec <lb/> respondere conatum. Atque
-					utinam hoc ubique fe­ <lb/> cisses! nusquam enim in sermonibus nostris quid
-					<lb/> recte responderes invenire potuisti, et tamen pene <lb/> ubique tacere
-					noluisti. Sed cum in aliis tam multa <lb/> dixeris, causae quoe inter nos agitur
-					non necessaria , <lb/> et tempus loquendo consumpseris; gratiae tibi agendae
-					<lb/> sunt, ubi nonnulla sic vidisti te refutare non posse, ut <lb/> ea malles
-					summo silentio praeterire. <note type="footnote"> I Apud Lov., <hi rend="italic"
-							>plene.</hi>
-					</note>
-					</p>
-				</div>
-				<ab>
-					<title type="sub">
-						<hi rend="italic">LIBER SECUNDUS (a).</hi>
-					</title>
-				</ab>
-				<p>Refelluntur singillatim quae in Collatione Maximinus dixit ultima sua
-					disputatione, cujus disputationis suae prolixitato <lb/> respondendi tempus tunc
-					eripuit Augustino.</p>
-				<p>PRAEFATIO. - Res jam postulat ut in eoquod reliquum <lb/> est, opitulante Domino,
-					impleam promissionem meam. <lb/> In operis quippe hujus exordio, Prius,
-					inquam,ostendam <lb/>
-					<hi rend="italic">refellere te non potuisse quae dixi: deinde, quantum<lb/>
-						necessarium videbitur,</hi> ego <hi rend="italic">refellam quas ipse
-						dixisti.</hi>
-					<lb/> Quia ergo, sicut adjuvante Deo potui, ostendi ea quae <lb/> dixi non te
-					potuisse refellere; superest ut ea qux <lb/> dixisti, ego refellam, sicut Deo
-					adjuvante potuero. <lb/> Priores itaque prosecutiones tuas, quibus. continuo
-						<note type="footnote"> (I.) viias, reviius. </note>
-					<lb/> reddidi meas in hac disputatione quae nunc a me sus<lb/>cepta est, non
-					retractabo : illam vero ultimam lam <lb/> prolixam, ut milii die illo spatium
-					responsionis An­ <lb/> ferret, ita redarguam, si voluerit qui nos regit, ut
-					<lb/> acquiescas lumini veritatis, si contentionis tenebras <lb/> non amaveris.
-					In primis ergo superflua tua detrahant <lb/> necessitati responsionis meae.
-					Causa quippe inter nns <lb/> agitur, utrum Pater et Filius et Spiritus sanctus
-					di­ <lb/> versae, ut vos dicitis, an potius, ut nos dicimus, unius <lb/> sint
-					ejusdemque substantiae, unusque Deus sit ipsa <lb/>
-					<pb n="759"/> Trinitas : cum conveniat inter nos Patrem non esse <lb/> qui est
-					Filius, nee Filium esse qui est Pater, nec Pa­ <lb/> tremesse vel Filium qui
-					Spiritus sanctus est. Quid­ <lb/> quid igitur tanta tuae prosecutionis
-					prolixitate dixisti, <lb/> mule ostenderes alium esse Patrem, alium esse Fi­
-					<lb/> lium, alium esse Spiritum sanctum quando nobis­ <lb/> cum agitis.
-					superfluum prorsus esse cognosce : et si <lb/> tibi expugnandi occurrerint
-					Sabelliani, in eos ista <lb/> nohis vobisque communia, si placet, arma converte.
-					<lb/> Multa eliam locutus es, ut probares magnum Deum <lb/> esse Dominum Jesum
-					Christum : hoc quid ad nos, <lb/> cum hoc dicamus et nos? Laudes quoque Spiritus
-					<lb/> sancti magnas verasque fudisti : sed nos eas augere <lb/> possumus, non
-					negare : non itaque opus erat ut eas <lb/> contra nos diceres, quas dicimus
-					tecum. Christum <lb/> scdere ad dexteram Patris, nonne pariter confite­ <lb/>
-					mur? Quod tamen testimoniis divinorum eloquio­ <lb/> rum sic probare voluisti,
-					tanquam id alicubi negare­ <lb/> mus. Christum in carne venisse, utrique novimus
-					et <lb/> tenemus : sic adhibuisti ut hoc doceres divina testi­ <lb/> monia,
-					tanquam repugnemus. Haec et alia quae suis <lb/> ostendam locis, in quibus
-					operam supervacuam con­ <lb/> trivisti, ut moras necteres, tempusque produceres,
-					<lb/> commemorando attingere debeo, non redarguere <lb/> disputando.</p>
-				<div type="textpart" subtype="chapter" n="1">
-					<p>CAPUT PRIMUM. — Dicis me <hi rend="italic">auxilio</hi> principum mu­ <lb/>
-					<hi rend="italic">nitum, non loqui secundum timorem Dei;</hi> cum scias nobis
-					<lb/> esse praeceptum orare pro regibus, ut in agnitionem <lb/> veniant
-					veritatis (I Tim. II, i, 4): quod in quibusdam <lb/> esse impletum, nos Deo
-					agimus gratias, vos doletis. <lb/> Verba autem nostra recte intelligentibus
-					indicant, quis <lb/> nostrum loquatur secundum timorem Dei : utrum qui <lb/> sic
-					laudat Deum Patrem , ut ad ejus taudem referat, <lb/> quod sibi Filium generavit
-					xqualem; an qui sic geni­ <lb/> torem debonestat et genitum, ut et illum dicat
-					non <lb/> potuisse gignere per omnia sui similem filium, et <lb/> isium dicat
-					non dcgenerasse jam natum, sed dcgeae­ <lb/> rem natum.</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="2">
-					<p>CAPUT II. — Dicis <hi rend="italic">vos Christum colere, ut Deum <lb/> omnis
-						creaturae cui flectitur</hi> omne <hi rend="italic">genu, cœlestium, ter­
-						<lb/> restrium et infernorum</hi> : quem tamen Deo Patri esse <lb/> non
-					vultis aequalem, quia <hi rend="italic">hoc Pater ei donavit:</hi> ait <lb/>
-					enim Apostolus, <hi rend="italic">Propter quod et Deus eun. exaltavit, <lb/> et
-						donavit ei nomen quod est super omne nomen , ut</hi> in <lb/>
-					<hi rend="italic">nomine Jesu omne genu flectatur,</hi> etc. Nec quaeritis cui
-					<lb/> donaverit; utrum homini, an Deo. Quomodo1 enim <lb/> donaverit, evidenter
-					apparet. <hi rend="italic">Humiliavit,</hi> inquit, <hi rend="italic">se­ <lb/>
-						metipsum usque ad mortem, mortem autem crucis. Pro­</hi>
-					<lb/> pter <hi rend="italic">quod et Deus eum</hi> exaltavit, <hi rend="italic"
-						>et donavit ei nomen <lb/> quod est super omne nomen (Philipp.</hi> II, 8,
-					9). Si ergo <lb/> propterea donavit ei nomen quod est super omne no­ <lb/> men,
-					quia factus est obediens usque ad mortem cru­ <lb/> cis; numquid antequam hoc
-					fieret, non erat altus Dei <lb/> Filius Deus, Dei Verbum, Deus apud Deum; sed
-					<lb/> posteaquam propter hoc exaltatus est, quia factus est <lb/> obediens usque
-					ad mortem crucis, tunc coepit esse <lb/> altus Dei Filius, unicus Dei, Deus,
-					tunc cœpit habere <lb/> nomen quad est super omne nomcn? Quis hoc insi- <note
-						type="footnote"> 1 In Mss., <hi rend="italic">Quando.</hi>
-					</note>
-					<lb/> pientissimus dixerit? Hoc illi ergo donatum est ut ho­ <lb/> mini,
-					secundum quem Filius factus est obediens usque <lb/> ad mortem crucis, quod jam
-					habebat idem ipse Dei <lb/> Filius, Deus de Deo natus aequalis.</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="3">
-					<p>CAPUT III. — Objicis mihi, quod dicam Spiritum <lb/> sanctum aequalem esse Filio.
-					Dico plane. <hi rend="italic">Da,</hi> inquis, <lb/>
-					<hi rend="italic">testimonia ubi adoratur Spiritus sanctus.</hi> Ut video, hinc
-					<lb/> eam vis ostendi aequalem Christo, si adoratur ut Chri­ <lb/> stus. Jam
-					ergo confitere Christum Patr! arqualcm, <lb/> quem tu ipse adorari confiteris ut
-					Patrem. Quales au­ <lb/> tem homines estis, quam religiosas humilitatis, qui
-					<lb/> Spiritum sanctum adorare non vultis, ciim legntis, <lb/>
-					<hi rend="italic">Littera occidit, Spiritus</hi> autem <hi rend="italic"
-						>vivificat</hi> ( II <hi rend="italic">Cor.</hi> III, 6 ) ? <lb/> Non vultis
-					ergo adorare, quem vivificare animas non <lb/> negatis : cum pater Abraham
-					homines adoraverit, <lb/> quia concesserunt ei monumentum, ubi poneret mor
-					<lb/>tuae corpus uxoris. Sic cnim scriptum est : <hi rend="italic">Venit
-						au.<lb/> tem Abraham plangere Saram et lugere. Et</hi> surrexit <lb/>
-					<hi rend="italic">Abraham de supra mortem ejus, et dixit filiis II et. : <lb/>
-						Peregrinus et advena sum ego vobiscum; daie ergo</hi> mihi <lb/>
-					<hi rend="italic">possessionem monumenti, ubi sepeliam mortuum</hi> meum. <lb/>
-					<hi rend="italic">Responderunt autem filii Heth ad</hi> Abraham , <hi
-						rend="italic">dicentes :<lb/> Absit hoc, domine; audi nunc et noa : rex a
-						Deo in</hi> es <lb/>
-					<hi rend="italic">in</hi> nobis ; <hi rend="italic">in electis monumentis
-						nostris sepeli mortuum <lb/> tuum : nemo enim nostrum prohibet te a
-						monumento <lb/> suo, ut sepelias mortuum tuum ibi. Surgens autem <lb/>
-						Abraham adoravit plebem</hi> filiorum <hi rend="italic">Heth (Gen.</hi>
-					XlIII, <lb/> 2-7). Et vos Spiritum sanctum non permittitis adorari, <lb/> ut
-					ipsi Dei gratiae remaneatis ingrati ! Sed, <hi rend="italic">Da,</hi> in­ <lb/>
-					quis, <hi rend="italic">testimonia ubi adoratur Spiritus sanctus</hi> : quasi
-					<lb/> non ex iis quae legimus , aliqua eliam quae non legi­ <lb/> mus,
-					intelligamus. Sed ne quaTere multa compellar, <lb/> tu ubi legisti Patrem Deum
-					ingenitum vel innatum? <lb/> Et tamen verum est. Quod vero aliquoties dixisti,
-					<lb/> etiam Filio esse incomparabilem Patrem, nec legis, <lb/> nec verum est. Si
-					autem religionem qua colitur Deus, <lb/> sicut dignum est cogitares, multo plus
-					esse cerneres <lb/> quod habet Spiritus sanctus templum, quam si cum <lb/>
-					legeres adoratum. Et homines enim , sicut supra do­ <lb/> cui, a sanctis novimus
-					adoratos : templum vero non <lb/> est factum ab hominibus, nisi aut vero Deo,
-					sicut Sa­ <lb/> lomon fecit; aut cis qui pro diis habentur, sicut gen­ <lb/> tes
-					quae ignorant Deum. Spiritus autem sanctus, quod <lb/> cum magno honore de Deo
-					dictum est, <hi rend="italic">non in manu­ <lb/> factis templis habilat</hi> (
-						<hi rend="italic">Act.</hi> XVII, 24 ), sed corpus no­ <lb/> strum templum
-					est Spiritus sancti. Et ne corpora no­ <lb/> stra contemnas, membra sunt Christi
-					( I <hi rend="italic">Cor.</hi> vi, 19, <lb/> 15). Qualis ergo Deus, cui templum
-					aedificatur, et a <lb/> Deo, et de membris Dei ?</p></div>
-				<div type="textpart" subtype="chapter" n="4">
-					<p>CAPUT IV. — Dicis <hi rend="italic">Christum esse</hi> in <hi rend="italic"
-						>dextera Dei,<lb/> et interpellare pro nobis (Rom.</hi> VIII, 34). Quod cur
-					no­ <lb/> bis objicis, si eum non solum Deum, verum etiam <lb/> hominem
-					agnoscis? Quid te igitur adjuvat, quod se­ <lb/> dere ad dexteram Patris assidue
-					legitur ? Quid nobis, <lb/> non quidem inanibus testimoniis, sed tamen inaniler,
-					<lb/> probare niteris quod fatemur.</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="5">
-					<p>CAPUT V. — Dicis <hi rend="italic">vos Spiritum sanctum</hi> compe­ <lb/>
-					<hi rend="italic">tenter honorare ut doctorem, ut ducatorem,</hi> ut <hi
-						rend="italic">illumina­</hi>
-					<lb/> torem, ut <hi rend="italic">sanctificatorem; Christum colere, ut
-						creato­</hi>
-					<lb/>
-					<pb n="761"/>
-					<hi rend="italic">rem; Patrem</hi> cun, <hi rend="italic">sincera devotione
-						adorare,</hi> ut <hi rend="italic">aucto­</hi>
-					<lb/> rem. Si auctorem propterea dicis Patrem, quia de <lb/> ipso est Filius,
-					non est autem ipse de Filio; et quia <lb/> de illo et Filio sic procedit
-					Spiritus sanctus, ut. ipse <lb/> hoc dederit Filio gignendo eum talem, ut etiam
-					de <lb/> ipso procedat Spiritus sanctus : si creatorem sic dicis <lb/> Filium,
-					ut creatorem non neges Patrem nec Spiritum <lb/> sanctum; si denique Spiritum
-					sanctum sic dicis do­ <lb/> ctorem , ducatorem, illuminatorem, sanctificatorem,
-					<lb/> ut haec opera nec Patri audeas auferre nec Filio : ista <lb/> tua etiam
-					nostra sint verba. Si autem talia tibi idola <lb/> ponis in corde, ut duos
-					facias deos, unum majorem, <lb/> id est, Patrenl, alium minorem, id est, Filium
-					; Spi­ <lb/> ritum vero sanctum ita omnium trium minimum fin­ <lb/> gas, ut nec
-					Deum nuncupare digneris : non haec est <lb/> nostra fides, quoniam non est
-					christiana fides, ac per <lb/> hoc nec fides. Etiam hoc tibi ignoscimus, quod
-					impe­ <lb/> rite usus verbo , Chritum significasti <hi rend="italic">ad terrena
-						de­ <lb/> scendisse contagia.</hi> Et quia hoc in te corrigere volui, <lb/>
-					ut scires conlagia quomodo appellare debeamus; ca­ <lb/> lumnias <hi
-						rend="italic">esse</hi> istas dicis, <hi rend="italic">et</hi> eas <hi
-						rend="italic">de philosophicas artis<lb/> instructione venire</hi>
-					arbitraris. Sufficit mihi quod ita <lb/> putasti Christum ad terrena descendisse
-					contagia, <lb/> ut tamen confitereris nullum habuisse peccatum.</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="6">
-					<p>CAPUT VI. — Illud sane quod commemoravi, <lb/> partus animalium, quae cum terrena
-					sint atque mor­ <lb/> talia, hoc tamen gignunt quod ipsa sunt, ut homo ho­ <lb/>
-					minem, canis canem; puto quod non aspernatus hor­ <lb/> ruisti, sed te aspernari
-					atque horrere finixisti, dicens, <lb/>
-					<hi rend="italic">tam. fœdam comparationem</hi> in <hi rend="italic">illam
-						tantam immensita­ <lb/> tem non debuisse produci.</hi> Cur enim boc dixisti,
-					nisi <lb/> ne tibi de ipsis corruptibilibus fetibus fauces veritas <lb/>
-					premeret, et te respirare non sineret, sicut ct facit ? <lb/> Qandoquidem
-					creaturam corruptibilem cernitis , hoc <lb/> quod ipsa est gignere fetum situm,
-					et Deum Patrem <lb/> omnipotentem creditis non potuisse nisi ejus dege­ <lb/>
-					nerante natura g:gnerc unicum suum.</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="7">
-					<p>CAPUT VII. — Sed dicis: <hi rend="italic">Dominus Dominum ge­<lb/> nuit,
-						Deus</hi> Den. <hi rend="italic">genuit, Rex Regem genuit, Creator <lb/>
-						Creatorem</hi> genuit, <hi rend="italic">bonus bonum genuit, sapiens
-						sapien­<lb/> tem genuit, clemens clementem, potens potentem.</hi> Si sub
-					<lb/> his verbis cavcre te putas quod vobis objicitur, non <lb/> vos credere
-					Dcum potuisse gignere id quod est ipse, <lb/> et ideo dicis, <hi rend="italic"
-						>Dominus Dominum genuit, Deus Deum <lb/> genuit,</hi> et caetera : cur ergo
-					sicut dixisti, <hi rend="italic">Potens po­<lb/> tentem;</hi> non dicis,
-					Omnipotens omnipotentem? Si quod <lb/> sentis vis dicere, dic: Dominus major,
-					dominum mi­ <lb/> norem genuit; Deus major, deum minorem; Rex ma­ <lb/> jor,
-					regem miuorem; Creator major, creatorem mi­ <lb/> norem; melior bonum,
-					sapientior sapientem, clemen­ <lb/> tior clementem, potentior potentem. Si autem
-					ista <lb/> non dicis, et nihil minus quam Pater habet, Filium <lb/> babere
-					consentis, cur non dicis aequalem? Et illa <lb/> omnia cur non sic percurris, ut
-					dicas: D minus aequa­ <lb/> lem Dominum genuit, Deus aequalem Deum, Rex <lb/>
-					aequalem Regem, Creatoraequalem Creatorem, bonus <lb/> aequaliter bonum, sapiens
-					aequaliter sapientem, de­ <lb/> mens aequaliter clementem, potens aequaliter
-					poten­ <lb/> tem? Si autcm negasaequalem aperte dic esse dege­ <lb/> nerem. Non
-					enim quem deum minorem, de Deo ula... <lb/> jore natum esse dicitis, saltem
-					sicut infantem crescere <lb/> sinitis, ut aliquando suo Patri possit esse
-					aequalis. Ad <lb/> hoc cnim eum perfectum dicitis esse natum , non ut <lb/> binc
-					laus ejus cresceret, sed ut minor ejus natura re­ <lb/> nianerct. Et cum isia
-					sentiatis. seqneris tamen, et di­ <lb/> cis : Nihil sublraxtt <hi rend="italic"
-						>Pater in generando Filium.</hi> Quo­ <lb/> modo nihil subtraxit in
-					generando Filium, quem non <lb/> aequalem genuit, sed minorem? An ideo nihil
-					sub­ <lb/> traxit, quia nihi! corum quae gignendo dedit, abstulit <lb/> genito ?
-					Ita sane nihil subtraxit: sed et filiis hominum <lb/> qui prospere nascuntur,
-					nihil aufert Creator jam na­ <lb/> tis ; quin potius addit, ut accedat
-					crescentibus quod <lb/> nascentibus defuit. Quid ergo magnum de Patre dixi­
-					<lb/> sti erga unicum Filium, qui non ex nihilo vel ex ali­ <lb/> qua materia
-					factus, sed ex ipso natus est? Quid ma­ <lb/> gnum est quia non subtraxit quod
-					dedit, si quod dare <lb/> potuit, non dando subtraxit? Ubi est, quod eum invi­
-					<lb/> dum non esse dixisti? An forte dare non potuit? Uhi <lb/> est omnipotentia
-					DeiTatris? Prorsus ad hunc articu­ <lb/> lum res colligitur, ut Deus Pater
-					aequalem sibi gignere <lb/> Filium aut non potuerit, aut noluerit. Si non
-					potuit, <lb/> infirmus; si noluit, invidus invenitur. Sed utrumque <lb/> hoc
-					falsum est. Patri igitur Deo Filius verus aequalis <lb/> eat. Si ergo, ut
-					laudas, placet tibi quod a me comme­ <lb/> moratum est, <hi rend="italic"
-						>Invisibilia enim ejus, per ea quce facta<lb/> sunt, intellecta
-						conspiciuntur (Rom.</hi> I, 20) : per id qnod <lb/> factum est in creatura
-					visibili, ut pnrentes id quod <lb/> ipsi sunt generent, intellige ipvisibilcm
-					nativitatem . <lb/> veri Filii Dei, ne Deum Patrem dicas id quod non est <lb/>
-					ipse gcnuisse. Si autem hoc genuit quod est ipse; <lb/> unam Patris et Filii
-					esse substantiam negare nolite.</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="8">
-					<p>CAPUT VIII. — Jam vero sequentia, quae sic con­ <lb/> nexuisti, ut de cruce vel
-					incarnatione Christi probare <lb/> nobis velles quod pariter credimus; servasti
-					morem <lb/> mum : sed nihil tibi ad ista respondens, etiam ego <lb/> servo
-					promissum meum.</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="9">
-					<p>CAPUT IX. — 1. De iuvisibili Filio cum agere­ <lb/> mus, quem consensisti esse
-					invisibilem secundum di­ <lb/> vinitatem, qui prius solum Patrem invisibilem
-					esse <lb/> praesumpseras, ad rem non pertinentia multa dixisti <lb/> de
-					invisibilibus creaturis : quod poterunt judicare qui <lb/> legerint. De
-					invisibili Dco inter nos agitur : et hoc <lb/> csl quod quaestionem facit, quia
-					vos invisibilcm solum <lb/> Patrem dictum putatis, ubi Apostolus ait, <hi
-						rend="italic">Immortali,<lb/> invisibili soli Dco</hi> (I <hi rend="italic"
-						>Tim.</hi> I, 17). Si dixisset, Soli Patri ; <lb/> diflicilius fortasse
-					quaestio solverelur: quia vero dixit, <lb/>
-					<hi rend="italic">soli Deo;</hi> non est utique contra nos : et Unigenitus <lb/>
-					quippe in Dei forma, ct Spiritus sancius in sua na­ <lb/> tura est invisibilis.
-					Unus enim et solus Deus a nobis <lb/> ipsa Trinitas praedicatur. Quod utrum
-					verum sapia­ <lb/> mus, in aliis locis a nobis est demonstratum, et ubi <lb/>
-					adhuc opus fuerit, demonstrabitur. Nunc in ista quae<lb/>simone non immerito
-					potest movere, quomodo de solo <lb/> Dco, qui cst ipsa Trinitas, dictum sil, <hi
-						rend="italic">Invisibili soli</hi>
-					<lb/> Deo : cum sil etiam quaedam invisibilis creatura; <lb/> propter quod
-					dictum ost de Christo, quia <hi rend="italic">in ipso con­ <lb/> dita sunt</hi>
-					omnia <hi rend="italic">visibilia et invisibilia ( Coloss.</hi> I, 16). <lb/>
-					Quia ergo sunt dii falsi vbibiles, ideo dicturi est, In­ <lb/>
-					<pb n="763"/> risibili <hi rend="italic">soli Deo honor et gloria.</hi> Etsi
-					enim est creatura <lb/> invisibilis, non tamen deus nobis est. Sed et si non
-					<lb/> dictum esset, <hi rend="italic">soli Dco;</hi> sed dictum esset, <hi
-						rend="italic">Reg; autem<lb/> saeculorum, immortali, invisibili soti honor
-						et gloria:</hi>
-					<lb/> quis nisi Deus esset? Honor ergo ei gloria soli Deo, <lb/> qui Deus
-					invisibilis est, non qui solus invisibilis : <lb/> quoniam est, ut diximus, ct
-					creatura invisibilis. Item <lb/> quaeri potest quomodo dictum sit, <hi
-						rend="italic">Deum nemo vidit <lb/> unquam (Joan.</hi> I, 18); cum ejusdem
-					Domnini verba <lb/> sint, <hi rend="italic">Nescitis quia Angeli</hi> eorum <hi
-						rend="italic">semper vident fuciem<lb/> Patris</hi> mei <hi rend="italic"
-						>qui in cœlis est (Matth.</hi> XVIII, 10)? Quae <lb/> sententia vos
-					rcdarguit, qui nescitis quemadmodum <lb/> dicatis invisibilem Patrem. Illud
-					autem quod ait, <lb/> Noti <hi rend="italic">quia Patrem vidit</hi> quisquam ,
-						<hi rend="italic">nisi qui eat a Deo, <lb/> hic vidit</hi> Patrem <hi
-						rend="italic">(Joan.</hi> VI, 46); ad homines reforri <lb/> potest quod
-					dictum est, <hi rend="italic">quisquam.</hi> Et quia ipse homo <lb/> erat qui
-					tunc loquebatur in carne, ita hoc dixit, ac si <lb/> diccret, Non quia Patrem
-					vidit quisqunm bominum, <lb/> nisi cgo : sicut dictum est, <hi rend="italic"
-						>Quis sapiens, et intelliget <lb/> haec (Psal.</hi> cvi, 43) ? Non enim et
-					de sanctis Angelis <lb/> id accipi potest. Unde Apostolus de invisibili Deo
-					<lb/> apertius posuit: <hi rend="italic">Quem nemo hominum vidit, nec
-						videre<lb/> potest</hi> (I Tim. vi, 16). Non enirn ait, Nemo; sed, <hi
-						rend="italic">Nemo <lb/> hominum.</hi> Ubi ostendit quemadmodum intelligi
-					debeat <lb/> quod dictum est, <hi rend="italic">Deum nemo vidit</hi> unquam ; id
-					est, <lb/> nemo hominum : <hi rend="italic">sicut, Nemo ascendit in</hi> coelum
-						<hi rend="italic">(Joan.</hi>
-					<lb/> III, 15); cum Angeli soleant illuc ascendere, quin so­ <lb/> lent inde
-					descendere. Nec tamen Apostolus dixit, <lb/> Nemo hominum poterit videre Deum ;
-					sed, <hi rend="italic">Nemo<lb/> potest,</hi> Poterit cnim homo, sed tunc cum
-					aeternum <lb/> crit fidelium praemium , videre Deum. Propter quod <lb/> Joannes
-					apostolus : <hi rend="italic">Dilectissimi,</hi> inquil, <hi rend="italic">filii
-						Dei su­ <lb/> mus, et nondum apparuit quid erimus</hi> : scimus <hi
-						rend="italic">quia</hi>
-					<lb/> cum <hi rend="italic">apparuerit, similes ei erimus, quoniam</hi>
-					videbimus <lb/>
-					<hi rend="italic">eum sicuti cst (</hi> I <hi rend="italic">Joan.</hi> III, 2).
-					Quid est ergo quod dicis, <lb/> solum esse invisibilem Patrem? quod fruslra
-					diceres, <lb/> etiamsi a solo Filio videretur. Nunc vera cum divina <lb/>
-					testentur cloquia cum videri et ab Angelis, videndum <lb/> etiam ab hominibus,
-					cum facti fuerint aequales Ange­ <lb/> lis <hi rend="italic">(Matth.</hi> XXII,
-					50); quid est quod dicis? Ubi est <lb/> quod definire ausus es, <hi
-						rend="italic">minora videri a</hi> ,Majoribus, <lb/>
-					<hi rend="italic">majora autem a minoribus</hi> non <hi rend="italic"
-						>videri?</hi> Quod quidem <lb/> postea perdidisti, quando videri a Filio
-					confessus cs <lb/> Patrem, cum ct in ipsa substantia divinitatis dicas <lb/>
-					Filium minorem, Patremque majorem. Sed quid di­ <lb/> cturus os de Angelis , qui
-					semper vident faciem Dei <lb/> Patris? Numquid propter regulam tuam, quam sine
-					<lb/> consideratione fixisti, putandi sunt Angeli Patre Deo <lb/> esse
-					majores?</p>
-					<p>2. Scd eleganter te existimas invenisse quod diceres, <lb/> ubi :isti de Filio:
-						<hi rend="italic">Vidit ergo Patrem, sed vidit incapa­ <lb/> bilem.</hi> Nec
-					attendis, quia ctsi vidit incapabilcm, quem <lb/> sicut putas, capere non
-					putuit; non tamen invisibilcm, <lb/> quem videre potuit. Tu autem nobiscum non
-					de ca­ <lb/> pabili ut incapabili, scd dc visibili et invisibili, cum <lb/> ista
-					diceres, disputabas : quia nHc Apostolus ait, In­ <lb/> capabili; scd ait, <hi
-						rend="italic">Invisibili soli Dco.</hi> Unde hoc testi­ <lb/> monium pro te
-					adhibendum putasti, ut binc etiam <lb/> decolorares Filium, tanquam ipse in Dei
-					forma invisi­ <lb/> bilis non sit. Sed quoniam veritate convictus, et Filium
-					<lb/> confessus cs invisibilcm, praeparasti tibi, quantum exi­ <lb/> Stimo, sic
-					dicere, Invisibilis invisibilem genuit; quo­ <lb/> modo dixisti, <hi
-						rend="italic">potens potentem :</hi> ut cum discutereris, <lb/> hoc a te
-					quomodo diceretur, responderes, Invisibilior <lb/> invisibilem gcnuit, sicut
-					potentior potentem. sapien­ <lb/> tiur sapientem, et caMera tua. Sed quain
-					sapicnicr <lb/> oslendisli Filio incapabilem Patrem, Filium vcro ca <lb/>
-					pabilem Patri. Dixisti enim : fidit <hi rend="italic">ergo Patrem, sed <lb/>
-						vidit incapabilem. Pater autem,</hi> ill'luis, <hi rend="italic">sic videt
-						Filium,<lb/> ut tenens in sinu suo et</hi> Iubens. Sic non sapiunt, nisi
-					<lb/> qui carnaliter sapiunt. Sinum quippe tibi fingis, ut vi­ <lb/> deo,
-					aliquam capacitatem majoris Patris, qua Filium <lb/> minorem capiat atque
-					contineat : sicut hominem cor­ <lb/> poralitcr capit domus, aut sicut sinus
-					nutricis capit <lb/> infantem. Ergo inter mirabilia Christi et hoc deputa­ <lb/>
-					bitur, quia in forma servi crevit, et major est factus <lb/> quam in forma Dei
-					fuerat, ut cum prius portaretur in <lb/> sinu Patris, nunc sedeat ad dexteram
-					Patris. Abjice <lb/> ista puerilia vel anicularia phantasmata de corde tuo:
-					<lb/> et sinum Patris ideo dictum accipe, ut intelligatur iste <lb/> gcnilus,
-					ille genitor; non ut ille major, hic minor. <lb/> Nam si incapabilis est Pater,
-					Filius vero incapabilis <lb/> non est, non veraciter dictum est, <hi
-						rend="italic">Omnia quae habet <lb/> Pater, mea sunt (Joan.</hi> XVI, 15) :
-					quandoquidem re­ <lb/> sponderi ei potest, Ecce incapabilitatem habet Pater,
-					<lb/> quae non est tua. Sed quoniam veraciter dictum est <lb/> quod Veritas
-					dixit, et omnia quae habet Pater, Filii <lb/> sunt; non potest non esse Filii
-					quantacumque sit in­ <lb/> capabilitas Patris. EL hanc Domini sententiam, ubi
-					<lb/> ait, <hi rend="italic">Omnia quae habet Pater, mea sunt;</hi> tanquam re­
-					<lb/> ctissimam regulam ad vos, sive convincendos, sivc, <lb/> quod magis
-					cupimus, corrigendos, per multa adhibere <lb/> debemus : ut ubicumque aliquid
-					tribuitis Patri quod <lb/> Filio denegatis, ipsam fidclissimam testem contra er.
-					<lb/> rores vestros, vel contra mendacia producamus. Quid <lb/> opus cst autem
-					in eo tibi resistere, quod bunnam <lb/> sapicnliam contendis esse visibilcm; cum
-					ipsam <lb/> animam humanam, in qua est utique humana sa­ <lb/> pientia,
-					invisibilem esse concesseris ? Sed quod­ <lb/> libet sentias de universa
-					invisibili creatura, quantum <lb/> ad Dcum pertinet, de quo inter nos agitur,
-					satis tibi <lb/> demonstratum est non esse solum invisibilem Pa­ <lb/> trem.</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="10">
-					<p>CAPUT X. — i. Putas Dcum Patrem cum F'ilio ct <lb/> Spirilu sancto unum Deum esse
-					non possc : timcs <lb/> cnim ne Palcr solus non sit unus Dcus, sed pars
-						<unclear>umus</unclear>
-					<lb/> Dei qui constat ex tribus. Noli liincre, nulla fit pur­ <lb/> tium in
-					dcitatis unitate divisio. Unus est Dcus Pater <lb/> et Filius ct Spiritus
-					sanctus, hoc est ipsa Trinitas. <lb/> Unus cst Deus, de quo dictum est, quia <hi
-						rend="italic">Nullus Deus, <lb/> nisi unus</hi> (I <hi rend="italic"
-						>Cor.</hi> VIII, 4) : et qui dixit, <hi rend="italic">Audi, Israel; <lb/>
-						Dominus Deus tuus, Dominus unus cst.</hi> Cui uni et soli <lb/> Ico servire
-					nos sine ullo scrupulo agnoscimus, quan­ <lb/> do audimus ct Icgimus : <hi
-						rend="italic">Dominum Deum tuum adora.</hi>
-					<lb/> bis, <hi rend="italic">ct iili soli</hi> servies <hi rend="italic"
-						>(Deut.</hi> vi, 4, 13). Nc forte propter <lb/> haec verba, Christo cujus
-					membra sumus (I <hi rend="italic">Cor. vi,</hi>
-					<lb/> 13), vel Spiritui sancto cujus templum sumus <hi rend="italic">(Jd.</hi>
-					<lb/> III, 17), servire nolimus, si quod dictum C'Si, Domino <lb/>
-					<pb n="765"/> Dco tuo <hi rend="italic">soli servies,</hi> sic acceperimus,
-					tanquam de solo <lb/> Patre, et non de ipsa Trinilaie sil dictum. Vos autem,
-					<lb/> cum quaeri<unclear>tur</unclear> a vobis, quem credatis esse de quo <lb/>
-					scriptum cst, <hi rend="italic">Dominus Deus tuus, Dominus unus est;</hi>
-					<lb/> respondetis, Deus Pater est. Itemque cum quaeritur <lb/> de quo Domino Deo
-					dictum sil, <hi rend="italic">Dominum Deum tuum</hi>
-					<lb/> adorabis, <hi rend="italic">et illi soli servies;</hi> rursus respondetis,
-					De Dco <lb/> Patre. Tunc vobis dicitur : Si Domninus Deus noster <lb/> Dominus
-					unus cst, et hic Pater est; quare vos facitis <lb/> du<unclear>ns</unclear>
-					dominos dcos, dicendo etiam Christum esse Do­ <lb/> minum Deum ? Item si Pater
-					est, cui uni Domino Deo <lb/> ac soli serviendum cst; quomodo obtemperatis huic
-					<lb/> praecepto, qui tanquam Domino Deo servitis et Chri­ <lb/> sto? Neque enim
-					illi soli servi, qui servit et huic. <lb/> Secundum fidem autem rectam,
-					quicumque ipsam <lb/> Trinitatem unum Dominum Deum esse nostrum di­ <lb/>
-					dicimus, profecto cum ei soli ea quas Deo dcbelur <lb/> servitute servimus,
-					Domino Deo soli nos servire con­ <lb/> fidimus.</p>
-					<p>2. <hi rend="italic">Ergo</hi> , inquis, <hi rend="italic">Deus Puler pars est
-						Dei.</hi> Absit. <lb/> Tres enim personae sunt Pater et Filius et Spiri­
-					<lb/> tus sanctus : et hi tres quia unius substantiae sunt, <lb/> unum sunt, ct
-					summc unum sunt, ubi nulla natura­ <lb/> rum, nulla cst diversitas voluntatum.
-					Si autem na­ <lb/> tura unmn essent, et consensione non essent , non <lb/> summe
-					unum essent : si vero natura dispares essent, <lb/> unum non essent. Hi ergo
-					tres, qui unum sunt-pro­ <lb/> pter ineffabilem conjunctionem deitatis, qua
-					ineffa­ <lb/> biliter copulantur, unus Ocus cst. Porro autem Chri­ <lb/> stusuna
-					persona est gemiae substantiae, quia et Deus <lb/> et homo est. Nec tamen Deus
-					pars hujus personae <lb/> dici potest : alioquin Filius Dei Deus antequam sus­
-					<lb/> ciperet formam sel'vi, non erat totus, et crevit cum <lb/> homo divinitati
-					cjus accessit. Quod si in una persona <lb/> absurdissime dicitur, quia pars rci
-					ullius esse non <lb/> .potest Deus; quanto magis pars Trinitatis esse non <lb/>
-					potest, quicumque unus in tribus ? Dcinde ubi ait <lb/> Apostolus, <hi
-						rend="italic">Qui adhaeret Domino, unus spiritus est;</hi>
-					<lb/> (1 <hi rend="italic">Cor.</hi> vi, 11 ); numquid hujus unius pars est
-					Domi­ <lb/> nus ? Si cnim hoc dicimus , quid aliud dicere depre­ <lb/> hendimur,
-					nisi quod augeatur adhaerente hominc, et <lb/> recedente minuatur ? In Trinilalc
-					igitur qu:c Dcus <lb/> cst, et Pater Deus est, et Filius Deus cst, ct Spiritus
-					<lb/> sanctus Dens est, ct simul hi Ires unus Deus : nec <lb/> hujus Trinitatis
-					tertia pars cst unus, nuc major pars <lb/> duo qnam unus est ibi; nec majus
-					aliquid sunt onmes <lb/> quam singuli : quia spiritualls, non corporalis est
-					<lb/> magnitudo. Qui potest capere, capiat ( <hi rend="italic">Matth.</hi> xix ,
-					<lb/> 42 ) : qui autem non potest, credat, et oret ut quod <lb/> credit
-					intelligat. Verum cst enim quod dicitur per <lb/> prophetam, Nisi <hi
-						rend="italic">credidcritis , non intelligetis ( Isa;.</hi>
-					<lb/> VII, 9 ).</p>
-					<p>5. Tu nempe dixisti; <hi rend="italic">unum Deum</hi> non <hi rend="italic">ex
-						partibus <lb/> esse compositum.</hi> Et quia de Patre hoc vis intelligi, <lb/>
-					<hi rend="italic">Ille,</hi> innuis , <hi rend="italic">quod est, virtus est
-						ingenita,</hi> simplex. <lb/> £t tamen in hac simplici virtute quam multa
-					comme­ <lb/> moraveris, vide. Nam superiora verbi tua sunt : <lb/>
-					<hi rend="italic">Deus Deum genuit, Dominus Dominum genuit, Rex lle­</hi>
-					<unclear/><lb/>
-					<hi rend="italic">qem genuit,</hi> Creator <hi rend="italic">Creatorem genuit,
-						bonus bonum</hi>
-					<lb/> genuit, <hi rend="italic">sapiens sapientem genuit, clemens</hi>
-					clementem, <lb/>
-					<hi rend="italic">potens potentem.</hi> Cur ergo in virtute simplici, quod <lb/>
-					est Dcus, non timuisti tot commemorare virtutes ? <lb/> Ut enim omittam quatuor
-					quas loco superiore po­ <lb/> suisti, et alias quatuor dicam, quas
-						enunt<unclear>iare</unclear> usitatis <lb/> nominibus possimus; numquid
-					bonitas ct sapiculia ct <lb/> clementia et potentia partes sunt unius virtutis,
-					<lb/> quam simplicem e.sc dixisti ? Si dixeris, Partces sunt; <lb/> simplex crgo
-					virtus ex partibus constat, et simplex <lb/> ista virtus te definiente unus est
-					Deus. Unum ergo <lb/> Deum ex partibus compositum esse dicis ? Non dico , <lb/>
-					inquis. Non sunt ergo partes : et tamen quat<unclear>uor</unclear> sunt, <lb/>
-					et una virtus est, eademque simplex est. Si ergo in <lb/> una Patris persona ,
-					et plura invenis, et partes non <lb/> invenis; quanto magis Pater ct Filius ct
-					Spiritus <lb/> sanctus, et propter individuam deitatem unus Deus <lb/> est, et
-					propter uniuscujusque proprietatem tres per­ <lb/> sonae sunt, et propter
-					singulorum perfectionem partes <lb/> unius Dci nan sunt? Virtus cst Pater,
-					virtus Filius, <lb/> virtus Spiritus sanctus. Hoc verum dicis : sed quod <lb/>
-					virtutem de virtute gcnitam, et virtutem de virtute <lb/> procedentem non vis
-					eamdem habere naturam, hoc <lb/> falsum dicis, hoc contra fidem rectam et
-					catholicam <lb/> dicis.</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="11">
-					<p>CAPUT XI. — Redis ut quaeras a me, quomodo <lb/> sit invisibilis Filius, unde jam
-					dixi superius, quod <lb/> visum est dicendum. Sed si <hi rend="italic">ob
-						hoc,</hi> inquis, <hi rend="italic">Filius</hi> in­ <lb/>
-					<hi rend="italic">visibilis a te pronuntiatur, eo quod oculis humanis con­ <lb/>
-						templari</hi> non <hi rend="italic">possit ; cur non et</hi> coelestes <hi
-						rend="italic">virtutes pariter <lb/> invisibiles</hi> pronuntias, <hi
-						rend="italic">quando nec ipsae obtutibus huma­ <lb/> nis videri</hi> possunt
-					? Ita hoc dicis, quasi possit ab ho­ <lb/> mine comprehendi quis ille sit modus,
-					quo cœlestes <lb/> virtutes sunt invisibiles; aut ad hoC quaerendum esse <lb/>
-					debeamus intenti, dicente Scriptura, <hi rend="italic">Altiora te</hi> ne <lb/>
-					<hi rend="italic">quaesieris (Eccli.</hi> III, 22). Quod praeceptum ipse con­
-					<lb/> temnens, ausus es dicere angelum vidcri ab archan­ <lb/> gclo, archangelum
-					ab angelo non vidcri. Satis sit, <lb/> quod ostendi non esse consequens ut ideo
-					credamus <lb/> in forma Dei visibilem Filium, qnia scriptum est, <lb/>
-					<hi rend="italic">Invisibili soli Deo</hi> ( I <hi rend="italic">Tim.</hi> 1, 17
-					). Quod in de Patre <lb/> sic te accipere demonstrabas tanquam Filius invisibi­
-					<lb/> lis non sit, cum cum ct invisibilium creatorem Scri­ <lb/> p'ura testetur.
-					Verumtamen restat utdicas, Ambo qui. <lb/> dem invisibilcs sunt, id cst, ct
-					Pater et Filius , set! <lb/> Patcr invisibilior est : ac sic dando aliquid Patri
-					<lb/> quod non sit Filii, mendacem facias cumdem Filium <lb/> dicentem, <hi
-						rend="italic">Omnia quae habet Pater, mea suni (Joan.</hi>
-					<lb/> XVI, 15).</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="12">
-					<p>CAPUT XII. — i. HInc et de potentia sapis, quod <lb/> scilicet sit quidem potens
-					ct Filius, sed potentior Pa­ <lb/> ter Filio : ulauctoribus et doctoribus vobis
-					potuerit <lb/> potentem potens, nee potuerit omnipotcntem gignere <lb/>
-					omnipotens. Ac per hoc si habct Pater omnipoten<lb/>liam quam non habet
-					Filius, falsum est quod ait <lb/> Filius, <hi rend="italic">Omnia quae habet
-						Pater, mea sunt.</hi> Deinde si <lb/> aliquid facit Pater, quod facere non
-					potest Filius, <lb/> mcrito dicitur potentior Pater quam Filius : cum vero <lb/>
-					dical, <hi rend="italic">Quaecumque Pater facit, haec et Filius similiter <lb/>
-						facit</hi> ( <hi rend="italic">Joan.</hi> v, 19 ); nonne meiius
-						<unclear>audit</unclear>
-					<lb/>
-					<pb n="767"/> vos, nactusque ipsi creditur docenti quam dccipien­ <lb/> tibus
-					vobis ? <hi rend="italic">Sed potentiam</hi> Pater , inquis, <hi rend="italic">a
-						nemine, <lb/> Filius vero accepit a Patre.</hi> Fatemur et nos Filium ab
-					<lb/> illo accepisse potentiam, de quo natus est putens : <lb/> Patri vero
-					potentiam nullus dedit, quia nullus eum <lb/> genuit. Gignendo enin dedit
-					potentiam Pater Filio, <lb/> sicut omnia quae habet in substantia sua , gignendo
-					<lb/> dedit ei quem genuit de substantia sua. Sed quaeritur <lb/> utrum tantam,
-					quanta ipsi est, potentiam Pater Filio <lb/> dederit, an minorem. Si tantam, non
-					solum potentem <lb/> poiens, verum etiam omnipotentem genuisse dicatur, <lb/>
-					credatur, intelligatur omnipotens : si minorem, <lb/> quomodo omnii qune habet
-					Pater, Filii sunt ? Si Pa­ <lb/> iris omnipotentia Filii non est, quomodo
-					quaecumque <lb/>
-					<hi rend="italic">Pater facit, h</hi>ae<hi rend="italic">c et Filius</hi>
-					similiter <hi rend="italic">facit</hi> ? quod ulique <lb/> non potest, si
-					omnipotens non est.</p>
-					<p>2. Ac per hoc quod ait Apostolus , <hi rend="italic">Beatus et solus</hi>
-					<lb/> potens : non cogor de Patre tantummodo accipere; <lb/> sed de Deo, quod
-					est ipsa Trinitas. Loquens enim <lb/> ad Timotheum : Praecipio, inquit, tibi <hi
-						rend="italic">coram Deo, <lb/> qui vivificat omnia, et Christo Jesu qui</hi>
-					testimonium <lb/>
-					<hi rend="italic">reddidit sub Pontio Pilato bonam confessionem, ut ser­ <lb/>
-						ves mandatum sine macula, irreprehensibile, usque ad<lb/> adventum Domini
-						nostri Jesu Christi; quem temporibus <lb/> propriis ostendet beatus et solus
-						potens, Rex regum et <lb/> Dominus dominantium;</hi> qui <hi rend="italic"
-						>solus habet immortalitatem, <lb/> et lucem inhabitat inaccessibilem; quem
-						nemo</hi> hominum <lb/>
-					<hi rend="italic">vidit, nec videre potest; eui est honor et gloria</hi> in
-					saecu­ <lb/> la <hi rend="italic">saeculorum. Amen</hi> (I <hi rend="italic"
-						>Tim.</hi> VI, 13-16). Nihil hic vi­ <lb/> deo dictum quod non conveniat
-					Trinitati. Sed ut nunc <lb/> taceam de Spiritu sancto, quem nec saltem minorem
-					<lb/> Filio Deum vultis, quia omnino Deum esse non vultis, <lb/> sufficit ut vos
-					de Patre convincamus et Filio. Numquid <lb/> enim quia dixit Apostolus, <hi
-						rend="italic">Testificor tibi coram Deo <lb/> qui vivificat omnia;</hi>
-					Pater solus, non et Filius vivifi­ <lb/> cat omnia ? Si dixeris Patrem solum
-					vivificare omnia, <lb/> quomodo ergo <hi rend="italic">quaecumque Pater facit,
-						h</hi>ae<hi rend="italic">c et Filius</hi>
-					<lb/> similiter <hi rend="italic">facit ?</hi> Quandoquidem Pater, ut putas,
-					vivifi­ <lb/> cat omnia, qnod Filius non facit. Deinde ubi ait, <lb/>
-					<hi rend="italic">SicuL Pater suscitat mortuos et vivificat, sic et Filius <lb/>
-						quos vult vivificat (Joan.</hi> v, 21); quomodo verum eSI, <lb/> si Pater
-					sine Filio vivificat omnia? Proinde quod <lb/> addidit, <hi rend="italic">Et
-						Christo Jesu qui testimonium reddidit sub</hi>
-					<lb/> Pollio <hi rend="italic">Pilato bonam confessionem;</hi> de Filio proprie
-					<lb/> diccre voluit: quia Filius quidem sicut Pater vivificat <lb/> omnia ; sed
-					sub Pontio Pilato in forma servi Filium <lb/> novimus passum fuisse, non Patrem.
-					Deinde subjun­ <lb/> gitur, <hi rend="italic">Ut serves mandatum sine macula,
-						irreprehensi­ <lb/> bile, usque ad adventum Domini nostri Jesu Christi;<lb/>
-						quem temporibus propriis ostendet beatus et solus po­ <lb/> tens :
-						quem,</hi> scilicet adventum Domini Christi ; osten­ <lb/>
-					<hi rend="italic">det</hi> utique Dcus, quod non solus est l'ater, quia <lb/>
-					secundum veritatem, non secundum vestrum errorem, <lb/> Trinitas unus est Deus
-						<hi rend="italic">: beatus et solus</hi> potens, <hi rend="italic">Rex<lb/>
-						regum et Dominus dominantium.</hi> Numquid enim vel vos <lb/> dicere audetis
-					Filium non esse Regem regum et Do­ <lb/> minum dominantium ? De quo inter
-					caetera scriptum est <lb/> in Apocalypsi Joannis: <hi rend="italic">Et ipse
-						calcat torcular vini po­ <lb/> tentis, et in tunica et in femore habet nomen
-						scriptum, <lb/> Rex regum et Dominus dominantium (Apoc.</hi> XII, 15, <lb/>
-					16). Sed ne forte dicatis quod nomen Patris Filius <lb/> habet scriptum in veste
-					et in femore ; alio loco ejus­ <lb/> dem libri superius legitur : <hi
-						rend="italic">Et Agnus vincet eos, <lb/> quoniam Dominus dominantium est et
-						Rex regum (Id.</hi>
-					<lb/> XVII, 14). Quapropter secundum vos, duo suut regcs <lb/> regum et domini
-					dominantium : et contra vos est, si <lb/> de Patre tantum ait Apostolus, <hi
-						rend="italic">Beatus et</hi> solus <hi rend="italic">votens,<lb/> Rex regum
-						et Dominus dominantium.</hi> V crum autem <lb/> secundum rectam fidem ipsa
-					Trinitas unus est Deus, <lb/>
-					<hi rend="italic">beatus et</hi> sotus <hi rend="italic">potens, Rex regum et
-						Dominus domi­<lb/> nantium, qui solus habet immortalitatem, et lucem ha­
-						<lb/> bitat inaccessibilem.</hi> Et quomodo erit verum, <hi rend="italic"
-						>Accedite<lb/> ad eum, et</hi> illuminamini <hi rend="italic">(Psal.</hi>
-					XXIIII, 6) ; nisi quia hoc <lb/> nemo potest, si de se quisque praesumpserit,
-					sed si <lb/> ipse donaverit? Immortalitatem autem Deus habere <lb/> dicitur
-					solus, quia est immutabilis solus. In omni enim <lb/> mutabili natura nonnulla
-					mors est ipsa mutatio, quia <lb/> facit aliquid in ea non esse quod erat.
-					Proinde et <lb/> ipsa anima humana, quae propterea dicitur immorta­ <lb/> lis,
-					quoniam qualilercurnque secundum modum suum <lb/> nunquam desinit vivere, habet
-					tamen pro ipto suo <lb/> modo quamdam mortem suam : quia si juste vivebat <lb/>
-					et peccat, moritur justitiae; si peccatrix erat et justi­ <lb/> ficatur, moritur
-					peccato : ut alias ejus mutationes <lb/> taceam, de quibus longum est disputare.
-					Et creatu­ <lb/> rarum natura coelestium mori potuit, quia peccare <lb/> potuit:
-					nam et Angeli peccaverunt, et daemones facti <lb/> sunt, quorum est diabolus
-					princeps. Et qui non pec­ <lb/> caverunt, peccare potuerunt. Et cuicumque
-					creaturae <lb/> rationali praestatur ut peccare non possit, non est hoc <lb/>
-					naturae propriae, sed Dei grali;c. Ac per boc solus Deus <lb/> habct
-					immortalitatem, qui non cujusquam gratia, sed <lb/> natura sua, nec potuit, nee
-					potest aliqua conversione <lb/> mutari, nec potuit nec poterit aliqua mutatione
-					pec­ <lb/> care. Quem secundum naturam qua Deus est, <hi rend="italic">nemo<lb/>
-						hominum vidit, nec videre potest:</hi> sed poterit aliquan­ <lb/> do, si ad
-					illum numerum hominum pertinet, de quibus <lb/> dictum est, <hi rend="italic"
-						>Beati mundo corde, quoniam</hi> ipsi Deum <lb/>
-					<hi rend="italic">videbunt (Matth.</hi> v, 8). Cui Deo, id est Patri et Filio
-					<lb/> et Spiritui sancio, qua; Trinitas unus est Deus, honor <lb/> et gloria in
-					s;rcula saeculorum; Amen.</p>
-					<p>3. Absit autem ut, quomodo putas, ideo sit Pater <lb/> potentior Filio, quia
-					creatorem genuit Pater, Filius <lb/> autem non genuit creatorem. Neque enim non
-					po­ <lb/> luit <hi rend="italic">(a),</hi> sed non oportuit. Immoderata enim
-					esset <lb/> divina generatio , si genitus Filius nepotem gigneret <lb/> Patri :
-					quia et ipse nepos, nisi avo suo pronepotem <lb/> gigneret, secundum vestram
-					mirabilem sapientiam <lb/> impotens diceretur. Similiter etiam ille si nepotem
-					<lb/> non gigneret avo suo, et pronepotem proavo suo,.. <lb/> non a vobis
-					appellaretur omnipotens : nec impleretur <lb/> gencrationis series, si semper
-					alter cx altero nasce<note type="footnote"><hi rend="italic">(n)</hi> Plerique
-						ac melioris notse Mss., <hi rend="italic">ycqne</hi> enim <hi rend="italic"
-							>potnt.</hi>
-						<lb/> Altameo Magister Sent. in i, dist. 7, citat, seque <hi rend="italic"
-							>(',nm lion<lb/> putuit:</hi> id est, non ex impotentia tilii, sed ex
-						rui namra <lb/> venit ut Filius noti generet. Neque c&gt;gimur intelligere,
-						<lb/> Filium potuisse alium geaerare filium, quod AugusUnuiu <lb/>
-						existimassi! creilit Petavius in lib. 7 Theolog. dog:u. de <lb/> IriniUle,
-						cap. 13, It. G. </note>
-					<lb/>
-					<pb n="769"/> retur; nec eam perficeret ullus, si non sufficeret unus. <lb/>
-					Omnipotens itaque omnipotentem genuit Filium ; <lb/> quoniam <hi rend="italic"
-						>quaecumque Pater facit, h</hi>aec <hi rend="italic">et Filius simili­<lb/>
-						ter facil.</hi> Filiurn quippe ipsum genuit utique Pall'is <lb/> natura, non
-					fecit.</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="13">
-					<p>CAPUT XIII. — i. In illo etiam testimonio, ubi <lb/> ait Apostulus, <hi
-						rend="italic">Soli sapienti Deo;</hi> non dissimilis error <lb/> est vester
-					: sed quod vobis respondimus de potentia, <lb/> hoc etiam de sapientia
-					respondemus. Si cnim dixis­ <lb/> set Apostolus, Soli sapienti Patri; nec sic
-					inde Filium <lb/> sepnrarct. Num enim quia in Apocalypsi de Filio <lb/> legitur,
-						<hi rend="italic">Habens nomen scriptum, quod nemo scit</hi> nisi <lb/>
-					<hi rend="italic">ipse ( Apoc.</hi> xix, 12); ideo Pater nescit hoc nomen, <lb/>
-					a quo est inseparabilis Filius ? Sicut ergo scit et <lb/> Pater quod Demo scire
-					dictus est nisi Filius, quia <lb/> inseparabiles sunt: sic etiam si dictum
-					esset, Soli <lb/> sapienti Patri ; simul intelligi deberet ct Filius, quia <lb/>
-					inseparabiles sunt. Cum vero non sit dictum, Soli <lb/> sapienti Patri; sed <hi
-						rend="italic">Soli sapienti Deo;</hi> et Deus unus <lb/> sit ipsa Trinitas :
-					multo cst facilior nobis bujus solu­ <lb/> tio quaestionis; ut sic intelligamus
-					solum-Deum sa­ <lb/> picntem, sicut intelleximus solum potentem, id est, <lb/>
-					Patrem et Filium et Spiritum sanctum , qui est unus <lb/> ct solus Deus, cui
-					soli servire jussi sumus : ne male <lb/> intelligentes, vel potius non
-					intelligentes, contra boc <lb/> praeceptum facere videamur, quia et Domino
-					Christo <lb/> ea quae Deo debetur servitute servimus. Non enim <lb/> dictum est,
-					Dominum Deum tuum Patrem adorabis, <lb/> ctilii plus servies; ut servire
-					permitteremur et Filio, <lb/> plus tamen Patri tanquam majori, minus autem Filio
-					<lb/> tanquam minori Deo : sed dictum est, <hi rend="italic">Dominum <lb/>
-						Deum</hi> tuum <hi rend="italic">adorabis, et illi soli servies (Deut.</hi>
-					vi, 43); <lb/> soli scilicet omnipotenti, soli sapienti Deo; ut vos <lb/>
-					repelleremini, qui nolentes accipere unum solum <lb/> Deum Patrem et Filium et
-					Spiritum sanctum, et <lb/> dicentes unum Dominum Deum, cui soli serviendum <lb/>
-					est, non esse nisi Deum Patrem, ct tamen etiam <lb/> Filium Deum et Dominum
-					confitentes; apertissime <lb/> duos deos et dominos, majorem unum, minorem <lb/>
-					alterum dicitis : et reos vos, secundum errorem ve­ <lb/> strum, praecepti hujus
-					violati esse monstratis, quia <lb/> non solum majori, verum etiam minori, ea
-					quae Do­ <lb/> mino Deo debetur servitute servitis.</p>
-					<p>i. Ubi autem dixit Apostolus, <hi rend="italic">Soli sapienti Deo;</hi>
-					<lb/> cum scriberet ad Romanos, in fine Epistolae sic Io­ <lb/> quitur: <hi
-						rend="italic">Ei autem</hi> qui <hi rend="italic">potens est,</hi> inquit,
-					vos <hi rend="italic">confirmare<lb/> secundum Evangelium</hi> meum, <hi
-						rend="italic">et prceconium Jesu Chri­</hi>
-					<lb/> sti ; <hi rend="italic">secundum revelationem mysterii temporibus</hi>
-						aeterni<hi rend="italic">s<lb/> taciti, manifestati autem nunc per
-						Scripturam Propne­ <lb/> tarum; secundum pr</hi>ae<hi rend="italic"
-						>ceptum</hi> ae<hi rend="italic">terni Dei, in obedien­ <lb/> tinm fidei in
-						omnes gentes cogniti; soli sapienti Deo <lb/> per Jesum Christum, cui gloria
-						in</hi> saecula <hi rend="italic">saculorum<lb/> (Rom.</hi> xvi, 25 27). Hoc
-					est, <hi rend="italic">Ei qui potens est vos<lb/> confirmare, soli sapienti Deo
-						gloria</hi> in <hi rend="italic">saecula s</hi>ae<hi rend="italic"
-						>culo­</hi>
-					<lb/> rum. Quod autem interp ositum est, <hi rend="italic">per Jesum Chri­ <lb/>
-						stum ;</hi> utrum soli Sapienti Deo per Jcsuin Christum <lb/> accipidebcat,
-					ut scilicet solus Deus sapicns pcr Je­ <lb/> sam Christum sapiens esse
-					intelligatur, non partici <lb/> pando, sed gignendo sapientiam, quod cst
-					Christus <lb/> Jesus; an vero non per Jcsum Christum sapienti, <lb/> sed per
-					Jesnm Christum gloria Deo soli sapienti, <lb/> videtur ambiguum. Sed quis audeat
-					dicere per Jesum <lb/> Christum fieri ut sit sapiens Deus Pater; cum secun­
-					<lb/> dum substantiam suam non dubitandum sit eum esse <lb/> sapientem,
-					potiusque sit substantia Filii pcr gignen­ <lb/> tem Patrem, quam substantia
-					Patris per genitum <lb/> Filium ? Restat ergo ut soli sapienti Deo gloria sit
-					<lb/> per Jesum Cbristum, hoc est, clara cum laude noti­ <lb/> tia, qua innotuit
-					gentibus Deus Trinitas : ideo per <lb/> Jesum Christum, quia, ut alia taceam,
-					ipse praecepit <lb/> baptizari gentes in nomine Patris ct Filii et Spiritus
-					<lb/> sancti <hi rend="italic">(Malth.</hi> XXVIII, 19); ubi praecipue
-					commendata <lb/> est hujus individuae gloria Trinitatis. Deus itaque, <lb/> quod
-					est ipsa Trinitas, propterea solus sapiens recto <lb/> dicitur, quia solus
-					secundum substantiam suam sa­ <lb/> piens est: non secundum accidentem vel
-					accedentem <lb/> participationem sapientiae, sicut sapiens est rationalis <lb/>
-					quaecumque creatura. Quod vero additum est, <hi rend="italic">cui,</hi> ut <lb/>
-					diceretur, <hi rend="italic">cui gloria ;</hi> cum sufficeret si dictum esset,
-					<lb/> Ei autem gloria : inusitatam nostrae linguae indicat <lb/> locutionem; non
-					sensum quem requiramus, vel de <lb/> quo ambigamus, insinuat. Quid enim sensui
-					deperit, <lb/> si dicatur, Ei gloria , cui per Cbrislum gloria ? Hoc <lb/> est
-					namque, <hi rend="italic">per Jesum Christum cui gloria;</hi> quod est, <lb/>
-					cui per Jesum Christum gloria. Sed horum alter in­ <lb/> usitatus, alter
-					usitatus est ordo verborum.</p></div>
-				<div type="textpart" subtype="chapter" n="14">
-					<p>CAPUT XIV. — 1. Quaeris a me, Si <hi rend="italic">de</hi> substantia <lb/>
-					<hi rend="italic">Patris eat Filius, de substantia Patris eat etiam Spiritus
-						<lb/> sanctus; cur unus Filius sit, et alius non sit filius.</hi>
-					<lb/> Ecce respondeo, sive capias, sive non capias. De <lb/> Patre est Filius,
-					de Patrc est Spiritus sanctus : sed <lb/> ille genitus, iste procedens : ideo
-					ille Filius cst Pa­ <lb/> tris, de quo cst genitus ; iste autem Spiritus utrius­
-					<lb/> que, quoniam de utroque procedit. Sed ideo cum de <lb/> illo Filius
-					loqueretur, ait, <hi rend="italic">De Patre procedit (Joan.</hi>
-					<lb/> xv, 26); quoniam Pater processionis cjus esi auctor, <lb/> qui talem
-					Filium genuit, et gignendo ei dedit ut <lb/> etiam de ipso procederet Spiritus
-					sanctus. Nam nisi <lb/> procederet et de ipso, non diceret discipulis, <hi
-						rend="italic">Accipite<lb/> Spiritum sanctum;</hi> eumque insufflando daret
-						<hi rend="italic">(Id.</hi>
-					<lb/> xx, 22), ut a se quoque procedere significans, aperte <lb/> ostenderet
-					flando, quod spirando dabat occulle. Quia <lb/> ergo si nasceretur, non tantum
-					de Patre, nec tantum <lb/> de Filio, sed de ambobus utique nasceretur; sine
-					<lb/> dubio filius diceretur amborum. Ac per hoc quia <lb/> filius amborum nullo
-					modo est, non oportuit nasci <lb/> cum de ambobus. Amborum ea ergo Spiritus,
-					pro­ <lb/> cedendo de ambobus. Quid aulem inter nasci et pro­ <lb/> ceaere
-					intersit, de illa excellentissima natura loquens <lb/> explicare quis potest ?
-					Non omne quod proccdit na­ <lb/> scitur, quamvis omne procedat quod nascitur ;
-					sicut <lb/> non omne quod bipes cst homo est, quamvis bipes <lb/> sit omnis qui
-					homo est. Haec scio : distinguere autem <lb/> inter illam generationem et hanc
-					processinem ne­ <lb/> scio, nun valeo, non sufficio. Ac per hoc quia et illa
-					<lb/> et ista est ineffabilis, sicut propheta de Filio loquens <lb/> ait, <hi
-						rend="italic">Generationem ejus quis enarrabit (Isai.</hi> LUI, 8)? ita
-					<lb/> de Spiritu sancto verissimc dicitur, Processionem <lb/>
-					<pb n="771"/> ejus quis cnarrahil? Satis sit ergo nobis, quia non <lb/> est a
-					scipso Filius, sed ab illo de quo natus est: non <lb/> cst a seipso Spiri!us
-					sanctus, sed ab illo de quo pro­ <lb/> cedit. Et quia de utroque procedit, sicut
-					jam osten. <lb/> dimus : unde et Spiritus Patris dictus est, ubi legi- .tur,
-					<lb/> lur, Si <hi rend="italic">autem Spiritus ejus qui</hi> suscitavit <hi
-						rend="italic">Christum a</hi>
-					<lb/> mortuis, <hi rend="italic">habitat in vobis;</hi> ct Spiritus Filii, ubi
-					legitur, <lb/> Qui <hi rend="italic">autem Spiritum Christi</hi> MOM <hi
-						rend="italic">habet, hic</hi> non <hi rend="italic">est ejus<lb/> (Rom.</hi>
-					VIII, ii, 9). Non enim duo sunt Spirilus sancii, <lb/> tanquam singuli
-					singulorum, unns Patris, aller Filii; <lb/> ped unus potius Patris et Filii : de
-					quo uno Spirilu <lb/> scriptum est, Etenim in <hi rend="italic">Spiritu</hi> uno
-					nos <hi rend="italic">omnes</hi> in <lb/> unum <hi rend="italic">corpus
-						laptizati</hi> sumus, sivc Judaei, <hi rend="italic">sive Graeci, <lb/>
-						sive</hi> servi, <hi rend="italic">sive tiberi; et omnes</hi> unum <hi
-						rend="italic">Spiritum</hi> potavi­ <lb/> mus (I <hi rend="italic">Cor.</hi>
-					XII, 13). Et alio ioco : <hi rend="italic">Unum corpus et</hi>
-					<lb/> unus <hi rend="italic">Spiritus (Ephes.</hi> IV, 4).</p>
-					<p>2. Quid ergo haec Trinitas, nisi unius ejosdemque <lb/> substantiae est?
-					Quandoquidem non de aliqua materia <lb/> vel de nihilo est Filius, sed de quo
-					cst genitus : item­ <lb/> que Spiritus sanctus non de aliqua maleria, vcl de
-					<lb/> nihilo, sed indc est unde proccdiL. Vos autem nec <lb/> Filium de Patris
-					substantia genitum vultis, et tamen <lb/> eum nee ex nihilo, nec ex aliqua
-					materia, sed ex <lb/> Patre esse conceditis. Nee videtis quam necesse sit, <lb/>
-					ut qui non csl ex nihilo, non est cx aliqua re alia, <lb/> scd ex Deo, nisi cx
-					Dei substantia csse non possit, <lb/> et hoc esse quod Deus est de quo cst, hoc
-					est, Dcus <lb/> de Dco. Quocirca Deus de Dco natus, quia non aliud <lb/> prius
-					fuit, sed natura coaeterna de Dco est, non est <lb/> aliud quam est ille de quo
-					est, hoc est, unius cjus­ <lb/> demquc naturae, vel unius ejusdemque
-					substantiae. <lb/> Quod cum auditis, qualc cor habcalis ignoro, qui <lb/>
-					putatis nos sic Filium dicere natum esse de Patre, <lb/> quomodo nascuntur de
-					corporibus corpora : et quo­ <lb/> niam corruptibilitcr is'a nascuntur,
-					accusatis nos <lb/> tanquam generationi Unigeniti, quae dc Patre est, <lb/>
-					corporalem passionem corruptionemque tribuamus. <lb/> Carnalibus quippe
-					cogitationibus pleni substantiam <lb/> Ovi de se ipsa gignere possc Filium non
-					putatis, nisi <lb/> hoc patiatur quod substaulia quando gignit patitur <lb/>
-					carnis. Erratis, non scientes Scripturas, neque vir­ <lb/> lutem Dci <hi
-						rend="italic">(Matth.</hi> XIII, 29). Quando legitis, <hi rend="italic">VI
-						simus<lb/> in vero Filio ejus Jesu Christo</hi> (I <hi rend="italic"
-						>Joan.</hi> v, 20); verum <lb/> Oei Filium cogitate. Hunc autem Filium nullo
-					modo <lb/> verum Dci Filium cogitatis, si eum natum esse de <lb/> substantia
-					Patris negatis. Num onim jam erat homi­ <lb/> nis filius, et Deo donante factus
-					est Dei filius; ex <lb/> Deo quidcm natus, sed grat a, non natura ? An forte
-					<lb/> eui non hominis lilius, tamen aliqua jam crat qualis­ <lb/> cumque
-					creatura, et in Dci filium, Deo mutante, , <lb/> conversa est? Si nihil horum.
-					ergo aut de nihilo aut <lb/> de aliqua substantia natus rst. Sed ne crederemus
-					<lb/> de nihilo esse Dei Filium vos putare, jam nus ab ista <lb/> sollicitudine
-					liberasti : affirmasti enim non vos dicere, <lb/> de nihilo esse Dei Filiuin. Dc
-					aliqua ergo substantia <lb/> est. Si non de Patris; de qua? Dicite. Sed non in­
-					<lb/> venitis. Jam igitur unigenitum Dei Filium Jesum Chri­ <lb/> stum Dominum
-					nostrum de Patris esse substantia non <lb/> vos nobiscum pigeat conteri.</p>
-					<p>5. Pater crgo et Filius unius sunt ejusdemquc sub­ <lb/> stantiae. noc est illud
-					Homousion, quod in concilio <lb/> Nicaeno adversus haereticos Arianos a
-					catholicis Pa­ <lb/> tribus veritatis anctoritate et auctoritatis veritate fir­
-					<lb/> matum est : quod postea in concilio Ariminensi, <lb/> propter novitatem
-					verhi minus quam oportuit intel­ <lb/> lectum, quod tamen I fides antiqua
-					pepererat, multis <lb/> paucorum fraude deceptis , haeretica impietas sub <lb/>
-					haeretico imperatore Constantio labefactare tentavit. <lb/> Sed post non longum
-					tempus libertate fidei catholicae <lb/> praevalente, posicaquam vis verbi, sicut
-					debuit, in­ <lb/> tellecta est, Heroousion illud catholicae fidei sanitate <lb/>
-					longe lateque defensum est. Quid est enim Homou­ <lb/> sion, nisi unius
-					ejusdemque substantiae? Quid est, <lb/> inquam , Homousion, nisi, <hi
-						rend="italic">Ego et Pater</hi> unum <hi rend="italic">su­</hi>
-					<lb/> mus ( <hi rend="italic">Joan. x,</hi> 50 ) i Sed nunc nec ego Nicaenum,
-					nee <lb/> tu dehes Ariminense tanquam praejudicaturus pro­ <lb/> ferre
-					concilium. Nec ego hujus auctoritate, nec tu <lb/> illius detineris :
-					Scripturarum auctoritatibus, non <lb/> quorumque propriis, sed utrisque
-					communibus testi­ <lb/> bus, res cum re, causa cum causa, ratio cum rationo
-					<lb/> concerlet. Utrique legimus, <hi rend="italic">Ut simus in vero Filio<lb/>
-						ejus Jesu Christo; ipse est verus Deus et vita</hi> ae<hi rend="italic"
-						>terna.</hi>
-					<lb/> Utriquc tanti ponderis molibus cedamus. Dic ergo <lb/> nobis, utrum iste
-					verus Dei Filius, ab eis qui gratia <lb/> lilii sunt hujus nominis quadam
-					proprietate discretus, <lb/> de nulla substantia sit, an de aliqua. <hi
-						rend="italic">Non dico,</hi> inquis, <lb/>
-					<hi rend="italic">de nulla, ne de nihilo dicam.</hi> Ergo de aliqua est : <lb/>
-					quTro, de qua ? Si non de Patris, aliam quere. Si <lb/> aliam non invenis , quia
-					omnino non invenis; Patris <lb/> agnoscc, et Filium cum Patre Homousion
-					confitere. <lb/> Caro de carne nascitur, filius carnis de substantia <lb/>
-					carnis nascitur. Corruptionem de medio tollite, pas­ <lb/> siones carnales a
-					lumine mentis abjicitc, et invisibilia <lb/> Dei, per ca quae facta sunt ,
-					intellecta conspicite <lb/>
-					<hi rend="italic">(Rom.</hi> I. 20). Credite Creatorem, qui dedit carui car­
-					<lb/> nrm gignere, qui dedit parentibus vcros carnis filios <lb/> de carnis
-					substantia generare, ac sic filios cum parcn­ <lb/> tibus unius esse substantiae
-					, multo magis potuisse <lb/> verum gignere Filium de sua substantia, et unam cum
-					<lb/> vero Filio habere substantiam, manente incorruptione <lb/> spirituali, ct
-					longissime hinc alicna corruptione car­ <lb/> nali.</p>
-					<p>4. Nam de anima quid dixeris, nescio. Verba enim <lb/> tua sunt, ubi dicis : <hi
-						rend="italic">Nee enim ad</hi> animae <hi rend="italic">ingenuitatem <lb/>
-						comparatis tantam illam magnificentiam, sed ad fragili­ <lb/> tatem
-						corporis. De corpore utique,</hi> inquis, <hi rend="italic">nascitur
-						caro,<lb/> corporalis filius : non tamen de anima anima nascitur.</hi>
-					<lb/> Post istam quasi definitionem tuam, rursus affirmas <lb/> animam filios
-					generare. Adjungis cuiun, et dicis : Si <lb/>
-					<hi rend="italic">ergo nostra anima incorruptibiliter</hi> generat <hi
-						rend="italic">et</hi> impassi­ <lb/>
-					<hi rend="italic">biliter,</hi> nullam sentiens <hi rend="italic">diminutionem,
-						non inquinatio­</hi>
-					<lb/> nem <hi rend="italic">aliquam; scd legitime secundum</hi> jura <hi
-						rend="italic">divina ge­ <lb/> ncrat</hi> filium , <hi rend="italic"
-						>sapientia</hi> consensum I <hi rend="italic">accommodans <lb/> corpori,
-						ipsa integra</hi> manet : <hi rend="italic">quanta magis omnipotens</hi>
-					<note type="footnote"> I Mss., <hi rend="italic">mimis quam potuit intellectam,
-							qucm tamen,</hi> etc. </note><note type="footnote"> I Editio Erasmi, hic
-						et supra in collatione cum vaximino, <lb/>
-						<hi rend="italic">generatum Iiliunl, savientium</hi> COn.ensu, <hi
-							rend="italic">acconunodans</hi> cor<lb/>1&gt;o i. Minus recte. tov.
-						constanter, <hi rend="italic">ct</hi> capktuU.-6ed paiti­ <lb/> cuh, <hi
-							rend="italic">et,</hi> aL est a Mss. </note>
-					<lb/>
-					<pb n="773"/> Deus ? Et paulo post dicis : <hi rend="italic">Quanto magis Deus
-						Puter <lb/> meorruptibilis incorruptibiliter</hi> genuit <hi rend="italic"
-						>Filium</hi> ? Jam <lb/> supra dixi, nescire me quid volueris de anima
-					intel­ <lb/> ligi, de qua prius dixisti quod non nascatur anima de <lb/> anima,
-					et postea, quod anima incorruptibiliter gignat <lb/> filium. Si animam gignit,
-					quomodo non nascitur anima <lb/> de anima? Si carnem, tu videris quomodo sit
-					caro <lb/> verus animae filius. Christus enim, propter quem pu­ <lb/> lasti hanc
-					adhibendam similitudincm , verus est Dei <lb/> Filius. Si autem
-					incorruptibiliter gignere animam <lb/> filium sic accipi voluisti, quomodo ait
-					Apostolus , <hi rend="italic">In <lb/> Christo enim Jesu per Evángelium ego vos
-						genui</hi> (1 <hi rend="italic">Cor.</hi>
-					<lb/> iv, 15); cur non attendis, quod jam erant ilłae animae <lb/> in vctere
-					vita, quas per Evangelium renovando Apo­ <lb/> stolus genuit ? Verbum autem Dei
-					Deus unigenitus <lb/> Filius, sicut jam disputavimus, non prius aliquid <lb/>
-					fuit, et renovatione est generatus a Patre, sed cum <lb/> Patre semper fuit;
-					sicut est semper atque erit mira­ <lb/> bili atque ineffabili modo genitus ab
-					aeterno coaeter­ <lb/> nus. Sed si ob hoc introduxisti hanc dissimilem simi­
-					<lb/> litudinem, ut assereres Deum Patrem incorruptibi­ <lb/> liter genuisse :
-					noli laborare; confiteor omnino, in­ <lb/> corruptibiliter genuisse Deum Patrem
-					, sed quod est <lb/> ipse genuisse. Iterum enim dico hic, quod vobis saepe <lb/>
-					dicendum est: Aut de aliqua substantia natus est Dei <lb/> Filius, aut de nulla.
-					Si. de nulla, ergo de nihilo ; <lb/> quod vos non dicere jam tencmus. Si de
-					aliqua, nec <lb/> tamen de Patris, non vcrus est Filius. Si de Patris , <lb/>
-					unius ejusdemque substantiae sunt Pater et Filius. <lb/> Quomodo autcm nihil
-					Filio subtraxit, ut dicis, si <lb/> ejusdem substantiae est, et tamen minor est,
-					nec sicut <lb/> infans crescere potest ?</p>
-					<p>5. Jam vero de immortalitate Dei, quia non Pa­ <lb/> irem, sed Deum qui et Patcr
-					est et Filius et Spiritus <lb/> sanctus , solum habere immortalitatem dixit
-					Aposto­ <lb/> lus, satis superius disputavi, quando ipsum aposto­ <lb/> icum
-					testimonium et posui totum , et exposui.</p>
-					<p>6. Displicet tibi , quod aequalem Patri asserimus <lb/> Filium : quasi possit
-					esse inaequalis, qui verus est <lb/> Filius, non natus ex tempore, sed gignenti
-					coaeternus, <lb/> sicut splendor ab igne genitus gignenti manifestatur <lb/>
-					aequaevus. Sed <hi rend="italic">habet,</hi> inquis , <hi rend="italic">Dei
-						Filius auctorem</hi> Pa­ <lb/>
-					<hi rend="italic">trem.</hi> Si propterea Deum Patrem Deo Filio dicis <lb/>
-					auctorem, quia ille genuit, genitus est iste; quia iste <lb/> de illo est, non
-					illc de isto; fatcor et concedo. Si au­ <lb/> lem per nomen auctoris minorem vis
-					facere Filium, <lb/> Patrernque majorem, nec ejusdem substantiae Filium <lb/>
-					cujus est Pater; detestabor et respuam : quia ct filius <lb/> hominis, in
-					quantum est filius, habet auctorem do <lb/> quo natus cst, patrem; nee tamen
-					ideo non est ejus­ <lb/> dem substantiae cujus est pater ; et quod iste minor,
-					<lb/> major est ille, potest tamen ad formam patris valen­ <lb/> tiamque
-					pervenire crescendo, in qua patrem propterea <lb/> non omni modo invenit talem ,
-					quia et ille defecit <lb/> senescendo. Sic enim necesse est varietur aetale mor­
-					<lb/> talitas, ubi temporalis est, non aeterna nativitas. Non <lb/> autem illa
-					siC cst, ubi nee crescit . FiliuS, nec sene­ <lb/> scit Pater. Et ideo amborum
-					non impar cst aetas; qnia <lb/> ubi est aeternitas, nou est aetas : idco forma
-					non im­ <lb/> par amborum; quoniam verus Filius, qni non ut au­ <lb/> geretur
-					cst natus, ne remanerct degener, a qualis <lb/> est natus, Sit ergo nalivitatc
-					humana longe melior ct <lb/> excellentior divina nativitas, incorruptibili et
-					invio­ <lb/> labili generatione : non tamen sit deterior, diversi­ <lb/> late
-					naturae.</p>
-					<p>7. Sed <hi rend="italic">vitam Filius,</hi> inquit, <hi rend="italic">accepit a
-						Patre.</hi> Acce­ <lb/> pit sicut genitus a gignente. <hi rend="italic"
-						>Omnia,</hi> inquit, <hi rend="italic">quae ha­<lb/> bet Pater,mea sunt.
-						(Joan.</hi> xvi, 15). Omnia ergo quae <lb/> habet Pater, dedit ille
-					gignendo, accepit iste na­ <lb/> scendo. Nec dando ille amisit quod habuit; nee
-					iste <lb/> cum esset et non haberet accepit: sed sicut ille per­ <lb/> mansit
-					habens omnia, cum ea quae habet Filio dede­ <lb/> rit omnia ; sic iste nunquam
-					fuit sinc omnibus, quae <lb/> non egendo, sed nascendo accepit ut Filius : quia
-					<lb/> nunquam potuit esse non natus, et ca sine quibus <lb/> non est natus, ct
-					est immutabilis natus, semper ha­ <lb/> buit, quia semper est natus. Si cniin
-					aliquid eorum <lb/> Quae habet Pater non dedit Filio, falsum est quod ait <lb/>
-					Filius : <hi rend="italic">Omnia qum habet Pater, mea sunt.</hi> Sed quia <lb/>
-					verum est, prorsus omnia quae habet Pater, dedit, <lb/> ut diximus, ille
-					gignendo, accepit iste nascendo. <lb/> Ac per hoc dedit ille vitam, quia gcnuit
-					vitam; ac­ <lb/> cepit iste vitam, quia natus est vita : si minor, si de­ <lb/>
-					color *, si diversa, non ergo quam Pater habuit hanc <lb/> dedit Filio. Et
-					quomodo vcrum est, <hi rend="italic">Omnia quae</hi> ha­ <lb/>
-					<hi rend="italic">bet Pater, mea sunt ?</hi> Sed quis audeat dicere, Verum <lb/>
-					non cst . quod Veritas dixit? Quapropter <hi rend="italic">sicut habet <lb/>
-						Pater vitam in semetipso, sic dedit et Filio</hi> vitam <hi rend="italic"
-						>ha­<lb/> bere</hi> in <hi rend="italic">semetipso</hi> ( <hi rend="italic"
-						>Id.</hi> v, 26). Sicut habet dedit, <lb/> quod habet dedit, qualem habeL,
-					talem dedit; quan­ <lb/> tam habet, tantam dedit. Omnia quae habct Pater, <lb/>
-					Filii sunt. Non ergo aliquid minus quam Pater habet <lb/> Filio dedit; nec
-					amisit Pater vitam, quam Filio dedit. <lb/> Vivendo enim tenuit, quam pignendo
-					dedit. Vita est <lb/> autem ipse Pater, vita est ipse Filius. Et ille quippe
-					<lb/> et iste id habet quod et ipse I : sed ille de nulle vita, <lb/> iste vita
-					de vita; sed talis qualis illa, tanta quanta <lb/> illa, hoc omnino quod illa ;
-					quia ,crus est Filius, qnia <lb/> perfectus cst Filius, quia non est degener ab
-					uno Deo <lb/> Patre Deus unicus Filius, Patri ergo aequalis est Fi­ <lb/> lius.
-					Quidquid eum dicis a Patre accepisse, fatemur <lb/> et nos : prorsus Pater
-					dedit, Filius accepit. Sed cum <lb/> Pater omnia quae habet gignendo dedit,
-					aequalem <lb/> utique genuit, quoniam nihil rninus dedit. Quomodo <lb/> ergo tu
-					dicis, quia ille dedit, ille accepit, ideo aequa­ <lb/> lem Filium Patri non
-					esse : cum eum cui data suut <lb/> omnia, et ipsam aequalitatem videas accepisse
-					? <lb/> Scriptum est quidem, Beatum <hi rend="italic">est magis d(tre quam <lb/>
-						accipcre (Act.</hi> xx, 35) : sed in hac vita ubi est ino. <lb/> pia, qua
-					utique melior cst copia. Melius enim cst <lb/> habere, quam egere ; et melius
-					est donare, quam ac­ <lb/> cipere '; erogare, quam mendicare. Ubi antem qui
-					<lb/> dcdit, gignendo dedit ; ct qui accepit, nascendo ac­ <lb/> cepit: non
-					inopi subventum est, scd ipsa copia gu­ <lb/> ncrata est. Nec potest qui accepit
-					ei qui dedit esM <note type="footnote"> I Editi, <hi rend="italic"
-							>discolor.</hi> At Mss., <hi rend="italic">decolor.</hi>
-					</note><note type="footnote"> 1 sic Mss. Editi vero, <hi rend="italic">quod est
-							ipse.</hi>
-					</note><note type="footnote"> I Mn. Er. et MSS. omittunt, <hi rend="italic"
-							>qutun ucciiwe; crogare.</hi>
-					</note>
-					<lb/>
-					<pb n="775"/> inaequalis, qnia ct hoc accepit ut esset aequalis. Nihil <lb/>
-					euim Patre minus habet illc qui dicit, <hi rend="italic">Omnia quae<lb/> habet
-						Pater, mea sunt.</hi> aequalis est igitur. Sed quia <lb/>
-					<hi rend="italic">semetipsum exinanivit, fomam servi accipiens,</hi> non <lb/>
-					formam Dei perdens; ita factus cst in eadem servi <lb/> forma <hi rend="italic"
-						>obediens usque ad</hi> mortem <hi rend="italic">crucis (Philipp. II,</hi>
-					<lb/> i, 8), in qua paulo minus minoratus est ab Angelis <lb/>
-					<hi rend="italic">( f'Bal.</hi> VIII, C), ut Patri in forma Dei maneret
-					aequalis: <lb/> quia non est forma illa mutabilis.</p>
-					<p>8. Quid itaque mirum est, si na quae commemoras, <lb/> dicit, <hi rend="italic"
-						>Ego quae plucila sunt Patri, facio semper ( Joan.</hi>
-					<lb/> VIII, 29) : ct ad monumentum Lazari, <hi rend="italic">Pater. gratias<lb/>
-						ago tibi, qnia audisti me; et ego sciebam quia semper</hi> me <lb/>
-					<hi rend="italic">aidus, sed</hi> propter <hi rend="italic">eoa qui circumstant
-						dixi, ut credant <lb/> quia</hi> tu <hi rend="italic">me misisti (ld.</hi>
-					XI, 41, 42) : ct iterum, <hi rend="italic">Aie</hi> opor­ <lb/>
-					<hi rend="italic">tet operari opera ejus qui me misit (Id.</hi> IX, 4) : ct an­
-					<lb/> tequam panes frangeret, prius <hi rend="italic">Patri gratias egit
-						(Matth.</hi>
-					<lb/> XXVI, 26 ; <hi rend="italic">Marc.</hi> vin, 6, <hi rend="italic">et
-						Joan.</hi> vi, 11) ? Si his atque <lb/> hujusmodi testimoniis id ostendere
-					voluisses, quod <lb/> in forma servi Filius minor cst Patrc, et in ipsa for­
-					<lb/> ma Dei iste de illo non ille de isto est; quod saepe si­ <lb/> gnificans ,
-					multa ita dicit, ut cum non intelligentes <lb/> etiain in ipsa divinitate
-					arbitrentur minorem : sic te­ <lb/> neres rectam regulam fidci, ut non
-					contradiceres ve­ <lb/> rilati; nec per talia testimonia oppugnarcs Evange­
-					<lb/> lium, sed doceres. Quae suut eniin placita Patris , <lb/> quae non sunt et
-					Filii V aut unde potest facerc Filius, <lb/> nisi quae placita sunt Patri, a quo
-					habet omnia in qui­ <lb/> bus aequalis est Patri? Quomodo non gratias agit <lb/>
-					Patri de quo est, praesertim in forma servi , in qua <lb/> illo minor cst?
-					Quomodo non Patrem rogat ut homo, <lb/> qui cum Patrc cxaudit ut Deus ? Quis
-					autem christia­ <lb/> nus ignorat qucd Pater miserit, missusque SiL Filius?
-					<lb/> Non euim genitorem ab co quem genuit, sed genilum <lb/> a genitore mitti
-					oportebat : verum haec non est in­ <lb/> aequalitas subsiantiae, sed ordo
-					naturae ; non quodalter <lb/> prior esset allero, sed quod alter esset ex
-					allero. <lb/> Oportebat ergo operari eum qui missus cst, opera <lb/> ejus a quo
-					missus est: et quae sunt opera Patris, quae <lb/> non suut et Filii; cum dicat
-					idem Filius, <hi rend="italic">Quaecumque <lb/> Pater facit, haec et Filius
-						similiter facit (Joan.</hi> v, 19) ? <lb/> Opera tamen Patiis esse dicit:
-					non » nim obliviscitur <lb/> a quo sit; a Patre quippe illi est ut operator
-					talium <lb/> operum sit. Ilac autcm vos ita intelligilis , ut hinc <lb/> etiam
-					putetis Patrem Filio esse majorem, quia dixit <lb/> passerem non caderc in
-					lerram sine Patris voluntate <lb/>
-					<hi rend="italic">(Matth.</hi> x, 29); quasi cadat sine voluntate Filii. An
-					<lb/> usque adco minorem vultis Filium, ut non habcat in <lb/> potestate nec
-					passeres? Sed si non vultis huic regulae <lb/> acquiescere , ut ubicumque
-					legeritis in auctoritate <lb/> divinorum eloquiorum , quo 1 minor Patre Filius
-					vi­ <lb/> deatur ostendi, aut ex forma servi dictum accipiatis, <lb/> in qua
-					vcre innuor est Patre; aut ideo dictum , quo <lb/> non demonstretur major vel
-					minor ullus esse allero, <lb/> scd demonstretur esse alter ex altero : si huic,
-					in­ <lb/> quam, rectissimae regulae non vultis acquiescere ; certe <lb/> tamcn
-					verum Dni Filium nulla ratione dicetis, si non <lb/> ejusdem substantiae, cujus
-					Pater es!, cum esse dica- <note type="footnote"> I falili, quibus. Concinnius
-						':ss., <hi rend="italic">q!:o.</hi>
-					</note>
-					<lb/> lis. Ut enim humanum aliquid dicam propter infirmi. <lb/> tatem carnalium
-					: cum homines duo sunt, pater et <lb/> filius, si obediens sit patri filius, et
-					aliqua existente <lb/> causa roget patrem , gratias agat patri, aliquo lIcui..
-					<lb/> que Initiatur a patre, ubi se dicat non venisse facere <lb/> voluntatem
-					suam, sed ejus a quo missus est; num­ <lb/> quid hinc ostenditur non ejusdem
-					cujus pater est esse <lb/> substantix ? Cur ergo ubi de Filio Dei talia legitis,
-					<lb/> statim in tantum sacrilcgium corde atque ore prorui­ <lb/> tis, ut veri
-					Filii Dei unam eamdemque cum Patre <lb/> substantiam non esse credatis atque
-					dicatis ?</p>
-					<p>9. Quid quod etiam illud commemorandum putasti, <lb/> quod manifestissime ut homo
-					loquitur: <hi rend="italic">Potestatem ha­ <lb/> beo ponendi animam meam, et
-						potestatem habeo iterum <lb/> sumendi eam. Hoc</hi> enim praeceptum <hi
-						rend="italic">accepi a Patre meo?</hi>
-					<lb/> Quid hoc adjuvat causam tuam ? Numquid enim aliud <lb/> dixit, nisi,
-					Potestatem habco-moriendi et resurgendi ? <lb/> Quod itaque ait, <hi
-						rend="italic">Nemo eam tollit a me, sed ego</hi> eam <lb/>
-					<hi rend="italic">pono</hi> a me, <hi rend="italic">et iterum sumo eam
-						(Joan.</hi> x, 18) ; quid in­ <lb/> telligi voluit, nisi se non fuisse
-					moriturum, nisi ipse <lb/> voluisset ? Numquid tamen nisi horno esset , mori et
-					<lb/> resurgere potuisset ? Sic autem introduxisti hoc testi­ <lb/> monium, ut
-					praełoquereris, dicens, <hi rend="italic">Hic sane et de sua <lb/> potestate
-						quam a Patre accepit dicebat,</hi> « <hi rend="italic">Potestatem <lb/>
-						habeo ponendi animam</hi> meam, <hi rend="italic">ei potestatem habeo
-						ite­<lb/> rum sumendi eam</hi> : &gt; tanquam si homo non esset, po­ <lb/>
-					siturus esset animam. Ut homo ergo, non ut Dcus, <lb/> accepit hanc potestatem :
-					quamvis non dixerit, Hanc <lb/> potestatem; sed, <hi rend="italic">hoc</hi>
-					praeceptum <hi rend="italic">accepi a Patre</hi> meo. <lb/> Quis autem nesciat
-						<unclear>aluid</unclear> esse praeceptum , aliud po­ <lb/> testatem ? Hoc
-					enim habemus in potestate, quod cum <lb/> volumus possumus. Pracceplum vcro id
-					nobiscum agit, <lb/> ut quod jam est in potestate faciamus : si autem non­ <lb/>
-					dum est in potestate, oremus nohis patestatem dari, <lb/> ut qnod praeceptum cst
-					impleamus. Quocirca si ea <lb/> qu:c aperta sunt velitis attendere, ut homo
-					acceperat <lb/> hanc potestatem. Sed propter contentiosos ego ad <lb/> utrumque
-					concludam : Si ut homo accepit hanc po­ <lb/> testatem, nihil libi prodesse hoc
-					testimonium et tu <lb/> vidcs; quia si ex hac potestate a Patre accepta, mi­
-					<lb/> norem Patre Filium vis probare, nee nos dubitamus, <lb/> quod in quantum
-					homo est Christus, minor est Patre : <lb/> si autem ut Deum vis accepisse hanc
-					potestatem, Hi.. <lb/> gnendo cum Pater aequalem sibi, dedit ei omnium <lb/>
-					rerum tantam, quanta ipsi Patri est 1, potestatem. Si <lb/> enim minus habet in
-					potestate aliquid quam Patcr, <lb/> non sunt ejus omnia quae habet Pater : sed
-					quia ejus <lb/> sunt, tantem procul dubio habel potestatem quantam <lb/> Pater.
-					Praeceptum quoque aut ut homo accepit, aut <lb/> ut Deus : si ut ho:no, nulla
-					quaestio ea, quia ut homo <lb/> est Patre minor: si ut Dcus, non hinc ostenditur
-					mi­ <lb/> nor; quia nascendo id accepit, non indigendo. In <lb/> Verbo cnim
-					unico Dei omnia praecepta sunt Dei , quae <lb/> ille gignens dedit nascenti, non
-					cum genuisset addi­ <lb/> dil indigenti : ac per hoc tantum genuit quantus cst
-					<lb/> ipse; quia de scipso genuit vcrum Filium, et perfc­ <lb/> ctum genuit
-					plenitudine divinitatis, non perficiendum <note type="footnote"> 1 ):ss., <hi
-							rend="italic">qunnti ipsi:ts csl.rat. is.</hi>
-					</note>
-					<lb/>
-					<pb n="777"/> a tatis accessu 1. Sed humilius a tc quaero, quare <lb/> tilium
-					hominis quemlibet hominem, si preceptum ac­ <lb/> cipiat a patre, nun eum dicis
-					alterius esse substan­ <lb/> tiae, et Filium Dci Demn ob hoc audes negare pa -
-					<lb/> ternae esse substantiae, quia praeceptum accepit a <lb/> Patre? Prorsus,
-					ct praeceptum a Patre accepit,et <lb/> ejusdem substantiae est, cujus est ille
-					qui dedit. Quis <lb/> te contradicentem ferat, si ad te audiendum homines <lb/>
-					patresfiliique concurrant, ejusdem utrique substan­ <lb/> tiae ; nec ideo filii
-					degeneres, quod ita praecepta eis <lb/> dederint patres? Sud forte dicis, patres
-					doctos filiis <lb/> indoctis. dedisse praecepta. Refer nuac te ad Dei fi­ <lb/>
-					lium, de Dco Patrc natum Deum, qui utique imper­ <lb/> fectus est natus, si
-					praeceptum accepit indoctus. Quia <lb/> vero perfectus est natus, praeceptum
-					dedit ille gi­ <lb/> gnendo, accepit iste nascendo. Nunquam enim verus <lb/> Dei
-					Filius indoctus fuit : filius autem numquam non fuit.</p></div>
-				<div type="textpart" subtype="chapter" n="15">
-					<p>CAPUT XV. — i. In forma Dei Filium esse non <lb/> negas, et Dco Patri aequalem
-					negas, majorem Patris <lb/> iormam putans esse quam Filii : tanquam non ha­
-					<lb/> buerit Pater unde formam suam compleret in Filio, <lb/> quem de se ipso
-					genuit ,non fecit ex nihilo, non ex <lb/> alio. Aut si formam suam in unico
-					Filio plonam gi­ <lb/> gnere potuit, nec tamen genuit plenam, sed minorem ;
-					<lb/> quid sequatur altenditc, et in viam redite, ne coga­ <lb/> mini Patrem
-					invidum dicere. Dicitis Deum Filium, <lb/> dicitis Dominum; sed ut duos deos
-					dominosque facia­ <lb/> tis, contra Scripturam clamantem, Audi, <hi
-						rend="italic">Israel; Do­</hi>
-					<lb/> minus <hi rend="italic">Deus</hi> tuus, <hi rend="italic">Dominus</hi>
-					unus est <hi rend="italic">(Deut.</hi> VI, 4). Quid <lb/> autem in hoc
-					sacrilegio vobis prodest, quod Patri da­ <lb/> tis tantam formam, quantam non
-					datis Filio? Num­ <lb/> quid si unus major, alter est minor, ideo non suut <lb/>
-					dii et domini duo? Si carere cupitis hoc errore, sic <lb/> dicite alium esse
-					Patrem, aliam esse filium, ut tamen <lb/> simul ambos non duos dicatis, sed unum
-					Dominum <lb/> Deum. Dicitis rogem Filium de rege Patre utique na . <lb/> tum:
-					nec intuemini in genere humano filios regum <lb/> etiamsi non sunt ex ,regibus
-					reges, esse tamen ex ho­ <lb/> minibus homines; nec habere potestatem cum pa­
-					<lb/> tribus regiam, et tamen eamdem tenere naturam. Vos <lb/> autem Filio Dei
-					rogis regnum cum Patre conceditis, <lb/> ct naturam paternam, vanitate impia
-					denegatis ; cum­ <lb/> que Deo Patri dicitis inrqualem, <hi rend="italic">qui
-						non rapinam,</hi>
-					<lb/> hoc est, non alienum <hi rend="italic">arbitratus est esse aequalis Deo
-						;<lb/> sed</hi> tamen non intendens quae sua sunt , sed qu;c no­ <lb/> stra
-					sunt, <hi rend="italic">semetipsum exinanivit;</hi> non formam Dei <lb/>
-					perdens, sed formam <hi rend="italic">serii accipiens,</hi> in qua est Patri <lb/>
-					<hi rend="italic">factus obediens usque ad mortem crucis (Philipp.</hi> II,
-					<lb/> C 8). I.. qua forma cnm non vultis sic agnoscere Pa­ <lb/> tre Deo
-					minorem. ut in Dci forma Patri non negetis <lb/> aequalem. « Nos, i inquis, *
-					dicti sumus filii gratia, <lb/> non natura hoc nati : ideo unigenitus est
-					Filius, quia <lb/> qnod est secundum divinitatis suae naturam , hoc cst <lb/>
-					natus Filius. i Haec non tua solum, verum etiam no­ <lb/> stra suit verba. Cur
-					erro quem Dei Filium natura <lb/> non gratia confiteris, ejusdem naturae, cujus
-					Pater <lb/> cst, non esse contendis,nec quid mali abs tc dicatur <note
-						type="footnote"> I Sic Am. F.r et Mss. At Lov., <hi rend="italic">el
-							uc;'jert,znt qcnuit plt';:i- <lb/> Vtdincm divinitatis, non perficiendam
-							aetatis accessu</hi></note>
-					<lb/> attendis ? Nunnc regis <unclear>Dei</unclear> Filio paternum regnum au
-					<lb/> ferres tolerabilius quam naturam?</p>
-					<p>2, Dc Spiritu autem sancto, quomodo e' ipse de <lb/> Deo sit, nec tamen et ipse
-					filius sit, quoniam proce­ <lb/> dendo, non nascendo legitur esse de Deo, jam
-					supe­ <lb/> rius, quantum satis visum est, disputavi. Nos, inquis, <lb/>
-					<hi rend="italic">in Patrem Deum innatum,</hi> naturam non <hi rend="italic"
-						>accepimus.</hi>
-					<lb/> Et tanquam rationem reddens, cur Dei Patris non <lb/> dicatis esse naturam
-					, mox adjungis, et dicis, <hi rend="italic">Credi­</hi>
-					<lb/> mus <hi rend="italic">quod ait Christus,</hi> i <unclear/><hi
-						rend="italic">Spirituc eat Deus</hi> » <hi rend="italic">(Joan. IV.</hi>
-					<lb/> 24) : quasi Christus secundum id quod Deus est, <lb/> non spiritus sit,
-					quem tamen natura Filium esse <lb/> dixisti. Nan ergo Pater ideo natura non est,
-					quia spi­ <lb/> ritus est. Sed forte quia natu uon est, idco eum non <lb/>
-					vultis esse naturam; putatis enim quod a nascendo <lb/> uatura sit dicta.
-					Scitote ergo, quod unaquaeque res <lb/> esse dicitur per substantiam, hoc esse
-					utique per <lb/> naturam. Certe si non putatis esse dicendum, ejusdem <lb/>
-					filium cujus Pater est esse naturne; dicite cujus Pa­ <lb/> ter est esse
-					substantiae : ad causam quae inter nog <lb/> agitur, sufficit nobis. Verumtamen
-					admonendi cstis, <lb/> ut intueamini quod ait Apostolus, <hi rend="italic">His
-						qui natura</hi> non <lb/> sunt <hi rend="italic">dii, servistis (Galat.</hi>
-					IV, 8): ubi certe nos Deo <lb/> qui natura est Deus, servire monstravit. Vos
-					ergo qui <lb/> Deum Patrem non natura Deum esse creditis, ubi <lb/> cum
-					constituatis, advertite; et si ullus in vobis pudor <lb/> est, erubescite. Eccc
-					nos dicimus vobis, non servi­ <lb/> mus Deo qui natura non est Deus; ne simus
-					tales, <lb/> quales fuerunt illi quihus dictum cst, <hi rend="italic">His</hi>
-					qui <hi rend="italic">natura <lb/> non sunt dii, servistis.</hi> Vos si tales
-					esse vultis, <lb/> petimus ne velitis, et Deum Patrem natura Dcum <lb/> esse
-					dicatis : ejusque Filium, quem non gratia, sed na­ <lb/> tura Filium jam esse
-					dicitis, ejusdem nature cujus <lb/> Pater est non negetis, ne nihil aliud qnam
-					Filium <lb/> esse verum negetis. Quomodo enim dicitis, et ve­ <lb/> rum Filium
-					vos profiteri, et Putri similem non ne­ <lb/> gare, quando cum negatis unius cum
-					Patre esse sub­ <lb/> stantiae ? Sicnt autem verum Filium indicat una sub­ <lb/>
-					stantia, sic non verum diversa substantia. Quomodo <lb/> autem Filium Patri
-					similem dicitis, cui Patris sub­ <lb/> stantium ,dare non vultis ? Nonnc similis
-					homini est <lb/> pictura vel statua, et tamen filius dici non potest, <lb/> qnia
-					diversa substantia est ? Homo nempe ad Dci si­ <lb/> militudine ii factus cst;
-					tamen quia non est unius <lb/> ejusdemque substantiae, fton est verus filius; et
-					ideo <lb/> fit gratia filius, quia non est natura. Si ergo vultis <lb/> Dei
-					Filium verum confiteri, prius illum ac praecipuc <lb/> dicite unius ejusdemque
-					substantiae, ut tanquam ve­ <lb/> rum Filium ct Dei Filium pcr omnia similem
-					Patri <lb/> esse dicatis. Nam quem substantiam putatis habere <lb/> diversam,
-					plus eum dissimilem quam similem dicitis, <lb/> et omnino verum Filium
-					denegatis. Nam vultis I <lb/> nosse, ad ostendendum verum filium quantum va­
-					<lb/> leat una eademque substantia : etiamsi filius hominis <lb/> homo in
-					quibusdam similis, in quibusdam sit disci­ <lb/> milis patri; tamen quia ejusdem
-					substantiae est, ne­ <lb/> gari vcrus filius uon potest: et quia verus est
-					filius, <lb/> negari ejusdem substantiae non potest. Vos autem ita <note
-						type="footnote"> ' sola editio 1.0\'.: <hi rend="italic">Sec vultis.</hi>
-					</note>
-					<note type="footnote"> PATROl... XLII. </note>
-					<note type="footnote">
-						<hi rend="italic">(Vingt-cinq.)</hi>
-					</note>
-					<lb/>
-					<pb n="779"/> dicitis verum Dei Filium similem Patri, ut substantiae <lb/>
-					velitis esse diversa, per qnam solam potest filius ve­ <lb/> ros ostendi. Nam
-					duo verihomines etsi nullus corum <lb/> filius silahcrius, umus tamen suni et
-					ejusdem sub. <lb/> stantiae : homo autem alterius, hominis verus filius <lb/>
-					nullo modo potest nisi ejusdem cum patre esse sub­ <lb/> stantiae,etiamsi non
-					sit par omn a similis patri <lb/> Quocirca verus Dei Filius ct unius cum Patre
-					Fubstan <lb/> tiae est, quia verus Filius est : et per omnia est Patri <lb/>
-					similis, quia Dei Filius est. Nequc enim sicut contin­ <lb/> git in filiis
-					hominum vel quoramcumque animalium, <lb/> ita fas est dicere, verum Dei Filium
-					substantiae qui­ <lb/> dem unius esse cum Palrc, sed non per omina <lb/> similem
-					Patri. Nicaenum igitur tenete nobiscum con­ <lb/> cilium , si voltis Christum
-					dicere verum Dei Filium.</p>
-					<p>5. <hi rend="italic">Diversas,</hi> inquis, <hi rend="italic">accusamur dicere
-						natura.</hi> Et <lb/> quid aliud dicis de Den Patre ct Dco Filio? quid aliud
-					<lb/> dicis? An idco putas ab isia accusatione purgari% <lb/> quia continuo
-					subjungis dicens : <hi rend="italic">Hoc scito quod nos <lb/> dicimus, quod
-						Puter</hi> spiritus spiritum <hi rend="italic">genuit ante omnia<lb/>
-						saecula, Deus Deum genuit?</hi> .loc quidem dicitis, et <lb/> veruin dicitis
-					: sed hoc tacuisti, quod falsum ct exse­ <lb/> crabilc dicitis. <hi
-						rend="italic">Spiritus</hi> enim spiritum genuit, verum <lb/> dicitis : sed
-					hoc verum ea intentione vos dicitis, <lb/> quia etiam diversae naturae dicitur
-					spiritus. Nam di­ <lb/> versa; naturae sunt Spiritus Dei, sive Spiritus Deus,
-					<lb/> et spiritus hominis; et tamen uterque dicitur spiritus: <lb/> Itemdiversae
-					naturae sunt spiritus hominis et spiritus <lb/> pecoris; et tamen nihilominus
-					uterque spiritus dicitur. <lb/> hem dicitur, Deus Dens, et dicitur deus homo :
-					sicut <lb/> dictum cst, <hi rend="italic">Dii estis</hi> ( <hi rend="italic"
-						>Psal.</hi> nIxi, 6). Et sicut datus <lb/> est 1 deus Moyses Pharaoni <hi
-						rend="italic">( Exod.</hi> VII, 1). Et cum <lb/> sit Dei ct hominis diversa
-					substantia, tan:en uterque <lb/> appellatur Deus. Prorsus veraciter arguimini,
-					quam­ <lb/> vis dicatis de Deo Patre cl Deo Filio, <hi rend="italic">Spiritus
-						spiri­<lb/> tum</hi> genuit, naturas tamen diversas diccre : et quam­ <lb/>
-					vis dicatis, <hi rend="italic">Deus Deum genuit;</hi> etiam sic non recedere
-					<lb/> a diversitate naturae, quia non per omnia similem <lb/> Patri esse dicitis
-					Filium. Nam si per omnia si­ <lb/> mitem diceretis correquenter intelligeremini
-					quod <lb/> cos diceretis etiam unius cjusdemque esse naturae <lb/> sive
-					substantiae. Si ergo ab hoc crimine quod vobis <lb/> objicitur, Dei Patris et
-					Dei Filii vos dicere naturas <lb/> esse diversas, purgare te cogitas: sicut
-					dicis, <hi rend="italic">Spiritus</hi>
-					<lb/> spiritum <hi rend="italic">genuit;</hi> ita dic, Spiritus ejusdem naturae
-					sivc <lb/> substantiae spiritum genuit. Item, sicut dicis, <hi rend="italic"
-						>Dens<lb/> Deum genuit;</hi> ita die, Deus ejusdem naturae sive sub­ <lb/>
-					stantiae Deum genuit. Hoc si credideris, et dixeris, <lb/> nihil de bac re
-					ulterius accusaberis. Si autem hoc non <lb/> dixeris , quid prodest quia dicis,
-					Verus <hi rend="italic">innatus Pater <lb/> verum genuit Filium;</hi> cum procul
-					dubio verus Filius <lb/> ton sit, si non est unius ejusdemque substantiae eum
-					<lb/> illo qui genuit ?</p>
-					<p>4. Dicit quidem Filius ad Patrem , <hi rend="italic">Haec</hi> est <hi
-						rend="italic">autem<lb/> vita œterna,</hi> ut cognoscant te solum terum <hi
-						rend="italic">Deum, et <lb/> quem misisti</hi> Jesum <hi rend="italic"
-						>Christum (Joan.</hi> XVII, 5) : Id est, . <lb/> te et quem misisti Jesum
-					Christum, cognoscant solum <lb/> verum Deum. In quibus verbis vos solum Patrem
-					non <note type="footnote">a Sic, 3bd. Fditi autem, dictus est. </note>
-					<lb/> cum Filio verum accipientes Deum , quid allud quita <lb/> Filium ncgatis
-					'crum Deum? Quia vero Pater ct Fl- <lb/> lius, non duo dii, sed unus cst Deus;
-					sine dubio et <lb/> Filius vcrus est Deus, et adjuncto Spiritu sancto <lb/>
-					solus est Deus. Ncque enim movere nos debel, quod <lb/> nominatus non est hoc
-					loco Spiritus sanctus, tanquam <lb/> non sit Deus, aut non sit verus Deus. Tale
-					est cnim <lb/> fioc quale si quis dicit, nescire Christum ea quae Dei <lb/>
-					sunt; quoniam dixit Apostolus sic : <hi rend="italic">Et quae Dei sunt,</hi>
-					<lb/> nemo <hi rend="italic">scit,</hi> nisi <hi rend="italic">Spiritus Dei</hi>
-					(I <hi rend="italic">Cor.</hi> II, 11). Hoc cst <lb/> enim. Nemo <hi
-						rend="italic">scit,</hi> nisi Spiritus <hi rend="italic">Dei;</hi> quod est
-					, Solus <lb/> ea scit Spiritus Dei. Sieut ergo ab hac scientia, quam <lb/> non
-					habere nisi Spiritus Dei dictus est, non excludi. <lb/> tur Christus; sic ab eo
-					quod Patcr et Christus dictus <lb/> est solusverus Deus, non excluditur Spiritus
-					sanctus. <lb/> Sic et nomen illud quod in Apocalypsi nemo nosse <lb/> dictus
-					est, nisi ipse qui hoc habebat scriptum <hi rend="italic">( Apoc.</hi>
-					<lb/> XIX, 12), id est Christus, noverat utique et Pater, <lb/> quod nrgare non
-					potestis; noverat et Spiritus sanctus, <lb/> etiamsi ncgetis. <hi rend="italic"
-						>Spiritus</hi> enim <hi rend="italic">omnia</hi> scrutatur, <hi
-						rend="italic">etiam<lb/> altitudines Dei</hi> (I <hi rend="italic">Cor.</hi>
-					II, 10). Nisi forte quia scruta­ <lb/> tor dictus est, ncgatur apprehendere :
-					negetur ergo <lb/> Dens apprehendere corda et renes hominum; scri­ <lb/> ptum
-					est enim , <hi rend="italic">Scrutans corda et renes Deus (Psal.</hi>
-					<lb/> VII,10). Ita ergo dictus est solus verus Deus Pater et <lb/> Jesus
-					Christus, ut ab bac veritate deitatis nullo modo <lb/> alienaretur Spiritus
-					sanctus. Non autem Filius, ut <lb/> tibi vidctur, <hi rend="italic">solum
-						potentem , solum sapientem, solum</hi>
-					<lb/> bonum <hi rend="italic">Patrem</hi> dicit <hi rend="italic">esse
-						Deum.</hi> Deus autem unus ct <lb/> solus est ipsa Trinitas, ut ostendunt ea
-					quae superius <lb/> jam saepissime diximus.</p>
-					<p>5. Quod autem <hi rend="italic">non</hi> proficientem , <hi rend="italic">sed
-						perfectum <lb/> Deus Pater genuerit Filium Deum;</hi> verum dicis. Sed <lb/>
-					quod ipsam Filii perfectionem, perfectioni Patris non <lb/> vis aquare; hoc
-					falsum dicis, ct vcritati qua verus <lb/> cst Filius contradicis. <hi
-						rend="italic">Homo enim</hi> si <hi rend="italic">posset,</hi> inquis &gt; <lb/>
-					<hi rend="italic">perfectum mox generare filium, non parvulum genera­ <lb/>
-						ret,</hi> qui <hi rend="italic">coaugmentatis annis tandem aliquando</hi>
-					aui <hi rend="italic">geni- ,</hi>
-					<lb/> toris <hi rend="italic">impleat voluntatem.</hi> Verissime 1 omnino contra
-					<lb/> te loqueris. Sed ut contra te non sit quod loqucris, <lb/> agnosce
-					aequalitatem Patris et Filii. Quia et homo si <lb/> posset, filium mox generaret
-					arqpalem , nec exspe­ <lb/> ctaret annos, per quos in forma filii posset
-					voluntas <lb/> ejus impleri. Deus ergo cur non aequalem genuit Fi­ <lb/> lium ,
-					cui nec anni necessarii fuerunt per quos id im­ <lb/> pleretur, nec omnipotentia
-					defuit? An forte noluit? <lb/> Ergo, quod absit, invidit. Sed non invidit :
-					aequaleur <lb/> igitur gcnui:. Ac per hoc unius ejusdemque substan­ <lb/> tiae :
-					quandoquidem homo, qui propterea quia non <lb/> potest non gignit aequalem ,
-					ejusdem tamen subslan­ <lb/> tiae gignit filium, cujus est ipse. Quod si non
-					esset, <lb/> profecto verus filius esse non posset. Quid est ergo <lb/> quod
-					dicis , <hi rend="italic">Pater tatem genuit</hi> Filium <hi rend="italic"
-						>qualis et</hi> nune <lb/> eat, <hi rend="italic">qualis</hi> et <hi
-						rend="italic">permanet sine fine?</hi> Hoc bene diceres , si <lb/> Patri
-					aequalem verum Filium non negares. Cum vero <lb/> perfectum dicis, et aequalem
-					negas, et talem qnalii <note type="footnote"> * EdSti: <hi rend="italic"
-							>Fcritatem</hi> veris <hi rend="italic">iiml,</hi> Pic. At Ma&lt;L
-						omiUnat <hi rend="italic">veri­<lb/> tctem.</hi>
-					</note>
-					<lb/>
-					<pb n="781"/> est natus sine line permanere non negas; procul dubio <lb/>
-					minorem Patre filium sine fine mancre pronuntias. <lb/> AC per hoc nascitur
-					filius hominis minor Patre ; et <lb/> quia imperfectus nascitur, crescendo ad
-					formam per­ <lb/> venit patris : natus est filius Dei minor Patre; et <lb/> quia
-					perfectus atque immortaliter natu est, nullum <lb/> accipit incrementum , sed
-					cum ipsa perfectio a forma <lb/> Patris in aeternum efficit alienum. Ecce qu:e
-					creditis , <lb/> cccequae dicitis; ecce sunt, quod pejus est, quae docetis.
-					<lb/> Sed <hi rend="italic">inauditorum,</hi> inquis , <hi rend="italic">eat
-						arbitrio</hi> , nt <hi rend="italic">eligant alte­</hi>
-					<lb/> rum <hi rend="italic">de duobus : aut obedientem Patri Filium</hi> , qui i
-					se <lb/>
-					<hi rend="italic">evinanivit, formam servi accipiens <unclear>o</unclear>, cui
-						et Pater « donavit <lb/> nomen quod est super omne nomen</hi> &gt; <hi
-						rend="italic">(Philipp.</hi> II, 7, 9); <lb/>
-					<hi rend="italic">aut interpretationem tuam.</hi> Prorsus auditores quibus <lb/>
-					donat bominus intellectum, non unum de duobus <lb/> istis eligunt, sed utrumque;
-					id cst, et obedientem Pa<lb/>Iri Filiuin , et interpretationem, vcl potius
-					cxposilio­ <lb/> nem meam, qua ostendi sic obedientem fuisse in for­ <lb/> nia
-					servi, ut formam non amitteret Dei, in qua :'qua­ <lb/> lis est Patri. Tu vero
-					vide quam contumeliose Filio <lb/> Dci tribuas obedientiam , cujus minuis in
-					divinitate <lb/> naturam.</p></div>
-				<div type="textpart" subtype="chapter" n="16">
-					<p>CAPUT XVI. - !. Quando autem a me audisti <lb/> prop. r Judaeos , <hi
-						rend="italic">humilitatis, non veritatis gratia , <lb/> dixisse Filium quod
-						Deus ejus sit Puter ejus ?</hi> Hoc a <lb/> me ita nunquam audire potuisti,
-					sicut nunquam dixi: <lb/> sed plane dili, propter formam servi dictum esse.
-					<lb/> Sicut autem ipsa forma servi vera , non falsa ea; ita <lb/> Patrem suum
-					esse eliam propter illam Deum suum * <lb/> veraciter dixit, non humiliter
-					finxit. Quis enim est <lb/> humilitatis, fructus ubi detrimentum est veritatis ?
-					<lb/> Tn autem istam certissimam veritatem ita es refutare <lb/> conatus, ut
-					diceres ideo verba ipsa, quibus ait Domi­ <lb/> nus , <hi rend="italic">Deum
-						meum et Deum vestrum,</hi> ad formam servi <lb/> non pertinere, quia eis
-					verbis post resurrectionem <lb/> ustis est Dominus, quasi formam servi
-					resurrectione <lb/> consumpserit, ac non potius in melius commutaverit: <lb/>
-					quasi non qui mortuus est, ipse etiam resurrexerit; <lb/> quasi non forma quae
-					occisa est, ipsa rcvixerit; quasi <lb/> uon ipsa in caelum levata sit , in ipsa
-					Dei Filius se­ <lb/> deat ad dexteram Patris, in ipsa venturus sit ad vivos
-					<lb/> et mortuos judicandos. Nonnc clarissima Contestatio <lb/> est Angelorum
-					dicentium , <hi rend="italic">Sic veniet, quemadmodum</hi>
-					<lb/> vidistis eum euntem in <hi rend="italic">cœlum (Act.</hi> I, 11). Cur ergo
-					<lb/> post resurrectionem non diceret, <hi rend="italic">Ascendo ad Patrem <lb/>
-						meum et Patrem restrum, Deum</hi> meum <hi rend="italic">et Deum re­</hi>
-					<lb/> strum <hi rend="italic">(Joan.</hi> xx, 47); quando in eadem forma fuerat
-					<lb/> ascensurus, propter quam ex tempore Deus est ejus,. <lb/> qui sine tempore
-					Pater est cjus ? Propter quam for­ <lb/> fam non solum post resurrectionem,
-					verum etiam <lb/> post judicium <hi rend="italic">subjectus erit ei , qui iUi
-						subjecit onmia</hi>
-					<lb/> (1 <hi rend="italic">Cor.</hi> xv, 28). Quotquot ergo testimonia posuisti,
-					<lb/> quibus probares dictum esse Deum Christi, eum qui <lb/> Pater est Christi,
-					discutere quemadmodum dicta sint, <lb/> superfluum judico : sed a te frustra
-					commemorata <lb/> esse, puto quod nec tu dcbeas dubitare.</p>
-					<p>2. Jam vero illud ubi Dominos in eadem carne <lb/> quam resuscitaverat
-					constitutus, et eumdem homincm <lb/> g<unclear>erens</unclear> , ait ad
-					discipulos suos, <hi rend="italic">Data</hi> est <hi rend="italic">mihi</hi>
-					omnis <lb/>
-					<hi rend="italic">potestas in cœlo</hi> et in <hi rend="italic">terra :
-						cuntes</hi>
-					<unclear/><hi rend="italic">avecte omnes gentes, <lb/> baptizantes</hi> toa <hi
-						rend="italic">in</hi> numine <hi rend="italic">Patris ei Filii et</hi>
-					Spiritus <lb/>
-					<hi rend="italic">sancti; docentes eoa servare omnia</hi> quaecumque <hi
-						rend="italic">mandu<unclear>vi</unclear>
-						<lb/> vobis (matth.</hi> XXVIII, 18-20): utquid commemoraveris, <lb/> .et
-					quid inde probare volucris * prorsus nescio. Num­ <lb/> quid enim ait, Data est
-					mihi a Deo meo potestas <lb/> Quod si dixisset, propter ipsam humanam formam
-					<lb/> dictum fuisse ambigi non dcboret. Quia vero non dixit; <lb/> quid isto
-					testimonio volueris agrre, non intelligo. Imo <lb/> intelligo te id egisse , ut
-					abundantius loquereris. Si <lb/> enim tanquam Dco duta est hxc potestas ,
-					nascenti <lb/> cain Pater dedit, non indigenti; quia gignendo dedit, <lb/> non
-					augendo. Si vero tanquam homini data est haec <lb/> potestas , qni I habet
-					quaestionis? An forte nos admo­ <lb/> ncre voluisti, quod baptizari Dominus
-					jusserit gculcs <lb/> in nominc Patris ct Filii ct Spiritus sancti ? Ubi au­
-					<lb/> dis unum nomen , ct unam non vis intelligere dcila­ <lb/> tem.</p>
-					<p>3. Quod autem dicisv ct ante incarnationem Chri­ <lb/> sti , Patrem dictuin csse
-					Dum ejus, quoniam scri. <lb/> ptum est \ Unxit <hi rend="italic">te, Deus,
-						Deus</hi> tuus; longe antequam <lb/> Christus venisset in carne : itane Ron
-					intelligis in <lb/> prophetia esse praed clum , tanquam fucrit factum <lb/> quod
-					erat futurum ? Annon sic in prophetia ait ipso <lb/> Dominus , <hi rend="italic"
-						>Foderunt manus meas et pedes (Psal.</hi> xxi, <lb/> 48); ct caeterea quihus
-					passionem suam tanto ante <lb/> prae<unclear>nuntiavit</unclear>, et quod
-					futurum fuerat, tanquam jam <lb/> factum esset expressit? Dictum ea ergo in
-					prophetia <lb/> rerum futurarum , tanquani locutione rerum praeteri­ <lb/>
-					tarum, <hi rend="italic">Unxit te, Deus, Deus tuus oleo exsultationis pra <lb/>
-						participibus tuis :</hi> participes ejus significans, qui futuri <lb/> fiii
-					rant servi ejus, socii ejus, amici cjus, fratres ejus, <lb/> membra ejus.
-					Praedictum est ergo quod futurum erat, <lb/> ut ungeret Deus Christi hominem
-					Christum: qui tamen <lb/> sic factus est homo, ut maneret Deus. Ungeret autem.
-					<lb/> non visibili ct corporali oleo , sed Spiritu sancto, <lb/> quem Scriptura
-					nomine olei exsultationis, figurata, ut <lb/> solet, locutione significat. Dixit
-					autem , <hi rend="italic">Unxit;</hi> non <lb/> dixit, Uncturus est: quia in
-					praedestinatione jam fa­ <lb/> ctum erat, quod suo tempore futurum erat. Ubi tn
-					<lb/> timens ne Spiritus sanctus, quo unctus est Christus . <lb/> major videatur
-					esse quam Christus, quia revera ma­ <lb/> jor est homine Christo; qui enim
-					sanctificat, eo qui <lb/> sanctificatur est major: hoc ergo timens, voluisti
-					olco <lb/> exsultationis eam laetitiam significatam videri, qua <lb/> Filius
-					exsultavit cum Patre, quando est condita ere:.­ <lb/> tura. Et commemorasti, ut
-					soles, testimonia causa <lb/> tuae non necessaria , de laetitia Patris et Filii.
-					Sed <lb/> quid facturus es? quo iturus i Quomodo id quod est <lb/> luce clarius,
-					aut negaturus, aut in aliud quodcumque <lb/> versurus es, cum recitatur tibi
-					quod beatus Petrus in <lb/> Apostolorum Actibus dixit : <hi rend="italic"
-						>Hunc</hi> Jesum a <hi rend="italic">Naza­ <lb/> reth, quem unxit Deus
-						Spiritu sancto (Act.</hi> x, 38). <lb/> Ecce quod prophetabatur, quando
-					dictum est, <hi rend="italic">Unxit <lb/> te Deu, Deus tuus oleo
-						exsultationis,</hi> vel, <hi rend="italic">oleo laetitiae,</hi>
-					<lb/> prae <hi rend="italic">participibus</hi> tuis. Deus enim cui dictum est in
-					eo­ <lb/> dem Psahno , Thronus tuus, Deus, in <hi rend="italic">saeculum
-						saeculi; <lb/> virga directionis , virga regni tui : dilexisti
-						justitiam,</hi> et <lb/>
-					<hi rend="italic">odio habuisti iniquitatem; propterea</hi> unxit <hi
-						rend="italic">te Deus, Deus</hi>
-					<lb/>
-					<pb n="783"/>
-					<hi rend="italic">tuus (Psal.</hi> XLIV, 7, 8) : a Deo Patre unctus est Filius,
-					<lb/> qui sic bomo factus est ut mancrel Deus, qua unctione <lb/> plenus erat,
-					id est, Spiritu sancto. Propter quod de <lb/> illo scriptum cst : Jesus <hi
-						rend="italic">autem plenus Spiritu sancto, <lb/> reversus est a Jordanc
-						(Luc.</hi> iv, 1).</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="17">
-					<p>CAPUT XVII.— 1. Dicis in persona Spiritus sancti <lb/> non posse suscipi quod de
-					Filio dictum est, <hi rend="italic">Omnia <lb/> per ipsum fucta sunt</hi> , et
-						<hi rend="italic">sine ipso</hi> facturi <hi rend="italic">est nihil <lb/>
-						(Joan.</hi> I, 3). Et hoc ideo hidis, ut quibus potueris <lb/> persuadeas,
-					qnod vobis male persuasum est, Spiri­ <lb/> tum sanctum non esse creatorem :
-					quasi legeris , <lb/> Omnia per ipsum facta sunt sine Spiritu sancto ; aut,
-					<lb/> Omnia per neminem facta sunt, nisi per ipsum. Quan­ <lb/> quam si et tale
-					aliquid legeres, sic Spiritum sanctum <lb/> ab hac operatione , qua constituta
-					est creatura , cre­ <lb/> dere non deberenmus exclusum; sicut Filius non <lb/>
-					excluditur ab ea scientia de qua dictum est, <hi rend="italic">Quce <lb/> Dei
-						sunt, tiemo scit,</hi> nisi Spiritus <hi rend="italic">Dei</hi> (I <hi
-						rend="italic">Cor.</hi> II, 11). <lb/> Si autem quia non est nominatus ,
-					quod etiam per <lb/> ilium facta sit creatura, quando de Filio dictum <lb/> est
-					, <hi rend="italic">Omnia per</hi> ipsum <hi rend="italic">facta</hi> sunt ;
-					idco putas Dei <lb/> Spiritum non esse creatorem : procnl dubio , lice <lb/> in
-					ejus nomine poteris baptizatos dicere , quibus <lb/> ait Petrus, <hi
-						rend="italic">Agite pœnitentiam, et baptizetur unus­ <lb/> quisque
-						vestrum</hi> in <hi rend="italic">nomine Domini Jesu Christi ( Act.</hi>
-					<lb/> II , 38) ; qnia non ait, Et S. iritus sancti : nee in <lb/> Patris nomine,
-					quia nec ipsc ibi et nominatus. <lb/> Si auteur etiam non nominatis Patre et
-					Spiritu <lb/> sancto , in nomine Jesu Christi jussi sun ba­ <lb/> plizari ; et
-					tamen intelliguntur non baptizati nisi in <lb/> nomine Patris et Filii et
-					Spiritus sanct! : cur non sic <lb/> audis de Filio Dei, Omnia pur <hi
-						rend="italic">ipsum facta sunt;</hi> ut <lb/> et non nominatum intellig
-						<unclear>as</unclear> ibi ctiam Spiritum san­ <lb/> cium?</p>
-					<p>2. NaiD quid excellentius in creaturis quam virtu­ <lb/> tes cœlorum? Scriptum
-					est autem : <hi rend="italic">Verbo DOli,;,. i <lb/> cœli firmati sunt; et</hi>
-					Spiritu <hi rend="italic">oris ejus, omnis virtus eo­ <lb/> rum (Psal.</hi>
-					XXXII, 6). Dixeras nempe non me talia re­ <lb/> perire in Scripturis divinis,
-					quibus Spiritum sanctum <lb/> aequalem asseram Filio. Ecce reperi ubi etiam
-					major <lb/> possit videri, nisi revocet pietas. quae illum veraciter <lb/>
-					confitetur aequalem. Nam utique majus aliquid sunt <lb/> virtutes cœlorum, quae
-					firmatae sunt Spiritu oris Do­ <lb/> mini, id est Spiritu sancto, quam cœli, qui
-					firmati <lb/> sunt Verto Domini, hoc est, unigentio Filio. Sed si <lb/> consulas
-					veritatem , res utraque ab utroque firmata <lb/> est; ct id quod de uno dicitur
-					et de altero tacetur, de <lb/> utroque intelligitur. Quid est autem
-					inconsideratius, <lb/> quam negare esse creatorem Spiritum Dei, cum Do­ <lb/>
-					mino dicatur : <hi rend="italic">Auferes spiritum eorum, et deficient, et</hi>
-					<lb/> in <hi rend="italic">pulverem</hi> suum convertentur : <hi rend="italic"
-						>emittes</hi> I <hi rend="italic">Spiritum</hi>
-					<lb/> tuum, et <hi rend="italic">creabuntur; et innovabis faciem</hi> terrae <hi
-						rend="italic">(Psal.</hi>
-					<lb/> CIII, 29, 30) Nisi forte minus idoneus erat Spiritus <lb/> sanctus
-					creandis rebus quae fuerant defecturae, cum <lb/> sit idoneus creandis quae sunt
-					sine line mansurae. <lb/> Paulo ante dixi : Quid est excellentius in creaturis
-					<lb/> quam virtutes cœłorum? Quid dicam de carne Crea­ <note type="footnote"> *
-						Pd'U, <hi rend="italic">emitte.</hi> At Mss , <hi rend="italic"
-							>cmitl:s.</hi> F.L sic Aiigustiinis, Enarr. <lb/> ill ontodeui psalmum
-						105. </note>
-					<lb/> toris ? Quandoquidem Creator ipse per quem facia <lb/> sunt omnia, <hi
-						rend="italic">Panis,</hi> inquit, <hi rend="italic">quem ego dedero, caro
-						mea<lb/> est pro mundi vita (Joan.</hi> vi, 52). Quid ergo? Mundus <lb/> per
-					Filium factus est, et creator est Filius : caro cjus <lb/> quae data est pro
-					mundi viia , per Spiritum sanc tum <lb/> facia est, et non cst creator Spiritus
-					sanctus? Cum <lb/> enim virgo Maria dixisset angelo promittenti Ci filium, <lb/>
-					<hi rend="italic">Quomodo fiet istud, quoniam virum non</hi> cognosco ? re­
-					<lb/> spondit angelus, <hi rend="italic">Spiritus sanctus superveniet</hi> in te
-					, <hi rend="italic">et <lb/> virtus Altissimi obumbrabit tibi; propterea quod
-						nasce­<lb/> tur ex te sanctum, vocabitur Filius Dei (Luc.</hi> I, 34, 35).
-					<lb/> Hic tu, quod in consequentibus quodam loco tuae prose­ <lb/> cutionis
-					adverti, asserere conaharis Spiritum sanctum <lb/> pra'cessisse, ut mundaret et
-					sanctificaret virginem <lb/> Mariam; ac deinde veniret Virtus Altissimi, hoc est
-					<lb/> Sapientia Uci, quod est Christus (I <hi rend="italic">Cor.</hi> i, 24); ei
-					<lb/> ipsa , sicut scriptum est, aedificaret sibi domun <lb/>
-					<hi rend="italic">(Prov.</hi> IX, i), hoc est, ipsa sihi crearcl carnem, non
-					<lb/> Spiritus sanctus. Quid est ergo quod ait sa nctum Evan­ <lb/> gellum, <hi
-						rend="italic">Inventa eat</hi> in <hi rend="italic">utero habens de Spiritu
-						sancto<lb/> (Matth.</hi> I, 18) ? Nempe obstructum cst os loquentium <lb/>
-					iniqua ( <hi rend="italic">PsaL</hi> LXII, 12 ). Si ergo cogitas os veraciter
-					<lb/> aperire, n on solum Filium , verum etiam Spiritum <lb/> sanctum creatorem
-					carnis Filii confitere.</p>
-					<p>3. An f orte dicturus es, ea facta esse per Spiritum <lb/> sanctum quae
-					commemoravi, id est, quod omnis virtus <lb/> coelorum per eum firmata sit, quod
-					per cum creaban­ <lb/> tur homines denuo, qni primo ita creantur ut conver­
-					<lb/> tantur in pulverem suum ; quod ipse carnem opera­ <lb/> tus est Christi
-					(nam de anima nolo aliquid dicere , <lb/> cujus difficillima quaestio est); et
-					si quid aliud per <lb/> Spiritum sanctum creatum potuerit inveniri: non ta­
-					<lb/> men omnii, sicut per unigcnitum Filium , de quo <lb/> dictum est, Omnia
-					per <hi rend="italic">ipsum facta</hi> sunt? Si hoc dicis, <lb/> non limes ne
-					tibi dicatur, eo potiorem esse Spiritum <lb/> sanctum Filio, quod elegit sibi
-					meliora qua; faceret, <lb/> nec facere inferiora dig<unclear>natus</unclear>
-					est? Sed quis hoc sapit, <lb/> nisi qui desipit? Facta sunt ergo cuncta per
-					Filium ; <lb/> absit, nt Spiritu sancto ab hoc opere separato : sicut <lb/> de
-					illis magnis operibus dictum est, <hi rend="italic">Omnia autem haec<lb/>
-						operatur unus atque</hi> idem <hi rend="italic">Spiritus</hi> (1 <hi
-						rend="italic">Cor.</hi> XII, i 1); nec <lb/> tamen ab hac operatione Filius
-					separatur.</p>
-					<p>4. Magnum sane aliquid tibi dicere videris, quia di­ <lb/> cis : Filius <hi
-						rend="italic">erat</hi> in <hi rend="italic">principio antequam aliquid
-						esset; <lb/> Pater vero, ante principium</hi> Ubi legisti, ut iirc cre
-					<lb/>dcres? Unde praesumpsisti ut haec diceres , ubi nec <lb/> auctoritas ulla,
-					nec ratio est ? Quid est enim ante <lb/> principium , quandoquidem quidquid ante
-					esset, hoc <lb/> esset principium ? Si ergo Pater antc 1 principtum <lb/> est,
-					ante seipsum est; quia et ipse principium est. <lb/> Quid est autem, <hi
-						rend="italic">In</hi> principio erat <hi rend="italic">Verbum (Joan.</hi> I,
-					i); <lb/> nisi, In Patre crat Filius ? Et ipse Filius interrogatus <lb/> a
-					,ludaris quis esset, respondit : <hi rend="italic">Principium, quia et<lb/>
-						loquor vobis (Id.</hi> VIII, 25). Pater crgo principium non <lb/> de
-					principio; Filius principiu.n de principio : scd <lb/> utrumque simul, non duo ,
-					sed unum principium ; <lb/> sicut Pater Deus et Filius Deus, ambo autem siut
-					<lb/> non dun dii, sed unus Deus. Nee Spiritum sanctum <note type="footnote">1
-						Hie ajud l.ov. omissum est, <unclear>esse</unclear>. </note>
-					<lb/>
-					<pb n="785"/> ab utroque procedentem negabo esse principium : <lb/> sed haec
-					tria simul sicut unum Deum, ita unum dico <lb/> esse principium.</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="18">
-					<p>CAPUT XVIII — i. Quid, si <hi rend="italic">audierit,</hi> inquis, Pa­ <lb/> trem
-						<hi rend="italic">dicentem,</hi> « <hi rend="italic">Tecum</hi> principium
-					in <hi rend="italic">die</hi> virtuti, <hi rend="italic">tum, <lb/> in
-						splendoribus tanctorum, ex utero ante luciferum</hi> ge­ <lb/> nui <hi
-						rend="italic">te &gt; (Psal.</hi> CIX, 3) Quid promittis. vel quid mi­ <lb/>
-					naris , si audiero quod frequenter audio, et fideliter <lb/> credo? Sed hinc te
-					nihil adjuvari , cur non videas, <lb/> plurimum miror. Sive enim ex persona sua
-					hoc pro­ <lb/> pheta dicat ad Dominum Jesum , sive ex persona Pa­ <lb/> tris ad
-					Filium, cum ego ambas generationes Christi, <lb/> et ex Den Patrc sine tempore,
-					et ex homine matre in <lb/> plenitudine temporis accipiam, vencrer, praedicem,
-					<lb/> non est hoc testimonium adversum me. Sed moras <lb/> innectere voluisse
-					indicat te, ubi ego potius intelligo, <lb/> quare <hi rend="italic">ex
-						utero</hi> dixerit <hi rend="italic">genui te :</hi> quia huc et tu ex per
-					<lb/>sona Patris accipis dictum. Non enim quemadmodum <lb/> corporis humani
-					sunt membra disposita , sic habet <lb/> uterum Dens ; sed verbum translatum est
-					a corporali <lb/> ad incorporalem substantiam , ut intelligeremus de <lb/>
-					Patris substantia genitum unigenitum Filium ; ac per <lb/> hoc quid aliud quam
-					unius ejusdemque substantiae ? <lb/> Ego itaque hoc testimonium proferre contra
-					te debui : <lb/> sed gratias ago quia commonuisti. Considera ergo <lb/> quantum
-					mali sit, quod ejusdem subustantiae Filiam <lb/> negatis, quem genitum
-					confitemini ex utero Patris, <lb/> injuriam gravissimam facientes Deo , tanquam
-					illud <lb/> quod ipse non esset,, ex utero gignere potuisset. Non­ <lb/> ne
-					sentitis vos generationem Dei credere vitiosam , <lb/> praedicare monstruosam,
-					qui dicere audctis ex utero. <lb/> Dei processisse diversam naturam? Si antem
-					hoc, sic­ <lb/> ut debclis, horretis, respuilaque nobiscum, jam tnn­ <lb/> dem
-					concilium Nicaenum et Homousion laudate ac <lb/> tenete nobiscum.</p>
-					<p>2. Quis autem nou videat defectum tuum, ubi cum. <lb/> andisses, me
-					commemorante,1 in prophetia dixisse <lb/> Christum suo Patri, De <hi
-						rend="italic">ventre</hi> matris meae <hi rend="italic">Deus</hi> meus <lb/>
-					<hi rend="italic">es tu (Psal</hi> xxi, ii ); ut intelligeremus ejus na­ <lb/>
-					turae ilium esse Deum quam Filius ipsius ex tempore <lb/> de ventre matris
-					accepit, Patrem vero naturae illius <lb/> quam do se ipse generavit: tu non
-					inveniens quid re­ <lb/> sponderes, tamen ne laceres dixisti, <hi rend="italic"
-						>Ex ventre</hi> matris <lb/> natum profiteri. Christum secundum <hi
-						rend="italic">carnem;</hi> et addi­ <lb/> disti, <hi rend="italic">quod
-						nec</hi> Judaei <hi rend="italic">diffidunt.</hi> Ac deinde quaesisti, <lb/>
-					<hi rend="italic">Car</hi> ista <hi rend="italic">testimonia in medium</hi> noR
-						<hi rend="italic">proferantur, quae <lb/> illam</hi> nativitatem <hi
-						rend="italic">demonstrant in</hi> principio, sicut <hi rend="italic">et
-						prae­ <lb/> cedent</hi> noa, inquis, instruit testimonium ? Quasi ego <lb/>
-					illam nativitatem Christi, non temporalem, sad aeter­ <lb/> nam, propter quam
-					dictum est, <hi rend="italic">In principio erat Ver­<lb/> bum,</hi> non credam,
-					non praedicem, non amplectar; <lb/> sed tantum ex ventre matris natum asseram
-					Chri­ <lb/> stum? Ecce ego dico Deum Filium de Deo Patre sine <lb/> tempore
-					genitum. Quomodo sit autem etiam Deus <lb/> ejus qui Pater est ejus, ostendi,
-					propter hominem <lb/> quem suscepit, et in quo natus cst de ventre matris, <lb/>
-					sinc concubitu hominis patris. Ad quod probandum <lb/> testimonium dedi, ubi ait
-					in prophetia Patri sun, <hi rend="italic">De <lb/> ventre matris meae Deut
-						meus</hi> es <hi rend="italic">tu.</hi> Tu qui dicis me es <lb/> ventre
-					matris natum profiteri Christum , quod nee Ju­ <lb/> daei diffidunt, quasi ego
-					istam nativitatem Christi In. <lb/> lam profitear; Meli per inania conari
-					evadere , et dic <lb/> potius quare mihi non responderi, ubi dicit Christus
-					<lb/> Patri, <hi rend="italic">De ventre matris meae Deut</hi> meut es <hi
-						rend="italic">tu.</hi> Ad hoc <lb/> enim quoniam vidisti non te habere quod
-					diceres, <lb/> aliam nativitatem quae Dei de Deo. est, interponem <lb/> dam
-					putasti qua fugeres. Rogo te; quando quid rc­ <lb/> spondeas non habes, quanto
-					melius taceres?</p>
-					<p>3. Si propter <hi rend="italic">corpus,</hi> inquis, in <hi rend="italic">quo
-						se</hi> exinanivit, <lb/>
-					<hi rend="italic">debitorem</hi> te <hi rend="italic">sentit</hi> suo <hi
-						rend="italic">genitori;</hi> multo magis qui illum <lb/>
-					<hi rend="italic">tantum ac talem genuit, necesse est</hi> x! eam <hi
-						rend="italic">veneretur,<lb/> eique</hi> offerat <hi rend="italic"
-						>semper</hi> obsequium. Quodlibet de venera­ <lb/> tione et obsequio Filii
-					erga Patrem carnaliter sentias, <lb/> Puer ejus, nisi de ventre matris ejus, non
-					est Deus <lb/> ejus. Jam quantumvis obsequatur Deo Patri Deus <lb/> Filius,
-					quoniam ,-ideo te non intelligere quanta sil in <lb/> illa generatione geniti et
-					genitoris aequalitas, num­ <lb/> quid ideo est diversa natura patris hominis et
-					hominis <lb/> filii, quoniam filius obsequitur patri? Hoc est omnino <lb/>
-					intolerabile in vobis, qnia de obsequio Filii diversam <lb/> vultis probare
-					substantiam Patris et Filii. Prorsus <lb/> alia quaestio cst, Utruin sint unias
-					ejusdemque sub­ <lb/> stantiae Pater et Filius; et alia quacstio est, Utrum
-					<lb/> Patri Filius obsequatur. Interim verum Filium non <lb/> negemus, qui nullo
-					modo est verus Filius, si non est <lb/> ipsius et Patris ana eademque natura.
-					Dicite ergo <lb/> Deum Patrem; et Deum Filiium unius ejusdemque <lb/> esse
-					substantia!. Extorqueat vobis divinitas, quod <lb/> humanitati donavit ipsa
-					divinitas. Obsequitur homo <lb/> patri suo, de quo natus est homo; tamen
-					obsequendo <lb/> esse non desinit homo. Ei si, non dico pariter hono­ <lb/>
-					ratus, sed honoratior esset ftlius, gauderet pater, non <lb/> invideret:
-					honoraret tamen etiam ille patrem, etsi <lb/> non parvulus, accessu augendus
-					aLlatis, sed ei natus <lb/> esset aequalis. aequalem vero si pater homo potuis­
-					<lb/> set , nullo dubitante genuisset. Quis ergo audeat di­ <lb/> cere, Hoc nec
-					Omnipotens potuit? Addo cHam, quia <lb/> si posset homo, majorem se ipso
-					melioremque <lb/> gigneret filium : sed majus vel melius Deo quidquam <lb/> non
-					potest esse; ergo ei verum Filium credamus <lb/> aequalem. Quod si dixeris, Eo
-					ipso major est Pater <lb/> Filio, quia de nullo genitus, genuit tamen aequaletn:
-					<lb/> cito respondebo, Imo ideo non est major Pater Filio, <lb/> quia aequalem
-					genuit, non minorem. Originis enim <lb/> quaestio est, Quis de quo sit :.
-					aequalitatis autem, <lb/> Qualis aut quantus sit. Proinde si admittit ratio veri<lb/>tatis ut aequali Patri Filius obsequatur aequalis, non <lb/> negnmus
-					obsequium : si autem per obsequium mino­ <lb/> rem natura1 vultis credere,
-					prohibemus: nullo modo <lb/> enim Deus Pater ut babcre unici Filii posset obse­
-					<lb/> quium, vellet denegare naturam.</p>
-					<p>4. Par entibus autom ut esset subditus Christus , <lb/> non dvinae majestatis
-					fuit, sed aetatis humanae Fru­ <lb/> stra itaque dixisti : <hi rend="italic">Si
-						parentibus fuit subditus quot<lb/> creavit</hi> ( <hi rend="italic"
-						>Luc.</hi> II, 51 ), <hi rend="italic">quanto magis suo genitori qui <lb/>
-						eum tantum ac talem genuit?</hi> Respondetur enim lihi ; <note
-						type="footnote"> I AIR. ct Er., <hi rend="italic">minorem natum</hi> plures
-						Mss., <hi rend="italic">nnnorem</hi> fM' <lb/> turam. </note>
-					<lb/>
-					<pb n="787"/> Si parentibus fuit subditus propter pueritiam, quanto <lb/> magis
-					Den propter ipsam hominis formam? Quam <lb/> formam eum immortalem fecerit, non
-					morti perdide­ <lb/> rit; quid miraris si etiam post hujus saeculi finem sub­
-					<lb/> jectus erit in ea illi, qui ei subjecit omnia ? Tu autem <lb/> non propter
-					formam servi dicis Filium Patri esse sub­ <lb/> jectum , sed quia cum tantum ac
-					talem genuit. id est <lb/> magnum Deum, quanvis Patre ipso minorem : ubi ct
-					<lb/> Patri dcrogas, qui Filium sibi unicum, aut non potuit, <lb/> aut noluit
-					gignere aequalem; ut ipsi Filio qni unicus <lb/> Patri non est generatus
-					aequalis. et idco perfectus est <lb/> natus, ne unquam vel crescendo fieret,
-					quod non po­ <lb/> tuit esse nascendo.</p>
-					<p>5. Non autem, ut putas, corpus tantum Filii, id est, <lb/> corpus hominis, verum
-					etiam buinanum spiritum Pa­ <lb/> tri dicimus esse subjectum : et secundum id
-					quod <lb/> botro factus est intelligimus dictum. <hi rend="italic">Cnm antem
-						omnia<lb/> tlli</hi> subjecta fuerint <hi rend="italic">tunc et ipse Filius
-						subjectus erit illi</hi>
-					<lb/> qui a subjecit <hi rend="italic">omnia</hi> (1 <hi rend="italic">Cor.</hi>
-					xv, 28). Secundum id quod <lb/> Christus est caput ct corpus: caput scilicet
-					ipse Sal­ <lb/> vator qui surrexit a mortuis, et scdel ad dexteram Pa­ <lb/>
-					tris; et Ecclesia quae est corpus ejus, plenitudo ejns, <lb/> sicut apertissime
-					dicit Apostolus <hi rend="italic">(Coloss.</hi> I, 18). Ac <lb/> per boc cum
-					omuia Christo subjecta fuerint, et capiti <lb/> et corpori erunt sinc
-					dubitatione subjecta. Nam secun­ <lb/> dum id quod sine tempore Deus natus est,
-					nihil un­ <lb/> qnam potuit ei non esse subjectum.</p>
-					<p>6. Scimus, quod nos commemoraridos putasti, <hi rend="italic">quia <lb/>
-						Pater</hi> non <hi rend="italic">judicat quemquam, sed omne judicium
-						dedit</hi>
-					<lb/> Filio <hi rend="italic">(Joan.</hi> v, 22). Vellem tamen diceres nobis,
-					quo­ <lb/> modo Pater non judicat quemquam , cum dicat ipse <lb/> identidem
-					Filius, <hi rend="italic">Ego non quaero</hi> gloriam <hi rend="italic">meam;
-						est</hi>
-					<lb/> qui <hi rend="italic">quaerat, et judicet (Id.</hi> VIII, 50) : ut srias
-					idco di­ <lb/> ctum, <hi rend="italic">Pater non judicat</hi> quemquam, <hi
-						rend="italic">sed omne judicium <lb/> dedit Filio;</hi> quoniam judicandis
-					vivis et marnis for­ <lb/> ma hominis apparebit, quam non hahct Pater: pro­
-					<lb/> pter quod ait propheta, <hi rend="italic">Videbunt in quent
-						pupugerunt<lb/> (Zach.</hi> XII, 10). Sed invisibiliter etiam Pater erit cum
-					<lb/> eo, quia inseparabilis est ab eo. Si enim, <hi rend="italic">Non</hi> sum <lb/>
-					<hi rend="italic">solus, quoniam Pater</hi> mecum est, ait ipse moriturus <lb/>
-					<hi rend="italic">(Joan.</hi> XVI, 52); quanto magis secum habebit Patrem, <lb/>
-					de mortuis et vivis judicaturus? Cum illo crit etiam <lb/> Spiritus sanctus.
-					Quomodo enim deseret eum Spiritus <lb/> sanctus in rcgali sede, quo plenas
-					regressu! est a Jor­ <lb/> dane <hi rend="italic">(Luc.</hi> IV, 1)! Quod itaque
-					scriptum est ad lie.. <lb/> braeos, <hi rend="italic">Nunc autem necdum videmus
-						omnia subjecta ei :</hi>
-					<lb/> cum <hi rend="italic">autem modico minus ab Angelis minoratum videmus
-						<lb/> Jesum propter passionem mortis (Hebr.</hi> II, 8, 9): do­ <lb/> cere
-					nos debet quomodo intelligendum sit quod scri­ <lb/> ptum est ad Corinthios, Cum
-						<hi rend="italic">autem omnia illi subjecta</hi>
-					<lb/> fuerint: quia secundum id dictum est quod factus est <lb/> homo, non
-					secundum id quod est Deus. Sic ergo in <lb/> homine apparens, in quo per
-					passionem mortis mino­ <lb/> ratus est modico minus ab Angelis, vivos et
-					mortuos. <lb/> judicabit, quando dicturus est : <hi rend="italic">Venite,
-						benedicti Pa­</hi>
-					<lb/> tris <hi rend="italic">mei percipite regnum</hi> ( <hi rend="italic"
-						>Matth.</hi> xxv, 34 ). Quo tu <lb/> testimonio non hominem, sed Deum
-					minorem suo <lb/> Patre quasi probare voluisti : sed sicut ab eit qui in­ <lb/>
-					telligunt perspicitur, nun probasti.</p></div>
-				<div type="textpart" subtype="chapter" n="19">
-					<p>CAPUT XIX. — De Spiritus sancti autem gemiii­ <lb/> bus, quia non ipse gemit, sed
-					inspirans nobis deside­ <lb/> rium sanctum nos facit gemere quamdiu peregrina­
-					<lb/> mur a Domino, jam tibi sunicienter respondisse me <lb/> existimo. £t tales
-					de Scripturis sanctis locutiones, <lb/> quantum satis videbatur ostendi, quoniam
-					sic dicitur <lb/> gemere Spiritus sanctus, quia nos facit gemere ; sicut <lb/>
-					dixit Deus, <hi rend="italic">Nunc cognovi (Gen.</hi> XXII, 12), quando co­
-					<lb/> gnoscere hominem fecit. Non eqim tunc cognoverat <lb/> quod tunc se
-					dixerat cognovisse, qni omnia scit an­ <lb/> tequam fiant. Ad quod te respondere
-					non potuisse, <lb/> quid predest quia scutis, quando non consentis ?</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="20">
-					<p>CAPUT XX. — i. Jam eliam de verbis Domini <lb/> ubi ait, <hi rend="italic"
-						>Ego</hi> et <hi rend="italic">Pater</hi> unum sumus <hi rend="italic"
-						>(Joan.</hi> x, 30); nihil <lb/> te respondere potuisse monstravi. Sed ut
-					hic quoquo <lb/> ostendam, si exemplis, ut dicis, quibus ego usus sum, <lb/> vis
-					probare quomodo dictum sit, <hi rend="italic">Ego et Puter</hi> unum <lb/>
-					<hi rend="italic">sumus;</hi> ct ob hoc commemoras apostolicum testimo­ <lb/>
-					nium. quod a me p'situm est, ubi ait <hi rend="italic">Qui adhaeret <lb/>
-						Domino, unus spiritus est</hi> ( I <hi rend="italic">Cor.</hi> VI 17): dic
-					ct tu, <lb/> Cum adhaeeret Patri Filius, unus Deus e t. Nou enim <lb/> ait
-					Apostolus, <hi rend="italic">Qui adhaeret Domino,</hi> unum sunt; sicut <lb/>
-					dictum est, <hi rend="italic">Ego et Pater unum sumus:</hi> sed ait, unus <lb/>
-					<hi rend="italic">spiritus edt.</hi> Cum autem tu non dicas, Cum adhaere t <lb/>
-					Patri Filius, unus Deus est ; utquid et tu adhibes hoc <lb/> Apostoli
-					testimonium, ubi ait, <hi rend="italic">Qui adhaeret Domino, <lb/> unus spiritus
-						est ;</hi> nisi ut te etiam a te producto teSte <lb/> convincam? Nunc saltem
-					distingue duo bta, quae non <lb/> potuisti, cum simul essemus, in nostra
-					disputatione <lb/> distinguere. Diligenter itaque attende quod dico. <lb/>
-					Quando de rcbus duabus nul plurimus dicitur, Unus <lb/> est, vel, una est, et
-					additur quid unus vel quid una; <lb/> ct de his quae diversae, et de his quae
-					sunt unius sub­ <lb/> stantiae dici potest. Diversae sunt enim substantiae spi.
-					<lb/> ritus hominis et Spiritus Domini 1 :et tamen dictum <lb/> est, Qui <hi
-						rend="italic">adhaeret Domino unus spiritus tat.</hi> Unius au­ <lb/> tem
-					substauti;e sunt animae hominum ct corda homi­ <lb/> num; de quibus dictum est,
-						<hi rend="italic">Erat Ulis anima</hi> una <hi rend="italic">et<lb/>
-						cor</hi> unum <hi rend="italic">(Act.</hi> IV, 52). Ubi autem dicitur de
-					duobus <lb/> aut pluribus, Unum sunt, nec additur quid unum sint; <lb/> non
-					diversae intelliguntur, sed unius esse substantiae: <lb/> sicut dictum est, <hi
-						rend="italic">Qui plantat et qui rigut,</hi> unum 'unt <lb/> (I <hi
-						rend="italic">Cor.</hi> III, 8); et, <hi rend="italic">Ego et Pater</hi>
-					unum <hi rend="italic">sumus.</hi> Tu au­ <lb/> tem qni Patrem cl Filium
-					diversas vis rsse substan­ <lb/> tias, invenire non potuisti, ubi de diversis
-					substantiis <lb/> dic tum fuerit, Unum sunt. Et qui non vis dicere, Cum <lb/>
-					Filius adhaeret Patri, unus Deus est; adhibuisti et tu, <lb/> apostolicum
-					testimonium quod ego adhibueram; sed <lb/> adhibuisti contra te ipsum, uhi ait,
-						<hi rend="italic">Qui adhaeret</hi> Do<lb/>Mnino, <hi rend="italic">unus
-						spiritus est.</hi> Si enim de his qui diversae <lb/> substantiae sunt, recte
-					dici potuit, <hi rend="italic">unus spiritus</hi> est; <lb/> quantQ magis de bis
-					qui unius substantiae sunt recte <lb/> dicitur, Unus Deus est? Si haec
-					intelligis, non te ad <lb/> ea respondisse jam perspicis, et de consensu
-					volunta­ <lb/> tis tc inaniter tam multa dixisse cognoscis. Etiam <lb/> nos
-					quippe incompambilem consensum voluntatis at­ <lb/> que individuae charitatis
-					Patris et Filii et Spiritus san­ <lb/> fti confitemur, propter quod dirinms ,
-					Haec Trinitas <note type="footnote">1 Antiquiores Mss.t <hi rend="italic">et
-							Spiritus nomimis.</hi>
-					</note>
-					<pb n="789"/>
-					<unclear/><lb/> unus est Deus. Sed nos boc etiam, quod vos non di­ <lb/> citis,
-					dicimus, propter unam eamdemque naturam at­ <lb/> que substantiam, Hi tres unum
-					sunt. Haec si discre­ <lb/> veris, et contentiosus esse nolueris, non te ad ea
-					re­ <lb/> spondisse aliquid jam videbis, et de hac quaestione <lb/> procul dubio
-					jam tacebis.</p>
-					<p>2, Ubi autem dixil Eilius Patri, <hi rend="italic">Verum non quod</hi>
-					<lb/> ego <hi rend="italic">volo, sed quod. tu vis;</hi> quid te adjuvat quod
-					tua <lb/> verba subjungis ctdicis, <hi rend="italic">Ostendit vere voluntatem
-						suam <lb/> subjectam</hi> suo genitori : quasi nos. negemus, hominis <lb/>
-					voluntatem voluntati Dei debere esse subjectam? Nam <lb/> ex natura hominis hoc
-					dixisse Dominum cito vidct ,. <lb/> qui locum ipsum sancti Evangelii pauLo
-					attentius in­ <lb/> tuetur. Ibi enim dixit: <hi rend="italic">Tristis est anima
-						mea usque ad</hi>
-					<lb/> martem ( <hi rend="italic">Matth.</hi> XXVI, 39, 38 ). Numquid ex natura
-					<lb/> unici Verbi posset hoc dici? Sed homo qui putas ger <lb/> mere naturam
-					Spiritus sancti, cur non etiam naturam <lb/> Verbi Dei unigeniti tristem dicas
-					esse potuissc?- Ille <lb/> tamen, ne quid diceretur tale, non ait, Tristis sum ;
-					<lb/> quamvis etiamsi line dixisset, non nisi ex natum ho­ <lb/> minis
-					oportuisset intelligi : sed ait, Tristis <hi rend="italic">est</hi> anima <lb/>
-					<hi rend="italic">mea ;</hi> quam sicut homo utique habebat humanam. <lb/>
-					Quamquam ct in hoc quod ait, <hi rend="italic">Non quod ego volo ;</hi>
-					<lb/> aliud se ostendit voluisse quam Pater : qnod nisi hu­ <lb/> mano corde non
-					potuisset, cum infirmitatem nostram <lb/> in suum, non divinum , sed humanum
-					transfiguraret <lb/> affectum. Homine quippe non assumpto, nullo modo <lb/>
-					Patri diceret unicum Veibum, <hi rend="italic">Non quod ego volo.</hi>
-					<lb/> Nunquam enim posset immutabilis illa natura quid­ <lb/> quam
-						<unclear>aliud</unclear> velle quam Pater. Haec si distingueretis, <lb/>
-					Ariani haeretici non essetis.</p>
-					<p>3. Nam et illud quod dictum est, Descendi <hi rend="italic">de cœ­<lb/> to, non
-						ut faciam volunlatem meam, sed voluntatem ejus</hi>
-					<lb/> qui <hi rend="italic">me misit (Joan.</hi> V!, 58) : potest quidem accipi
-					<lb/> etiam secundum id quod est unigenitum Verbum ; ut <lb/> ideo voluntatem
-					non suam dixerit esse, sed Patris , <lb/> quoniam de Patre est quidquid est
-					Filius; non est all­ <lb/> tem de Filio quidquid est Pater : secundum quod di­
-					<lb/> ctum est, <hi rend="italic">Mea doctrina non eat mea, sed ejus qui me</hi>
-					<lb/> mit <hi rend="italic">(Id.</hi> vn, 16); quoniam Patris doctrina ipse est
-					<lb/> qui Patris est Verbum, et utique non ost a se ipso, <lb/> sed a Patre. Et
-					rursus cum dicit, <hi rend="italic">Omnia quae</hi> habet <lb/>
-					<hi rend="italic">Pater,</hi> mea <hi rend="italic">sunt (Id.</hi> XVI, 15) ;
-					Patri se ostendit aequa­ <lb/> lem. Non absurdum est tamen , ut etiam hoc secun­
-					<lb/> dum id quod homo factus est, dixisse accipiatur : <hi rend="italic">Dc­
-						<lb/> scendi de caelo, non</hi> ut <hi rend="italic">faciam voluntatem meam,
-						sed vo­ <lb/> luntatem ejus qui me misit.</hi> Secundus enim Adam, qui <lb/>
-					tollit peccatum mundi, isto modo se discrevit a pri­ <lb/> mo Adam , per quem
-					peccatum intravit in mundum <lb/>
-					<hi rend="italic">(Rom.</hi> v, t2) : quia iste non fecit voluntatem suam, <lb/>
-					sed ejus a quo missus est; cum ille fecerit suam, non <lb/> ejus a quo creatus
-					est. Nee moveat quomodo Christus <lb/> secundum id quod homo- est, descenderit
-					de cœlo, <lb/> cum de matre quae in terra erat factus sit homo. Hoc <lb/> enim
-					propter unitatem personae dictum est, quoniam <lb/> una persona est Christus
-					Deus et homo. Propter quod <lb/> etiam : <hi rend="italic">Nemo,</hi> inquit,
-						<hi rend="italic">ascendit</hi> in <hi rend="italic">caelum,</hi> nisi <hi
-						rend="italic">qui de <lb/> cœlo descendit. Filius hominis, qui eat in caelo
-						(Joan.</hi>
-					<lb/> III, 13). Si ergo attendas distinctionem substantiarum, <lb/> Filius Dei
-					de coelo descendit, Filius hominis cruci­ <lb/> fixus est : si nnitatem
-					personae, et Filius hominis de­ <lb/> scendit de caelo, et Filius Dei est
-					crucifhus. Ipso <lb/> est enim Dominus gloriae, de quo ait Apostolus : <hi
-						rend="italic">Si<lb/> enim cognovissent,</hi> nunquam Dominum <hi
-						rend="italic">gloriae crucifixi<lb/> sent (I Cor.</hi> II, 8). Propter hanc
-					ergo unitatem perso­ <lb/> nae, non solum Filium hominis dixit descendisse de
-					<lb/> cœlo, sed esse dixit in coelo, cum loquerctur in terra. <lb/> Non ergo
-					voluntatem suam fecit, quia peccatum non <lb/> fecit: sed voluntatem fecit
-					illius qui eum misit. Tunc <lb/> enim facit homo voluntatem Dei, quando facit.
-					justi. <lb/> tiam qua: ex Deo est.</p>
-					<p>4. Nec sic arbitremur a Patre missum. esse Filium, <lb/> ut non sit missus ab
-					Spiritu sancto; cum vox ipsius <lb/> sit per prophetam, <hi rend="italic">Et
-						nunc</hi> Dominus misit <hi rend="italic">me, et Spi.</hi>
-					<lb/> ritus <hi rend="italic">ejus.</hi> Hoc enim Filium dixisse, indicant ea
-					quai <lb/> sunt dicta superius. Nam sic ad ista verba perventum <lb/> est : <hi
-						rend="italic">Audite me,</hi> inquit, <hi rend="italic">Jacob,</hi> et <hi
-						rend="italic">Israel quem ego to <lb/> cabo. Ego sum</hi> primus, <hi
-						rend="italic">et ego</hi> sum in <hi rend="italic">aeternum ; et</hi> ma
-					<lb/> nus <hi rend="italic">mea</hi> fundavit <hi rend="italic">terram, dextera
-						mea solidavit ccelum. <lb/> Yocabo illos, et astabunt simul ; convenient
-						etiam</hi> uni­ <lb/>
-					<hi rend="italic">versi, et audient. Quis illi. nuntiavit haec?</hi> Diligens te <lb/>
-					<hi rend="italic">feci voluntatem tuam</hi> super <hi rend="italic">Babylonia,
-						ut</hi> tollatur semen <lb/>
-					<hi rend="italic">Chaldaeorum. Ego locutus sum, ego</hi> vocavi; <hi
-						rend="italic">adduri<lb/> illum, et prosperam</hi> viam <hi rend="italic"
-						>ejus feci. Convenite ad me, ei<lb/> audite ista. Nec enim ab initio in
-						obscuro locutus sum : <lb/> cum <unclear>fiebant</unclear>, ibi eram; et
-						nunc Dominus misit</hi> me, et <lb/>
-					<hi rend="italic">Spiritus ejus (Isai.</hi> XLVIII, 12-16). Quid hoc apertius?
-					<lb/> Nee sic a Patre et Spiritu sancto missus est. ut se ipse <lb/> non miserit
-					: sicut a Patre ostenditur traditus, ubi <lb/> legitur, Qui <hi rend="italic"
-						>Filio proprio non pepercit, scd pro nobis<lb/> omnibus tradidit eum
-						(Rom.</hi> VIII, 32) ; alio autem loco de <lb/> ipso Filio dicitur, <hi
-						rend="italic">Qui me dilexit, et tradidit scipsum<lb/> pro me (Galat.</hi>
-					II. 20). Quomodo autem non facit va­ <lb/> luntatem suam, qui dixit, Sicut <hi
-						rend="italic">Pater</hi> suscitatmortuos <lb/>
-					<hi rend="italic">et vivificat, sic et Filius quos vult vivificat (Joan.</hi> V,
-					21); <lb/> et cum ei dictuin esset <hi rend="italic">Si vis, potes me
-						mundare;</hi>
-					<lb/> respondit, <hi rend="italic">Volo, mundare;</hi> et ad verbum continuo
-					<lb/> f. ctum est quod velle se dixit <hi rend="italic">(Matth.</hi> VIII, 2, 3)
-					? Sicci <lb/> autcm Filias facit voluntatem Patris, sic et Pater facit <lb/>
-					voluntatem Filii. Nam Filius dicit: <hi rend="italic">Pater, volo</hi> ut <hi
-						rend="italic">ubi <lb/> ego</hi> sum, <hi rend="italic">et isti sint mecum
-						(Joan.</hi> XVII, 24). Non dixit <lb/> Peto, vel, Rogo; sed, vo!o : ut isto
-					volente faceret <lb/> ille, sicut illo volente faciebat iste : et non alia ille,
-					<lb/> alia istc; sed quae ille, haec etiam iste. <hi rend="italic"
-						>Quaecumque<lb/> enim Pater facit, haec et</hi> Filiussimiliter facit <hi
-						rend="italic">(ld.</hi> v, 19). <lb/> Verba sunt ipsius, verba veritatis
-					suut, falsa esse non <lb/> possunt.</p></div>
-				<div type="textpart" subtype="chapter" n="21">
-					<p>CAPUT XXI. — 1. Suscipere tc dicis quod protuli, <lb/>
-					<hi rend="italic">Nescitis quia templum DA estis, et Spiritus Dei habitat</hi>
-					<lb/> in <hi rend="italic">vobis</hi> (I <hi rend="italic">Cor.</hi> III, 16) ?
-					Quod proposuisti 1 dicere idoo <lb/> dictum esse, quia <hi rend="italic">in
-						nemine habitat Deus, quem non<lb/> ante Spiritus sanctus sanctificaverit,
-						atque purgaverit;</hi>
-					<lb/> quasi templum Den habitaturo, non sibi, sanctificet et <lb/> purget
-					Spiritus sanctus : cum Apostolus hincostenderit <lb/> ipsum esse Deum, cujus nos
-					dixcrat templum : quia <lb/> non ait,. et Spiritus Dei sanctificat et purgat
-					vos, ut <lb/> Deus habitet in vobis, sed ait, <hi rend="italic">Spiritus
-						Dei</hi> habitat in <note type="footnote">* Sic aliquot Mss. At editi, <hi
-							rend="italic">qvod potuisti.</hi>
-					</note>
-					<lb/>
-					<pb n="791"/> tobia. Uliqne in templo suo Deus habitat : nam quid <lb/> est
-					templum Dei, nisi habitaculum Dei ? Vidisti autem <lb/> etiam tu consequenter
-					esse Deum nostrum cujus StI­ <lb/> mus templum : et noluisti aliud testimonium
-					comme­ <lb/> morare quod protuli, <hi rend="italic">Nescitis qnia corpus vestrum
-						<lb/> templum in vobis Spiritus sancti est, quem habetis</hi> n Deo? <lb/>
-					Jam ergo confitere Dcum esse Spiritum sanctum. <lb/> Neque enim, nisi esset
-					Deus, haberet templum, et <lb/> templum non manufactum, sed aedificatum
-					dememhris <lb/> Dei : <hi rend="italic">Christus</hi> enim <hi rend="italic"
-						>super omnia est Deus benedictus in</hi>
-					<lb/> saecula <hi rend="italic">(Rom.</hi> IX, 5), cujus membra sunt nostra cor­
-					<lb/> pora. Qui enim dixit, <hi rend="italic">Nescitis quia corpus vestrum <lb/>
-						templum</hi> in vobis <hi rend="italic">Spiritus sancti est?</hi> ipse
-					dixit, <hi rend="italic">Ne­ <lb/> scitis quia corpora vestra membra sunt
-						Christi (I</hi> Cor. VI, <lb/> 19, 15) ? Itane vero cui de lignis lapidibus
-					Salemon <lb/> aedificavit templum, Deus est, et cui templum
-						<unclear>aedilica­</unclear>
-					<lb/> tur de membris Christi, hoc est, de membris Dei, <lb/> D:iis uon est? cum
-					loquens de Deo beatissimus mar­ <lb/> tyr Stephanus dixerit : Salomon <hi
-						rend="italic">aedificavit ei</hi> domum ; <lb/>
-					<hi rend="italic">sed Summus non</hi> in <hi rend="italic">manufactis templis
-						inhabitat (Act.</hi> VII, <lb/> 47. 48). Et tamen Christi membra, quorum
-					caput eat <lb/> super omnes cœlos, templum sunt Spiritus sain ti, <lb/> quem
-					constat venisse de coelo. Istum negare Deum <lb/> quid est, nisi non esse et
-					nolle esae templum ejus? <lb/> Alloquitur nos Apostolus dicens : Obsecro autem
-						<hi rend="italic">vos.<unclear/><lb/> fiatres, per miserationes Dei, ut
-						exhibeatis corpora</hi> vestru <lb/>
-					<hi rend="italic">hostiam vivam,</hi> sanctam, Deo <hi rend="italic">placentem
-						(Rom.</hi> XII, 1). <lb/> Corpora itaque fidelium hostia sunt Deo, membra
-					<lb/> Christi, templum Spiritus sancti, et Deus non est <lb/> Spiritus sanctus!
-					Quis hoc dicit, nisi in quo non inha­ <lb/> hilal? Quoniam in quo habitat,
-					utique templum ejus <lb/> cst. Denique cum dixisset Apostolus : <hi
-						rend="italic">Nescitis quia <lb/> corpus</hi> vestrum templum <hi
-						rend="italic">in vobis Spiritus sancti est, <lb/> quem habetis a Deu, et non
-						estis</hi> vestri? <hi rend="italic">empti</hi> enim <lb/>
-					<hi rend="italic">estis pretio magno ;</hi> continuo secutus adjunxit, <hi
-						rend="italic">Clorifi­<lb/> cale</hi> ergo <hi rend="italic">Deum</hi> in
-						<hi rend="italic">corpore vestro</hi> (I <hi rend="italic">Cor.</hi> VI, 19,
-					20). <lb/> Ubi dilucido ostendit Deum esse Spiritum sanctum, <lb/> glorificandum
-					scilicet in corporc nostro, tanquam in <lb/> templo suo. Et qnod Ananiae, dixit
-					apostolus Petrus, <lb/> Ausus <hi rend="italic">es mentiri Spiritui sancto?</hi>
-					atque ostendens <lb/> Deum esse Spiritum sanctum, <hi rend="italic">Non es,</hi>
-					inquit, <hi rend="italic">homi­ <lb/> nibus mentitus, sed Deo (Act.</hi> v, 3,
-					4).</p>
-					<p>2. Miror autem cor vestrum, quantum sermone <lb/> explicare uon possum, quomodo
-					cum sic laudctis" <lb/> Spiritum sanctum, ut eum sanctificandis fidelibus <lb/>
-					ubique asseratis esse praesentem, tamen negare att­ <lb/> deatis Deum. Itane
-					Deus non est, qui replevit orb m <lb/> terrarum? Scriptura enim dicit: <hi
-						rend="italic">Spiritus</hi> Domini <hi rend="italic">re­</hi>
-					<lb/> plevit <hi rend="italic">orbem</hi> terrarum <hi rend="italic">(Sap.</hi>
-					I, 7). Sed quid dicamus <lb/> quod replevit orbem, qui replevit urbis etiam Re­
-					<lb/> demptorem ? Dominus enim <hi rend="italic">Jesus plenus Spiritu<lb/>
-						sancto regressus</hi> est <hi rend="italic">a Jordane (Luc.</hi> IV, 1) : et
-					praesu­ <lb/> mitis dicere, quia ipse Dominus Jesus Deus erat, et <lb/> SpiritUs
-					sanctus quo plenus erat, non erat Deus; tam <lb/> male sentientes de Spiritu
-					sancto, ul non ci tribuatis <lb/> saltum quod tributum est Moysi famulo Dci, qii
-					non <lb/> munera gratiarum, scd plagaruin prodigia in eodem <lb/> Spiritu
-					sancto, quia ipse est <hi rend="italic">digitus Dei(Exod.</hi> VIII, 19), <lb/>
-					aegyptiis ingerebat, et tamen Phar.toni deus erat. <lb/> Uno luco erat ad
-					affligendos aegyptios, et Pharaoni <lb/> deus erat ( Exod. VII, 1): ubique adest
-					Spiritus sanctus <lb/> ad homines in aeternam vitam regenerandos, et non <lb/>
-					est eis Deus! lino vero est, et Deus verus est, quia <lb/> vcri Dei membra
-					templum ejus est. Et uiiquc sub­ <lb/> jectum est templum illi cujus est templum
-					: qUomodo <lb/> ergo Deus non cst, cui sunt membra Dei subjecta' <lb/> Ac per
-					hoC et Dominus est templi sui : qnis enim hoc <lb/> neget, quis ila desipiat, ut
-					dicat non esse aliquem <lb/> dominum domus suae? Quomodo ergo Spiritus sanctus
-					<lb/> non est Dominus, qui Dominus est membrorum Do­ <lb/> mini ? Ipse cst
-					quippe Spiritus Domini, de quo uno <lb/> codemque loco dictum est : Cum <hi
-						rend="italic">autem</hi> conversus <lb/>
-					<hi rend="italic">fuerit ad Dominum, auferetur velamen. Dominus autem<lb/>
-						Spiritus est ;</hi> ubi <hi rend="italic">autem Spiritus Domini, ibi
-						libertas</hi>
-					<lb/> (II Cor. III, 16, 17).</p>
-					<p>3. Jam creatorcm superius demonstravi Spiritum <lb/> sanctum: quomodo autem rex
-					non est, cujus templum <lb/> est quae membra sunt regis? Quomodo non consedet
-					<lb/> Patri et Filio, qui replevit Filium, qui membra Filii <lb/> suam possidct
-					domum? Nisi forte quando Filius re­ <lb/> gressus est a Jordane, plenus erat
-					Spiritu sancto; et <lb/> quando sedere cœpit ad dexteram Patris, exclusit a so
-					<lb/> Spiritum sanctum? Deimle cum de Patre procedat, <lb/> quomodo cum Patre
-					non sedeat? Cuu ipsa sessio non <lb/> sit utique cogitanda carnaliter : alioquin
-					opinaturi <lb/> sumus honorabilius Filium sedere quam Patrem; ho­ <lb/>
-					norabilius quippe scdetur ad dexteram : cl videbitur <lb/> esse consequens ut
-					Pater sedeat ad sinistram. Postremo <lb/> qualis vobis persuaserit spiritus, ut
-					sancto Spiritui <lb/> denegctis quod sanctis hominibus sancta Scriptura <lb/>
-					concedit, vos videritis. Ait enim Apostolus : Cum <lb/>
-					<hi rend="italic">essemus mortui peccatis, convivificavit nos Christo,
-						cujus<lb/> gratia</hi> sumus salvi facti ; <hi rend="italic">et simul
-						excitavit, et simul se­<lb/> dere fecit</hi> in <hi rend="italic"
-						>caelestibus</hi> in <hi rend="italic">Christo Jesu (Ephes.</hi> II, 5, 6).
-					<lb/> Sancti ergo quos sanctificat Spiritus sanctus, convivi­ <lb/> ficati
-					Christo, ita simul sessuri praedestinati sunt, ut <lb/> jam factum dicat
-					Apostolus, quod certum est adfutu • <lb/> rum : et ipsi Spiritui sancto
-					subtrahitur a vobis quis­ <lb/> quis est ille consessus, taoquam sedere cum
-					Patre vel <lb/> Filio sit indignus, qui eadem sede efficit dignos. Cui <lb/>
-					movetis etiam quaestionem quod non adoretur, et hoc <lb/> utique simillimo
-					errore, cum legatis, ut jam supra <lb/> docui, a sanctis ctiam homines adoratos.
-					Et tamen ut <lb/> invidiam blaspbemantis evites; ita laudas Spiritum <lb/>
-					sanctum, ut tribuas ei quod non habet ulla creatura, <lb/> et detrahas ei quod
-					adipiscitur et humana creatura.</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="22">
-					<p>CAPUT XXII. — i. Dixisse me quod commemo­ <lb/> ras, fateor, et nunc dico , quod
-					Salvator noster non <lb/> dixerit, Ut ipsi et nos unum ; sed, <hi rend="italic"
-						>Ut ipsi sint unum</hi>
-					<lb/> Et de his evangelicis verbis satis a ure rccolo jani <lb/> fuisse
-					responsum, cum ostenderem refellere te ion <lb/> potuisse quae dixi. Quoniam
-					poposci ut proferres ubi <lb/> legeris. <hi rend="italic">Unum sunt,</hi> dictum
-					esse de alquibus rebus <lb/> quae non essent unius ejusdemque substantiae :
-						<unclear>neque</unclear>
-					<lb/> protulisti. Quid enim te adjuvat, quod dilectionis <lb/> consensione
-					affirmas dictum esse de Paulo et Apollo, <lb/>
-					<hi rend="italic">Qui plantat autem et qui rigat, unum sunt (I Cor.</hi> III,
-					8), <lb/> cum eos non ostendas diversae fuisse substantiae? <lb/>
-					<pb n="793"/> Ambo quippe homines crant. Si enim non diligerent <lb/> invicem,
-					natura unum essent. dileclione non essent : <lb/> si anilem unum natura uon
-					essent, unum dici dile­ <lb/> ctione non possent. Poscit ergo Filius ut ita sint
-					<lb/> unum,quomodo ipse ct Pater unum sunt; id est , <lb/> non solum natura,
-					quod jam erant ; verum eliain <lb/> perfectione charitatis atque justitiae, pro
-					suae capaci­ <lb/> late naturae, quantum in Dei regno esse potuerint: <lb/> ut
-					etiam ipsi summe unum sint in natura sua, quem­ <lb/> admodum Pater et Filius
-					summe unum sunt, quamvis <lb/> in excellentiore atque incomparabiliter meliore
-					na­ <lb/> tura sua. Dixit ergo ad Patrem Filius : <hi rend="italic">Pater
-						sancte, <lb/> serva eos</hi> in <hi rend="italic">nomine</hi> tuo, <hi
-						rend="italic">quos dedisti mihi ;</hi> ut <hi rend="italic">ant unum, <lb/>
-						sicut et nos.</hi> Non dixit, Ut sint unum nobiscum; <lb/> aut, Ut simus
-					unum ipsi et nos. Item pauk) post : <lb/>
-					<hi rend="italic">Non</hi> pro <hi rend="italic">Itis autem rogo tantum,</hi>
-					sed <hi rend="italic">et pro</hi> eia <hi rend="italic">qui cre.</hi>
-					<lb/> dituri <hi rend="italic">sunt</hi> per verbum ipsorum in <hi rend="italic"
-						>me;</hi> ut <hi rend="italic">omnes</hi> unum <hi rend="italic">sint,<lb/>
-						sicut</hi> tu <hi rend="italic">Pater in me, et ego</hi> in te, ut <hi
-						rend="italic">et</hi> ipsi in nobis unum <lb/>
-					<hi rend="italic">sint.</hi> Neque hic dixit, Ut ipsi et nos unum simus, sed, <lb/>
-					<hi rend="italic">unum sint in nobis.</hi> Quoniam homines qni natura unum <lb/>
-					suni, summe atque perfecte secundum suum modum <lb/> unum esse non possunt
-					justitiae plenitudine , nisi in <lb/> Deo perficiantur, ut unum sint in Patre et
-					Filio; id <lb/> est, in ipsis unum, non cum ipsis unum. Adhuc se­ <lb/> quitur,
-					et adjungit : <hi rend="italic">Ut mundus credat</hi> quia <hi rend="italic">tu
-						me mi- <lb/> sisti, et ego</hi> claritatem quam mihi <hi rend="italic"
-						>dedisti, dedi illis</hi> , ut <lb/> sint unum, sicut nos unum sumus: <hi
-						rend="italic">ego</hi> in <hi rend="italic">eis,</hi> et tu <hi
-						rend="italic">in</hi>
-					<lb/> me, <hi rend="italic">ut sint consummati</hi> in unum. Neque hie dixit, Ut
-					<lb/> nobiscum sint unum, ant, Ut ipsi et nos simus unum. <lb/> Deinde cum
-					addidisset, <hi rend="italic">Ut cognoscat mundus quia tu</hi>
-					<lb/> me <hi rend="italic">misisti, et</hi> dilexisti <hi rend="italic">eos</hi>
-					sicut <hi rend="italic">et</hi> me <hi rend="italic">dilexisti;</hi> seculus
-					<lb/> adjunxit, <hi rend="italic">Pater, volo</hi> ut <hi rend="italic">ubi
-						ego</hi> sum, <hi rend="italic">et</hi> ipsi <hi rend="italic">sint</hi> me­
-					<lb/> cum (Joan. XVII, 11-24).<hi rend="italic">Ubi</hi> sum,inquit, <hi
-						rend="italic">mecum</hi> sint : <lb/> non ait, Unum mecum sint 1. Hoc ergo
-					voluit, ut cum <lb/> illo essent, non ut illi et ipse unum essent. Quid est
-					<lb/> quod dicere voluisti 4 <hi rend="italic">Dilectionis fecit mentionem,</hi>
-					et <lb/> non substantiae ? Quamvis tu non eo loco ista Domini <lb/> verba
-					posueris, quo ab ipso sunt posita. Sed qnid <lb/> ad Hos ? quandoquidem non
-					ipsos et se, vel ipsos et <lb/> Patrem dixit aut voluit unam esse; sed ipsos
-					unum <lb/> esse voluit, quos noverat unius esse substantiae. Sic­ <lb/> ut <hi
-						rend="italic">ei nos</hi> , inquit unum sumus : quos identidem no­ <lb/>
-					verat unius essp substantia.</p>
-					<p>2. Tu si vis aliquid respondere, ostende secundum <lb/> Scripturam sanctam de
-					aliquibus rebus dici, Unum <lb/> sunt, quarum est diversa substantia. Hoc enim
-					Chri­ <lb/> stus non dixit, quod tamen tu ausus es dicere, id est, <lb/>
-					<hi rend="italic">Apostolos</hi> unum esse <hi rend="italic">cum Patre et</hi>
-					Filio , <hi rend="italic">in eo quod</hi> in <lb/> amnilus <hi rend="italic">ad
-						voluntatem</hi> Dei <hi rend="italic">Patris respicientes, ad</hi> imi­ <lb/>
-					<hi rend="italic">tationem Filii subditi uni Deo Patri et ipsi</hi> inveniun­ <lb/>
-					<hi rend="italic">tur</hi> (a). Haec dicens, Deum et homines sanctos unum <lb/>
-					esse fecisti. Potest ergo quisquam sanctorum dicere , <lb/> Ego et Dens unum
-					sumus? Absit hoc a cordibus et <lb/> oribus sanctis. Puto autem qnod et vos a
-					quocumque <lb/> hoc audiatis, horrescilis , nec fertis quemquam ho­ <lb/> minem,
-					quantolibet munere sanctitatis excellat, di­ <lb/> contem , Ego et Deus unum
-					sumus. Sed forte arro- <note type="footnote">4 I.ov. etquidain Mss. omitlunt,
-							<hi rend="italic">yon ait, vnum mecum sint</hi>
-					</note>
-					<note type="footnote"> !aj vide serm. i tO, n. ł, tom </note>
-					<lb/> gantiae videatur, si hoc de seipso aliquis dicat. Itane <lb/> vcro
-					quisquam vestrum etsi non audet dicere, Ego et <lb/> Deus unum sumus; saltem
-					audet dicere, Paulus et <lb/> Deus unum sunt; sicut incunctanter dicimus, Paulus
-					<lb/> et Apollo unum sunt; Deus Pater et Deus Filius <lb/> unum sunt? Porro, si
-					non audetis dicere , Quilihet <lb/> hono sanctus, quilibet propheta , quilibet
-					apostolus, <lb/> et Deus, unum sunt; quis te urgebal, quis te impin­ <lb/>
-					gebat, quis te praecipitabat 1, ut diceres, <hi rend="italic">Apostoli<lb/> unum
-						sunt cum Patre et Filio? Unum sunt,</hi> inquis, <lb/>
-					<hi rend="italic">Pater et Filius, non tamen</hi> unus : continuoque sub <lb/>
-					jungis, <hi rend="italic">Unum ad concordiam pertinet; Unus, ad</hi> nu­ <lb/>
-					<hi rend="italic">merum singularitatis.</hi> Volebas autem dicere , Unum <lb/>
-					sunt, ad concordiam pertinet; Unus est, ad numerum <lb/> singularitatis : sed te
-					a consideratione verborum tuo­ <lb/> rum impetus disputationis avertit. Nam et
-					Unum et <lb/> Unus utique ad numerum pertinet singularem. Scd <lb/> quod verum I
-					est; Unum sunt, propter id quod ad­ <lb/> dilum est, Sunt, pluralem indicat
-					numerum , qua­ <lb/> dam singularitate connexum : Unus est autem , aper­ <lb/>
-					tissime est numerus singularis. Sed numquid Aposto­ <lb/> lus diceret, Qui antem
-					adhaeret Domino, unum sunt? <lb/> Quid enim aliud diccret, si hoc diceret, nisi,
-					Homo <lb/> sanctus, et Deus, unum sunt? Sed ahsit, absit ab illa <lb/> sapientia
-					ista sententia : et tamen dixit, Qui <hi rend="italic">autem<lb/> adhœret
-						Domno,</hi> unus <hi rend="italic">spiritus</hi> eat (I <hi rend="italic"
-						>Cor.</hi> VI, 47); ut <lb/> noveris de his dici, Unum sunt, qaae unius sunt
-					ejus­ <lb/> demque substantiae : sient quibusdam bominibus di­ <lb/> etum est,
-						<hi rend="italic">Omnes enim</hi> vos <hi rend="italic">unum estis in
-						Christo</hi> Jesu <lb/>
-					<hi rend="italic">(Galat.</hi> III, 28); et sicut. ait Ipse Christus, <hi
-						rend="italic">Ego et Pa­ <lb/> ter</hi> unum sumus <hi rend="italic"
-						>(Joan.</hi> x, 30). Cum autem unns dici­ <lb/> tur, et qmd unus dicitur 3 :
-					et de diversis substantiis <lb/> dici potest, sicut dictum est, Qui adhaeret
-					Domino % <lb/>
-					<hi rend="italic">unus</hi> spiritus <hi rend="italic">est;</hi> et de rebus
-					unius substantiae, sient, <lb/> dictum est, <hi rend="italic">Erat eis anima et
-						cor unum (Act.</hi> IV, 32). <lb/>
-					<hi rend="italic">Erat,</hi> dixit; non dixit, Erant: quoniam dixit et quid
-					<lb/> crat; id est, <hi rend="italic">anima et cor.</hi> Sic etiam de Patre et
-					Filio, <lb/> et, Unum sunt, dicimus, quia unius substantiae duo <lb/> sunt : et,
-					Unus est, dicimus, sed addimus quid unus; <lb/> id est, unusDeus, unus Dominus ,
-					unus Omnipotens, <lb/> et si quid hujusmodi, Satis me vobis duarum istarum <lb/>
-					locutionum arbitror inculcasse distantiam. Scrutare <lb/> itaque Scripturas
-					canonicas veteres et novas, et in­ <lb/> vcni, si potes, ubi dicta sunt aliqua,
-					Unum sunt, quae <lb/> sunt diversae paturae atque substantiae.</p>
-					<p>3. Sane falli te nolo in Epistola Joannis apostoli, <lb/> ubi ait: <hi
-						rend="italic">Tres sunt testes; spiritus, et aqua, et sanguis;<lb/> et tres
-						unum sunt</hi> (I <hi rend="italic">Joan.</hi> v, 8). Ne forte dicas spiri­
-					<lb/> tum et aquam et sanguinem diversas esse substantias, <lb/> et tamen dictum
-					esse , <hi rend="italic">tres unum sunt :</hi> propter hoc <lb/> admonui ne
-					fallaris. Haec enim sacramenta sunt, in <lb/> quibus non quid sint, sed quid
-					ostendant semper at<lb/>tenditur : quoniam signa sunt rerum , alind existen
-					<lb/>tia, et aliud significanlia. Si ergo illa quae bis signifi <lb/> canlur,
-					intelligantur, ipsa inveniuntur unius esse sub- <note type="footnote">1 Apud Er.
-						Lugd. et ven., <hi rend="italic">quis te wgebat, quis</hi> pr(r' <lb/>
-						<hi rend="italic">cipitahat ?</hi> M. </note><note type="footnote"> ' Apud
-						Lov. et quosdam Mss., <hi rend="italic">verbum.</hi>
-					</note><note type="footnote"> a sic Mss. Kdili auicm, <hi rend="italic">ct quid
-							unus naturaj ct quid</hi> :&lt;&lt; <lb/>
-						<hi rend="italic">ndjicitur.</hi>
-					</note>
-					<lb/>
-					<pb n="795"/> stantiae ; tanquam si dicamus , Petra et aqua unum <lb/> sunt,
-					volentes per petram significare Christum ; per <lb/> aquam, Spiritum sanctum :
-					quis dubitat petram et <lb/> aquam diversas esse naturas ? Sed quia Christus et
-					<lb/> Spiritus sanctus unius sunt ejusdemque naturae ; idco <lb/> cum dicitur
-					Petra et aqua unum sunt; ex ea parte <lb/> recie accipi potest , qua istae duae
-					res quarum est di­ <lb/> versa natura, aliarum quoque signa sunt rerum qua­ <unclear/>
-					<lb/> rumest una natura. Tria itaque novimus de corpor- <lb/> Domini exisse, cum
-					penderet in ligno : primo, spiri­ <lb/> tum ; unde scriptum est, <hi
-						rend="italic">Et inclinato capite tradidit</hi>
-					<lb/> spiritum ; deinde , quando latus ejus lancca perfora­ <lb/> tum est,
-					sanguinem et aquom <hi rend="italic">(Joan.</hi> XIX, 50, 34). <lb/> Quae tria
-					si per se ipsa intueamur , diversas habent <lb/> singula quaeque substantias; ac
-					per hoc non sunt <lb/> unum. Si vero ea, quae his significata sunt, velimus
-					<lb/> inquirere , non absurde occurrit ipsa Trinitas , qui <lb/> unus, solus ,
-					verus, summus est Deus, Pater et Fi­ <lb/> lius et Spiritus sanctus, de quibus
-					verissime dici. po­ <lb/> tuit, <hi rend="italic">Tres</hi> sunt testes , <hi
-						rend="italic">et tres</hi> unum <hi rend="italic">sunt</hi> : ut nomine
-					<lb/> spiritus significatum accipiamus Deum Patrem : de <lb/> ipso quippe
-					adorando loquebamur Dominus, ubi ait, <lb/> Spiritus <hi rend="italic">eat Deus
-						(Id.</hi> IV, 24). Nomine autem sangui­ <lb/> nis, Filium : quia, <hi
-						rend="italic">Verbum caro factum est (Id.</hi> I, 14). <lb/> Et nomine aquae
-					Spiritum sanctum : cum enim de <lb/> aqua loqueretur Jesus, quam daturus erat
-					sitientibus, <lb/> ait evangelista, <hi rend="italic">Hoc autem dixit de
-						Spiritu, quem ac­</hi>
-					<lb/> cepturi <hi rend="italic">erant credentes</hi> in <hi rend="italic">eum
-						(Id.</hi> VII, 39). Tesles <lb/> vero esse Patrem et Filium et Spiritum
-					sanctum , <lb/> quis Evangelio credit, et dubitat, dicente Filio, <hi
-						rend="italic">Ego</hi>
-					<lb/> sum <hi rend="italic">qui testimonium perhibeo de me: et testimonium <lb/>
-						perhibet de</hi> me, <hi rend="italic">qui misit me, Pater (Jd.</hi> VIII,
-					18)? Ubi <lb/> etsi non est commemoratus Spiritus sanctus, non ta­ <lb/> men
-					intelligitur separatus. Sed nec de ipso alihi ta­ <lb/> cua, eumque testem satis
-					aperteque monstravit. Nam <lb/> curi illum promitteret, ait : <hi rend="italic"
-						>Ipse testimonium perhibebit <lb/> de me.</hi> Hi <hi rend="italic">sunt
-						tres testes: et tres unum sunt (Id.</hi> xv, <lb/> 26), quia unius
-					substantiae sunt. Quod antemi signa <lb/> quibus significati sunt, de corpore
-					Domini exierunt, <lb/> figuraverunt Ecclesiam praedicantem Trinitatis unam <lb/>
-					eamdemque naturam : quoniam hi tres qui trino mo* <lb/> do significati sunt,
-					unum sunt; Ecclesia vero eos <lb/> praedicans, corpus est Christi. Si ergo. Ires
-					res quibus <lb/> significati sunt, ex corpore Domini exierunt : sicut <lb/> ex
-					corpore Domini sonuit, ut baptizarentur gentes <hi rend="italic">in <lb/> nomine
-						Patris et Filii et Spiritus sancti (Matth.</hi> XXVIII, <lb/> 19). <hi
-						rend="italic">In</hi> nomine; non, In nominibus : hi enim tres <lb/> unum
-					sunt, et hi tres unus est Deus. Si quo autem <lb/> ano modo tanti sacramenti
-					ista profunditas , quae in <lb/> Epistola Joannis legitur, exponi et intelligi
-					potest <lb/> secundum catholicam fidem, quae nec confundit nec <lb/> separat Ti
-					iuitatem , nec abnuit tres personas , nec <lb/> diversas credit esse
-					substantias, nulla ratione respu­ <lb/> endum est. Quod enim ad exercendas
-					mentes fide­ <lb/> lium in Scripturis sanctis obscure ponitur,gratulan­ <lb/>
-					dum cst, si multis modis, non tamen insipienter ex­ <lb/> punitur.</p>
-				</div>
-				<div type="textpart" subtype="chapter" n="23">
-					<p>CAPUT XXIII. — 1. Quid est autem quod po<lb/>Mis ut astruam , <hi
-						rend="italic">Si pater et Filias et Spiritus san­<lb/> ctus</hi> unus <hi
-						rend="italic">est Deus</hi> ; cum hoe astruat voce clarissima <lb/>
-					Scriptura divina dicens , <hi rend="italic">Audi, Israel; Dominus Deus</hi>
-					<lb/> tuus, <hi rend="italic">Dominus</hi> unus <hi rend="italic">est (
-						Deut,</hi> VI, 4)? Quod et vos <lb/> uiiquc audiretis, si Israel esse
-					velletis, non carnali­ <lb/> ter ut Judaeri, sed spiritualiter ut Christiani.
-					Qui enim <lb/> non vult fideliter audire quod dictum est, <hi rend="italic"
-						>Audi, Israel; <lb/> Dominus Deus tuus, Dominus unus est;</hi> superest ut
-					<lb/> eum qui hoc dixit, credat esse mendacem. Si autem <lb/> mendax ille non
-					est, vox ista vera est : si vox ista <lb/> vera est, quaestio ista finita est.
-					Procul dubio quippe <lb/> vos veritascogit Patrem aL Filium et Spiritum sanctum
-					<lb/> confiteri unum Dominum Deum. Sed Spiritum san­ <lb/> ctum, cujus templum
-					non manufactum, sed corpus <lb/> est nostrum , cujus templum non ligna et
-					lapides, sed <lb/> membra sunt Christi, negatis Deum : de ipso Christo <lb/>
-					quid dicturi estis, quem Deum et Dominum confite­ <lb/> mini? Respondete itaque
-					nobis, utrum Pater et Filius <lb/> unus sit Dominus Deus. Si cnim non est
-						<unclear>mius</unclear>, duo <lb/> sunt : si duo sunt, mentitur qui dicit,
-						<hi rend="italic">Audi , Israel; <lb/> Dominus Deus tuus, Dominus unus est
-						;</hi> mentitur qui <lb/> dicit, <hi rend="italic">Videte quoniam ego sum
-						Deus , et non cst</hi>
-					<unclear>otius</unclear>
-					<lb/>
-					<hi rend="italic">praeter me (Id.</hi> XXIII, 39). Sed quia illum
-						<unclear>menten­</unclear>
-					<lb/> tem dicere non audetis, quare vos corrigere dubita­ <lb/> tis, et venire
-					vel redire ad catholicam fidem , quae <lb/> Patrem et Filium et Spiritum sanctum
-					non tres do­ <lb/> minos deos, sed unum Dominum Dcum credit et <lb/> audit
-					clamantem populo suo, <hi rend="italic">Audi, Israel; Dominus, <lb/> Deus</hi>
-					tuus, Dominus <hi rend="italic">unus est;</hi> et, <hi rend="italic">Videte
-						quoniam egu</hi>
-					<lb/> sum <hi rend="italic">Dominus, et non est alius praeter me ?</hi> Si te
-					dicam <lb/> surdum et caecum, qui nec audis ista, nec vides, con­ <lb/>
-					tumeliosum sine dubio me putabis. Ecce non dico : <lb/> expone nobis quomodo
-					accipias, <hi rend="italic">Audi, Israel ; Do­ <lb/> minus Deus</hi> tuus , <hi
-						rend="italic">Dominus</hi> unus <hi rend="italic">est :</hi> utrum ibi sit
-					<lb/> intelligendus et Christus, an non sit. Si enim dixeris, <lb/> Ibi est;
-					confiteberis mecum Patrem et Filium unum <lb/> esse Dominum Deum. Si autem
-					responderis, Christum <lb/> non esse ibi intelligendum , duos contra vocem divi­
-					<lb/> nam introducturus es dominos deos, quoniam non <lb/> nogas etiam Christum
-					esse Dominum Deum. Similiter <lb/> abs te quaero quomodo accipias, <hi
-						rend="italic">Videte quoniam ego<lb/> sum Dominus, et non est alius
-						pr</hi>ae<hi rend="italic">ter</hi> me. Ibi est et <lb/> Christus, an non
-					est? Si ibi est, profecto Pater ct <lb/> Filius unus est Dominus : si autem ibi
-					non est, et <lb/> tamen Dominus est; mentitur qui dicit, <hi rend="italic">Non
-						est alius <lb/> praeter me.</hi> Est enim alius Dominus Filius, si non <lb/>
-					unus est Domninus Pater et Filius. Quantumlibet enim <lb/> excellentius laudes
-					Patrem, et infra cum deprimas <lb/> Filium, id agis , ut aequales non sint, non
-					ut duo non <lb/> sint. Clama , quantum vis, Pater est major, Filius <lb/> minor
-					: respondetur tibi, Duo sunt tamen major ct <lb/> minor. Nec dictum cst, Dominus
-					Dens tuus major, <lb/> Dominus unus est : sed dictum est , <hi rend="italic"
-						>Dominus</hi> Deus <lb/>
-					<hi rend="italic">tuus, Dominus unus est.</hi> Neque dictum est, Non est <lb/>
-					alius aequalis mihi : sed diclum est, <hi rend="italic">Non est alius <lb/>
-						Dominus praeter me.</hi> Aut ergo confitere Patrem et <lb/> Filium unum esse
-					Dominum Dcum , aut apene nega <lb/> Dominum Deum esse Christum , sicut aperte
-					negas <lb/> Dominum Deum esse Spiritum sanctum. Quod si <lb/> . leceris , istis
-					quidem te divinis vocibus non urgebo, <lb/>
-					<pb n="797"/> sedalia testimonia divina proferam, quibus te et iii <lb/> isto
-					errore detestabiliorem convincam 1. Nunc autem <lb/> et si negas Dominum Deum e
-					se Spiritum sancium, <lb/> tamen ut istis Dei vocibus conteraris, satis est quod
-					<lb/> Christum Dominum Deum confiteris : qui si non est <lb/> cum Patre unus
-					Dominus Ocus, duo domini dii nostri <lb/> erunt, et falsae illae Dei voces
-					erunt, <hi rend="italic">Dominus Deus <lb/> tuus, Dominus unus est ;</hi> et,
-						<hi rend="italic">Non eat alius</hi> praeter <hi rend="italic">me.</hi>
-					<lb/> Scd quanto melius erunt vestra verba emendata, quam <lb/> pei verba
-					mendacia ?</p>
-					<p>i. Quaeris a me utrum , <hi rend="italic">Judaico modo te horter</hi> pro­ <lb/>
-					<hi rend="italic">fiteri</hi> unum <hi rend="italic">Denm; an de subjectione
-						Filii potius secun­<lb/> dum quod fides habet</hi> Christiana , <hi
-						rend="italic">ostendatur unus esse<lb/> Deus, cujus Filius noster est
-						Deus.</hi> Ita hoc dicis, quasi <lb/> Judaeorum sil vox, <hi rend="italic"
-						>Audi, Israel; Dominus Deus</hi> tuus, <lb/>
-					<hi rend="italic">Dominus unus est ;</hi> aut, <hi rend="italic">Ego sum
-						Dominus, et non eat <lb/> alius prœter me.</hi> Ipse Deus hoc dixit:
-					agnosce, et <lb/> tace ; vel potius edissere quomodo ,'crum dixerit, <lb/> quem
-					nullus nostrum andet affirmare mentitum. <lb/> Edissere, inquam, quomodo verum
-					st, <hi rend="italic">Dominus Deus</hi>
-					<lb/> tuus, <hi rend="italic">Dominus unus est ;</hi> si domini dii nostri, nt
-					di­ <lb/> citis, duo sunt, unus major , alius minor : edissere <lb/> quomodo
-					verum sit, <hi rend="italic">Ego sum Dominus, et non est</hi>
-					<lb/> alius <hi rend="italic">prœter me.</hi> Quis enim hoc dixcril qu;cro,
-					utrum <lb/> pater, an Filius. Si Pater dixit, <hi rend="italic">Ego</hi> sum
-					Dominus, <lb/> et <hi rend="italic">non est alius praeter me;</hi> non verum
-					dixit, quia <lb/> est alius Dominus Filius. Si Filius hoc dixit: nee ipse <lb/>
-					verum dixit, quia est alius Dominus Pater. Si autem <lb/> hoc dixit Trinitas ;
-					profecto et verum dixit, et vos <lb/> falsum diccre ostendit. Trinitas quippe
-					secundum <lb/> rectam fidcm , id cst, Pater et Filius et Spiritus san­ <lb/>
-					ctus, in cujus nomine baptizamur, et unus Dominus <lb/> Deus noster est, ct
-					praeter ipsum alius non est. Ipse <lb/> est enim Deus de quo dicit Apostolus :
-						<hi rend="italic">Nullus</hi><hi rend="italic">est<lb/> Deus,</hi> nisi unus
-					(I <hi rend="italic">Cor.</hi> VIII , 4). Nam si hoc de Patre <lb/> acceperis
-					dictum , non tibi ent Deus Christus , quia <lb/> nun potest solvi Scriptura ,
-					dicens, <hi rend="italic">Nullus Deus, nisi</hi>
-					<lb/> unus : ut lic vobis taceam de Spiritu sancto , quem <lb/> superius Dominum
-					Deum ostendimus, vobis neganti­ <lb/> bus. Quapropter si Macedoniani haeretici
-					essetis, qui <lb/> de solo Spiritu sancto catholicae fidei consentire de­ <lb/>
-					trectant, Patrem vero et Filium duos quidem esse, <lb/> id est, illum Patrem ,
-					illum Filium , et aequales esse, <lb/> atque unius ejusdemque substantiae, nec
-					tamen duos <lb/> dominos deos, sed ambos simul unum Dominum <lb/> Deum essc
-					consentiunt : si ergo et vos saltem harte­ <lb/> nus erraretis, noh utique his
-					divinis vocibus urgerc­ <lb/> mini. Patrem quippe et Filium assereretis unum Do­
-					<lb/> minum Deum dixisse , <hi rend="italic">Non est alius prœter me.</hi> Uti­
-					<lb/> nam non restaret agere vobiscum, nisi ut adjungere­ <lb/> tis Spiritum
-					sanctum, et non dualitatem , sed Trini <lb/> tatem diceretis unum Dominum Deum.
-					Nunc vcro <lb/> cum sic asseritis Patrem Dominum Deum , et Filium <lb/> Dominum
-					Deum , ut simul ambos non dicatis unum <lb/> Dominum Deum, sed duos, majorem
-					unum,minorem <lb/> alterum ;prorsus confodimini gladio veritatis dicentis, <lb/>
-					<hi rend="italic">Audi, Israel ;</hi>Dominus <hi rend="italic">Deus tuus,
-						Dominus unus est:</hi>
-					<lb/> qui clamat, <hi rend="italic">Ego</hi> sum <hi rend="italic">Dominus, et
-						non est alius</hi> praeter <note type="footnote">I f.r. Usyl. v en., <hi
-							rend="italic">destestabiliorem</hi><hi rend="italic">comincam.</hi> M. </note>
-					<lb/> me. Neque enim Dom Pater sic rellet Israelitas a <lb/> cultu deorum
-					revocare multorum atque falsorum , ut <lb/> eis de uno Deo ac Domino mentiretur,
-					et diceret non <lb/> esse praeter se alium Dominum, cnm sciret Deum et <lb/>
-					Dominum esse suum Filium. Absit ut veritas et veri­ <lb/> tatis Pater mendacio
-					deciperet populum suum : hae­ <lb/> reticorum sit haec , uon catholicorum tam
-					horrenda <lb/> et detestanda blasphemia. Prorsus Deus verum dicit, <lb/> cum
-					dicit, <hi rend="italic">Audi, Israel; Dominus Dcus tuus, Dominus<lb/> unus
-						est:</hi> quia Patcr ct Filius et Sp ritus sanctus, non <lb/> tres dii, sed
-					unus Deus ; nec tres domini, sed unus <lb/> Dominus est. Prorsus verum dicit,
-						<hi rend="italic">Ego sum Dominus, <lb/> et non estalius prœter me ;</hi>
-					quia non hoc Pater tan­ <lb/> lum, sed ipsa Trinitas dicit : hic est Dominus
-					unus, <lb/> ct non alius praeter ipsum, Nam si Pater diceret, <hi rend="italic"
-						>Ego <lb/> sum Dominus, et non ert alius prœter me;</hi> negaretuti­ <lb/>
-					que Dominum esse unigenitum Filium. Et quis no­ <lb/> strum auderet eum Dominum
-					confiteri, contradicente <lb/> Patre atquc dicente, <hi rend="italic">Ego sum
-						Dominus, et non eat alius <lb/> prater me?</hi> Ac per boc secundumrectam
-					fidem , non <lb/> Patris, sed T riniiatis haec vox cst: et Patris ergo, et
-					Filii, <lb/> et Spiritus sancti. Obticescant igitur linguae ignoran­ <lb/> tium
-					vcritatcm : haec Trinitas Deus unus est. De hoc <lb/> uno Deo dicitur, Audi, <hi
-						rend="italic">Israel; Dominus Deus tuus,</hi>
-					<lb/> Dominus unus <hi rend="italic">est.</hi> llic Deus unus dicit, <hi
-						rend="italic">Ego</hi> sum <hi rend="italic">Do­ <lb/> minus, et non est
-						alius praeter me.</hi> Subjectus est quidem <lb/> Patri filius
-					secundumformam hominis : non tamen <lb/> sunt duo dii ct duo domini secundum
-					formam De!; <lb/> sed ambo cum Spirilu suo unus cst Dominus.</p>
-					<p>3. Testimonia quae de Paulo apostolo protulisti, <lb/> contra te loquuntur, ct
-					nescis. Dicit enim ille : <hi rend="italic">Gra­<lb/> tia vobis et pax a Deu
-						Patre nostro et Domino</hi> Jesu <lb/>
-					<hi rend="italic">Christo (Rom.</hi> I, 7; I <hi rend="italic">Cor.</hi> I, 3;
-					II <hi rend="italic">Cor.</hi> I, 2; <hi rend="italic">Gulat.</hi> i, <lb/> 3,
-						<hi rend="italic">et Ephes.</hi> I, 2). Quomodo est autem Dominus Je<lb/>sus Christus, si Pater dicit, <hi rend="italic">Ego sum Dominus,</hi> et non <lb/>
-					<hi rend="italic">eat</hi> alius <hi rend="italic">praeter me?</hi> Non ergo
-					solius Patris, ut dixi, <lb/> sed Trinitatis haec vox est. Adhibes alterurn
-					testimo­ <lb/> nium, et ipsum contra te ipsum, ubi ait Apostolus, <lb/>
-					<hi rend="italic">Unus Deus</hi> Puter , <hi rend="italic">ex quo omnia, et noa
-						in ipso ;</hi> et <lb/>
-					<hi rend="italic">unus Dominus</hi> Jesus <hi rend="italic">Christus, per quem
-						omnia, et <lb/> noa in ipso,</hi> sicut tu loculus es : Apostolus autem, <hi
-						rend="italic">a</hi>
-					<lb/> noa <hi rend="italic">per ipsum</hi> ait; non ait, in <hi rend="italic"
-						>ipso.</hi> Sed hoc quid ad <lb/> causam ? Solent ista contingere ex memoria
-					proferen <lb/> tibus testimonia, non ex codice illa legentibus : quod <lb/> ad
-					rem pertinet potius intuere. Ecce, dixit Aposto­ <lb/> lus, <hi rend="italic"
-						>Unus Deus Pater, ex quo omnia, et nos in</hi> ipso, <lb/>
-					<hi rend="italic">et unus Dominus Jesus Christus,</hi><hi rend="italic">per quem
-						omnia, et</hi>
-					<lb/> noa <hi rend="italic">per</hi> ipsum <hi rend="italic">Cor.</hi> VIII, 6).
-					Omnino duas personas, <lb/> unam Patris, alteram Filii, sine ulla confusione et
-					<lb/> sine ullo errore distinxit. Neque enim duo sunt dii <lb/> patres, sed unus
-					Deus Pater : nec duo sunt domini <lb/> Jesu Christi, sed unus Dominus Jesus
-					Christus. In <lb/> illa quippe Trinitate quaeDeus cst, unus est Pater, <lb/> non
-					duo vel tres; et unus Filius, non duo vel tres; <lb/> et unus amborum Spiritus,
-					non duo vel tres : ct ipse <lb/> unus Pater utique Deus est, et ipse unus Filius
-					etiam <lb/> vobis fatentibus Deus cst, et ipse amborum Spiritus <lb/> etiam
-					vobis negantibus Deus cst. Sic et Dominiun s <lb/> quaeras, singulum quemque
-					respondeo ; sed simu! <lb/>
-					<pb n="799"/> omnes non Ires dominos tlcos, sud unum Domiuum <lb/> Deum dico.
-					Haec est fides nostra, qnoniam haec fides <lb/> est recta, quae fides etiam
-					catholica nuncupatur. Tu <lb/> antem qui huic fidei contradicis, quaeso te,
-					expone <lb/> nobis, eliam Josus Christus quomodo sit Dominus, <lb/> qui non
-					Trinitatis, sed solius Patris esse asseris vo­ <lb/> cem, <hi rend="italic">Ego
-						sum Dominus, et non est alius praeter me.</hi>
-					<lb/> Nempe turbaris ; nempe quid respondeas non invenis, <lb/> nisi quia
-					tacere, quando convinceris, non vis. Si enim <lb/> non Deus Trinitas, sed Pater
-					tantum dixit, <hi rend="italic">Ego sum <lb/> Dominus, et non est alius prœter
-						me :</hi> procul dubio ne­ <lb/> gavit esse Dominum Filium; quoniam si
-					Dominus est <lb/> pt Filius, falso dictum est, <hi rend="italic">Non eat alius
-						Dominus<lb/> prœter me.</hi> Non enim agitur de Domino, quales sunt <lb/>
-					homines domini hominum servorum, quos Apostolus <lb/> secundum carnem dominos
-					esse dicit <hi rend="italic">(Ephes.</hi> VI, 5 ): <lb/> sed de Domino agitur,
-					cui servitus illa debetur, quae <lb/> graece <foreign xml:lang="grc"
-						>λατρεία</foreign> dicitur, secundum quam dictum est, <lb/>
-					<hi rend="italic">Dominum Deum</hi> tuum <hi rend="italic">adorabis, et illi
-						soli servies (Deut,</hi>
-					<lb/> VI, 13). Qui Dominus Deus si non Trinitas, sed solus <lb/> est Pater :
-					prohibemur utique Domino Cbristo tali <lb/> servitude servire, in <hi
-						rend="italic">eo</hi> quod audimus, <hi rend="italic">Illi soli aer­</hi>
-					<lb/> vies ; si ita dictum est, ac si diccrelur, Deo Patri soli <lb/> servies.
-					Qui profecto si solus, et non ipsa Trinitas <lb/> dixit, <hi rend="italic"
-						>Ego</hi> sum DorMiMus, <hi rend="italic">et</hi> non <hi rend="italic">eat
-						alius</hi> prœter <hi rend="italic">me;</hi>
-					<lb/> negavit csse Filium Dominum talem, quali domino <lb/> servitus illa
-					debetur, qua nonnisi Deo cum vera ret!­ <lb/> gione servitur. Non enim dixit,
-					Ego sum Dominus <lb/> majoraut melior*et non est tantus aut talis praeter <lb/>
-					ine : sed volens sibi soli ea quae Domino Deo debetur <lb/> servitute serviri,
-						<hi rend="italic">Ego sum,</hi> inquit, <hi rend="italic">Dominus, et non
-						est<lb/> alius</hi> praeter <hi rend="italic">me.</hi> Porro si vox ista,
-					sicut catholica fi­ <lb/> des dicit, unius Dei est, quod est ipsa Trinitas; sine
-					<lb/> ulla dubitatione huic soli serviendam est ea servitute, <lb/> quae nonnisi
-					Domino Deo debetur, quia ipse est Do­ <lb/> minus, et non est alius praeter
-					ipsum.</p>
-					<p>4. Deinde quaero quomodo accipias quod dictum <lb/> est, Unus <hi rend="italic"
-						>Deus Pater, ex quo omnia, et nos</hi> in <hi rend="italic">ipso; <lb/>
-						et</hi> unus <hi rend="italic">Dominus Jesus</hi> Christ: s, <hi
-						rend="italic">per quem omnia, et noa <lb/> per</hi> ipsum. Numquid non et ex
-					Filio sunt omnia : <lb/> quandoquidem ipse dicit, <hi rend="italic">Quœcumque
-						Pater facit, haec<lb/> et</hi> Filius <hi rend="italic">similiter facit
-						(Joan.</hi> v, 19)? Si autem ita dis­ <lb/> linguis, ut non sint per Patrem
-					omnia, sed ex Patre; <lb/> nec omnia sint ex Filio, sed per Filium : quis eorum
-					<lb/> tihi vidctur esse illc de quo idem apostolus dicit, 0 <lb/>
-					<hi rend="italic">altitudo diritiarum</hi><hi rend="italic">sapientiœ et
-						scientiœ Dei ! quam in­ <lb/> scrutabilia sunt judicia ejus, et
-						investigabiles viœ ejus ! <lb/> Quis enim cognovit sensum</hi> Domini ? <hi
-						rend="italic">Aut quis consilia­</hi>
-					<lb/> rius <hi rend="italic">ejus</hi> fuit ? <hi rend="italic">Aut quis prior
-						dcdit illi, et retribuetur ei? <lb/> Quoniam ex</hi> ipso, <hi rend="italic"
-						>et per ipsum, et in ipso</hi> sunt <hi rend="italic">omnia : <lb/> ip1i
-						gloria in sœcula</hi> sœculorum. Amen <hi rend="italic">(Rom.</hi>XI,
-					33-36). <lb/> Utrum Pater eat intelligondus, an Filius? Deum nam­ <lb/> que
-					prius nominavit, dicens : 0 <hi rend="italic">allitudo divitiarum sa­</hi>
-					<lb/> pientiae <hi rend="italic">et scientia Dei!</hi> Postea vcro eum Dominum
-					ap­ <lb/> pellait. ubi ait: <hi rend="italic">Quis enim</hi> cognovit sensum <hi
-						rend="italic">Domini?</hi> Sed <lb/> hocnon habet controversiam :utrumque
-					eniin nomen <lb/> etiam vos et Patri assigNatis et Filio. Neque enim sic <lb/>
-					dicitis DeumPatrem, ut negetis esse Deum Filium; <lb/> tut sic dicitis Deum
-					Filium, ut negetis esse Dcum Pa­ <lb/> trem. Quatnvis in hoc ap ostolico
-					testimonio quod ad­ <lb/> hibuisti, Deus dicatur Pater, Do t imis Filius, id
-					est, <lb/>
-					<hi rend="italic">Unus Deus</hi> Pater, <hi rend="italic">ex quo omnia; et</hi>
-					unus Dominus <hi rend="italic">Je­ <lb/> sus Christus, per quem omnia.</hi> Sed
-					illud attende abi di­ <lb/> ctum est. <hi rend="italic">0 altitudo
-						divitiarum</hi><hi rend="italic">sapientiae et</hi> scientiae <lb/>
-					<hi rend="italic">Dei!</hi> Nam sive Pater sit iste, sive Filius, <hi
-						rend="italic">ex ipso, et <lb/> per</hi> ipsum, <hi rend="italic">et</hi> in
-						<hi rend="italic">ipso sunt omnia.</hi> Quomodo ergo ex <lb/> Patre omnia,
-					non ex Filio; et per Filium omnia, non <lb/> per Patrem : quandoquidem quemlibet
-					eorum Apo­ <lb/> stolus voluerit hoc loco intelligi, <hi rend="italic">Ex</hi>
-					ipso , inquit, <hi rend="italic">et</hi>
-					<lb/> per ipsum, <hi rend="italic">et</hi> in <hi rend="italic">ipso sunt
-						omnia?</hi> Si ergo sive de Pa­ <lb/> tre sive de Filio, verissime tamen
-					dicitur, quod ex <lb/> ipso <hi rend="italic">et per ipsum, et in ipso sunt</hi>
-					omnia; sine dubio <lb/> Patris et Filii demonstratur aequalitas. Si autem quo­
-					<lb/> niam non nominavit Patrem et Filium et Spiritum <lb/> sanctum, sed Dcum et
-					Dominum, quod et ipsa Trini­ <lb/> tas dici potest, singula horum trium referri
-					ad singu­ <lb/> los voluit : <hi rend="italic">ex ipso</hi> dicens, propter
-					Patrem; <hi rend="italic">et per <lb/> ipsum,</hi> propter <hi rend="italic"
-						>Filium ; in ipso,</hi> propter Spiritum san­ <lb/> ctum : cur hanc
-					Trinitatem unum DominumDeum <lb/> non vultis agnoscere? Quandoquidem non ait, Ex
-					<lb/> ipsis, et per ipsos, et in ipsis; sed ait, <hi rend="italic">ex ipso; et
-						per</hi>
-					<lb/> ipsum, <hi rend="italic">et in ipso sunt</hi> omnia : nec ait, Ipsis
-					gloria; sed, <lb/>
-					<hi rend="italic">ipsi gloria</hi> in saecula sPeculorum. <hi rend="italic"
-						>Amen.</hi>
-					</p>
-					<p>5. Falleris sane, qui putas de Patre solo esse di­ <lb/> ctum, <hi rend="italic"
-						>Nemo bonus, nisi unus Deus.</hi> Si enim dixisset, <lb/> Nemo bonus, nisi
-					unus Patcr; nee sic exclusum Fi­ <lb/> lium et Spiritum sanctum ab ista unitate
-					bonitatis vo­ <lb/> luisset intelligi : quia et illud quod simili locutiono
-					<lb/> dictum est, quam supra commemoravi, <hi rend="italic">Ea quœ</hi><hi
-						rend="italic">Dei <lb/> sunt, nemo scit, nisi Spiritus Dei (I Cor.</hi> n,
-					41): non <lb/> excludit ab hac scientia Filium Dei. Quanto ergo no­ <lb/> bis
-					latitudo intelligentiae magis patet, quia non dixit, <lb/> Nemo bonus, nisi unus
-					Pater; sed, <hi rend="italic">Nemo bonus,</hi> nisi <lb/> unus <hi rend="italic"
-						>Deus;</hi> quod est ipsa Trinitas. Quaerebat quippe <lb/> ille cui hoc
-					respondit Jesus, non bonum qualecumque, <lb/> sed bonum quo fieret beatus; imo
-					ipsam beatitudinem <lb/> veram, id est, vitam desiderabat aeternam : et inter­
-					<lb/> pellaverat tanquam hominem Christum, nescicns eum <lb/> esse etiam Deum.
-					Dixerat enim : <hi rend="italic">Magister bone, quid <lb/> faciam, ut vitam</hi>
-					aeternam consequar ? Tunc ait ille: <lb/>
-					<hi rend="italic">Quid me dicis bonum? Nemo bonus,</hi> nisi unus <hi
-						rend="italic">Deus <lb/> (Marc.</hi> x, 17, 18). Vel, sicut legitur apud
-					alium evan­ <lb/> gelistam, qnod tantumdem valet, <hi rend="italic">Nemo
-						bonus,</hi> nisi <lb/>
-					<hi rend="italic">solus Deus (Luc.</hi> XVIII, 19). Tanquam diceret : Recte
-					<lb/> mc appellabis bonum, si me noveris Deum. Nam <lb/> qnando me nihil aliud
-					quam hominem putas, quid me <lb/> dicis bonum ?Non te facit bonum nec bcatum,
-					nisi <lb/> bonum immutabile quod solus est Deus. Nam bonus <lb/> angelus, bonus
-					homo, bona caetera creatura : haec <lb/> non ita bona sunt, ut ea quisquis
-					adeptus fuerit, sit <lb/> beatus; nec ulla est beata vita, si non sit aeterna.
-					<lb/> Quomodo autem non est tale bonum Dei Filius ve­ <lb/> rus, cumsit verus
-					Deus et vita aeterna, ad quam cu­ <lb/> piebat ille qui interrogaverat pervenire
-					?</p>
-					<p>6. Proinde cum ego asseram, <hi rend="italic">Nemo bonus,</hi> nisi unus <lb/> et
-						<hi rend="italic">solus Deus,</hi> de ipsa Trinitate dictum esse, qui Deus
-					<lb/> unus et solus est; tu autcm asseras de solo Dco Pa­ <lb/> tre dictum esse,
-					quia ipse de nullo alio Deus, de nullo <lb/>
-					<pb n="801"/> alio honus est ; Filius autem de Patre Dcus, de Patre <lb/> magnus
-					et bonus est diligenter attende quis nostrum <lb/> bene sentiat de Deo Patre et
-					de Deo Filio; utrum <lb/> ego qui dico, Dens quidem Pater, non de alio Dco <lb/>
-					Deus est, Deus autem Filius de Patre Deo Deus est, <lb/> sed tantus iste de
-					illo, quantus ille de nullo ; et bo­ <lb/> nus Pater non de alio bono bonus est,
-					Filius vero de <lb/> Pairc buno bonus est, sed tam bonus hic de illo, <lb/> quam
-					bonus ille de nullo : an tu qui propterea dicis <lb/> solum esse Patrem Deum
-					bonum, quia nec Deus est <lb/> de alio Dco,nec bonus de alio bono; Filium vero
-					<lb/> idco Patri non esse cocequandum, quia de illo Deus <lb/> est, de illo
-					bonus est? In qua sententia utrumque <lb/> blasphemas : et Patrem scilicet, quia
-					non tantum ge­ <lb/> nuit quantus cet ipse, nec talem qualis est ipse; et <lb/>
-					Filium, quia talis tantusque nasci non meruit, qualis <lb/> quantusque est ille
-					qui genuit. Denique ista ipsa duo <lb/> de quibus agimus, hoc cst, dcitas et
-					bonitas, quoniam <lb/> dictum est, <hi rend="italic">Nemo</hi> bonus, nisi <hi
-						rend="italic">unus Deus,</hi> in hac tua <lb/> opinione deficiunt. Tantum
-					enim quantus est ipse, et <lb/> talem qualis est ipse, si non potuit gignere,
-					quomodo <lb/> Dens est? si noluit, quomodo bonus cst?</p>
-					<p>7. <hi rend="italic">Pater,</hi> inquis, <hi rend="italic">fons</hi> bonitatis
-						<hi rend="italic">est, qui quod est</hi> bo­ <lb/> nIs <hi rend="italic">a
-						nemine accepit.</hi> Numquid ideo minus bonus est <lb/> Filius, quoniam quod
-					bonus est, ab eo Patrc accepit, <lb/> qui naseenli Filio tantam bonitatem
-					quantacumque <lb/> illi est, quia Deus est, dare potuit; et dedit, quia bo­
-					<lb/> nus invidere non potuit ? Nam si minus bonitatis, <lb/> quam quod ipse
-					habet unico dedit, minus bonus est <lb/> et ipse quam debuit : quod sentire
-					dementiae est. Er­ <lb/> go quantum ipse habet bonitatis, tantum F:lio de­ <lb/>
-					dit *. Et quia natura est, non gratia Filius, na­ <lb/> scenti, non indigenti
-					dedit; et plenus plenum, fons <lb/> bonitatis fontem genuit bonitatis. Ac per
-					boc nec <lb/> auxit in se hic quod accepit, nec minuit in se ille qui <lb/>
-					dedit 2: quia non habet immutabilitas unde defi­ <lb/> ciat, non habet plenitudo
-					quo crescat. Quid est <lb/> autem ipsa bonitas , nisi vita vivificans ? Proin­
-					<lb/> de quia fons fontem genuit, <hi rend="italic">sicut Pater suscitat mor­
-						<lb/> tuos et vivificat, sic et Filius quos vult vivificat</hi> (Joan. <lb/>
-					v , 21). Hoc ipse Filius dixit, non ego. Unde merito <lb/> Deo Patri dicitur,
-						<hi rend="italic">Quoniam apud te eat fons vitae.</hi> Quis <lb/> est autem
-					iste fons vitae apud Patrem, nisi de quo di­ <lb/> citur, In <hi rend="italic"
-						>principio erat</hi> Verbum, <hi rend="italic">et</hi> Verbum <hi
-						rend="italic">erat apud <lb/> Deum, et Deus erat Verbum; hoc erat</hi> in
-						<hi rend="italic">principio apud <lb/> Deum</hi> : de quo etiam paulo post
-					dictum est, <hi rend="italic">Et tila<lb/> erat lux</hi> hominum <hi
-						rend="italic">(Id.</hi> i, 1, 2, 4)? Haec vita fons vitae <lb/> est, et lux
-					ista lux lucis est. Unde cum dictum esset, <lb/>
-					<hi rend="italic">Apud te est fons vitae;</hi> continuo subjunctum est, <hi
-						rend="italic">In <lb/> lumine tuo videbimus lumen</hi> (Psal. XXXV, 10), hoc
-					est, <lb/> in Filio luo Spiritum sanctum ; quem tu quoque esse <lb/>
-					illuminatorem in Collationis nostrae priina parte nrm <lb/> fessus es. Fons ergo
-					de fonte, Filius de Patra, et si­ <lb/> mul ambo fons unus: lux de luce, Filius
-					de Patre, et <lb/> simul ambo lux una : sicut Dcus de Dco, et simul <lb/> ambo
-					utique Deus unus: et hoc totum non sine Spi­ <lb/> ritu amborum. Ex hoc fonte
-					bonitatis, ex hoc fonte <note type="footnote">* ouxlam Mss., <hi rend="italic"
-							>tantfui Vmco dedit.</hi>
-					</note><note type="footnote"> 'sic Myg. Editi vcro, <hi rend="italic">quod
-							dedit.</hi>
-					</note>
-					<lb/> vitae, ex hoc immutabili lumine, ex hac indeficiente <lb/> plenitudine, id
-					est, Patre, et Filio, et Spiritu sancto, <lb/> uno Domino Dco solo, sccundum
-					mensuram fidei su:e <lb/> quicumque veraciter credunt, sumentes boni fiunt, vi­
-					<lb/> vificantur, illuminantur, implentur. Quibus tu unige <lb/> nilum Filium,
-					pace tua dixcrim, nescio qua incredi­ <lb/> bili temeritate junxisti. Tua quippe
-					ista sunl verba : <lb/>
-					<hi rend="italic">Sive,</hi> inquis, <hi rend="italic">Filius, sive qui per
-						Filium sunt facti, de <lb/> illo uno fonte bonitatis unusquisque secundum
-						mensu­ <lb/> ram fidei suae assumpserunt ut essent boni.</hi> Ubi est ergo
-					<lb/> quod fueras ante confessus, illum natura Filium esse, <lb/> non gratia 1?
-					Ecce contra sententiam luam venis: ecce <lb/> jam prodis nefarium secretum
-					haeresis vestrae, quia <lb/> unigenitum verum Dei Filium, verum Dcum, non na­
-					<lb/> tura Filium, sed gratia profitemini. Si enim et ipse, <lb/> sicut verba
-					tua clamant, secundum mensuram fidei <lb/> SUm, ut bonus esset, assumpsit;
-					gratia est ergo Fi­ <lb/> lius, non natura : cL fuit aliquando non bonus, et
-					cre­ <lb/> dendo factus est bonus; quia ut esset bonus, quemad­ <lb/> modum
-					dicis, secundum mensuram fidei suae de illo <lb/> qui Pater est, fonte bonitatis
-					assumpsit. Legimus qui­ <lb/> dcm quod <hi rend="italic">Jesus</hi> proficiebat
-					aetate et <hi rend="italic">sapientia, et gratia <lb/> Dei erat</hi> in <hi
-						rend="italic">illo (Luc.</hi> II, 52) : sed secundum formaro <lb/> hominis
-					quam pro nobis accepit ex nobis, non secun­ <lb/> dum formam Dei, in qua non
-					alienam arbitratus est <lb/> esse aequalis Deo <hi rend="italic">(Philipp.</hi>
-					II, 6). Verumtamen etiam <lb/> in ipsa forma hominis legimus eum aetate et
-					sapientia <lb/> profccissc, non tamen ut ex non bono bonus fieret <lb/> credendo
-					meruisse. Neque nunc inter nos quaestio <lb/> vertitur de natura filii hominis,
-					in qua Dei Filius mi­ <lb/> nor cst Patre: sed de natura Filii Dei, in qua, ut
-					nos <lb/> dicimus, vos negatis, aequalis es. Patri : quia Filius <lb/> verus,
-					Filius unicus, Filius de vero Deo verus Dcus, <lb/> in nullo degeneravit a
-					Patre. Proinde incomparabi­ <lb/> lem Patrem Filio, nec in Scripturis sanctis
-					alicubi <lb/> legere potuisti. Nec sana fide ipse dixisti immensum <lb/> etiam
-					Patrem; quoniam propterea dicis, ut Filium <lb/> non pariter immensum, sed
-					mensura existimes ter­ <lb/> minatum. Tecum habeto mensuram tuam, qua <lb/> tuum
-					falsum dominum metiaris, et de vero Domino <lb/> mentiaris.</p></div>
-				<div type="textpart" subtype="chapter" n="24">
-					<p>CAPUT XXIV. — Bene confiteris quod et Pater <lb/> diligat Filium, et Filius
-					diligat Patrem : sed si et hoc <lb/> confitcaris, quia non est major dilectio in
-					Patre quam <lb/> in Filio. Quia cnim natura divinitatis a quales sunt, <lb/>
-					aequaliter se invicem diligunt. Facit autem Filius sic­ <lb/> ut homo mandatum
-					Patris. Nani sicut Deus, ipse Fr- <lb/>
-					<lb/> lius est mandatum Patris, quia ipse est Verbum Pa­ <lb/> tris. Unde alio
-					loco de mandato Patris, hoc est, de se <lb/> ipso dicit : <hi rend="italic">Scio
-						quia mandatum ejus vita aeterna est <lb/> (Joan.</hi> XII, 50). Quod autem
-					ipse Dei Filius sit vin <lb/> aeterna, Scriptura divina testatur. Ubi autem ait,
-						<hi rend="italic">Qni <lb/> me vidit, vidit et Patrem (Id.</hi> XIV, 9);
-					quis nesciat ideo <lb/> dictum, quoniam quisquis per intelligentiam videt Fi­
-					<lb/> lium, Patri utique videt aequalem? Quod vos ideo non <lb/> vultis, quia
-					per oculos cordis, quantum ia bac <unclear>vita­</unclear>
-					<lb/> viden potest, Filium non videtis. <note type="footnote">* Plores Mss., <hi
-							rend="italic">nvs gratia.</hi>
-					</note></p>
-				<pb n="803"/>
-				</div>
+				<div type="textpart" subtype="book" n="2">
+					<ab>
+						<title type="sub">
+							<hi rend="italic">LIBER SECUNDUS (a).</hi>
+						</title>
+					</ab>
+					<p>Refelluntur singillatim quae in Collatione Maximinus dixit ultima sua
+						disputatione, cujus disputationis suae prolixitato <lb/> respondendi tempus
+						tunc eripuit Augustino.</p>
+					<p>PRAEFATIO. - Res jam postulat ut in eoquod reliquum <lb/> est, opitulante
+						Domino, impleam promissionem meam. <lb/> In operis quippe hujus exordio,
+						Prius, inquam,ostendam <lb/>
+						<hi rend="italic">refellere te non potuisse quae dixi: deinde, quantum<lb/>
+							necessarium videbitur,</hi> ego <hi rend="italic">refellam quas ipse
+							dixisti.</hi>
+						<lb/> Quia ergo, sicut adjuvante Deo potui, ostendi ea quae <lb/> dixi non
+						te potuisse refellere; superest ut ea qux <lb/> dixisti, ego refellam, sicut
+						Deo adjuvante potuero. <lb/> Priores itaque prosecutiones tuas, quibus.
+						continuo <note type="footnote"> (I.) viias, reviius. </note>
+						<lb/> reddidi meas in hac disputatione quae nunc a me sus<lb/>cepta est, non
+						retractabo : illam vero ultimam lam <lb/> prolixam, ut milii die illo
+						spatium responsionis An­ <lb/> ferret, ita redarguam, si voluerit qui nos
+						regit, ut <lb/> acquiescas lumini veritatis, si contentionis tenebras <lb/>
+						non amaveris. In primis ergo superflua tua detrahant <lb/> necessitati
+						responsionis meae. Causa quippe inter nns <lb/> agitur, utrum Pater et
+						Filius et Spiritus sanctus di­ <lb/> versae, ut vos dicitis, an potius, ut
+						nos dicimus, unius <lb/> sint ejusdemque substantiae, unusque Deus sit ipsa <lb/>
+						<pb n="759"/> Trinitas : cum conveniat inter nos Patrem non esse <lb/> qui
+						est Filius, nee Filium esse qui est Pater, nec Pa­ <lb/> tremesse vel Filium
+						qui Spiritus sanctus est. Quid­ <lb/> quid igitur tanta tuae prosecutionis
+						prolixitate dixisti, <lb/> mule ostenderes alium esse Patrem, alium esse Fi­
+						<lb/> lium, alium esse Spiritum sanctum quando nobis­ <lb/> cum agitis.
+						superfluum prorsus esse cognosce : et si <lb/> tibi expugnandi occurrerint
+						Sabelliani, in eos ista <lb/> nohis vobisque communia, si placet, arma
+						converte. <lb/> Multa eliam locutus es, ut probares magnum Deum <lb/> esse
+						Dominum Jesum Christum : hoc quid ad nos, <lb/> cum hoc dicamus et nos?
+						Laudes quoque Spiritus <lb/> sancti magnas verasque fudisti : sed nos eas
+						augere <lb/> possumus, non negare : non itaque opus erat ut eas <lb/> contra
+						nos diceres, quas dicimus tecum. Christum <lb/> scdere ad dexteram Patris,
+						nonne pariter confite­ <lb/> mur? Quod tamen testimoniis divinorum eloquio­
+						<lb/> rum sic probare voluisti, tanquam id alicubi negare­ <lb/> mus.
+						Christum in carne venisse, utrique novimus et <lb/> tenemus : sic adhibuisti
+						ut hoc doceres divina testi­ <lb/> monia, tanquam repugnemus. Haec et alia
+						quae suis <lb/> ostendam locis, in quibus operam supervacuam con­ <lb/>
+						trivisti, ut moras necteres, tempusque produceres, <lb/> commemorando
+						attingere debeo, non redarguere <lb/> disputando.</p>
+					<div type="textpart" subtype="chapter" n="1">
+						<p>CAPUT PRIMUM. — Dicis me <hi rend="italic">auxilio</hi> principum mu­ <lb/>
+							<hi rend="italic">nitum, non loqui secundum timorem Dei;</hi> cum scias
+							nobis <lb/> esse praeceptum orare pro regibus, ut in agnitionem <lb/>
+							veniant veritatis (I Tim. II, i, 4): quod in quibusdam <lb/> esse
+							impletum, nos Deo agimus gratias, vos doletis. <lb/> Verba autem nostra
+							recte intelligentibus indicant, quis <lb/> nostrum loquatur secundum
+							timorem Dei : utrum qui <lb/> sic laudat Deum Patrem , ut ad ejus taudem
+							referat, <lb/> quod sibi Filium generavit xqualem; an qui sic geni­
+							<lb/> torem debonestat et genitum, ut et illum dicat non <lb/> potuisse
+							gignere per omnia sui similem filium, et <lb/> isium dicat non
+							dcgenerasse jam natum, sed dcgeae­ <lb/> rem natum.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="2">
+						<p>CAPUT II. — Dicis <hi rend="italic">vos Christum colere, ut Deum <lb/>
+								omnis creaturae cui flectitur</hi> omne <hi rend="italic">genu,
+								cœlestium, ter­ <lb/> restrium et infernorum</hi> : quem tamen Deo
+							Patri esse <lb/> non vultis aequalem, quia <hi rend="italic">hoc Pater
+								ei donavit:</hi> ait <lb/> enim Apostolus, <hi rend="italic">Propter
+								quod et Deus eun. exaltavit, <lb/> et donavit ei nomen quod est
+								super omne nomen , ut</hi> in <lb/>
+							<hi rend="italic">nomine Jesu omne genu flectatur,</hi> etc. Nec
+							quaeritis cui <lb/> donaverit; utrum homini, an Deo. Quomodo1 enim <lb/>
+							donaverit, evidenter apparet. <hi rend="italic">Humiliavit,</hi> inquit,
+								<hi rend="italic">se­ <lb/> metipsum usque ad mortem, mortem autem
+								crucis. Pro­</hi>
+							<lb/> pter <hi rend="italic">quod et Deus eum</hi> exaltavit, <hi
+								rend="italic">et donavit ei nomen <lb/> quod est super omne nomen
+								(Philipp.</hi> II, 8, 9). Si ergo <lb/> propterea donavit ei nomen
+							quod est super omne no­ <lb/> men, quia factus est obediens usque ad
+							mortem cru­ <lb/> cis; numquid antequam hoc fieret, non erat altus Dei
+							<lb/> Filius Deus, Dei Verbum, Deus apud Deum; sed <lb/> posteaquam
+							propter hoc exaltatus est, quia factus est <lb/> obediens usque ad
+							mortem crucis, tunc coepit esse <lb/> altus Dei Filius, unicus Dei,
+							Deus, tunc cœpit habere <lb/> nomen quad est super omne nomcn? Quis hoc
+							insi- <note type="footnote"> 1 In Mss., <hi rend="italic">Quando.</hi>
+							</note>
+							<lb/> pientissimus dixerit? Hoc illi ergo donatum est ut ho­ <lb/> mini,
+							secundum quem Filius factus est obediens usque <lb/> ad mortem crucis,
+							quod jam habebat idem ipse Dei <lb/> Filius, Deus de Deo natus
+							aequalis.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="3">
+						<p>CAPUT III. — Objicis mihi, quod dicam Spiritum <lb/> sanctum aequalem
+							esse Filio. Dico plane. <hi rend="italic">Da,</hi> inquis, <lb/>
+							<hi rend="italic">testimonia ubi adoratur Spiritus sanctus.</hi> Ut
+							video, hinc <lb/> eam vis ostendi aequalem Christo, si adoratur ut Chri­
+							<lb/> stus. Jam ergo confitere Christum Patr! arqualcm, <lb/> quem tu
+							ipse adorari confiteris ut Patrem. Quales au­ <lb/> tem homines estis,
+							quam religiosas humilitatis, qui <lb/> Spiritum sanctum adorare non
+							vultis, ciim legntis, <lb/>
+							<hi rend="italic">Littera occidit, Spiritus</hi> autem <hi rend="italic"
+								>vivificat</hi> ( II <hi rend="italic">Cor.</hi> III, 6 ) ? <lb/>
+							Non vultis ergo adorare, quem vivificare animas non <lb/> negatis : cum
+							pater Abraham homines adoraverit, <lb/> quia concesserunt ei monumentum,
+							ubi poneret mor <lb/>tuae corpus uxoris. Sic cnim scriptum est : <hi
+								rend="italic">Venit au.<lb/> tem Abraham plangere Saram et lugere.
+								Et</hi> surrexit <lb/>
+							<hi rend="italic">Abraham de supra mortem ejus, et dixit filiis II et. :
+								<lb/> Peregrinus et advena sum ego vobiscum; daie ergo</hi> mihi <lb/>
+							<hi rend="italic">possessionem monumenti, ubi sepeliam mortuum</hi>
+							meum. <lb/>
+							<hi rend="italic">Responderunt autem filii Heth ad</hi> Abraham , <hi
+								rend="italic">dicentes :<lb/> Absit hoc, domine; audi nunc et noa :
+								rex a Deo in</hi> es <lb/>
+							<hi rend="italic">in</hi> nobis ; <hi rend="italic">in electis
+								monumentis nostris sepeli mortuum <lb/> tuum : nemo enim nostrum
+								prohibet te a monumento <lb/> suo, ut sepelias mortuum tuum ibi.
+								Surgens autem <lb/> Abraham adoravit plebem</hi> filiorum <hi
+								rend="italic">Heth (Gen.</hi> XlIII, <lb/> 2-7). Et vos Spiritum
+							sanctum non permittitis adorari, <lb/> ut ipsi Dei gratiae remaneatis
+							ingrati ! Sed, <hi rend="italic">Da,</hi> in­ <lb/> quis, <hi
+								rend="italic">testimonia ubi adoratur Spiritus sanctus</hi> : quasi
+							<lb/> non ex iis quae legimus , aliqua eliam quae non legi­ <lb/> mus,
+							intelligamus. Sed ne quaTere multa compellar, <lb/> tu ubi legisti
+							Patrem Deum ingenitum vel innatum? <lb/> Et tamen verum est. Quod vero
+							aliquoties dixisti, <lb/> etiam Filio esse incomparabilem Patrem, nec
+							legis, <lb/> nec verum est. Si autem religionem qua colitur Deus, <lb/>
+							sicut dignum est cogitares, multo plus esse cerneres <lb/> quod habet
+							Spiritus sanctus templum, quam si cum <lb/> legeres adoratum. Et homines
+							enim , sicut supra do­ <lb/> cui, a sanctis novimus adoratos : templum
+							vero non <lb/> est factum ab hominibus, nisi aut vero Deo, sicut Sa­
+							<lb/> lomon fecit; aut cis qui pro diis habentur, sicut gen­ <lb/> tes
+							quae ignorant Deum. Spiritus autem sanctus, quod <lb/> cum magno honore
+							de Deo dictum est, <hi rend="italic">non in manu­ <lb/> factis templis
+								habilat</hi> ( <hi rend="italic">Act.</hi> XVII, 24 ), sed corpus
+							no­ <lb/> strum templum est Spiritus sancti. Et ne corpora no­ <lb/>
+							stra contemnas, membra sunt Christi ( I <hi rend="italic">Cor.</hi> vi,
+							19, <lb/> 15). Qualis ergo Deus, cui templum aedificatur, et a <lb/>
+							Deo, et de membris Dei ?</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="4">
+						<p>CAPUT IV. — Dicis <hi rend="italic">Christum esse</hi> in <hi
+								rend="italic">dextera Dei,<lb/> et interpellare pro nobis (Rom.</hi>
+							VIII, 34). Quod cur no­ <lb/> bis objicis, si eum non solum Deum, verum
+							etiam <lb/> hominem agnoscis? Quid te igitur adjuvat, quod se­ <lb/>
+							dere ad dexteram Patris assidue legitur ? Quid nobis, <lb/> non quidem
+							inanibus testimoniis, sed tamen inaniler, <lb/> probare niteris quod
+							fatemur.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="5">
+						<p>CAPUT V. — Dicis <hi rend="italic">vos Spiritum sanctum</hi> compe­ <lb/>
+							<hi rend="italic">tenter honorare ut doctorem, ut ducatorem,</hi> ut <hi
+								rend="italic">illumina­</hi>
+							<lb/> torem, ut <hi rend="italic">sanctificatorem; Christum colere, ut
+								creato­</hi>
+							<lb/>
+							<pb n="761"/>
+							<hi rend="italic">rem; Patrem</hi> cun, <hi rend="italic">sincera
+								devotione adorare,</hi> ut <hi rend="italic">aucto­</hi>
+							<lb/> rem. Si auctorem propterea dicis Patrem, quia de <lb/> ipso est
+							Filius, non est autem ipse de Filio; et quia <lb/> de illo et Filio sic
+							procedit Spiritus sanctus, ut. ipse <lb/> hoc dederit Filio gignendo eum
+							talem, ut etiam de <lb/> ipso procedat Spiritus sanctus : si creatorem
+							sic dicis <lb/> Filium, ut creatorem non neges Patrem nec Spiritum <lb/>
+							sanctum; si denique Spiritum sanctum sic dicis do­ <lb/> ctorem ,
+							ducatorem, illuminatorem, sanctificatorem, <lb/> ut haec opera nec Patri
+							audeas auferre nec Filio : ista <lb/> tua etiam nostra sint verba. Si
+							autem talia tibi idola <lb/> ponis in corde, ut duos facias deos, unum
+							majorem, <lb/> id est, Patrenl, alium minorem, id est, Filium ; Spi­
+							<lb/> ritum vero sanctum ita omnium trium minimum fin­ <lb/> gas, ut nec
+							Deum nuncupare digneris : non haec est <lb/> nostra fides, quoniam non
+							est christiana fides, ac per <lb/> hoc nec fides. Etiam hoc tibi
+							ignoscimus, quod impe­ <lb/> rite usus verbo , Chritum significasti <hi
+								rend="italic">ad terrena de­ <lb/> scendisse contagia.</hi> Et quia
+							hoc in te corrigere volui, <lb/> ut scires conlagia quomodo appellare
+							debeamus; ca­ <lb/> lumnias <hi rend="italic">esse</hi> istas dicis, <hi
+								rend="italic">et</hi> eas <hi rend="italic">de philosophicas
+								artis<lb/> instructione venire</hi> arbitraris. Sufficit mihi quod
+							ita <lb/> putasti Christum ad terrena descendisse contagia, <lb/> ut
+							tamen confitereris nullum habuisse peccatum.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="6">
+						<p>CAPUT VI. — Illud sane quod commemoravi, <lb/> partus animalium, quae cum
+							terrena sint atque mor­ <lb/> talia, hoc tamen gignunt quod ipsa sunt,
+							ut homo ho­ <lb/> minem, canis canem; puto quod non aspernatus hor­
+							<lb/> ruisti, sed te aspernari atque horrere finixisti, dicens, <lb/>
+							<hi rend="italic">tam. fœdam comparationem</hi> in <hi rend="italic"
+								>illam tantam immensita­ <lb/> tem non debuisse produci.</hi> Cur
+							enim boc dixisti, nisi <lb/> ne tibi de ipsis corruptibilibus fetibus
+							fauces veritas <lb/> premeret, et te respirare non sineret, sicut ct
+							facit ? <lb/> Qandoquidem creaturam corruptibilem cernitis , hoc <lb/>
+							quod ipsa est gignere fetum situm, et Deum Patrem <lb/> omnipotentem
+							creditis non potuisse nisi ejus dege­ <lb/> nerante natura g:gnerc
+							unicum suum.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="7">
+						<p>CAPUT VII. — Sed dicis: <hi rend="italic">Dominus Dominum ge­<lb/> nuit,
+								Deus</hi> Den. <hi rend="italic">genuit, Rex Regem genuit, Creator
+								<lb/> Creatorem</hi> genuit, <hi rend="italic">bonus bonum genuit,
+								sapiens sapien­<lb/> tem genuit, clemens clementem, potens
+								potentem.</hi> Si sub <lb/> his verbis cavcre te putas quod vobis
+							objicitur, non <lb/> vos credere Dcum potuisse gignere id quod est ipse,
+							<lb/> et ideo dicis, <hi rend="italic">Dominus Dominum genuit, Deus Deum
+								<lb/> genuit,</hi> et caetera : cur ergo sicut dixisti, <hi
+								rend="italic">Potens po­<lb/> tentem;</hi> non dicis, Omnipotens
+							omnipotentem? Si quod <lb/> sentis vis dicere, dic: Dominus major,
+							dominum mi­ <lb/> norem genuit; Deus major, deum minorem; Rex ma­ <lb/>
+							jor, regem miuorem; Creator major, creatorem mi­ <lb/> norem; melior
+							bonum, sapientior sapientem, clemen­ <lb/> tior clementem, potentior
+							potentem. Si autem ista <lb/> non dicis, et nihil minus quam Pater
+							habet, Filium <lb/> babere consentis, cur non dicis aequalem? Et illa
+							<lb/> omnia cur non sic percurris, ut dicas: D minus aequa­ <lb/> lem
+							Dominum genuit, Deus aequalem Deum, Rex <lb/> aequalem Regem,
+							Creatoraequalem Creatorem, bonus <lb/> aequaliter bonum, sapiens
+							aequaliter sapientem, de­ <lb/> mens aequaliter clementem, potens
+							aequaliter poten­ <lb/> tem? Si autcm negasaequalem aperte dic esse
+							dege­ <lb/> nerem. Non enim quem deum minorem, de Deo ula... <lb/> jore
+							natum esse dicitis, saltem sicut infantem crescere <lb/> sinitis, ut
+							aliquando suo Patri possit esse aequalis. Ad <lb/> hoc cnim eum
+							perfectum dicitis esse natum , non ut <lb/> binc laus ejus cresceret,
+							sed ut minor ejus natura re­ <lb/> nianerct. Et cum isia sentiatis.
+							seqneris tamen, et di­ <lb/> cis : Nihil sublraxtt <hi rend="italic"
+								>Pater in generando Filium.</hi> Quo­ <lb/> modo nihil subtraxit in
+							generando Filium, quem non <lb/> aequalem genuit, sed minorem? An ideo
+							nihil sub­ <lb/> traxit, quia nihi! corum quae gignendo dedit, abstulit
+							<lb/> genito ? Ita sane nihil subtraxit: sed et filiis hominum <lb/> qui
+							prospere nascuntur, nihil aufert Creator jam na­ <lb/> tis ; quin potius
+							addit, ut accedat crescentibus quod <lb/> nascentibus defuit. Quid ergo
+							magnum de Patre dixi­ <lb/> sti erga unicum Filium, qui non ex nihilo
+							vel ex ali­ <lb/> qua materia factus, sed ex ipso natus est? Quid ma­
+							<lb/> gnum est quia non subtraxit quod dedit, si quod dare <lb/> potuit,
+							non dando subtraxit? Ubi est, quod eum invi­ <lb/> dum non esse dixisti?
+							An forte dare non potuit? Uhi <lb/> est omnipotentia DeiTatris? Prorsus
+							ad hunc articu­ <lb/> lum res colligitur, ut Deus Pater aequalem sibi
+							gignere <lb/> Filium aut non potuerit, aut noluerit. Si non potuit,
+							<lb/> infirmus; si noluit, invidus invenitur. Sed utrumque <lb/> hoc
+							falsum est. Patri igitur Deo Filius verus aequalis <lb/> eat. Si ergo,
+							ut laudas, placet tibi quod a me comme­ <lb/> moratum est, <hi
+								rend="italic">Invisibilia enim ejus, per ea quce facta<lb/> sunt,
+								intellecta conspiciuntur (Rom.</hi> I, 20) : per id qnod <lb/>
+							factum est in creatura visibili, ut pnrentes id quod <lb/> ipsi sunt
+							generent, intellige ipvisibilcm nativitatem . <lb/> veri Filii Dei, ne
+							Deum Patrem dicas id quod non est <lb/> ipse gcnuisse. Si autem hoc
+							genuit quod est ipse; <lb/> unam Patris et Filii esse substantiam negare
+							nolite.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="8">
+						<p>CAPUT VIII. — Jam vero sequentia, quae sic con­ <lb/> nexuisti, ut de
+							cruce vel incarnatione Christi probare <lb/> nobis velles quod pariter
+							credimus; servasti morem <lb/> mum : sed nihil tibi ad ista respondens,
+							etiam ego <lb/> servo promissum meum.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="9">
+						<p>CAPUT IX. — 1. De iuvisibili Filio cum agere­ <lb/> mus, quem consensisti
+							esse invisibilem secundum di­ <lb/> vinitatem, qui prius solum Patrem
+							invisibilem esse <lb/> praesumpseras, ad rem non pertinentia multa
+							dixisti <lb/> de invisibilibus creaturis : quod poterunt judicare qui
+							<lb/> legerint. De invisibili Dco inter nos agitur : et hoc <lb/> csl
+							quod quaestionem facit, quia vos invisibilcm solum <lb/> Patrem dictum
+							putatis, ubi Apostolus ait, <hi rend="italic">Immortali,<lb/> invisibili
+								soli Dco</hi> (I <hi rend="italic">Tim.</hi> I, 17). Si dixisset,
+							Soli Patri ; <lb/> diflicilius fortasse quaestio solverelur: quia vero
+							dixit, <lb/>
+							<hi rend="italic">soli Deo;</hi> non est utique contra nos : et
+							Unigenitus <lb/> quippe in Dei forma, ct Spiritus sancius in sua na­
+							<lb/> tura est invisibilis. Unus enim et solus Deus a nobis <lb/> ipsa
+							Trinitas praedicatur. Quod utrum verum sapia­ <lb/> mus, in aliis locis
+							a nobis est demonstratum, et ubi <lb/> adhuc opus fuerit,
+							demonstrabitur. Nunc in ista quae<lb/>simone non immerito potest movere,
+							quomodo de solo <lb/> Dco, qui cst ipsa Trinitas, dictum sil, <hi
+								rend="italic">Invisibili soli</hi>
+							<lb/> Deo : cum sil etiam quaedam invisibilis creatura; <lb/> propter
+							quod dictum ost de Christo, quia <hi rend="italic">in ipso con­ <lb/>
+								dita sunt</hi> omnia <hi rend="italic">visibilia et invisibilia (
+								Coloss.</hi> I, 16). <lb/> Quia ergo sunt dii falsi vbibiles, ideo
+							dicturi est, In­ <lb/>
+							<pb n="763"/> risibili <hi rend="italic">soli Deo honor et gloria.</hi>
+							Etsi enim est creatura <lb/> invisibilis, non tamen deus nobis est. Sed
+							et si non <lb/> dictum esset, <hi rend="italic">soli Dco;</hi> sed
+							dictum esset, <hi rend="italic">Reg; autem<lb/> saeculorum, immortali,
+								invisibili soti honor et gloria:</hi>
+							<lb/> quis nisi Deus esset? Honor ergo ei gloria soli Deo, <lb/> qui
+							Deus invisibilis est, non qui solus invisibilis : <lb/> quoniam est, ut
+							diximus, ct creatura invisibilis. Item <lb/> quaeri potest quomodo
+							dictum sit, <hi rend="italic">Deum nemo vidit <lb/> unquam (Joan.</hi>
+							I, 18); cum ejusdem Domnini verba <lb/> sint, <hi rend="italic">Nescitis
+								quia Angeli</hi> eorum <hi rend="italic">semper vident fuciem<lb/>
+								Patris</hi> mei <hi rend="italic">qui in cœlis est (Matth.</hi>
+							XVIII, 10)? Quae <lb/> sententia vos rcdarguit, qui nescitis quemadmodum
+							<lb/> dicatis invisibilem Patrem. Illud autem quod ait, <lb/> Noti <hi
+								rend="italic">quia Patrem vidit</hi> quisquam , <hi rend="italic"
+								>nisi qui eat a Deo, <lb/> hic vidit</hi> Patrem <hi rend="italic"
+								>(Joan.</hi> VI, 46); ad homines reforri <lb/> potest quod dictum
+							est, <hi rend="italic">quisquam.</hi> Et quia ipse homo <lb/> erat qui
+							tunc loquebatur in carne, ita hoc dixit, ac si <lb/> diccret, Non quia
+							Patrem vidit quisqunm bominum, <lb/> nisi cgo : sicut dictum est, <hi
+								rend="italic">Quis sapiens, et intelliget <lb/> haec (Psal.</hi>
+							cvi, 43) ? Non enim et de sanctis Angelis <lb/> id accipi potest. Unde
+							Apostolus de invisibili Deo <lb/> apertius posuit: <hi rend="italic"
+								>Quem nemo hominum vidit, nec videre<lb/> potest</hi> (I Tim. vi,
+							16). Non enirn ait, Nemo; sed, <hi rend="italic">Nemo <lb/>
+								hominum.</hi> Ubi ostendit quemadmodum intelligi debeat <lb/> quod
+							dictum est, <hi rend="italic">Deum nemo vidit</hi> unquam ; id est,
+							<lb/> nemo hominum : <hi rend="italic">sicut, Nemo ascendit in</hi>
+							coelum <hi rend="italic">(Joan.</hi>
+							<lb/> III, 15); cum Angeli soleant illuc ascendere, quin so­ <lb/> lent
+							inde descendere. Nec tamen Apostolus dixit, <lb/> Nemo hominum poterit
+							videre Deum ; sed, <hi rend="italic">Nemo<lb/> potest,</hi> Poterit cnim
+							homo, sed tunc cum aeternum <lb/> crit fidelium praemium , videre Deum.
+							Propter quod <lb/> Joannes apostolus : <hi rend="italic"
+								>Dilectissimi,</hi> inquil, <hi rend="italic">filii Dei su­ <lb/>
+								mus, et nondum apparuit quid erimus</hi> : scimus <hi rend="italic"
+								>quia</hi>
+							<lb/> cum <hi rend="italic">apparuerit, similes ei erimus, quoniam</hi>
+							videbimus <lb/>
+							<hi rend="italic">eum sicuti cst (</hi> I <hi rend="italic">Joan.</hi>
+							III, 2). Quid est ergo quod dicis, <lb/> solum esse invisibilem Patrem?
+							quod fruslra diceres, <lb/> etiamsi a solo Filio videretur. Nunc vera
+							cum divina <lb/> testentur cloquia cum videri et ab Angelis, videndum
+							<lb/> etiam ab hominibus, cum facti fuerint aequales Ange­ <lb/> lis <hi
+								rend="italic">(Matth.</hi> XXII, 50); quid est quod dicis? Ubi est
+							<lb/> quod definire ausus es, <hi rend="italic">minora videri a</hi>
+							,Majoribus, <lb/>
+							<hi rend="italic">majora autem a minoribus</hi> non <hi rend="italic"
+								>videri?</hi> Quod quidem <lb/> postea perdidisti, quando videri a
+							Filio confessus cs <lb/> Patrem, cum ct in ipsa substantia divinitatis
+							dicas <lb/> Filium minorem, Patremque majorem. Sed quid di­ <lb/> cturus
+							os de Angelis , qui semper vident faciem Dei <lb/> Patris? Numquid
+							propter regulam tuam, quam sine <lb/> consideratione fixisti, putandi
+							sunt Angeli Patre Deo <lb/> esse majores?</p>
+						<p>2. Scd eleganter te existimas invenisse quod diceres, <lb/> ubi :isti de
+							Filio: <hi rend="italic">Vidit ergo Patrem, sed vidit incapa­ <lb/>
+								bilem.</hi> Nec attendis, quia ctsi vidit incapabilcm, quem <lb/>
+							sicut putas, capere non putuit; non tamen invisibilcm, <lb/> quem videre
+							potuit. Tu autem nobiscum non de ca­ <lb/> pabili ut incapabili, scd dc
+							visibili et invisibili, cum <lb/> ista diceres, disputabas : quia nHc
+							Apostolus ait, In­ <lb/> capabili; scd ait, <hi rend="italic">Invisibili
+								soli Dco.</hi> Unde hoc testi­ <lb/> monium pro te adhibendum
+							putasti, ut binc etiam <lb/> decolorares Filium, tanquam ipse in Dei
+							forma invisi­ <lb/> bilis non sit. Sed quoniam veritate convictus, et
+							Filium <lb/> confessus cs invisibilcm, praeparasti tibi, quantum exi­
+							<lb/> Stimo, sic dicere, Invisibilis invisibilem genuit; quo­ <lb/> modo
+							dixisti, <hi rend="italic">potens potentem :</hi> ut cum discutereris,
+							<lb/> hoc a te quomodo diceretur, responderes, Invisibilior <lb/>
+							invisibilem gcnuit, sicut potentior potentem. sapien­ <lb/> tiur
+							sapientem, et caMera tua. Sed quain sapicnicr <lb/> oslendisli Filio
+							incapabilem Patrem, Filium vcro ca <lb/> pabilem Patri. Dixisti enim :
+							fidit <hi rend="italic">ergo Patrem, sed <lb/> vidit incapabilem. Pater
+								autem,</hi> ill'luis, <hi rend="italic">sic videt Filium,<lb/> ut
+								tenens in sinu suo et</hi> Iubens. Sic non sapiunt, nisi <lb/> qui
+							carnaliter sapiunt. Sinum quippe tibi fingis, ut vi­ <lb/> deo, aliquam
+							capacitatem majoris Patris, qua Filium <lb/> minorem capiat atque
+							contineat : sicut hominem cor­ <lb/> poralitcr capit domus, aut sicut
+							sinus nutricis capit <lb/> infantem. Ergo inter mirabilia Christi et hoc
+							deputa­ <lb/> bitur, quia in forma servi crevit, et major est factus
+							<lb/> quam in forma Dei fuerat, ut cum prius portaretur in <lb/> sinu
+							Patris, nunc sedeat ad dexteram Patris. Abjice <lb/> ista puerilia vel
+							anicularia phantasmata de corde tuo: <lb/> et sinum Patris ideo dictum
+							accipe, ut intelligatur iste <lb/> gcnilus, ille genitor; non ut ille
+							major, hic minor. <lb/> Nam si incapabilis est Pater, Filius vero
+							incapabilis <lb/> non est, non veraciter dictum est, <hi rend="italic"
+								>Omnia quae habet <lb/> Pater, mea sunt (Joan.</hi> XVI, 15) :
+							quandoquidem re­ <lb/> sponderi ei potest, Ecce incapabilitatem habet
+							Pater, <lb/> quae non est tua. Sed quoniam veraciter dictum est <lb/>
+							quod Veritas dixit, et omnia quae habet Pater, Filii <lb/> sunt; non
+							potest non esse Filii quantacumque sit in­ <lb/> capabilitas Patris. EL
+							hanc Domini sententiam, ubi <lb/> ait, <hi rend="italic">Omnia quae
+								habet Pater, mea sunt;</hi> tanquam re­ <lb/> ctissimam regulam ad
+							vos, sive convincendos, sivc, <lb/> quod magis cupimus, corrigendos, per
+							multa adhibere <lb/> debemus : ut ubicumque aliquid tribuitis Patri quod
+							<lb/> Filio denegatis, ipsam fidclissimam testem contra er. <lb/> rores
+							vestros, vel contra mendacia producamus. Quid <lb/> opus cst autem in eo
+							tibi resistere, quod bunnam <lb/> sapicnliam contendis esse visibilcm;
+							cum ipsam <lb/> animam humanam, in qua est utique humana sa­ <lb/>
+							pientia, invisibilem esse concesseris ? Sed quod­ <lb/> libet sentias de
+							universa invisibili creatura, quantum <lb/> ad Dcum pertinet, de quo
+							inter nos agitur, satis tibi <lb/> demonstratum est non esse solum
+							invisibilem Pa­ <lb/> trem.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="10">
+						<p>CAPUT X. — i. Putas Dcum Patrem cum F'ilio ct <lb/> Spirilu sancto unum
+							Deum esse non possc : timcs <lb/> cnim ne Palcr solus non sit unus Dcus,
+							sed pars <unclear>umus</unclear>
+							<lb/> Dei qui constat ex tribus. Noli liincre, nulla fit pur­ <lb/> tium
+							in dcitatis unitate divisio. Unus est Dcus Pater <lb/> et Filius ct
+							Spiritus sanctus, hoc est ipsa Trinitas. <lb/> Unus cst Deus, de quo
+							dictum est, quia <hi rend="italic">Nullus Deus, <lb/> nisi unus</hi> (I
+								<hi rend="italic">Cor.</hi> VIII, 4) : et qui dixit, <hi
+								rend="italic">Audi, Israel; <lb/> Dominus Deus tuus, Dominus unus
+								cst.</hi> Cui uni et soli <lb/> Ico servire nos sine ullo scrupulo
+							agnoscimus, quan­ <lb/> do audimus ct Icgimus : <hi rend="italic"
+								>Dominum Deum tuum adora.</hi>
+							<lb/> bis, <hi rend="italic">ct iili soli</hi> servies <hi rend="italic"
+								>(Deut.</hi> vi, 4, 13). Nc forte propter <lb/> haec verba, Christo
+							cujus membra sumus (I <hi rend="italic">Cor. vi,</hi>
+							<lb/> 13), vel Spiritui sancto cujus templum sumus <hi rend="italic"
+								>(Jd.</hi>
+							<lb/> III, 17), servire nolimus, si quod dictum C'Si, Domino <lb/>
+							<pb n="765"/> Dco tuo <hi rend="italic">soli servies,</hi> sic
+							acceperimus, tanquam de solo <lb/> Patre, et non de ipsa Trinilaie sil
+							dictum. Vos autem, <lb/> cum quaeri<unclear>tur</unclear> a vobis, quem
+							credatis esse de quo <lb/> scriptum cst, <hi rend="italic">Dominus Deus
+								tuus, Dominus unus est;</hi>
+							<lb/> respondetis, Deus Pater est. Itemque cum quaeritur <lb/> de quo
+							Domino Deo dictum sil, <hi rend="italic">Dominum Deum tuum</hi>
+							<lb/> adorabis, <hi rend="italic">et illi soli servies;</hi> rursus
+							respondetis, De Dco <lb/> Patre. Tunc vobis dicitur : Si Domninus Deus
+							noster <lb/> Dominus unus cst, et hic Pater est; quare vos facitis <lb/>
+								du<unclear>ns</unclear> dominos dcos, dicendo etiam Christum esse
+							Do­ <lb/> minum Deum ? Item si Pater est, cui uni Domino Deo <lb/> ac
+							soli serviendum cst; quomodo obtemperatis huic <lb/> praecepto, qui
+							tanquam Domino Deo servitis et Chri­ <lb/> sto? Neque enim illi soli
+							servi, qui servit et huic. <lb/> Secundum fidem autem rectam, quicumque
+							ipsam <lb/> Trinitatem unum Dominum Deum esse nostrum di­ <lb/> dicimus,
+							profecto cum ei soli ea quas Deo dcbelur <lb/> servitute servimus,
+							Domino Deo soli nos servire con­ <lb/> fidimus.</p>
+						<p>2. <hi rend="italic">Ergo</hi> , inquis, <hi rend="italic">Deus Puler
+								pars est Dei.</hi> Absit. <lb/> Tres enim personae sunt Pater et
+							Filius et Spiri­ <lb/> tus sanctus : et hi tres quia unius substantiae
+							sunt, <lb/> unum sunt, ct summc unum sunt, ubi nulla natura­ <lb/> rum,
+							nulla cst diversitas voluntatum. Si autem na­ <lb/> tura unmn essent, et
+							consensione non essent , non <lb/> summe unum essent : si vero natura
+							dispares essent, <lb/> unum non essent. Hi ergo tres, qui unum sunt-pro­
+							<lb/> pter ineffabilem conjunctionem deitatis, qua ineffa­ <lb/> biliter
+							copulantur, unus Ocus cst. Porro autem Chri­ <lb/> stusuna persona est
+							gemiae substantiae, quia et Deus <lb/> et homo est. Nec tamen Deus pars
+							hujus personae <lb/> dici potest : alioquin Filius Dei Deus antequam
+							sus­ <lb/> ciperet formam sel'vi, non erat totus, et crevit cum <lb/>
+							homo divinitati cjus accessit. Quod si in una persona <lb/> absurdissime
+							dicitur, quia pars rci ullius esse non <lb/> .potest Deus; quanto magis
+							pars Trinitatis esse non <lb/> potest, quicumque unus in tribus ? Dcinde
+							ubi ait <lb/> Apostolus, <hi rend="italic">Qui adhaeret Domino, unus
+								spiritus est;</hi>
+							<lb/> (1 <hi rend="italic">Cor.</hi> vi, 11 ); numquid hujus unius pars
+							est Domi­ <lb/> nus ? Si cnim hoc dicimus , quid aliud dicere depre­
+							<lb/> hendimur, nisi quod augeatur adhaerente hominc, et <lb/> recedente
+							minuatur ? In Trinilalc igitur qu:c Dcus <lb/> cst, et Pater Deus est,
+							et Filius Deus cst, ct Spiritus <lb/> sanctus Dens est, ct simul hi Ires
+							unus Deus : nec <lb/> hujus Trinitatis tertia pars cst unus, nuc major
+							pars <lb/> duo qnam unus est ibi; nec majus aliquid sunt onmes <lb/>
+							quam singuli : quia spiritualls, non corporalis est <lb/> magnitudo. Qui
+							potest capere, capiat ( <hi rend="italic">Matth.</hi> xix , <lb/> 42 ) :
+							qui autem non potest, credat, et oret ut quod <lb/> credit intelligat.
+							Verum cst enim quod dicitur per <lb/> prophetam, Nisi <hi rend="italic"
+								>credidcritis , non intelligetis ( Isa;.</hi>
+							<lb/> VII, 9 ).</p>
+						<p>5. Tu nempe dixisti; <hi rend="italic">unum Deum</hi> non <hi
+								rend="italic">ex partibus <lb/> esse compositum.</hi> Et quia de
+							Patre hoc vis intelligi, <lb/>
+							<hi rend="italic">Ille,</hi> innuis , <hi rend="italic">quod est, virtus
+								est ingenita,</hi> simplex. <lb/> £t tamen in hac simplici virtute
+							quam multa comme­ <lb/> moraveris, vide. Nam superiora verbi tua sunt : <lb/>
+							<hi rend="italic">Deus Deum genuit, Dominus Dominum genuit, Rex
+								lle­</hi>
+							<unclear/><lb/>
+							<hi rend="italic">qem genuit,</hi> Creator <hi rend="italic">Creatorem
+								genuit, bonus bonum</hi>
+							<lb/> genuit, <hi rend="italic">sapiens sapientem genuit, clemens</hi>
+							clementem, <lb/>
+							<hi rend="italic">potens potentem.</hi> Cur ergo in virtute simplici,
+							quod <lb/> est Dcus, non timuisti tot commemorare virtutes ? <lb/> Ut
+							enim omittam quatuor quas loco superiore po­ <lb/> suisti, et alias
+							quatuor dicam, quas enunt<unclear>iare</unclear> usitatis <lb/>
+							nominibus possimus; numquid bonitas ct sapiculia ct <lb/> clementia et
+							potentia partes sunt unius virtutis, <lb/> quam simplicem e.sc dixisti ?
+							Si dixeris, Partces sunt; <lb/> simplex crgo virtus ex partibus constat,
+							et simplex <lb/> ista virtus te definiente unus est Deus. Unum ergo
+							<lb/> Deum ex partibus compositum esse dicis ? Non dico , <lb/> inquis.
+							Non sunt ergo partes : et tamen quat<unclear>uor</unclear> sunt, <lb/>
+							et una virtus est, eademque simplex est. Si ergo in <lb/> una Patris
+							persona , et plura invenis, et partes non <lb/> invenis; quanto magis
+							Pater ct Filius ct Spiritus <lb/> sanctus, et propter individuam
+							deitatem unus Deus <lb/> est, et propter uniuscujusque proprietatem tres
+							per­ <lb/> sonae sunt, et propter singulorum perfectionem partes <lb/>
+							unius Dci nan sunt? Virtus cst Pater, virtus Filius, <lb/> virtus
+							Spiritus sanctus. Hoc verum dicis : sed quod <lb/> virtutem de virtute
+							gcnitam, et virtutem de virtute <lb/> procedentem non vis eamdem habere
+							naturam, hoc <lb/> falsum dicis, hoc contra fidem rectam et catholicam
+							<lb/> dicis.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="11">
+						<p>CAPUT XI. — Redis ut quaeras a me, quomodo <lb/> sit invisibilis Filius,
+							unde jam dixi superius, quod <lb/> visum est dicendum. Sed si <hi
+								rend="italic">ob hoc,</hi> inquis, <hi rend="italic">Filius</hi> in­ <lb/>
+							<hi rend="italic">visibilis a te pronuntiatur, eo quod oculis humanis
+								con­ <lb/> templari</hi> non <hi rend="italic">possit ; cur non
+								et</hi> coelestes <hi rend="italic">virtutes pariter <lb/>
+								invisibiles</hi> pronuntias, <hi rend="italic">quando nec ipsae
+								obtutibus huma­ <lb/> nis videri</hi> possunt ? Ita hoc dicis, quasi
+							possit ab ho­ <lb/> mine comprehendi quis ille sit modus, quo cœlestes
+							<lb/> virtutes sunt invisibiles; aut ad hoC quaerendum esse <lb/>
+							debeamus intenti, dicente Scriptura, <hi rend="italic">Altiora te</hi>
+							ne <lb/>
+							<hi rend="italic">quaesieris (Eccli.</hi> III, 22). Quod praeceptum ipse
+							con­ <lb/> temnens, ausus es dicere angelum vidcri ab archan­ <lb/>
+							gclo, archangelum ab angelo non vidcri. Satis sit, <lb/> quod ostendi
+							non esse consequens ut ideo credamus <lb/> in forma Dei visibilem
+							Filium, qnia scriptum est, <lb/>
+							<hi rend="italic">Invisibili soli Deo</hi> ( I <hi rend="italic"
+								>Tim.</hi> 1, 17 ). Quod in de Patre <lb/> sic te accipere
+							demonstrabas tanquam Filius invisibi­ <lb/> lis non sit, cum cum ct
+							invisibilium creatorem Scri­ <lb/> p'ura testetur. Verumtamen restat
+							utdicas, Ambo qui. <lb/> dem invisibilcs sunt, id cst, ct Pater et
+							Filius , set! <lb/> Patcr invisibilior est : ac sic dando aliquid Patri
+							<lb/> quod non sit Filii, mendacem facias cumdem Filium <lb/> dicentem,
+								<hi rend="italic">Omnia quae habet Pater, mea suni (Joan.</hi>
+							<lb/> XVI, 15).</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="12">
+						<p>CAPUT XII. — i. HInc et de potentia sapis, quod <lb/> scilicet sit quidem
+							potens ct Filius, sed potentior Pa­ <lb/> ter Filio : ulauctoribus et
+							doctoribus vobis potuerit <lb/> potentem potens, nee potuerit
+							omnipotcntem gignere <lb/> omnipotens. Ac per hoc si habct Pater
+							omnipoten<lb/>liam quam non habet Filius, falsum est quod ait <lb/>
+							Filius, <hi rend="italic">Omnia quae habet Pater, mea sunt.</hi> Deinde
+							si <lb/> aliquid facit Pater, quod facere non potest Filius, <lb/>
+							mcrito dicitur potentior Pater quam Filius : cum vero <lb/> dical, <hi
+								rend="italic">Quaecumque Pater facit, haec et Filius similiter <lb/>
+								facit</hi> ( <hi rend="italic">Joan.</hi> v, 19 ); nonne meiius
+								<unclear>audit</unclear>
+							<lb/>
+							<pb n="767"/> vos, nactusque ipsi creditur docenti quam dccipien­ <lb/>
+							tibus vobis ? <hi rend="italic">Sed potentiam</hi> Pater , inquis, <hi
+								rend="italic">a nemine, <lb/> Filius vero accepit a Patre.</hi>
+							Fatemur et nos Filium ab <lb/> illo accepisse potentiam, de quo natus
+							est putens : <lb/> Patri vero potentiam nullus dedit, quia nullus eum
+							<lb/> genuit. Gignendo enin dedit potentiam Pater Filio, <lb/> sicut
+							omnia quae habet in substantia sua , gignendo <lb/> dedit ei quem genuit
+							de substantia sua. Sed quaeritur <lb/> utrum tantam, quanta ipsi est,
+							potentiam Pater Filio <lb/> dederit, an minorem. Si tantam, non solum
+							potentem <lb/> poiens, verum etiam omnipotentem genuisse dicatur, <lb/>
+							credatur, intelligatur omnipotens : si minorem, <lb/> quomodo omnii qune
+							habet Pater, Filii sunt ? Si Pa­ <lb/> iris omnipotentia Filii non est,
+							quomodo quaecumque <lb/>
+							<hi rend="italic">Pater facit, h</hi>ae<hi rend="italic">c et
+								Filius</hi> similiter <hi rend="italic">facit</hi> ? quod ulique
+							<lb/> non potest, si omnipotens non est.</p>
+						<p>2. Ac per hoc quod ait Apostolus , <hi rend="italic">Beatus et solus</hi>
+							<lb/> potens : non cogor de Patre tantummodo accipere; <lb/> sed de Deo,
+							quod est ipsa Trinitas. Loquens enim <lb/> ad Timotheum : Praecipio,
+							inquit, tibi <hi rend="italic">coram Deo, <lb/> qui vivificat omnia, et
+								Christo Jesu qui</hi> testimonium <lb/>
+							<hi rend="italic">reddidit sub Pontio Pilato bonam confessionem, ut ser­
+								<lb/> ves mandatum sine macula, irreprehensibile, usque ad<lb/>
+								adventum Domini nostri Jesu Christi; quem temporibus <lb/> propriis
+								ostendet beatus et solus potens, Rex regum et <lb/> Dominus
+								dominantium;</hi> qui <hi rend="italic">solus habet immortalitatem,
+								<lb/> et lucem inhabitat inaccessibilem; quem nemo</hi> hominum <lb/>
+							<hi rend="italic">vidit, nec videre potest; eui est honor et gloria</hi>
+							in saecu­ <lb/> la <hi rend="italic">saeculorum. Amen</hi> (I <hi
+								rend="italic">Tim.</hi> VI, 13-16). Nihil hic vi­ <lb/> deo dictum
+							quod non conveniat Trinitati. Sed ut nunc <lb/> taceam de Spiritu
+							sancto, quem nec saltem minorem <lb/> Filio Deum vultis, quia omnino
+							Deum esse non vultis, <lb/> sufficit ut vos de Patre convincamus et
+							Filio. Numquid <lb/> enim quia dixit Apostolus, <hi rend="italic"
+								>Testificor tibi coram Deo <lb/> qui vivificat omnia;</hi> Pater
+							solus, non et Filius vivifi­ <lb/> cat omnia ? Si dixeris Patrem solum
+							vivificare omnia, <lb/> quomodo ergo <hi rend="italic">quaecumque Pater
+								facit, h</hi>ae<hi rend="italic">c et Filius</hi>
+							<lb/> similiter <hi rend="italic">facit ?</hi> Quandoquidem Pater, ut
+							putas, vivifi­ <lb/> cat omnia, qnod Filius non facit. Deinde ubi ait, <lb/>
+							<hi rend="italic">SicuL Pater suscitat mortuos et vivificat, sic et
+								Filius <lb/> quos vult vivificat (Joan.</hi> v, 21); quomodo verum
+							eSI, <lb/> si Pater sine Filio vivificat omnia? Proinde quod <lb/>
+							addidit, <hi rend="italic">Et Christo Jesu qui testimonium reddidit
+								sub</hi>
+							<lb/> Pollio <hi rend="italic">Pilato bonam confessionem;</hi> de Filio
+							proprie <lb/> diccre voluit: quia Filius quidem sicut Pater vivificat
+							<lb/> omnia ; sed sub Pontio Pilato in forma servi Filium <lb/> novimus
+							passum fuisse, non Patrem. Deinde subjun­ <lb/> gitur, <hi rend="italic"
+								>Ut serves mandatum sine macula, irreprehensi­ <lb/> bile, usque ad
+								adventum Domini nostri Jesu Christi;<lb/> quem temporibus propriis
+								ostendet beatus et solus po­ <lb/> tens : quem,</hi> scilicet
+							adventum Domini Christi ; osten­ <lb/>
+							<hi rend="italic">det</hi> utique Dcus, quod non solus est l'ater, quia
+							<lb/> secundum veritatem, non secundum vestrum errorem, <lb/> Trinitas
+							unus est Deus <hi rend="italic">: beatus et solus</hi> potens, <hi
+								rend="italic">Rex<lb/> regum et Dominus dominantium.</hi> Numquid
+							enim vel vos <lb/> dicere audetis Filium non esse Regem regum et Do­
+							<lb/> minum dominantium ? De quo inter caetera scriptum est <lb/> in
+							Apocalypsi Joannis: <hi rend="italic">Et ipse calcat torcular vini po­
+								<lb/> tentis, et in tunica et in femore habet nomen scriptum, <lb/>
+								Rex regum et Dominus dominantium (Apoc.</hi> XII, 15, <lb/> 16). Sed
+							ne forte dicatis quod nomen Patris Filius <lb/> habet scriptum in veste
+							et in femore ; alio loco ejus­ <lb/> dem libri superius legitur : <hi
+								rend="italic">Et Agnus vincet eos, <lb/> quoniam Dominus dominantium
+								est et Rex regum (Id.</hi>
+							<lb/> XVII, 14). Quapropter secundum vos, duo suut regcs <lb/> regum et
+							domini dominantium : et contra vos est, si <lb/> de Patre tantum ait
+							Apostolus, <hi rend="italic">Beatus et</hi> solus <hi rend="italic"
+								>votens,<lb/> Rex regum et Dominus dominantium.</hi> V crum autem
+							<lb/> secundum rectam fidem ipsa Trinitas unus est Deus, <lb/>
+							<hi rend="italic">beatus et</hi> sotus <hi rend="italic">potens, Rex
+								regum et Dominus domi­<lb/> nantium, qui solus habet immortalitatem,
+								et lucem ha­ <lb/> bitat inaccessibilem.</hi> Et quomodo erit verum,
+								<hi rend="italic">Accedite<lb/> ad eum, et</hi> illuminamini <hi
+								rend="italic">(Psal.</hi> XXIIII, 6) ; nisi quia hoc <lb/> nemo
+							potest, si de se quisque praesumpserit, sed si <lb/> ipse donaverit?
+							Immortalitatem autem Deus habere <lb/> dicitur solus, quia est
+							immutabilis solus. In omni enim <lb/> mutabili natura nonnulla mors est
+							ipsa mutatio, quia <lb/> facit aliquid in ea non esse quod erat. Proinde
+							et <lb/> ipsa anima humana, quae propterea dicitur immorta­ <lb/> lis,
+							quoniam qualilercurnque secundum modum suum <lb/> nunquam desinit
+							vivere, habet tamen pro ipto suo <lb/> modo quamdam mortem suam : quia
+							si juste vivebat <lb/> et peccat, moritur justitiae; si peccatrix erat
+							et justi­ <lb/> ficatur, moritur peccato : ut alias ejus mutationes
+							<lb/> taceam, de quibus longum est disputare. Et creatu­ <lb/> rarum
+							natura coelestium mori potuit, quia peccare <lb/> potuit: nam et Angeli
+							peccaverunt, et daemones facti <lb/> sunt, quorum est diabolus princeps.
+							Et qui non pec­ <lb/> caverunt, peccare potuerunt. Et cuicumque
+							creaturae <lb/> rationali praestatur ut peccare non possit, non est hoc
+							<lb/> naturae propriae, sed Dei grali;c. Ac per boc solus Deus <lb/>
+							habct immortalitatem, qui non cujusquam gratia, sed <lb/> natura sua,
+							nec potuit, nee potest aliqua conversione <lb/> mutari, nec potuit nec
+							poterit aliqua mutatione pec­ <lb/> care. Quem secundum naturam qua Deus
+							est, <hi rend="italic">nemo<lb/> hominum vidit, nec videre potest:</hi>
+							sed poterit aliquan­ <lb/> do, si ad illum numerum hominum pertinet, de
+							quibus <lb/> dictum est, <hi rend="italic">Beati mundo corde,
+								quoniam</hi> ipsi Deum <lb/>
+							<hi rend="italic">videbunt (Matth.</hi> v, 8). Cui Deo, id est Patri et
+							Filio <lb/> et Spiritui sancio, qua; Trinitas unus est Deus, honor <lb/>
+							et gloria in s;rcula saeculorum; Amen.</p>
+						<p>3. Absit autem ut, quomodo putas, ideo sit Pater <lb/> potentior Filio,
+							quia creatorem genuit Pater, Filius <lb/> autem non genuit creatorem.
+							Neque enim non po­ <lb/> luit <hi rend="italic">(a),</hi> sed non
+							oportuit. Immoderata enim esset <lb/> divina generatio , si genitus
+							Filius nepotem gigneret <lb/> Patri : quia et ipse nepos, nisi avo suo
+							pronepotem <lb/> gigneret, secundum vestram mirabilem sapientiam <lb/>
+							impotens diceretur. Similiter etiam ille si nepotem <lb/> non gigneret
+							avo suo, et pronepotem proavo suo,.. <lb/> non a vobis appellaretur
+							omnipotens : nec impleretur <lb/> gencrationis series, si semper alter
+							cx altero nasce<note type="footnote"><hi rend="italic">(n)</hi> Plerique
+								ac melioris notse Mss., <hi rend="italic">ycqne</hi> enim <hi
+									rend="italic">potnt.</hi>
+								<lb/> Altameo Magister Sent. in i, dist. 7, citat, seque <hi
+									rend="italic">(',nm lion<lb/> putuit:</hi> id est, non ex
+								impotentia tilii, sed ex rui namra <lb/> venit ut Filius noti
+								generet. Neque c&gt;gimur intelligere, <lb/> Filium potuisse alium
+								geaerare filium, quod AugusUnuiu <lb/> existimassi! creilit Petavius
+								in lib. 7 Theolog. dog:u. de <lb/> IriniUle, cap. 13, It. G. </note>
+							<lb/>
+							<pb n="769"/> retur; nec eam perficeret ullus, si non sufficeret unus.
+							<lb/> Omnipotens itaque omnipotentem genuit Filium ; <lb/> quoniam <hi
+								rend="italic">quaecumque Pater facit, h</hi>aec <hi rend="italic">et
+								Filius simili­<lb/> ter facil.</hi> Filiurn quippe ipsum genuit
+							utique Pall'is <lb/> natura, non fecit.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="13">
+						<p>CAPUT XIII. — i. In illo etiam testimonio, ubi <lb/> ait Apostulus, <hi
+								rend="italic">Soli sapienti Deo;</hi> non dissimilis error <lb/> est
+							vester : sed quod vobis respondimus de potentia, <lb/> hoc etiam de
+							sapientia respondemus. Si cnim dixis­ <lb/> set Apostolus, Soli sapienti
+							Patri; nec sic inde Filium <lb/> sepnrarct. Num enim quia in Apocalypsi
+							de Filio <lb/> legitur, <hi rend="italic">Habens nomen scriptum, quod
+								nemo scit</hi> nisi <lb/>
+							<hi rend="italic">ipse ( Apoc.</hi> xix, 12); ideo Pater nescit hoc
+							nomen, <lb/> a quo est inseparabilis Filius ? Sicut ergo scit et <lb/>
+							Pater quod Demo scire dictus est nisi Filius, quia <lb/> inseparabiles
+							sunt: sic etiam si dictum esset, Soli <lb/> sapienti Patri ; simul
+							intelligi deberet ct Filius, quia <lb/> inseparabiles sunt. Cum vero non
+							sit dictum, Soli <lb/> sapienti Patri; sed <hi rend="italic">Soli
+								sapienti Deo;</hi> et Deus unus <lb/> sit ipsa Trinitas : multo cst
+							facilior nobis bujus solu­ <lb/> tio quaestionis; ut sic intelligamus
+							solum-Deum sa­ <lb/> picntem, sicut intelleximus solum potentem, id est,
+							<lb/> Patrem et Filium et Spiritum sanctum , qui est unus <lb/> ct solus
+							Deus, cui soli servire jussi sumus : ne male <lb/> intelligentes, vel
+							potius non intelligentes, contra boc <lb/> praeceptum facere videamur,
+							quia et Domino Christo <lb/> ea quae Deo debetur servitute servimus. Non
+							enim <lb/> dictum est, Dominum Deum tuum Patrem adorabis, <lb/> ctilii
+							plus servies; ut servire permitteremur et Filio, <lb/> plus tamen Patri
+							tanquam majori, minus autem Filio <lb/> tanquam minori Deo : sed dictum
+							est, <hi rend="italic">Dominum <lb/> Deum</hi> tuum <hi rend="italic"
+								>adorabis, et illi soli servies (Deut.</hi> vi, 43); <lb/> soli
+							scilicet omnipotenti, soli sapienti Deo; ut vos <lb/> repelleremini, qui
+							nolentes accipere unum solum <lb/> Deum Patrem et Filium et Spiritum
+							sanctum, et <lb/> dicentes unum Dominum Deum, cui soli serviendum <lb/>
+							est, non esse nisi Deum Patrem, ct tamen etiam <lb/> Filium Deum et
+							Dominum confitentes; apertissime <lb/> duos deos et dominos, majorem
+							unum, minorem <lb/> alterum dicitis : et reos vos, secundum errorem ve­
+							<lb/> strum, praecepti hujus violati esse monstratis, quia <lb/> non
+							solum majori, verum etiam minori, ea quae Do­ <lb/> mino Deo debetur
+							servitute servitis.</p>
+						<p>i. Ubi autem dixit Apostolus, <hi rend="italic">Soli sapienti Deo;</hi>
+							<lb/> cum scriberet ad Romanos, in fine Epistolae sic Io­ <lb/> quitur:
+								<hi rend="italic">Ei autem</hi> qui <hi rend="italic">potens
+								est,</hi> inquit, vos <hi rend="italic">confirmare<lb/> secundum
+								Evangelium</hi> meum, <hi rend="italic">et prceconium Jesu
+								Chri­</hi>
+							<lb/> sti ; <hi rend="italic">secundum revelationem mysterii
+								temporibus</hi> aeterni<hi rend="italic">s<lb/> taciti, manifestati
+								autem nunc per Scripturam Propne­ <lb/> tarum; secundum pr</hi>ae<hi
+								rend="italic">ceptum</hi> ae<hi rend="italic">terni Dei, in obedien­
+								<lb/> tinm fidei in omnes gentes cogniti; soli sapienti Deo <lb/>
+								per Jesum Christum, cui gloria in</hi> saecula <hi rend="italic"
+								>saculorum<lb/> (Rom.</hi> xvi, 25 27). Hoc est, <hi rend="italic"
+								>Ei qui potens est vos<lb/> confirmare, soli sapienti Deo
+								gloria</hi> in <hi rend="italic">saecula s</hi>ae<hi rend="italic"
+								>culo­</hi>
+							<lb/> rum. Quod autem interp ositum est, <hi rend="italic">per Jesum
+								Chri­ <lb/> stum ;</hi> utrum soli Sapienti Deo per Jcsuin Christum
+							<lb/> accipidebcat, ut scilicet solus Deus sapicns pcr Je­ <lb/> sam
+							Christum sapiens esse intelligatur, non partici <lb/> pando, sed
+							gignendo sapientiam, quod cst Christus <lb/> Jesus; an vero non per
+							Jcsum Christum sapienti, <lb/> sed per Jesnm Christum gloria Deo soli
+							sapienti, <lb/> videtur ambiguum. Sed quis audeat dicere per Jesum <lb/>
+							Christum fieri ut sit sapiens Deus Pater; cum secun­ <lb/> dum
+							substantiam suam non dubitandum sit eum esse <lb/> sapientem, potiusque
+							sit substantia Filii pcr gignen­ <lb/> tem Patrem, quam substantia
+							Patris per genitum <lb/> Filium ? Restat ergo ut soli sapienti Deo
+							gloria sit <lb/> per Jesum Cbristum, hoc est, clara cum laude noti­
+							<lb/> tia, qua innotuit gentibus Deus Trinitas : ideo per <lb/> Jesum
+							Christum, quia, ut alia taceam, ipse praecepit <lb/> baptizari gentes in
+							nomine Patris ct Filii et Spiritus <lb/> sancti <hi rend="italic"
+								>(Malth.</hi> XXVIII, 19); ubi praecipue commendata <lb/> est hujus
+							individuae gloria Trinitatis. Deus itaque, <lb/> quod est ipsa Trinitas,
+							propterea solus sapiens recto <lb/> dicitur, quia solus secundum
+							substantiam suam sa­ <lb/> piens est: non secundum accidentem vel
+							accedentem <lb/> participationem sapientiae, sicut sapiens est
+							rationalis <lb/> quaecumque creatura. Quod vero additum est, <hi
+								rend="italic">cui,</hi> ut <lb/> diceretur, <hi rend="italic">cui
+								gloria ;</hi> cum sufficeret si dictum esset, <lb/> Ei autem gloria
+							: inusitatam nostrae linguae indicat <lb/> locutionem; non sensum quem
+							requiramus, vel de <lb/> quo ambigamus, insinuat. Quid enim sensui
+							deperit, <lb/> si dicatur, Ei gloria , cui per Cbrislum gloria ? Hoc
+							<lb/> est namque, <hi rend="italic">per Jesum Christum cui gloria;</hi>
+							quod est, <lb/> cui per Jesum Christum gloria. Sed horum alter in­ <lb/>
+							usitatus, alter usitatus est ordo verborum.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="14">
+						<p>CAPUT XIV. — 1. Quaeris a me, Si <hi rend="italic">de</hi> substantia <lb/>
+							<hi rend="italic">Patris eat Filius, de substantia Patris eat etiam
+								Spiritus <lb/> sanctus; cur unus Filius sit, et alius non sit
+								filius.</hi>
+							<lb/> Ecce respondeo, sive capias, sive non capias. De <lb/> Patre est
+							Filius, de Patrc est Spiritus sanctus : sed <lb/> ille genitus, iste
+							procedens : ideo ille Filius cst Pa­ <lb/> tris, de quo cst genitus ;
+							iste autem Spiritus utrius­ <lb/> que, quoniam de utroque procedit. Sed
+							ideo cum de <lb/> illo Filius loqueretur, ait, <hi rend="italic">De
+								Patre procedit (Joan.</hi>
+							<lb/> xv, 26); quoniam Pater processionis cjus esi auctor, <lb/> qui
+							talem Filium genuit, et gignendo ei dedit ut <lb/> etiam de ipso
+							procederet Spiritus sanctus. Nam nisi <lb/> procederet et de ipso, non
+							diceret discipulis, <hi rend="italic">Accipite<lb/> Spiritum
+								sanctum;</hi> eumque insufflando daret <hi rend="italic">(Id.</hi>
+							<lb/> xx, 22), ut a se quoque procedere significans, aperte <lb/>
+							ostenderet flando, quod spirando dabat occulle. Quia <lb/> ergo si
+							nasceretur, non tantum de Patre, nec tantum <lb/> de Filio, sed de
+							ambobus utique nasceretur; sine <lb/> dubio filius diceretur amborum. Ac
+							per hoc quia <lb/> filius amborum nullo modo est, non oportuit nasci
+							<lb/> cum de ambobus. Amborum ea ergo Spiritus, pro­ <lb/> cedendo de
+							ambobus. Quid aulem inter nasci et pro­ <lb/> ceaere intersit, de illa
+							excellentissima natura loquens <lb/> explicare quis potest ? Non omne
+							quod proccdit na­ <lb/> scitur, quamvis omne procedat quod nascitur ;
+							sicut <lb/> non omne quod bipes cst homo est, quamvis bipes <lb/> sit
+							omnis qui homo est. Haec scio : distinguere autem <lb/> inter illam
+							generationem et hanc processinem ne­ <lb/> scio, nun valeo, non
+							sufficio. Ac per hoc quia et illa <lb/> et ista est ineffabilis, sicut
+							propheta de Filio loquens <lb/> ait, <hi rend="italic">Generationem ejus
+								quis enarrabit (Isai.</hi> LUI, 8)? ita <lb/> de Spiritu sancto
+							verissimc dicitur, Processionem <lb/>
+							<pb n="771"/> ejus quis cnarrahil? Satis sit ergo nobis, quia non <lb/>
+							est a scipso Filius, sed ab illo de quo natus est: non <lb/> cst a
+							seipso Spiri!us sanctus, sed ab illo de quo pro­ <lb/> cedit. Et quia de
+							utroque procedit, sicut jam osten. <lb/> dimus : unde et Spiritus Patris
+							dictus est, ubi legi- .tur, <lb/> lur, Si <hi rend="italic">autem
+								Spiritus ejus qui</hi> suscitavit <hi rend="italic">Christum a</hi>
+							<lb/> mortuis, <hi rend="italic">habitat in vobis;</hi> ct Spiritus
+							Filii, ubi legitur, <lb/> Qui <hi rend="italic">autem Spiritum
+								Christi</hi> MOM <hi rend="italic">habet, hic</hi> non <hi
+								rend="italic">est ejus<lb/> (Rom.</hi> VIII, ii, 9). Non enim duo
+							sunt Spirilus sancii, <lb/> tanquam singuli singulorum, unns Patris,
+							aller Filii; <lb/> ped unus potius Patris et Filii : de quo uno Spirilu
+							<lb/> scriptum est, Etenim in <hi rend="italic">Spiritu</hi> uno nos <hi
+								rend="italic">omnes</hi> in <lb/> unum <hi rend="italic">corpus
+								laptizati</hi> sumus, sivc Judaei, <hi rend="italic">sive Graeci,
+								<lb/> sive</hi> servi, <hi rend="italic">sive tiberi; et omnes</hi>
+							unum <hi rend="italic">Spiritum</hi> potavi­ <lb/> mus (I <hi
+								rend="italic">Cor.</hi> XII, 13). Et alio ioco : <hi rend="italic"
+								>Unum corpus et</hi>
+							<lb/> unus <hi rend="italic">Spiritus (Ephes.</hi> IV, 4).</p>
+						<p>2. Quid ergo haec Trinitas, nisi unius ejosdemque <lb/> substantiae est?
+							Quandoquidem non de aliqua materia <lb/> vel de nihilo est Filius, sed
+							de quo cst genitus : item­ <lb/> que Spiritus sanctus non de aliqua
+							maleria, vcl de <lb/> nihilo, sed indc est unde proccdiL. Vos autem nec
+							<lb/> Filium de Patris substantia genitum vultis, et tamen <lb/> eum nee
+							ex nihilo, nec ex aliqua materia, sed ex <lb/> Patre esse conceditis.
+							Nee videtis quam necesse sit, <lb/> ut qui non csl ex nihilo, non est cx
+							aliqua re alia, <lb/> scd ex Deo, nisi cx Dei substantia csse non
+							possit, <lb/> et hoc esse quod Deus est de quo cst, hoc est, Dcus <lb/>
+							de Dco. Quocirca Deus de Dco natus, quia non aliud <lb/> prius fuit, sed
+							natura coaeterna de Dco est, non est <lb/> aliud quam est ille de quo
+							est, hoc est, unius cjus­ <lb/> demquc naturae, vel unius ejusdemque
+							substantiae. <lb/> Quod cum auditis, qualc cor habcalis ignoro, qui
+							<lb/> putatis nos sic Filium dicere natum esse de Patre, <lb/> quomodo
+							nascuntur de corporibus corpora : et quo­ <lb/> niam corruptibilitcr
+							is'a nascuntur, accusatis nos <lb/> tanquam generationi Unigeniti, quae
+							dc Patre est, <lb/> corporalem passionem corruptionemque tribuamus.
+							<lb/> Carnalibus quippe cogitationibus pleni substantiam <lb/> Ovi de se
+							ipsa gignere possc Filium non putatis, nisi <lb/> hoc patiatur quod
+							substaulia quando gignit patitur <lb/> carnis. Erratis, non scientes
+							Scripturas, neque vir­ <lb/> lutem Dci <hi rend="italic">(Matth.</hi>
+							XIII, 29). Quando legitis, <hi rend="italic">VI simus<lb/> in vero Filio
+								ejus Jesu Christo</hi> (I <hi rend="italic">Joan.</hi> v, 20); verum
+							<lb/> Oei Filium cogitate. Hunc autem Filium nullo modo <lb/> verum Dci
+							Filium cogitatis, si eum natum esse de <lb/> substantia Patris negatis.
+							Num onim jam erat homi­ <lb/> nis filius, et Deo donante factus est Dei
+							filius; ex <lb/> Deo quidcm natus, sed grat a, non natura ? An forte
+							<lb/> eui non hominis lilius, tamen aliqua jam crat qualis­ <lb/> cumque
+							creatura, et in Dci filium, Deo mutante, , <lb/> conversa est? Si nihil
+							horum. ergo aut de nihilo aut <lb/> de aliqua substantia natus rst. Sed
+							ne crederemus <lb/> de nihilo esse Dei Filium vos putare, jam nus ab
+							ista <lb/> sollicitudine liberasti : affirmasti enim non vos dicere,
+							<lb/> de nihilo esse Dei Filiuin. Dc aliqua ergo substantia <lb/> est.
+							Si non de Patris; de qua? Dicite. Sed non in­ <lb/> venitis. Jam igitur
+							unigenitum Dei Filium Jesum Chri­ <lb/> stum Dominum nostrum de Patris
+							esse substantia non <lb/> vos nobiscum pigeat conteri.</p>
+						<p>5. Pater crgo et Filius unius sunt ejusdemquc sub­ <lb/> stantiae. noc
+							est illud Homousion, quod in concilio <lb/> Nicaeno adversus haereticos
+							Arianos a catholicis Pa­ <lb/> tribus veritatis anctoritate et
+							auctoritatis veritate fir­ <lb/> matum est : quod postea in concilio
+							Ariminensi, <lb/> propter novitatem verhi minus quam oportuit intel­
+							<lb/> lectum, quod tamen I fides antiqua pepererat, multis <lb/>
+							paucorum fraude deceptis , haeretica impietas sub <lb/> haeretico
+							imperatore Constantio labefactare tentavit. <lb/> Sed post non longum
+							tempus libertate fidei catholicae <lb/> praevalente, posicaquam vis
+							verbi, sicut debuit, in­ <lb/> tellecta est, Heroousion illud catholicae
+							fidei sanitate <lb/> longe lateque defensum est. Quid est enim Homou­
+							<lb/> sion, nisi unius ejusdemque substantiae? Quid est, <lb/> inquam ,
+							Homousion, nisi, <hi rend="italic">Ego et Pater</hi> unum <hi
+								rend="italic">su­</hi>
+							<lb/> mus ( <hi rend="italic">Joan. x,</hi> 50 ) i Sed nunc nec ego
+							Nicaenum, nee <lb/> tu dehes Ariminense tanquam praejudicaturus pro­
+							<lb/> ferre concilium. Nec ego hujus auctoritate, nec tu <lb/> illius
+							detineris : Scripturarum auctoritatibus, non <lb/> quorumque propriis,
+							sed utrisque communibus testi­ <lb/> bus, res cum re, causa cum causa,
+							ratio cum rationo <lb/> concerlet. Utrique legimus, <hi rend="italic">Ut
+								simus in vero Filio<lb/> ejus Jesu Christo; ipse est verus Deus et
+								vita</hi> ae<hi rend="italic">terna.</hi>
+							<lb/> Utriquc tanti ponderis molibus cedamus. Dic ergo <lb/> nobis,
+							utrum iste verus Dei Filius, ab eis qui gratia <lb/> lilii sunt hujus
+							nominis quadam proprietate discretus, <lb/> de nulla substantia sit, an
+							de aliqua. <hi rend="italic">Non dico,</hi> inquis, <lb/>
+							<hi rend="italic">de nulla, ne de nihilo dicam.</hi> Ergo de aliqua est
+							: <lb/> quTro, de qua ? Si non de Patris, aliam quere. Si <lb/> aliam
+							non invenis , quia omnino non invenis; Patris <lb/> agnoscc, et Filium
+							cum Patre Homousion confitere. <lb/> Caro de carne nascitur, filius
+							carnis de substantia <lb/> carnis nascitur. Corruptionem de medio
+							tollite, pas­ <lb/> siones carnales a lumine mentis abjicitc, et
+							invisibilia <lb/> Dei, per ca quae facta sunt , intellecta conspicite <lb/>
+							<hi rend="italic">(Rom.</hi> I. 20). Credite Creatorem, qui dedit carui
+							car­ <lb/> nrm gignere, qui dedit parentibus vcros carnis filios <lb/>
+							de carnis substantia generare, ac sic filios cum parcn­ <lb/> tibus
+							unius esse substantiae , multo magis potuisse <lb/> verum gignere Filium
+							de sua substantia, et unam cum <lb/> vero Filio habere substantiam,
+							manente incorruptione <lb/> spirituali, ct longissime hinc alicna
+							corruptione car­ <lb/> nali.</p>
+						<p>4. Nam de anima quid dixeris, nescio. Verba enim <lb/> tua sunt, ubi
+							dicis : <hi rend="italic">Nee enim ad</hi> animae <hi rend="italic"
+								>ingenuitatem <lb/> comparatis tantam illam magnificentiam, sed ad
+								fragili­ <lb/> tatem corporis. De corpore utique,</hi> inquis, <hi
+								rend="italic">nascitur caro,<lb/> corporalis filius : non tamen de
+								anima anima nascitur.</hi>
+							<lb/> Post istam quasi definitionem tuam, rursus affirmas <lb/> animam
+							filios generare. Adjungis cuiun, et dicis : Si <lb/>
+							<hi rend="italic">ergo nostra anima incorruptibiliter</hi> generat <hi
+								rend="italic">et</hi> impassi­ <lb/>
+							<hi rend="italic">biliter,</hi> nullam sentiens <hi rend="italic"
+								>diminutionem, non inquinatio­</hi>
+							<lb/> nem <hi rend="italic">aliquam; scd legitime secundum</hi> jura <hi
+								rend="italic">divina ge­ <lb/> ncrat</hi> filium , <hi rend="italic"
+								>sapientia</hi> consensum I <hi rend="italic">accommodans <lb/>
+								corpori, ipsa integra</hi> manet : <hi rend="italic">quanta magis
+								omnipotens</hi>
+							<note type="footnote"> I Mss., <hi rend="italic">mimis quam potuit
+									intellectam, qucm tamen,</hi> etc. </note><note type="footnote">
+								I Editio Erasmi, hic et supra in collatione cum vaximino, <lb/>
+								<hi rend="italic">generatum Iiliunl, savientium</hi> COn.ensu, <hi
+									rend="italic">acconunodans</hi> cor<lb/>1&gt;o i. Minus recte.
+								tov. constanter, <hi rend="italic">ct</hi> capktuU.-6ed paiti­ <lb/>
+								cuh, <hi rend="italic">et,</hi> aL est a Mss. </note>
+							<lb/>
+							<pb n="773"/> Deus ? Et paulo post dicis : <hi rend="italic">Quanto
+								magis Deus Puter <lb/> meorruptibilis incorruptibiliter</hi> genuit
+								<hi rend="italic">Filium</hi> ? Jam <lb/> supra dixi, nescire me
+							quid volueris de anima intel­ <lb/> ligi, de qua prius dixisti quod non
+							nascatur anima de <lb/> anima, et postea, quod anima incorruptibiliter
+							gignat <lb/> filium. Si animam gignit, quomodo non nascitur anima <lb/>
+							de anima? Si carnem, tu videris quomodo sit caro <lb/> verus animae
+							filius. Christus enim, propter quem pu­ <lb/> lasti hanc adhibendam
+							similitudincm , verus est Dei <lb/> Filius. Si autem incorruptibiliter
+							gignere animam <lb/> filium sic accipi voluisti, quomodo ait Apostolus ,
+								<hi rend="italic">In <lb/> Christo enim Jesu per Evángelium ego vos
+								genui</hi> (1 <hi rend="italic">Cor.</hi>
+							<lb/> iv, 15); cur non attendis, quod jam erant ilłae animae <lb/> in
+							vctere vita, quas per Evangelium renovando Apo­ <lb/> stolus genuit ?
+							Verbum autem Dei Deus unigenitus <lb/> Filius, sicut jam disputavimus,
+							non prius aliquid <lb/> fuit, et renovatione est generatus a Patre, sed
+							cum <lb/> Patre semper fuit; sicut est semper atque erit mira­ <lb/>
+							bili atque ineffabili modo genitus ab aeterno coaeter­ <lb/> nus. Sed si
+							ob hoc introduxisti hanc dissimilem simi­ <lb/> litudinem, ut assereres
+							Deum Patrem incorruptibi­ <lb/> liter genuisse : noli laborare;
+							confiteor omnino, in­ <lb/> corruptibiliter genuisse Deum Patrem , sed
+							quod est <lb/> ipse genuisse. Iterum enim dico hic, quod vobis saepe
+							<lb/> dicendum est: Aut de aliqua substantia natus est Dei <lb/> Filius,
+							aut de nulla. Si. de nulla, ergo de nihilo ; <lb/> quod vos non dicere
+							jam tencmus. Si de aliqua, nec <lb/> tamen de Patris, non vcrus est
+							Filius. Si de Patris , <lb/> unius ejusdemque substantiae sunt Pater et
+							Filius. <lb/> Quomodo autcm nihil Filio subtraxit, ut dicis, si <lb/>
+							ejusdem substantiae est, et tamen minor est, nec sicut <lb/> infans
+							crescere potest ?</p>
+						<p>5. Jam vero de immortalitate Dei, quia non Pa­ <lb/> irem, sed Deum qui
+							et Patcr est et Filius et Spiritus <lb/> sanctus , solum habere
+							immortalitatem dixit Aposto­ <lb/> lus, satis superius disputavi, quando
+							ipsum aposto­ <lb/> icum testimonium et posui totum , et exposui.</p>
+						<p>6. Displicet tibi , quod aequalem Patri asserimus <lb/> Filium : quasi
+							possit esse inaequalis, qui verus est <lb/> Filius, non natus ex
+							tempore, sed gignenti coaeternus, <lb/> sicut splendor ab igne genitus
+							gignenti manifestatur <lb/> aequaevus. Sed <hi rend="italic">habet,</hi>
+							inquis , <hi rend="italic">Dei Filius auctorem</hi> Pa­ <lb/>
+							<hi rend="italic">trem.</hi> Si propterea Deum Patrem Deo Filio dicis
+							<lb/> auctorem, quia ille genuit, genitus est iste; quia iste <lb/> de
+							illo est, non illc de isto; fatcor et concedo. Si au­ <lb/> lem per
+							nomen auctoris minorem vis facere Filium, <lb/> Patrernque majorem, nec
+							ejusdem substantiae Filium <lb/> cujus est Pater; detestabor et respuam
+							: quia ct filius <lb/> hominis, in quantum est filius, habet auctorem do
+							<lb/> quo natus cst, patrem; nee tamen ideo non est ejus­ <lb/> dem
+							substantiae cujus est pater ; et quod iste minor, <lb/> major est ille,
+							potest tamen ad formam patris valen­ <lb/> tiamque pervenire crescendo,
+							in qua patrem propterea <lb/> non omni modo invenit talem , quia et ille
+							defecit <lb/> senescendo. Sic enim necesse est varietur aetale mor­
+							<lb/> talitas, ubi temporalis est, non aeterna nativitas. Non <lb/>
+							autem illa siC cst, ubi nee crescit . FiliuS, nec sene­ <lb/> scit
+							Pater. Et ideo amborum non impar cst aetas; qnia <lb/> ubi est
+							aeternitas, nou est aetas : idco forma non im­ <lb/> par amborum;
+							quoniam verus Filius, qni non ut au­ <lb/> geretur cst natus, ne
+							remanerct degener, a qualis <lb/> est natus, Sit ergo nalivitatc humana
+							longe melior ct <lb/> excellentior divina nativitas, incorruptibili et
+							invio­ <lb/> labili generatione : non tamen sit deterior, diversi­ <lb/>
+							late naturae.</p>
+						<p>7. Sed <hi rend="italic">vitam Filius,</hi> inquit, <hi rend="italic"
+								>accepit a Patre.</hi> Acce­ <lb/> pit sicut genitus a gignente. <hi
+								rend="italic">Omnia,</hi> inquit, <hi rend="italic">quae ha­<lb/>
+								bet Pater,mea sunt. (Joan.</hi> xvi, 15). Omnia ergo quae <lb/>
+							habet Pater, dedit ille gignendo, accepit iste na­ <lb/> scendo. Nec
+							dando ille amisit quod habuit; nee iste <lb/> cum esset et non haberet
+							accepit: sed sicut ille per­ <lb/> mansit habens omnia, cum ea quae
+							habet Filio dede­ <lb/> rit omnia ; sic iste nunquam fuit sinc omnibus,
+							quae <lb/> non egendo, sed nascendo accepit ut Filius : quia <lb/>
+							nunquam potuit esse non natus, et ca sine quibus <lb/> non est natus, ct
+							est immutabilis natus, semper ha­ <lb/> buit, quia semper est natus. Si
+							cniin aliquid eorum <lb/> Quae habet Pater non dedit Filio, falsum est
+							quod ait <lb/> Filius : <hi rend="italic">Omnia qum habet Pater, mea
+								sunt.</hi> Sed quia <lb/> verum est, prorsus omnia quae habet Pater,
+							dedit, <lb/> ut diximus, ille gignendo, accepit iste nascendo. <lb/> Ac
+							per hoc dedit ille vitam, quia gcnuit vitam; ac­ <lb/> cepit iste vitam,
+							quia natus est vita : si minor, si de­ <lb/> color *, si diversa, non
+							ergo quam Pater habuit hanc <lb/> dedit Filio. Et quomodo vcrum est, <hi
+								rend="italic">Omnia quae</hi> ha­ <lb/>
+							<hi rend="italic">bet Pater, mea sunt ?</hi> Sed quis audeat dicere,
+							Verum <lb/> non cst . quod Veritas dixit? Quapropter <hi rend="italic"
+								>sicut habet <lb/> Pater vitam in semetipso, sic dedit et Filio</hi>
+							vitam <hi rend="italic">ha­<lb/> bere</hi> in <hi rend="italic"
+								>semetipso</hi> ( <hi rend="italic">Id.</hi> v, 26). Sicut habet
+							dedit, <lb/> quod habet dedit, qualem habeL, talem dedit; quan­ <lb/>
+							tam habet, tantam dedit. Omnia quae habct Pater, <lb/> Filii sunt. Non
+							ergo aliquid minus quam Pater habet <lb/> Filio dedit; nec amisit Pater
+							vitam, quam Filio dedit. <lb/> Vivendo enim tenuit, quam pignendo dedit.
+							Vita est <lb/> autem ipse Pater, vita est ipse Filius. Et ille quippe
+							<lb/> et iste id habet quod et ipse I : sed ille de nulle vita, <lb/>
+							iste vita de vita; sed talis qualis illa, tanta quanta <lb/> illa, hoc
+							omnino quod illa ; quia ,crus est Filius, qnia <lb/> perfectus cst
+							Filius, quia non est degener ab uno Deo <lb/> Patre Deus unicus Filius,
+							Patri ergo aequalis est Fi­ <lb/> lius. Quidquid eum dicis a Patre
+							accepisse, fatemur <lb/> et nos : prorsus Pater dedit, Filius accepit.
+							Sed cum <lb/> Pater omnia quae habet gignendo dedit, aequalem <lb/>
+							utique genuit, quoniam nihil rninus dedit. Quomodo <lb/> ergo tu dicis,
+							quia ille dedit, ille accepit, ideo aequa­ <lb/> lem Filium Patri non
+							esse : cum eum cui data suut <lb/> omnia, et ipsam aequalitatem videas
+							accepisse ? <lb/> Scriptum est quidem, Beatum <hi rend="italic">est
+								magis d(tre quam <lb/> accipcre (Act.</hi> xx, 35) : sed in hac vita
+							ubi est ino. <lb/> pia, qua utique melior cst copia. Melius enim cst
+							<lb/> habere, quam egere ; et melius est donare, quam ac­ <lb/> cipere
+							'; erogare, quam mendicare. Ubi antem qui <lb/> dcdit, gignendo dedit ;
+							ct qui accepit, nascendo ac­ <lb/> cepit: non inopi subventum est, scd
+							ipsa copia gu­ <lb/> ncrata est. Nec potest qui accepit ei qui dedit esM
+								<note type="footnote"> I Editi, <hi rend="italic">discolor.</hi> At
+								Mss., <hi rend="italic">decolor.</hi>
+							</note><note type="footnote"> 1 sic Mss. Editi vero, <hi rend="italic"
+									>quod est ipse.</hi>
+							</note><note type="footnote"> I Mn. Er. et MSS. omittunt, <hi
+									rend="italic">qutun ucciiwe; crogare.</hi>
+							</note>
+							<lb/>
+							<pb n="775"/> inaequalis, qnia ct hoc accepit ut esset aequalis. Nihil
+							<lb/> euim Patre minus habet illc qui dicit, <hi rend="italic">Omnia
+								quae<lb/> habet Pater, mea sunt.</hi> aequalis est igitur. Sed quia <lb/>
+							<hi rend="italic">semetipsum exinanivit, fomam servi accipiens,</hi> non
+							<lb/> formam Dei perdens; ita factus cst in eadem servi <lb/> forma <hi
+								rend="italic">obediens usque ad</hi> mortem <hi rend="italic">crucis
+								(Philipp. II,</hi>
+							<lb/> i, 8), in qua paulo minus minoratus est ab Angelis <lb/>
+							<hi rend="italic">( f'Bal.</hi> VIII, C), ut Patri in forma Dei maneret
+							aequalis: <lb/> quia non est forma illa mutabilis.</p>
+						<p>8. Quid itaque mirum est, si na quae commemoras, <lb/> dicit, <hi
+								rend="italic">Ego quae plucila sunt Patri, facio semper ( Joan.</hi>
+							<lb/> VIII, 29) : ct ad monumentum Lazari, <hi rend="italic">Pater.
+								gratias<lb/> ago tibi, qnia audisti me; et ego sciebam quia
+								semper</hi> me <lb/>
+							<hi rend="italic">aidus, sed</hi> propter <hi rend="italic">eoa qui
+								circumstant dixi, ut credant <lb/> quia</hi> tu <hi rend="italic">me
+								misisti (ld.</hi> XI, 41, 42) : ct iterum, <hi rend="italic"
+								>Aie</hi> opor­ <lb/>
+							<hi rend="italic">tet operari opera ejus qui me misit (Id.</hi> IX, 4) :
+							ct an­ <lb/> tequam panes frangeret, prius <hi rend="italic">Patri
+								gratias egit (Matth.</hi>
+							<lb/> XXVI, 26 ; <hi rend="italic">Marc.</hi> vin, 6, <hi rend="italic"
+								>et Joan.</hi> vi, 11) ? Si his atque <lb/> hujusmodi testimoniis id
+							ostendere voluisses, quod <lb/> in forma servi Filius minor cst Patrc,
+							et in ipsa for­ <lb/> ma Dei iste de illo non ille de isto est; quod
+							saepe si­ <lb/> gnificans , multa ita dicit, ut cum non intelligentes
+							<lb/> etiain in ipsa divinitate arbitrentur minorem : sic te­ <lb/>
+							neres rectam regulam fidci, ut non contradiceres ve­ <lb/> rilati; nec
+							per talia testimonia oppugnarcs Evange­ <lb/> lium, sed doceres. Quae
+							suut eniin placita Patris , <lb/> quae non sunt et Filii V aut unde
+							potest facerc Filius, <lb/> nisi quae placita sunt Patri, a quo habet
+							omnia in qui­ <lb/> bus aequalis est Patri? Quomodo non gratias agit
+							<lb/> Patri de quo est, praesertim in forma servi , in qua <lb/> illo
+							minor cst? Quomodo non Patrem rogat ut homo, <lb/> qui cum Patrc cxaudit
+							ut Deus ? Quis autem christia­ <lb/> nus ignorat qucd Pater miserit,
+							missusque SiL Filius? <lb/> Non euim genitorem ab co quem genuit, sed
+							genilum <lb/> a genitore mitti oportebat : verum haec non est in­ <lb/>
+							aequalitas subsiantiae, sed ordo naturae ; non quodalter <lb/> prior
+							esset allero, sed quod alter esset ex allero. <lb/> Oportebat ergo
+							operari eum qui missus cst, opera <lb/> ejus a quo missus est: et quae
+							sunt opera Patris, quae <lb/> non suut et Filii; cum dicat idem Filius,
+								<hi rend="italic">Quaecumque <lb/> Pater facit, haec et Filius
+								similiter facit (Joan.</hi> v, 19) ? <lb/> Opera tamen Patiis esse
+							dicit: non » nim obliviscitur <lb/> a quo sit; a Patre quippe illi est
+							ut operator talium <lb/> operum sit. Ilac autcm vos ita intelligilis ,
+							ut hinc <lb/> etiam putetis Patrem Filio esse majorem, quia dixit <lb/>
+							passerem non caderc in lerram sine Patris voluntate <lb/>
+							<hi rend="italic">(Matth.</hi> x, 29); quasi cadat sine voluntate Filii.
+							An <lb/> usque adco minorem vultis Filium, ut non habcat in <lb/>
+							potestate nec passeres? Sed si non vultis huic regulae <lb/> acquiescere
+							, ut ubicumque legeritis in auctoritate <lb/> divinorum eloquiorum , quo
+							1 minor Patre Filius vi­ <lb/> deatur ostendi, aut ex forma servi dictum
+							accipiatis, <lb/> in qua vcre innuor est Patre; aut ideo dictum , quo
+							<lb/> non demonstretur major vel minor ullus esse allero, <lb/> scd
+							demonstretur esse alter ex altero : si huic, in­ <lb/> quam, rectissimae
+							regulae non vultis acquiescere ; certe <lb/> tamcn verum Dni Filium
+							nulla ratione dicetis, si non <lb/> ejusdem substantiae, cujus Pater
+							es!, cum esse dica- <note type="footnote"> I falili, quibus. Concinnius
+								':ss., <hi rend="italic">q!:o.</hi>
+							</note>
+							<lb/> lis. Ut enim humanum aliquid dicam propter infirmi. <lb/> tatem
+							carnalium : cum homines duo sunt, pater et <lb/> filius, si obediens sit
+							patri filius, et aliqua existente <lb/> causa roget patrem , gratias
+							agat patri, aliquo lIcui.. <lb/> que Initiatur a patre, ubi se dicat non
+							venisse facere <lb/> voluntatem suam, sed ejus a quo missus est; num­
+							<lb/> quid hinc ostenditur non ejusdem cujus pater est esse <lb/>
+							substantix ? Cur ergo ubi de Filio Dei talia legitis, <lb/> statim in
+							tantum sacrilcgium corde atque ore prorui­ <lb/> tis, ut veri Filii Dei
+							unam eamdemque cum Patre <lb/> substantiam non esse credatis atque
+							dicatis ?</p>
+						<p>9. Quid quod etiam illud commemorandum putasti, <lb/> quod manifestissime
+							ut homo loquitur: <hi rend="italic">Potestatem ha­ <lb/> beo ponendi
+								animam meam, et potestatem habeo iterum <lb/> sumendi eam. Hoc</hi>
+							enim praeceptum <hi rend="italic">accepi a Patre meo?</hi>
+							<lb/> Quid hoc adjuvat causam tuam ? Numquid enim aliud <lb/> dixit,
+							nisi, Potestatem habco-moriendi et resurgendi ? <lb/> Quod itaque ait,
+								<hi rend="italic">Nemo eam tollit a me, sed ego</hi> eam <lb/>
+							<hi rend="italic">pono</hi> a me, <hi rend="italic">et iterum sumo eam
+								(Joan.</hi> x, 18) ; quid in­ <lb/> telligi voluit, nisi se non
+							fuisse moriturum, nisi ipse <lb/> voluisset ? Numquid tamen nisi horno
+							esset , mori et <lb/> resurgere potuisset ? Sic autem introduxisti hoc
+							testi­ <lb/> monium, ut praełoquereris, dicens, <hi rend="italic">Hic
+								sane et de sua <lb/> potestate quam a Patre accepit dicebat,</hi> «
+								<hi rend="italic">Potestatem <lb/> habeo ponendi animam</hi> meam,
+								<hi rend="italic">ei potestatem habeo ite­<lb/> rum sumendi eam</hi>
+							: &gt; tanquam si homo non esset, po­ <lb/> siturus esset animam. Ut
+							homo ergo, non ut Dcus, <lb/> accepit hanc potestatem : quamvis non
+							dixerit, Hanc <lb/> potestatem; sed, <hi rend="italic">hoc</hi>
+							praeceptum <hi rend="italic">accepi a Patre</hi> meo. <lb/> Quis autem
+							nesciat <unclear>aluid</unclear> esse praeceptum , aliud po­ <lb/>
+							testatem ? Hoc enim habemus in potestate, quod cum <lb/> volumus
+							possumus. Pracceplum vcro id nobiscum agit, <lb/> ut quod jam est in
+							potestate faciamus : si autem non­ <lb/> dum est in potestate, oremus
+							nohis patestatem dari, <lb/> ut qnod praeceptum cst impleamus. Quocirca
+							si ea <lb/> qu:c aperta sunt velitis attendere, ut homo acceperat <lb/>
+							hanc potestatem. Sed propter contentiosos ego ad <lb/> utrumque
+							concludam : Si ut homo accepit hanc po­ <lb/> testatem, nihil libi
+							prodesse hoc testimonium et tu <lb/> vidcs; quia si ex hac potestate a
+							Patre accepta, mi­ <lb/> norem Patre Filium vis probare, nee nos
+							dubitamus, <lb/> quod in quantum homo est Christus, minor est Patre :
+							<lb/> si autem ut Deum vis accepisse hanc potestatem, Hi.. <lb/> gnendo
+							cum Pater aequalem sibi, dedit ei omnium <lb/> rerum tantam, quanta ipsi
+							Patri est 1, potestatem. Si <lb/> enim minus habet in potestate aliquid
+							quam Patcr, <lb/> non sunt ejus omnia quae habet Pater : sed quia ejus
+							<lb/> sunt, tantem procul dubio habel potestatem quantam <lb/> Pater.
+							Praeceptum quoque aut ut homo accepit, aut <lb/> ut Deus : si ut ho:no,
+							nulla quaestio ea, quia ut homo <lb/> est Patre minor: si ut Dcus, non
+							hinc ostenditur mi­ <lb/> nor; quia nascendo id accepit, non indigendo.
+							In <lb/> Verbo cnim unico Dei omnia praecepta sunt Dei , quae <lb/> ille
+							gignens dedit nascenti, non cum genuisset addi­ <lb/> dil indigenti : ac
+							per hoc tantum genuit quantus cst <lb/> ipse; quia de scipso genuit
+							vcrum Filium, et perfc­ <lb/> ctum genuit plenitudine divinitatis, non
+							perficiendum <note type="footnote"> 1 ):ss., <hi rend="italic">qunnti
+									ipsi:ts csl.rat. is.</hi>
+							</note>
+							<lb/>
+							<pb n="777"/> a tatis accessu 1. Sed humilius a tc quaero, quare <lb/>
+							tilium hominis quemlibet hominem, si preceptum ac­ <lb/> cipiat a patre,
+							nun eum dicis alterius esse substan­ <lb/> tiae, et Filium Dci Demn ob
+							hoc audes negare pa - <lb/> ternae esse substantiae, quia praeceptum
+							accepit a <lb/> Patre? Prorsus, ct praeceptum a Patre accepit,et <lb/>
+							ejusdem substantiae est, cujus est ille qui dedit. Quis <lb/> te
+							contradicentem ferat, si ad te audiendum homines <lb/> patresfiliique
+							concurrant, ejusdem utrique substan­ <lb/> tiae ; nec ideo filii
+							degeneres, quod ita praecepta eis <lb/> dederint patres? Sud forte
+							dicis, patres doctos filiis <lb/> indoctis. dedisse praecepta. Refer
+							nuac te ad Dei fi­ <lb/> lium, de Dco Patrc natum Deum, qui utique
+							imper­ <lb/> fectus est natus, si praeceptum accepit indoctus. Quia
+							<lb/> vero perfectus est natus, praeceptum dedit ille gi­ <lb/> gnendo,
+							accepit iste nascendo. Nunquam enim verus <lb/> Dei Filius indoctus fuit
+							: filius autem numquam non fuit.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="15">
+						<p>CAPUT XV. — i. In forma Dei Filium esse non <lb/> negas, et Dco Patri
+							aequalem negas, majorem Patris <lb/> iormam putans esse quam Filii :
+							tanquam non ha­ <lb/> buerit Pater unde formam suam compleret in Filio,
+							<lb/> quem de se ipso genuit ,non fecit ex nihilo, non ex <lb/> alio.
+							Aut si formam suam in unico Filio plonam gi­ <lb/> gnere potuit, nec
+							tamen genuit plenam, sed minorem ; <lb/> quid sequatur altenditc, et in
+							viam redite, ne coga­ <lb/> mini Patrem invidum dicere. Dicitis Deum
+							Filium, <lb/> dicitis Dominum; sed ut duos deos dominosque facia­ <lb/>
+							tis, contra Scripturam clamantem, Audi, <hi rend="italic">Israel;
+								Do­</hi>
+							<lb/> minus <hi rend="italic">Deus</hi> tuus, <hi rend="italic"
+								>Dominus</hi> unus est <hi rend="italic">(Deut.</hi> VI, 4). Quid
+							<lb/> autem in hoc sacrilegio vobis prodest, quod Patri da­ <lb/> tis
+							tantam formam, quantam non datis Filio? Num­ <lb/> quid si unus major,
+							alter est minor, ideo non suut <lb/> dii et domini duo? Si carere
+							cupitis hoc errore, sic <lb/> dicite alium esse Patrem, aliam esse
+							filium, ut tamen <lb/> simul ambos non duos dicatis, sed unum Dominum
+							<lb/> Deum. Dicitis rogem Filium de rege Patre utique na . <lb/> tum:
+							nec intuemini in genere humano filios regum <lb/> etiamsi non sunt ex
+							,regibus reges, esse tamen ex ho­ <lb/> minibus homines; nec habere
+							potestatem cum pa­ <lb/> tribus regiam, et tamen eamdem tenere naturam.
+							Vos <lb/> autem Filio Dei rogis regnum cum Patre conceditis, <lb/> ct
+							naturam paternam, vanitate impia denegatis ; cum­ <lb/> que Deo Patri
+							dicitis inrqualem, <hi rend="italic">qui non rapinam,</hi>
+							<lb/> hoc est, non alienum <hi rend="italic">arbitratus est esse
+								aequalis Deo ;<lb/> sed</hi> tamen non intendens quae sua sunt , sed
+							qu;c no­ <lb/> stra sunt, <hi rend="italic">semetipsum exinanivit;</hi>
+							non formam Dei <lb/> perdens, sed formam <hi rend="italic">serii
+								accipiens,</hi> in qua est Patri <lb/>
+							<hi rend="italic">factus obediens usque ad mortem crucis (Philipp.</hi>
+							II, <lb/> C 8). I.. qua forma cnm non vultis sic agnoscere Pa­ <lb/> tre
+							Deo minorem. ut in Dci forma Patri non negetis <lb/> aequalem. « Nos, i
+							inquis, * dicti sumus filii gratia, <lb/> non natura hoc nati : ideo
+							unigenitus est Filius, quia <lb/> qnod est secundum divinitatis suae
+							naturam , hoc cst <lb/> natus Filius. i Haec non tua solum, verum etiam
+							no­ <lb/> stra suit verba. Cur erro quem Dei Filium natura <lb/> non
+							gratia confiteris, ejusdem naturae, cujus Pater <lb/> cst, non esse
+							contendis,nec quid mali abs tc dicatur <note type="footnote"> I Sic Am.
+								F.r et Mss. At Lov., <hi rend="italic">el uc;'jert,znt qcnuit
+									plt';:i- <lb/> Vtdincm divinitatis, non perficiendam aetatis
+									accessu</hi></note>
+							<lb/> attendis ? Nunnc regis <unclear>Dei</unclear> Filio paternum
+							regnum au <lb/> ferres tolerabilius quam naturam?</p>
+						<p>2, Dc Spiritu autem sancto, quomodo e' ipse de <lb/> Deo sit, nec tamen
+							et ipse filius sit, quoniam proce­ <lb/> dendo, non nascendo legitur
+							esse de Deo, jam supe­ <lb/> rius, quantum satis visum est, disputavi.
+							Nos, inquis, <lb/>
+							<hi rend="italic">in Patrem Deum innatum,</hi> naturam non <hi
+								rend="italic">accepimus.</hi>
+							<lb/> Et tanquam rationem reddens, cur Dei Patris non <lb/> dicatis esse
+							naturam , mox adjungis, et dicis, <hi rend="italic">Credi­</hi>
+							<lb/> mus <hi rend="italic">quod ait Christus,</hi> i <unclear/><hi
+								rend="italic">Spirituc eat Deus</hi> » <hi rend="italic">(Joan.
+								IV.</hi>
+							<lb/> 24) : quasi Christus secundum id quod Deus est, <lb/> non spiritus
+							sit, quem tamen natura Filium esse <lb/> dixisti. Nan ergo Pater ideo
+							natura non est, quia spi­ <lb/> ritus est. Sed forte quia natu uon est,
+							idco eum non <lb/> vultis esse naturam; putatis enim quod a nascendo
+							<lb/> uatura sit dicta. Scitote ergo, quod unaquaeque res <lb/> esse
+							dicitur per substantiam, hoc esse utique per <lb/> naturam. Certe si non
+							putatis esse dicendum, ejusdem <lb/> filium cujus Pater est esse
+							naturne; dicite cujus Pa­ <lb/> ter est esse substantiae : ad causam
+							quae inter nog <lb/> agitur, sufficit nobis. Verumtamen admonendi cstis,
+							<lb/> ut intueamini quod ait Apostolus, <hi rend="italic">His qui
+								natura</hi> non <lb/> sunt <hi rend="italic">dii, servistis
+								(Galat.</hi> IV, 8): ubi certe nos Deo <lb/> qui natura est Deus,
+							servire monstravit. Vos ergo qui <lb/> Deum Patrem non natura Deum esse
+							creditis, ubi <lb/> cum constituatis, advertite; et si ullus in vobis
+							pudor <lb/> est, erubescite. Eccc nos dicimus vobis, non servi­ <lb/>
+							mus Deo qui natura non est Deus; ne simus tales, <lb/> quales fuerunt
+							illi quihus dictum cst, <hi rend="italic">His</hi> qui <hi rend="italic"
+								>natura <lb/> non sunt dii, servistis.</hi> Vos si tales esse
+							vultis, <lb/> petimus ne velitis, et Deum Patrem natura Dcum <lb/> esse
+							dicatis : ejusque Filium, quem non gratia, sed na­ <lb/> tura Filium jam
+							esse dicitis, ejusdem nature cujus <lb/> Pater est non negetis, ne nihil
+							aliud qnam Filium <lb/> esse verum negetis. Quomodo enim dicitis, et ve­
+							<lb/> rum Filium vos profiteri, et Putri similem non ne­ <lb/> gare,
+							quando cum negatis unius cum Patre esse sub­ <lb/> stantiae ? Sicnt
+							autem verum Filium indicat una sub­ <lb/> stantia, sic non verum diversa
+							substantia. Quomodo <lb/> autem Filium Patri similem dicitis, cui Patris
+							sub­ <lb/> stantium ,dare non vultis ? Nonnc similis homini est <lb/>
+							pictura vel statua, et tamen filius dici non potest, <lb/> qnia diversa
+							substantia est ? Homo nempe ad Dci si­ <lb/> militudine ii factus cst;
+							tamen quia non est unius <lb/> ejusdemque substantiae, fton est verus
+							filius; et ideo <lb/> fit gratia filius, quia non est natura. Si ergo
+							vultis <lb/> Dei Filium verum confiteri, prius illum ac praecipuc <lb/>
+							dicite unius ejusdemque substantiae, ut tanquam ve­ <lb/> rum Filium ct
+							Dei Filium pcr omnia similem Patri <lb/> esse dicatis. Nam quem
+							substantiam putatis habere <lb/> diversam, plus eum dissimilem quam
+							similem dicitis, <lb/> et omnino verum Filium denegatis. Nam vultis I
+							<lb/> nosse, ad ostendendum verum filium quantum va­ <lb/> leat una
+							eademque substantia : etiamsi filius hominis <lb/> homo in quibusdam
+							similis, in quibusdam sit disci­ <lb/> milis patri; tamen quia ejusdem
+							substantiae est, ne­ <lb/> gari vcrus filius uon potest: et quia verus
+							est filius, <lb/> negari ejusdem substantiae non potest. Vos autem ita
+								<note type="footnote"> ' sola editio 1.0\'.: <hi rend="italic">Sec
+									vultis.</hi>
+							</note>
+							<note type="footnote"> PATROl... XLII. </note>
+							<note type="footnote">
+								<hi rend="italic">(Vingt-cinq.)</hi>
+							</note>
+							<lb/>
+							<pb n="779"/> dicitis verum Dei Filium similem Patri, ut substantiae
+							<lb/> velitis esse diversa, per qnam solam potest filius ve­ <lb/> ros
+							ostendi. Nam duo verihomines etsi nullus corum <lb/> filius silahcrius,
+							umus tamen suni et ejusdem sub. <lb/> stantiae : homo autem alterius,
+							hominis verus filius <lb/> nullo modo potest nisi ejusdem cum patre esse
+							sub­ <lb/> stantiae,etiamsi non sit par omn a similis patri <lb/>
+							Quocirca verus Dei Filius ct unius cum Patre Fubstan <lb/> tiae est,
+							quia verus Filius est : et per omnia est Patri <lb/> similis, quia Dei
+							Filius est. Nequc enim sicut contin­ <lb/> git in filiis hominum vel
+							quoramcumque animalium, <lb/> ita fas est dicere, verum Dei Filium
+							substantiae qui­ <lb/> dem unius esse cum Palrc, sed non per omina <lb/>
+							similem Patri. Nicaenum igitur tenete nobiscum con­ <lb/> cilium , si
+							voltis Christum dicere verum Dei Filium.</p>
+						<p>5. <hi rend="italic">Diversas,</hi> inquis, <hi rend="italic">accusamur
+								dicere natura.</hi> Et <lb/> quid aliud dicis de Den Patre ct Dco
+							Filio? quid aliud <lb/> dicis? An idco putas ab isia accusatione
+							purgari% <lb/> quia continuo subjungis dicens : <hi rend="italic">Hoc
+								scito quod nos <lb/> dicimus, quod Puter</hi> spiritus spiritum <hi
+								rend="italic">genuit ante omnia<lb/> saecula, Deus Deum genuit?</hi>
+							.loc quidem dicitis, et <lb/> veruin dicitis : sed hoc tacuisti, quod
+							falsum ct exse­ <lb/> crabilc dicitis. <hi rend="italic">Spiritus</hi>
+							enim spiritum genuit, verum <lb/> dicitis : sed hoc verum ea intentione
+							vos dicitis, <lb/> quia etiam diversae naturae dicitur spiritus. Nam di­
+							<lb/> versa; naturae sunt Spiritus Dei, sive Spiritus Deus, <lb/> et
+							spiritus hominis; et tamen uterque dicitur spiritus: <lb/> Itemdiversae
+							naturae sunt spiritus hominis et spiritus <lb/> pecoris; et tamen
+							nihilominus uterque spiritus dicitur. <lb/> hem dicitur, Deus Dens, et
+							dicitur deus homo : sicut <lb/> dictum cst, <hi rend="italic">Dii
+								estis</hi> ( <hi rend="italic">Psal.</hi> nIxi, 6). Et sicut datus
+							<lb/> est 1 deus Moyses Pharaoni <hi rend="italic">( Exod.</hi> VII, 1).
+							Et cum <lb/> sit Dei ct hominis diversa substantia, tan:en uterque <lb/>
+							appellatur Deus. Prorsus veraciter arguimini, quam­ <lb/> vis dicatis de
+							Deo Patre cl Deo Filio, <hi rend="italic">Spiritus spiri­<lb/> tum</hi>
+							genuit, naturas tamen diversas diccre : et quam­ <lb/> vis dicatis, <hi
+								rend="italic">Deus Deum genuit;</hi> etiam sic non recedere <lb/> a
+							diversitate naturae, quia non per omnia similem <lb/> Patri esse dicitis
+							Filium. Nam si per omnia si­ <lb/> mitem diceretis correquenter
+							intelligeremini quod <lb/> cos diceretis etiam unius cjusdemque esse
+							naturae <lb/> sive substantiae. Si ergo ab hoc crimine quod vobis <lb/>
+							objicitur, Dei Patris et Dei Filii vos dicere naturas <lb/> esse
+							diversas, purgare te cogitas: sicut dicis, <hi rend="italic"
+								>Spiritus</hi>
+							<lb/> spiritum <hi rend="italic">genuit;</hi> ita dic, Spiritus ejusdem
+							naturae sivc <lb/> substantiae spiritum genuit. Item, sicut dicis, <hi
+								rend="italic">Dens<lb/> Deum genuit;</hi> ita die, Deus ejusdem
+							naturae sive sub­ <lb/> stantiae Deum genuit. Hoc si credideris, et
+							dixeris, <lb/> nihil de bac re ulterius accusaberis. Si autem hoc non
+							<lb/> dixeris , quid prodest quia dicis, Verus <hi rend="italic">innatus
+								Pater <lb/> verum genuit Filium;</hi> cum procul dubio verus Filius
+							<lb/> ton sit, si non est unius ejusdemque substantiae eum <lb/> illo
+							qui genuit ?</p>
+						<p>4. Dicit quidem Filius ad Patrem , <hi rend="italic">Haec</hi> est <hi
+								rend="italic">autem<lb/> vita œterna,</hi> ut cognoscant te solum
+							terum <hi rend="italic">Deum, et <lb/> quem misisti</hi> Jesum <hi
+								rend="italic">Christum (Joan.</hi> XVII, 5) : Id est, . <lb/> te et
+							quem misisti Jesum Christum, cognoscant solum <lb/> verum Deum. In
+							quibus verbis vos solum Patrem non <note type="footnote">a Sic, 3bd.
+								Fditi autem, dictus est. </note>
+							<lb/> cum Filio verum accipientes Deum , quid allud quita <lb/> Filium
+							ncgatis 'crum Deum? Quia vero Pater ct Fl- <lb/> lius, non duo dii, sed
+							unus cst Deus; sine dubio et <lb/> Filius vcrus est Deus, et adjuncto
+							Spiritu sancto <lb/> solus est Deus. Ncque enim movere nos debel, quod
+							<lb/> nominatus non est hoc loco Spiritus sanctus, tanquam <lb/> non sit
+							Deus, aut non sit verus Deus. Tale est cnim <lb/> fioc quale si quis
+							dicit, nescire Christum ea quae Dei <lb/> sunt; quoniam dixit Apostolus
+							sic : <hi rend="italic">Et quae Dei sunt,</hi>
+							<lb/> nemo <hi rend="italic">scit,</hi> nisi <hi rend="italic">Spiritus
+								Dei</hi> (I <hi rend="italic">Cor.</hi> II, 11). Hoc cst <lb/> enim.
+							Nemo <hi rend="italic">scit,</hi> nisi Spiritus <hi rend="italic"
+								>Dei;</hi> quod est , Solus <lb/> ea scit Spiritus Dei. Sieut ergo
+							ab hac scientia, quam <lb/> non habere nisi Spiritus Dei dictus est, non
+							excludi. <lb/> tur Christus; sic ab eo quod Patcr et Christus dictus
+							<lb/> est solusverus Deus, non excluditur Spiritus sanctus. <lb/> Sic et
+							nomen illud quod in Apocalypsi nemo nosse <lb/> dictus est, nisi ipse
+							qui hoc habebat scriptum <hi rend="italic">( Apoc.</hi>
+							<lb/> XIX, 12), id est Christus, noverat utique et Pater, <lb/> quod
+							nrgare non potestis; noverat et Spiritus sanctus, <lb/> etiamsi ncgetis.
+								<hi rend="italic">Spiritus</hi> enim <hi rend="italic">omnia</hi>
+							scrutatur, <hi rend="italic">etiam<lb/> altitudines Dei</hi> (I <hi
+								rend="italic">Cor.</hi> II, 10). Nisi forte quia scruta­ <lb/> tor
+							dictus est, ncgatur apprehendere : negetur ergo <lb/> Dens apprehendere
+							corda et renes hominum; scri­ <lb/> ptum est enim , <hi rend="italic"
+								>Scrutans corda et renes Deus (Psal.</hi>
+							<lb/> VII,10). Ita ergo dictus est solus verus Deus Pater et <lb/> Jesus
+							Christus, ut ab bac veritate deitatis nullo modo <lb/> alienaretur
+							Spiritus sanctus. Non autem Filius, ut <lb/> tibi vidctur, <hi
+								rend="italic">solum potentem , solum sapientem, solum</hi>
+							<lb/> bonum <hi rend="italic">Patrem</hi> dicit <hi rend="italic">esse
+								Deum.</hi> Deus autem unus ct <lb/> solus est ipsa Trinitas, ut
+							ostendunt ea quae superius <lb/> jam saepissime diximus.</p>
+						<p>5. Quod autem <hi rend="italic">non</hi> proficientem , <hi rend="italic"
+								>sed perfectum <lb/> Deus Pater genuerit Filium Deum;</hi> verum
+							dicis. Sed <lb/> quod ipsam Filii perfectionem, perfectioni Patris non
+							<lb/> vis aquare; hoc falsum dicis, ct vcritati qua verus <lb/> cst
+							Filius contradicis. <hi rend="italic">Homo enim</hi> si <hi
+								rend="italic">posset,</hi> inquis &gt; <lb/>
+							<hi rend="italic">perfectum mox generare filium, non parvulum genera­
+								<lb/> ret,</hi> qui <hi rend="italic">coaugmentatis annis tandem
+								aliquando</hi> aui <hi rend="italic">geni- ,</hi>
+							<lb/> toris <hi rend="italic">impleat voluntatem.</hi> Verissime 1
+							omnino contra <lb/> te loqueris. Sed ut contra te non sit quod loqucris,
+							<lb/> agnosce aequalitatem Patris et Filii. Quia et homo si <lb/>
+							posset, filium mox generaret arqpalem , nec exspe­ <lb/> ctaret annos,
+							per quos in forma filii posset voluntas <lb/> ejus impleri. Deus ergo
+							cur non aequalem genuit Fi­ <lb/> lium , cui nec anni necessarii fuerunt
+							per quos id im­ <lb/> pleretur, nec omnipotentia defuit? An forte
+							noluit? <lb/> Ergo, quod absit, invidit. Sed non invidit : aequaleur
+							<lb/> igitur gcnui:. Ac per hoc unius ejusdemque substan­ <lb/> tiae :
+							quandoquidem homo, qui propterea quia non <lb/> potest non gignit
+							aequalem , ejusdem tamen subslan­ <lb/> tiae gignit filium, cujus est
+							ipse. Quod si non esset, <lb/> profecto verus filius esse non posset.
+							Quid est ergo <lb/> quod dicis , <hi rend="italic">Pater tatem
+								genuit</hi> Filium <hi rend="italic">qualis et</hi> nune <lb/> eat,
+								<hi rend="italic">qualis</hi> et <hi rend="italic">permanet sine
+								fine?</hi> Hoc bene diceres , si <lb/> Patri aequalem verum Filium
+							non negares. Cum vero <lb/> perfectum dicis, et aequalem negas, et talem
+							qnalii <note type="footnote"> * EdSti: <hi rend="italic">Fcritatem</hi>
+								veris <hi rend="italic">iiml,</hi> Pic. At Ma&lt;L omiUnat <hi
+									rend="italic">veri­<lb/> tctem.</hi>
+							</note>
+							<lb/>
+							<pb n="781"/> est natus sine line permanere non negas; procul dubio
+							<lb/> minorem Patre filium sine fine mancre pronuntias. <lb/> AC per hoc
+							nascitur filius hominis minor Patre ; et <lb/> quia imperfectus
+							nascitur, crescendo ad formam per­ <lb/> venit patris : natus est filius
+							Dei minor Patre; et <lb/> quia perfectus atque immortaliter natu est,
+							nullum <lb/> accipit incrementum , sed cum ipsa perfectio a forma <lb/>
+							Patris in aeternum efficit alienum. Ecce qu:e creditis , <lb/> cccequae
+							dicitis; ecce sunt, quod pejus est, quae docetis. <lb/> Sed <hi
+								rend="italic">inauditorum,</hi> inquis , <hi rend="italic">eat
+								arbitrio</hi> , nt <hi rend="italic">eligant alte­</hi>
+							<lb/> rum <hi rend="italic">de duobus : aut obedientem Patri Filium</hi>
+							, qui i se <lb/>
+							<hi rend="italic">evinanivit, formam servi accipiens
+									<unclear>o</unclear>, cui et Pater « donavit <lb/> nomen quod
+								est super omne nomen</hi> &gt; <hi rend="italic">(Philipp.</hi> II,
+							7, 9); <lb/>
+							<hi rend="italic">aut interpretationem tuam.</hi> Prorsus auditores
+							quibus <lb/> donat bominus intellectum, non unum de duobus <lb/> istis
+							eligunt, sed utrumque; id cst, et obedientem Pa<lb/>Iri Filiuin , et
+							interpretationem, vcl potius cxposilio­ <lb/> nem meam, qua ostendi sic
+							obedientem fuisse in for­ <lb/> nia servi, ut formam non amitteret Dei,
+							in qua :'qua­ <lb/> lis est Patri. Tu vero vide quam contumeliose Filio
+							<lb/> Dci tribuas obedientiam , cujus minuis in divinitate <lb/>
+							naturam.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="16">
+						<p>CAPUT XVI. - !. Quando autem a me audisti <lb/> prop. r Judaeos , <hi
+								rend="italic">humilitatis, non veritatis gratia , <lb/> dixisse
+								Filium quod Deus ejus sit Puter ejus ?</hi> Hoc a <lb/> me ita
+							nunquam audire potuisti, sicut nunquam dixi: <lb/> sed plane dili,
+							propter formam servi dictum esse. <lb/> Sicut autem ipsa forma servi
+							vera , non falsa ea; ita <lb/> Patrem suum esse eliam propter illam Deum
+							suum * <lb/> veraciter dixit, non humiliter finxit. Quis enim est <lb/>
+							humilitatis, fructus ubi detrimentum est veritatis ? <lb/> Tn autem
+							istam certissimam veritatem ita es refutare <lb/> conatus, ut diceres
+							ideo verba ipsa, quibus ait Domi­ <lb/> nus , <hi rend="italic">Deum
+								meum et Deum vestrum,</hi> ad formam servi <lb/> non pertinere, quia
+							eis verbis post resurrectionem <lb/> ustis est Dominus, quasi formam
+							servi resurrectione <lb/> consumpserit, ac non potius in melius
+							commutaverit: <lb/> quasi non qui mortuus est, ipse etiam resurrexerit;
+							<lb/> quasi non forma quae occisa est, ipsa rcvixerit; quasi <lb/> uon
+							ipsa in caelum levata sit , in ipsa Dei Filius se­ <lb/> deat ad
+							dexteram Patris, in ipsa venturus sit ad vivos <lb/> et mortuos
+							judicandos. Nonnc clarissima Contestatio <lb/> est Angelorum dicentium ,
+								<hi rend="italic">Sic veniet, quemadmodum</hi>
+							<lb/> vidistis eum euntem in <hi rend="italic">cœlum (Act.</hi> I, 11).
+							Cur ergo <lb/> post resurrectionem non diceret, <hi rend="italic"
+								>Ascendo ad Patrem <lb/> meum et Patrem restrum, Deum</hi> meum <hi
+								rend="italic">et Deum re­</hi>
+							<lb/> strum <hi rend="italic">(Joan.</hi> xx, 47); quando in eadem forma
+							fuerat <lb/> ascensurus, propter quam ex tempore Deus est ejus,. <lb/>
+							qui sine tempore Pater est cjus ? Propter quam for­ <lb/> fam non solum
+							post resurrectionem, verum etiam <lb/> post judicium <hi rend="italic"
+								>subjectus erit ei , qui iUi subjecit onmia</hi>
+							<lb/> (1 <hi rend="italic">Cor.</hi> xv, 28). Quotquot ergo testimonia
+							posuisti, <lb/> quibus probares dictum esse Deum Christi, eum qui <lb/>
+							Pater est Christi, discutere quemadmodum dicta sint, <lb/> superfluum
+							judico : sed a te frustra commemorata <lb/> esse, puto quod nec tu
+							dcbeas dubitare.</p>
+						<p>2. Jam vero illud ubi Dominos in eadem carne <lb/> quam resuscitaverat
+							constitutus, et eumdem homincm <lb/> g<unclear>erens</unclear> , ait ad
+							discipulos suos, <hi rend="italic">Data</hi> est <hi rend="italic"
+								>mihi</hi> omnis <lb/>
+							<hi rend="italic">potestas in cœlo</hi> et in <hi rend="italic">terra :
+								cuntes</hi>
+							<unclear/><hi rend="italic">avecte omnes gentes, <lb/> baptizantes</hi>
+							toa <hi rend="italic">in</hi> numine <hi rend="italic">Patris ei Filii
+								et</hi> Spiritus <lb/>
+							<hi rend="italic">sancti; docentes eoa servare omnia</hi> quaecumque <hi
+								rend="italic">mandu<unclear>vi</unclear>
+								<lb/> vobis (matth.</hi> XXVIII, 18-20): utquid commemoraveris,
+							<lb/> .et quid inde probare volucris * prorsus nescio. Num­ <lb/> quid
+							enim ait, Data est mihi a Deo meo potestas <lb/> Quod si dixisset,
+							propter ipsam humanam formam <lb/> dictum fuisse ambigi non dcboret.
+							Quia vero non dixit; <lb/> quid isto testimonio volueris agrre, non
+							intelligo. Imo <lb/> intelligo te id egisse , ut abundantius loquereris.
+							Si <lb/> enim tanquam Dco duta est hxc potestas , nascenti <lb/> cain
+							Pater dedit, non indigenti; quia gignendo dedit, <lb/> non augendo. Si
+							vero tanquam homini data est haec <lb/> potestas , qni I habet
+							quaestionis? An forte nos admo­ <lb/> ncre voluisti, quod baptizari
+							Dominus jusserit gculcs <lb/> in nominc Patris ct Filii ct Spiritus
+							sancti ? Ubi au­ <lb/> dis unum nomen , ct unam non vis intelligere
+							dcila­ <lb/> tem.</p>
+						<p>3. Quod autem dicisv ct ante incarnationem Chri­ <lb/> sti , Patrem
+							dictuin csse Dum ejus, quoniam scri. <lb/> ptum est \ Unxit <hi
+								rend="italic">te, Deus, Deus</hi> tuus; longe antequam <lb/>
+							Christus venisset in carne : itane Ron intelligis in <lb/> prophetia
+							esse praed clum , tanquam fucrit factum <lb/> quod erat futurum ? Annon
+							sic in prophetia ait ipso <lb/> Dominus , <hi rend="italic">Foderunt
+								manus meas et pedes (Psal.</hi> xxi, <lb/> 48); ct caeterea quihus
+							passionem suam tanto ante <lb/> prae<unclear>nuntiavit</unclear>, et
+							quod futurum fuerat, tanquam jam <lb/> factum esset expressit? Dictum ea
+							ergo in prophetia <lb/> rerum futurarum , tanquani locutione rerum
+							praeteri­ <lb/> tarum, <hi rend="italic">Unxit te, Deus, Deus tuus oleo
+								exsultationis pra <lb/> participibus tuis :</hi> participes ejus
+							significans, qui futuri <lb/> fiii rant servi ejus, socii ejus, amici
+							cjus, fratres ejus, <lb/> membra ejus. Praedictum est ergo quod futurum
+							erat, <lb/> ut ungeret Deus Christi hominem Christum: qui tamen <lb/>
+							sic factus est homo, ut maneret Deus. Ungeret autem. <lb/> non visibili
+							ct corporali oleo , sed Spiritu sancto, <lb/> quem Scriptura nomine olei
+							exsultationis, figurata, ut <lb/> solet, locutione significat. Dixit
+							autem , <hi rend="italic">Unxit;</hi> non <lb/> dixit, Uncturus est:
+							quia in praedestinatione jam fa­ <lb/> ctum erat, quod suo tempore
+							futurum erat. Ubi tn <lb/> timens ne Spiritus sanctus, quo unctus est
+							Christus . <lb/> major videatur esse quam Christus, quia revera ma­
+							<lb/> jor est homine Christo; qui enim sanctificat, eo qui <lb/>
+							sanctificatur est major: hoc ergo timens, voluisti olco <lb/>
+							exsultationis eam laetitiam significatam videri, qua <lb/> Filius
+							exsultavit cum Patre, quando est condita ere:.­ <lb/> tura. Et
+							commemorasti, ut soles, testimonia causa <lb/> tuae non necessaria , de
+							laetitia Patris et Filii. Sed <lb/> quid facturus es? quo iturus i
+							Quomodo id quod est <lb/> luce clarius, aut negaturus, aut in aliud
+							quodcumque <lb/> versurus es, cum recitatur tibi quod beatus Petrus in
+							<lb/> Apostolorum Actibus dixit : <hi rend="italic">Hunc</hi> Jesum a
+								<hi rend="italic">Naza­ <lb/> reth, quem unxit Deus Spiritu sancto
+								(Act.</hi> x, 38). <lb/> Ecce quod prophetabatur, quando dictum est,
+								<hi rend="italic">Unxit <lb/> te Deu, Deus tuus oleo
+								exsultationis,</hi> vel, <hi rend="italic">oleo laetitiae,</hi>
+							<lb/> prae <hi rend="italic">participibus</hi> tuis. Deus enim cui
+							dictum est in eo­ <lb/> dem Psahno , Thronus tuus, Deus, in <hi
+								rend="italic">saeculum saeculi; <lb/> virga directionis , virga
+								regni tui : dilexisti justitiam,</hi> et <lb/>
+							<hi rend="italic">odio habuisti iniquitatem; propterea</hi> unxit <hi
+								rend="italic">te Deus, Deus</hi>
+							<lb/>
+							<pb n="783"/>
+							<hi rend="italic">tuus (Psal.</hi> XLIV, 7, 8) : a Deo Patre unctus est
+							Filius, <lb/> qui sic bomo factus est ut mancrel Deus, qua unctione
+							<lb/> plenus erat, id est, Spiritu sancto. Propter quod de <lb/> illo
+							scriptum cst : Jesus <hi rend="italic">autem plenus Spiritu sancto,
+								<lb/> reversus est a Jordanc (Luc.</hi> iv, 1).</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="17">
+						<p>CAPUT XVII.— 1. Dicis in persona Spiritus sancti <lb/> non posse suscipi
+							quod de Filio dictum est, <hi rend="italic">Omnia <lb/> per ipsum fucta
+								sunt</hi> , et <hi rend="italic">sine ipso</hi> facturi <hi
+								rend="italic">est nihil <lb/> (Joan.</hi> I, 3). Et hoc ideo hidis,
+							ut quibus potueris <lb/> persuadeas, qnod vobis male persuasum est,
+							Spiri­ <lb/> tum sanctum non esse creatorem : quasi legeris , <lb/>
+							Omnia per ipsum facta sunt sine Spiritu sancto ; aut, <lb/> Omnia per
+							neminem facta sunt, nisi per ipsum. Quan­ <lb/> quam si et tale aliquid
+							legeres, sic Spiritum sanctum <lb/> ab hac operatione , qua constituta
+							est creatura , cre­ <lb/> dere non deberenmus exclusum; sicut Filius non
+							<lb/> excluditur ab ea scientia de qua dictum est, <hi rend="italic"
+								>Quce <lb/> Dei sunt, tiemo scit,</hi> nisi Spiritus <hi
+								rend="italic">Dei</hi> (I <hi rend="italic">Cor.</hi> II, 11). <lb/>
+							Si autem quia non est nominatus , quod etiam per <lb/> ilium facta sit
+							creatura, quando de Filio dictum <lb/> est , <hi rend="italic">Omnia
+								per</hi> ipsum <hi rend="italic">facta</hi> sunt ; idco putas Dei
+							<lb/> Spiritum non esse creatorem : procnl dubio , lice <lb/> in ejus
+							nomine poteris baptizatos dicere , quibus <lb/> ait Petrus, <hi
+								rend="italic">Agite pœnitentiam, et baptizetur unus­ <lb/> quisque
+								vestrum</hi> in <hi rend="italic">nomine Domini Jesu Christi (
+								Act.</hi>
+							<lb/> II , 38) ; qnia non ait, Et S. iritus sancti : nee in <lb/> Patris
+							nomine, quia nec ipsc ibi et nominatus. <lb/> Si auteur etiam non
+							nominatis Patre et Spiritu <lb/> sancto , in nomine Jesu Christi jussi
+							sun ba­ <lb/> plizari ; et tamen intelliguntur non baptizati nisi in
+							<lb/> nomine Patris et Filii et Spiritus sanct! : cur non sic <lb/>
+							audis de Filio Dei, Omnia pur <hi rend="italic">ipsum facta sunt;</hi>
+							ut <lb/> et non nominatum intellig <unclear>as</unclear> ibi ctiam
+							Spiritum san­ <lb/> cium?</p>
+						<p>2. NaiD quid excellentius in creaturis quam virtu­ <lb/> tes cœlorum?
+							Scriptum est autem : <hi rend="italic">Verbo DOli,;,. i <lb/> cœli
+								firmati sunt; et</hi> Spiritu <hi rend="italic">oris ejus, omnis
+								virtus eo­ <lb/> rum (Psal.</hi> XXXII, 6). Dixeras nempe non me
+							talia re­ <lb/> perire in Scripturis divinis, quibus Spiritum sanctum
+							<lb/> aequalem asseram Filio. Ecce reperi ubi etiam major <lb/> possit
+							videri, nisi revocet pietas. quae illum veraciter <lb/> confitetur
+							aequalem. Nam utique majus aliquid sunt <lb/> virtutes cœlorum, quae
+							firmatae sunt Spiritu oris Do­ <lb/> mini, id est Spiritu sancto, quam
+							cœli, qui firmati <lb/> sunt Verto Domini, hoc est, unigentio Filio. Sed
+							si <lb/> consulas veritatem , res utraque ab utroque firmata <lb/> est;
+							ct id quod de uno dicitur et de altero tacetur, de <lb/> utroque
+							intelligitur. Quid est autem inconsideratius, <lb/> quam negare esse
+							creatorem Spiritum Dei, cum Do­ <lb/> mino dicatur : <hi rend="italic"
+								>Auferes spiritum eorum, et deficient, et</hi>
+							<lb/> in <hi rend="italic">pulverem</hi> suum convertentur : <hi
+								rend="italic">emittes</hi> I <hi rend="italic">Spiritum</hi>
+							<lb/> tuum, et <hi rend="italic">creabuntur; et innovabis faciem</hi>
+							terrae <hi rend="italic">(Psal.</hi>
+							<lb/> CIII, 29, 30) Nisi forte minus idoneus erat Spiritus <lb/> sanctus
+							creandis rebus quae fuerant defecturae, cum <lb/> sit idoneus creandis
+							quae sunt sine line mansurae. <lb/> Paulo ante dixi : Quid est
+							excellentius in creaturis <lb/> quam virtutes cœłorum? Quid dicam de
+							carne Crea­ <note type="footnote"> * Pd'U, <hi rend="italic"
+									>emitte.</hi> At Mss , <hi rend="italic">cmitl:s.</hi> F.L sic
+								Aiigustiinis, Enarr. <lb/> ill ontodeui psalmum 105. </note>
+							<lb/> toris ? Quandoquidem Creator ipse per quem facia <lb/> sunt omnia,
+								<hi rend="italic">Panis,</hi> inquit, <hi rend="italic">quem ego
+								dedero, caro mea<lb/> est pro mundi vita (Joan.</hi> vi, 52). Quid
+							ergo? Mundus <lb/> per Filium factus est, et creator est Filius : caro
+							cjus <lb/> quae data est pro mundi viia , per Spiritum sanc tum <lb/>
+							facia est, et non cst creator Spiritus sanctus? Cum <lb/> enim virgo
+							Maria dixisset angelo promittenti Ci filium, <lb/>
+							<hi rend="italic">Quomodo fiet istud, quoniam virum non</hi> cognosco ?
+							re­ <lb/> spondit angelus, <hi rend="italic">Spiritus sanctus
+								superveniet</hi> in te , <hi rend="italic">et <lb/> virtus Altissimi
+								obumbrabit tibi; propterea quod nasce­<lb/> tur ex te sanctum,
+								vocabitur Filius Dei (Luc.</hi> I, 34, 35). <lb/> Hic tu, quod in
+							consequentibus quodam loco tuae prose­ <lb/> cutionis adverti, asserere
+							conaharis Spiritum sanctum <lb/> pra'cessisse, ut mundaret et
+							sanctificaret virginem <lb/> Mariam; ac deinde veniret Virtus Altissimi,
+							hoc est <lb/> Sapientia Uci, quod est Christus (I <hi rend="italic"
+								>Cor.</hi> i, 24); ei <lb/> ipsa , sicut scriptum est, aedificaret
+							sibi domun <lb/>
+							<hi rend="italic">(Prov.</hi> IX, i), hoc est, ipsa sihi crearcl carnem,
+							non <lb/> Spiritus sanctus. Quid est ergo quod ait sa nctum Evan­ <lb/>
+							gellum, <hi rend="italic">Inventa eat</hi> in <hi rend="italic">utero
+								habens de Spiritu sancto<lb/> (Matth.</hi> I, 18) ? Nempe obstructum
+							cst os loquentium <lb/> iniqua ( <hi rend="italic">PsaL</hi> LXII, 12 ).
+							Si ergo cogitas os veraciter <lb/> aperire, n on solum Filium , verum
+							etiam Spiritum <lb/> sanctum creatorem carnis Filii confitere.</p>
+						<p>3. An f orte dicturus es, ea facta esse per Spiritum <lb/> sanctum quae
+							commemoravi, id est, quod omnis virtus <lb/> coelorum per eum firmata
+							sit, quod per cum creaban­ <lb/> tur homines denuo, qni primo ita
+							creantur ut conver­ <lb/> tantur in pulverem suum ; quod ipse carnem
+							opera­ <lb/> tus est Christi (nam de anima nolo aliquid dicere , <lb/>
+							cujus difficillima quaestio est); et si quid aliud per <lb/> Spiritum
+							sanctum creatum potuerit inveniri: non ta­ <lb/> men omnii, sicut per
+							unigcnitum Filium , de quo <lb/> dictum est, Omnia per <hi rend="italic"
+								>ipsum facta</hi> sunt? Si hoc dicis, <lb/> non limes ne tibi
+							dicatur, eo potiorem esse Spiritum <lb/> sanctum Filio, quod elegit sibi
+							meliora qua; faceret, <lb/> nec facere inferiora
+								dig<unclear>natus</unclear> est? Sed quis hoc sapit, <lb/> nisi qui
+							desipit? Facta sunt ergo cuncta per Filium ; <lb/> absit, nt Spiritu
+							sancto ab hoc opere separato : sicut <lb/> de illis magnis operibus
+							dictum est, <hi rend="italic">Omnia autem haec<lb/> operatur unus
+								atque</hi> idem <hi rend="italic">Spiritus</hi> (1 <hi rend="italic"
+								>Cor.</hi> XII, i 1); nec <lb/> tamen ab hac operatione Filius
+							separatur.</p>
+						<p>4. Magnum sane aliquid tibi dicere videris, quia di­ <lb/> cis : Filius
+								<hi rend="italic">erat</hi> in <hi rend="italic">principio antequam
+								aliquid esset; <lb/> Pater vero, ante principium</hi> Ubi legisti,
+							ut iirc cre <lb/>dcres? Unde praesumpsisti ut haec diceres , ubi nec
+							<lb/> auctoritas ulla, nec ratio est ? Quid est enim ante <lb/>
+							principium , quandoquidem quidquid ante esset, hoc <lb/> esset
+							principium ? Si ergo Pater antc 1 principtum <lb/> est, ante seipsum
+							est; quia et ipse principium est. <lb/> Quid est autem, <hi
+								rend="italic">In</hi> principio erat <hi rend="italic">Verbum
+								(Joan.</hi> I, i); <lb/> nisi, In Patre crat Filius ? Et ipse Filius
+							interrogatus <lb/> a ,ludaris quis esset, respondit : <hi rend="italic"
+								>Principium, quia et<lb/> loquor vobis (Id.</hi> VIII, 25). Pater
+							crgo principium non <lb/> de principio; Filius principiu.n de principio
+							: scd <lb/> utrumque simul, non duo , sed unum principium ; <lb/> sicut
+							Pater Deus et Filius Deus, ambo autem siut <lb/> non dun dii, sed unus
+							Deus. Nee Spiritum sanctum <note type="footnote">1 Hie ajud l.ov.
+								omissum est, <unclear>esse</unclear>. </note>
+							<lb/>
+							<pb n="785"/> ab utroque procedentem negabo esse principium : <lb/> sed
+							haec tria simul sicut unum Deum, ita unum dico <lb/> esse
+							principium.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="18">
+						<p>CAPUT XVIII — i. Quid, si <hi rend="italic">audierit,</hi> inquis, Pa­
+							<lb/> trem <hi rend="italic">dicentem,</hi> « <hi rend="italic"
+								>Tecum</hi> principium in <hi rend="italic">die</hi> virtuti, <hi
+								rend="italic">tum, <lb/> in splendoribus tanctorum, ex utero ante
+								luciferum</hi> ge­ <lb/> nui <hi rend="italic">te &gt; (Psal.</hi>
+							CIX, 3) Quid promittis. vel quid mi­ <lb/> naris , si audiero quod
+							frequenter audio, et fideliter <lb/> credo? Sed hinc te nihil adjuvari ,
+							cur non videas, <lb/> plurimum miror. Sive enim ex persona sua hoc pro­
+							<lb/> pheta dicat ad Dominum Jesum , sive ex persona Pa­ <lb/> tris ad
+							Filium, cum ego ambas generationes Christi, <lb/> et ex Den Patrc sine
+							tempore, et ex homine matre in <lb/> plenitudine temporis accipiam,
+							vencrer, praedicem, <lb/> non est hoc testimonium adversum me. Sed moras
+							<lb/> innectere voluisse indicat te, ubi ego potius intelligo, <lb/>
+							quare <hi rend="italic">ex utero</hi> dixerit <hi rend="italic">genui te
+								:</hi> quia huc et tu ex per <lb/>sona Patris accipis dictum. Non
+							enim quemadmodum <lb/> corporis humani sunt membra disposita , sic habet
+							<lb/> uterum Dens ; sed verbum translatum est a corporali <lb/> ad
+							incorporalem substantiam , ut intelligeremus de <lb/> Patris substantia
+							genitum unigenitum Filium ; ac per <lb/> hoc quid aliud quam unius
+							ejusdemque substantiae ? <lb/> Ego itaque hoc testimonium proferre
+							contra te debui : <lb/> sed gratias ago quia commonuisti. Considera ergo
+							<lb/> quantum mali sit, quod ejusdem subustantiae Filiam <lb/> negatis,
+							quem genitum confitemini ex utero Patris, <lb/> injuriam gravissimam
+							facientes Deo , tanquam illud <lb/> quod ipse non esset,, ex utero
+							gignere potuisset. Non­ <lb/> ne sentitis vos generationem Dei credere
+							vitiosam , <lb/> praedicare monstruosam, qui dicere audctis ex utero.
+							<lb/> Dei processisse diversam naturam? Si antem hoc, sic­ <lb/> ut
+							debclis, horretis, respuilaque nobiscum, jam tnn­ <lb/> dem concilium
+							Nicaenum et Homousion laudate ac <lb/> tenete nobiscum.</p>
+						<p>2. Quis autem nou videat defectum tuum, ubi cum. <lb/> andisses, me
+							commemorante,1 in prophetia dixisse <lb/> Christum suo Patri, De <hi
+								rend="italic">ventre</hi> matris meae <hi rend="italic">Deus</hi>
+							meus <lb/>
+							<hi rend="italic">es tu (Psal</hi> xxi, ii ); ut intelligeremus ejus na­
+							<lb/> turae ilium esse Deum quam Filius ipsius ex tempore <lb/> de
+							ventre matris accepit, Patrem vero naturae illius <lb/> quam do se ipse
+							generavit: tu non inveniens quid re­ <lb/> sponderes, tamen ne laceres
+							dixisti, <hi rend="italic">Ex ventre</hi> matris <lb/> natum profiteri.
+							Christum secundum <hi rend="italic">carnem;</hi> et addi­ <lb/> disti,
+								<hi rend="italic">quod nec</hi> Judaei <hi rend="italic"
+								>diffidunt.</hi> Ac deinde quaesisti, <lb/>
+							<hi rend="italic">Car</hi> ista <hi rend="italic">testimonia in
+								medium</hi> noR <hi rend="italic">proferantur, quae <lb/> illam</hi>
+							nativitatem <hi rend="italic">demonstrant in</hi> principio, sicut <hi
+								rend="italic">et prae­ <lb/> cedent</hi> noa, inquis, instruit
+							testimonium ? Quasi ego <lb/> illam nativitatem Christi, non temporalem,
+							sad aeter­ <lb/> nam, propter quam dictum est, <hi rend="italic">In
+								principio erat Ver­<lb/> bum,</hi> non credam, non praedicem, non
+							amplectar; <lb/> sed tantum ex ventre matris natum asseram Chri­ <lb/>
+							stum? Ecce ego dico Deum Filium de Deo Patre sine <lb/> tempore genitum.
+							Quomodo sit autem etiam Deus <lb/> ejus qui Pater est ejus, ostendi,
+							propter hominem <lb/> quem suscepit, et in quo natus cst de ventre
+							matris, <lb/> sinc concubitu hominis patris. Ad quod probandum <lb/>
+							testimonium dedi, ubi ait in prophetia Patri sun, <hi rend="italic">De
+								<lb/> ventre matris meae Deut meus</hi> es <hi rend="italic"
+								>tu.</hi> Tu qui dicis me es <lb/> ventre matris natum profiteri
+							Christum , quod nee Ju­ <lb/> daei diffidunt, quasi ego istam
+							nativitatem Christi In. <lb/> lam profitear; Meli per inania conari
+							evadere , et dic <lb/> potius quare mihi non responderi, ubi dicit
+							Christus <lb/> Patri, <hi rend="italic">De ventre matris meae Deut</hi>
+							meut es <hi rend="italic">tu.</hi> Ad hoc <lb/> enim quoniam vidisti non
+							te habere quod diceres, <lb/> aliam nativitatem quae Dei de Deo. est,
+							interponem <lb/> dam putasti qua fugeres. Rogo te; quando quid rc­ <lb/>
+							spondeas non habes, quanto melius taceres?</p>
+						<p>3. Si propter <hi rend="italic">corpus,</hi> inquis, in <hi rend="italic"
+								>quo se</hi> exinanivit, <lb/>
+							<hi rend="italic">debitorem</hi> te <hi rend="italic">sentit</hi> suo
+								<hi rend="italic">genitori;</hi> multo magis qui illum <lb/>
+							<hi rend="italic">tantum ac talem genuit, necesse est</hi> x! eam <hi
+								rend="italic">veneretur,<lb/> eique</hi> offerat <hi rend="italic"
+								>semper</hi> obsequium. Quodlibet de venera­ <lb/> tione et obsequio
+							Filii erga Patrem carnaliter sentias, <lb/> Puer ejus, nisi de ventre
+							matris ejus, non est Deus <lb/> ejus. Jam quantumvis obsequatur Deo
+							Patri Deus <lb/> Filius, quoniam ,-ideo te non intelligere quanta sil in
+							<lb/> illa generatione geniti et genitoris aequalitas, num­ <lb/> quid
+							ideo est diversa natura patris hominis et hominis <lb/> filii, quoniam
+							filius obsequitur patri? Hoc est omnino <lb/> intolerabile in vobis,
+							qnia de obsequio Filii diversam <lb/> vultis probare substantiam Patris
+							et Filii. Prorsus <lb/> alia quaestio cst, Utruin sint unias ejusdemque
+							sub­ <lb/> stantiae Pater et Filius; et alia quacstio est, Utrum <lb/>
+							Patri Filius obsequatur. Interim verum Filium non <lb/> negemus, qui
+							nullo modo est verus Filius, si non est <lb/> ipsius et Patris ana
+							eademque natura. Dicite ergo <lb/> Deum Patrem; et Deum Filiium unius
+							ejusdemque <lb/> esse substantia!. Extorqueat vobis divinitas, quod
+							<lb/> humanitati donavit ipsa divinitas. Obsequitur homo <lb/> patri
+							suo, de quo natus est homo; tamen obsequendo <lb/> esse non desinit
+							homo. Ei si, non dico pariter hono­ <lb/> ratus, sed honoratior esset
+							ftlius, gauderet pater, non <lb/> invideret: honoraret tamen etiam ille
+							patrem, etsi <lb/> non parvulus, accessu augendus aLlatis, sed ei natus
+							<lb/> esset aequalis. aequalem vero si pater homo potuis­ <lb/> set ,
+							nullo dubitante genuisset. Quis ergo audeat di­ <lb/> cere, Hoc nec
+							Omnipotens potuit? Addo cHam, quia <lb/> si posset homo, majorem se ipso
+							melioremque <lb/> gigneret filium : sed majus vel melius Deo quidquam
+							<lb/> non potest esse; ergo ei verum Filium credamus <lb/> aequalem.
+							Quod si dixeris, Eo ipso major est Pater <lb/> Filio, quia de nullo
+							genitus, genuit tamen aequaletn: <lb/> cito respondebo, Imo ideo non est
+							major Pater Filio, <lb/> quia aequalem genuit, non minorem. Originis
+							enim <lb/> quaestio est, Quis de quo sit :. aequalitatis autem, <lb/>
+							Qualis aut quantus sit. Proinde si admittit ratio veri<lb/>tatis ut
+							aequali Patri Filius obsequatur aequalis, non <lb/> negnmus obsequium :
+							si autem per obsequium mino­ <lb/> rem natura1 vultis credere,
+							prohibemus: nullo modo <lb/> enim Deus Pater ut babcre unici Filii
+							posset obse­ <lb/> quium, vellet denegare naturam.</p>
+						<p>4. Par entibus autom ut esset subditus Christus , <lb/> non dvinae
+							majestatis fuit, sed aetatis humanae Fru­ <lb/> stra itaque dixisti :
+								<hi rend="italic">Si parentibus fuit subditus quot<lb/> creavit</hi>
+							( <hi rend="italic">Luc.</hi> II, 51 ), <hi rend="italic">quanto magis
+								suo genitori qui <lb/> eum tantum ac talem genuit?</hi> Respondetur
+							enim lihi ; <note type="footnote"> I AIR. ct Er., <hi rend="italic"
+									>minorem natum</hi> plures Mss., <hi rend="italic">nnnorem</hi>
+								fM' <lb/> turam. </note>
+							<lb/>
+							<pb n="787"/> Si parentibus fuit subditus propter pueritiam, quanto
+							<lb/> magis Den propter ipsam hominis formam? Quam <lb/> formam eum
+							immortalem fecerit, non morti perdide­ <lb/> rit; quid miraris si etiam
+							post hujus saeculi finem sub­ <lb/> jectus erit in ea illi, qui ei
+							subjecit omnia ? Tu autem <lb/> non propter formam servi dicis Filium
+							Patri esse sub­ <lb/> jectum , sed quia cum tantum ac talem genuit. id
+							est <lb/> magnum Deum, quanvis Patre ipso minorem : ubi ct <lb/> Patri
+							dcrogas, qui Filium sibi unicum, aut non potuit, <lb/> aut noluit
+							gignere aequalem; ut ipsi Filio qni unicus <lb/> Patri non est generatus
+							aequalis. et idco perfectus est <lb/> natus, ne unquam vel crescendo
+							fieret, quod non po­ <lb/> tuit esse nascendo.</p>
+						<p>5. Non autem, ut putas, corpus tantum Filii, id est, <lb/> corpus
+							hominis, verum etiam buinanum spiritum Pa­ <lb/> tri dicimus esse
+							subjectum : et secundum id quod <lb/> botro factus est intelligimus
+							dictum. <hi rend="italic">Cnm antem omnia<lb/> tlli</hi> subjecta
+							fuerint <hi rend="italic">tunc et ipse Filius subjectus erit illi</hi>
+							<lb/> qui a subjecit <hi rend="italic">omnia</hi> (1 <hi rend="italic"
+								>Cor.</hi> xv, 28). Secundum id quod <lb/> Christus est caput ct
+							corpus: caput scilicet ipse Sal­ <lb/> vator qui surrexit a mortuis, et
+							scdel ad dexteram Pa­ <lb/> tris; et Ecclesia quae est corpus ejus,
+							plenitudo ejns, <lb/> sicut apertissime dicit Apostolus <hi
+								rend="italic">(Coloss.</hi> I, 18). Ac <lb/> per boc cum omuia
+							Christo subjecta fuerint, et capiti <lb/> et corpori erunt sinc
+							dubitatione subjecta. Nam secun­ <lb/> dum id quod sine tempore Deus
+							natus est, nihil un­ <lb/> qnam potuit ei non esse subjectum.</p>
+						<p>6. Scimus, quod nos commemoraridos putasti, <hi rend="italic">quia <lb/>
+								Pater</hi> non <hi rend="italic">judicat quemquam, sed omne judicium
+								dedit</hi>
+							<lb/> Filio <hi rend="italic">(Joan.</hi> v, 22). Vellem tamen diceres
+							nobis, quo­ <lb/> modo Pater non judicat quemquam , cum dicat ipse <lb/>
+							identidem Filius, <hi rend="italic">Ego non quaero</hi> gloriam <hi
+								rend="italic">meam; est</hi>
+							<lb/> qui <hi rend="italic">quaerat, et judicet (Id.</hi> VIII, 50) : ut
+							srias idco di­ <lb/> ctum, <hi rend="italic">Pater non judicat</hi>
+							quemquam, <hi rend="italic">sed omne judicium <lb/> dedit Filio;</hi>
+							quoniam judicandis vivis et marnis for­ <lb/> ma hominis apparebit, quam
+							non hahct Pater: pro­ <lb/> pter quod ait propheta, <hi rend="italic"
+								>Videbunt in quent pupugerunt<lb/> (Zach.</hi> XII, 10). Sed
+							invisibiliter etiam Pater erit cum <lb/> eo, quia inseparabilis est ab
+							eo. Si enim, <hi rend="italic">Non</hi> sum <lb/>
+							<hi rend="italic">solus, quoniam Pater</hi> mecum est, ait ipse
+							moriturus <lb/>
+							<hi rend="italic">(Joan.</hi> XVI, 52); quanto magis secum habebit
+							Patrem, <lb/> de mortuis et vivis judicaturus? Cum illo crit etiam <lb/>
+							Spiritus sanctus. Quomodo enim deseret eum Spiritus <lb/> sanctus in
+							rcgali sede, quo plenas regressu! est a Jor­ <lb/> dane <hi
+								rend="italic">(Luc.</hi> IV, 1)! Quod itaque scriptum est ad lie..
+							<lb/> braeos, <hi rend="italic">Nunc autem necdum videmus omnia subjecta
+								ei :</hi>
+							<lb/> cum <hi rend="italic">autem modico minus ab Angelis minoratum
+								videmus <lb/> Jesum propter passionem mortis (Hebr.</hi> II, 8, 9):
+							do­ <lb/> cere nos debet quomodo intelligendum sit quod scri­ <lb/> ptum
+							est ad Corinthios, Cum <hi rend="italic">autem omnia illi subjecta</hi>
+							<lb/> fuerint: quia secundum id dictum est quod factus est <lb/> homo,
+							non secundum id quod est Deus. Sic ergo in <lb/> homine apparens, in quo
+							per passionem mortis mino­ <lb/> ratus est modico minus ab Angelis,
+							vivos et mortuos. <lb/> judicabit, quando dicturus est : <hi
+								rend="italic">Venite, benedicti Pa­</hi>
+							<lb/> tris <hi rend="italic">mei percipite regnum</hi> ( <hi
+								rend="italic">Matth.</hi> xxv, 34 ). Quo tu <lb/> testimonio non
+							hominem, sed Deum minorem suo <lb/> Patre quasi probare voluisti : sed
+							sicut ab eit qui in­ <lb/> telligunt perspicitur, nun probasti.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="19">
+						<p>CAPUT XIX. — De Spiritus sancti autem gemiii­ <lb/> bus, quia non ipse
+							gemit, sed inspirans nobis deside­ <lb/> rium sanctum nos facit gemere
+							quamdiu peregrina­ <lb/> mur a Domino, jam tibi sunicienter respondisse
+							me <lb/> existimo. £t tales de Scripturis sanctis locutiones, <lb/>
+							quantum satis videbatur ostendi, quoniam sic dicitur <lb/> gemere
+							Spiritus sanctus, quia nos facit gemere ; sicut <lb/> dixit Deus, <hi
+								rend="italic">Nunc cognovi (Gen.</hi> XXII, 12), quando co­ <lb/>
+							gnoscere hominem fecit. Non eqim tunc cognoverat <lb/> quod tunc se
+							dixerat cognovisse, qni omnia scit an­ <lb/> tequam fiant. Ad quod te
+							respondere non potuisse, <lb/> quid predest quia scutis, quando non
+							consentis ?</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="20">
+						<p>CAPUT XX. — i. Jam eliam de verbis Domini <lb/> ubi ait, <hi
+								rend="italic">Ego</hi> et <hi rend="italic">Pater</hi> unum sumus
+								<hi rend="italic">(Joan.</hi> x, 30); nihil <lb/> te respondere
+							potuisse monstravi. Sed ut hic quoquo <lb/> ostendam, si exemplis, ut
+							dicis, quibus ego usus sum, <lb/> vis probare quomodo dictum sit, <hi
+								rend="italic">Ego et Puter</hi> unum <lb/>
+							<hi rend="italic">sumus;</hi> ct ob hoc commemoras apostolicum testimo­
+							<lb/> nium. quod a me p'situm est, ubi ait <hi rend="italic">Qui
+								adhaeret <lb/> Domino, unus spiritus est</hi> ( I <hi rend="italic"
+								>Cor.</hi> VI 17): dic ct tu, <lb/> Cum adhaeeret Patri Filius, unus
+							Deus e t. Nou enim <lb/> ait Apostolus, <hi rend="italic">Qui adhaeret
+								Domino,</hi> unum sunt; sicut <lb/> dictum est, <hi rend="italic"
+								>Ego et Pater unum sumus:</hi> sed ait, unus <lb/>
+							<hi rend="italic">spiritus edt.</hi> Cum autem tu non dicas, Cum adhaere
+							t <lb/> Patri Filius, unus Deus est ; utquid et tu adhibes hoc <lb/>
+							Apostoli testimonium, ubi ait, <hi rend="italic">Qui adhaeret Domino,
+								<lb/> unus spiritus est ;</hi> nisi ut te etiam a te producto teSte
+							<lb/> convincam? Nunc saltem distingue duo bta, quae non <lb/> potuisti,
+							cum simul essemus, in nostra disputatione <lb/> distinguere. Diligenter
+							itaque attende quod dico. <lb/> Quando de rcbus duabus nul plurimus
+							dicitur, Unus <lb/> est, vel, una est, et additur quid unus vel quid
+							una; <lb/> ct de his quae diversae, et de his quae sunt unius sub­ <lb/>
+							stantiae dici potest. Diversae sunt enim substantiae spi. <lb/> ritus
+							hominis et Spiritus Domini 1 :et tamen dictum <lb/> est, Qui <hi
+								rend="italic">adhaeret Domino unus spiritus tat.</hi> Unius au­
+							<lb/> tem substauti;e sunt animae hominum ct corda homi­ <lb/> num; de
+							quibus dictum est, <hi rend="italic">Erat Ulis anima</hi> una <hi
+								rend="italic">et<lb/> cor</hi> unum <hi rend="italic">(Act.</hi> IV,
+							52). Ubi autem dicitur de duobus <lb/> aut pluribus, Unum sunt, nec
+							additur quid unum sint; <lb/> non diversae intelliguntur, sed unius esse
+							substantiae: <lb/> sicut dictum est, <hi rend="italic">Qui plantat et
+								qui rigut,</hi> unum 'unt <lb/> (I <hi rend="italic">Cor.</hi> III,
+							8); et, <hi rend="italic">Ego et Pater</hi> unum <hi rend="italic"
+								>sumus.</hi> Tu au­ <lb/> tem qni Patrem cl Filium diversas vis rsse
+							substan­ <lb/> tias, invenire non potuisti, ubi de diversis substantiis
+							<lb/> dic tum fuerit, Unum sunt. Et qui non vis dicere, Cum <lb/> Filius
+							adhaeret Patri, unus Deus est; adhibuisti et tu, <lb/> apostolicum
+							testimonium quod ego adhibueram; sed <lb/> adhibuisti contra te ipsum,
+							uhi ait, <hi rend="italic">Qui adhaeret</hi> Do<lb/>Mnino, <hi
+								rend="italic">unus spiritus est.</hi> Si enim de his qui diversae
+							<lb/> substantiae sunt, recte dici potuit, <hi rend="italic">unus
+								spiritus</hi> est; <lb/> quantQ magis de bis qui unius substantiae
+							sunt recte <lb/> dicitur, Unus Deus est? Si haec intelligis, non te ad
+							<lb/> ea respondisse jam perspicis, et de consensu volunta­ <lb/> tis tc
+							inaniter tam multa dixisse cognoscis. Etiam <lb/> nos quippe
+							incompambilem consensum voluntatis at­ <lb/> que individuae charitatis
+							Patris et Filii et Spiritus san­ <lb/> fti confitemur, propter quod
+							dirinms , Haec Trinitas <note type="footnote">1 Antiquiores Mss.t <hi
+									rend="italic">et Spiritus nomimis.</hi>
+							</note>
+							<pb n="789"/>
+							<unclear/><lb/> unus est Deus. Sed nos boc etiam, quod vos non di­ <lb/>
+							citis, dicimus, propter unam eamdemque naturam at­ <lb/> que
+							substantiam, Hi tres unum sunt. Haec si discre­ <lb/> veris, et
+							contentiosus esse nolueris, non te ad ea re­ <lb/> spondisse aliquid jam
+							videbis, et de hac quaestione <lb/> procul dubio jam tacebis.</p>
+						<p>2, Ubi autem dixil Eilius Patri, <hi rend="italic">Verum non quod</hi>
+							<lb/> ego <hi rend="italic">volo, sed quod. tu vis;</hi> quid te adjuvat
+							quod tua <lb/> verba subjungis ctdicis, <hi rend="italic">Ostendit vere
+								voluntatem suam <lb/> subjectam</hi> suo genitori : quasi nos.
+							negemus, hominis <lb/> voluntatem voluntati Dei debere esse subjectam?
+							Nam <lb/> ex natura hominis hoc dixisse Dominum cito vidct ,. <lb/> qui
+							locum ipsum sancti Evangelii pauLo attentius in­ <lb/> tuetur. Ibi enim
+							dixit: <hi rend="italic">Tristis est anima mea usque ad</hi>
+							<lb/> martem ( <hi rend="italic">Matth.</hi> XXVI, 39, 38 ). Numquid ex
+							natura <lb/> unici Verbi posset hoc dici? Sed homo qui putas ger <lb/>
+							mere naturam Spiritus sancti, cur non etiam naturam <lb/> Verbi Dei
+							unigeniti tristem dicas esse potuissc?- Ille <lb/> tamen, ne quid
+							diceretur tale, non ait, Tristis sum ; <lb/> quamvis etiamsi line
+							dixisset, non nisi ex natum ho­ <lb/> minis oportuisset intelligi : sed
+							ait, Tristis <hi rend="italic">est</hi> anima <lb/>
+							<hi rend="italic">mea ;</hi> quam sicut homo utique habebat humanam.
+							<lb/> Quamquam ct in hoc quod ait, <hi rend="italic">Non quod ego volo
+								;</hi>
+							<lb/> aliud se ostendit voluisse quam Pater : qnod nisi hu­ <lb/> mano
+							corde non potuisset, cum infirmitatem nostram <lb/> in suum, non divinum
+							, sed humanum transfiguraret <lb/> affectum. Homine quippe non assumpto,
+							nullo modo <lb/> Patri diceret unicum Veibum, <hi rend="italic">Non quod
+								ego volo.</hi>
+							<lb/> Nunquam enim posset immutabilis illa natura quid­ <lb/> quam
+								<unclear>aliud</unclear> velle quam Pater. Haec si distingueretis,
+							<lb/> Ariani haeretici non essetis.</p>
+						<p>3. Nam et illud quod dictum est, Descendi <hi rend="italic">de cœ­<lb/>
+								to, non ut faciam volunlatem meam, sed voluntatem ejus</hi>
+							<lb/> qui <hi rend="italic">me misit (Joan.</hi> V!, 58) : potest quidem
+							accipi <lb/> etiam secundum id quod est unigenitum Verbum ; ut <lb/>
+							ideo voluntatem non suam dixerit esse, sed Patris , <lb/> quoniam de
+							Patre est quidquid est Filius; non est all­ <lb/> tem de Filio quidquid
+							est Pater : secundum quod di­ <lb/> ctum est, <hi rend="italic">Mea
+								doctrina non eat mea, sed ejus qui me</hi>
+							<lb/> mit <hi rend="italic">(Id.</hi> vn, 16); quoniam Patris doctrina
+							ipse est <lb/> qui Patris est Verbum, et utique non ost a se ipso, <lb/>
+							sed a Patre. Et rursus cum dicit, <hi rend="italic">Omnia quae</hi>
+							habet <lb/>
+							<hi rend="italic">Pater,</hi> mea <hi rend="italic">sunt (Id.</hi> XVI,
+							15) ; Patri se ostendit aequa­ <lb/> lem. Non absurdum est tamen , ut
+							etiam hoc secun­ <lb/> dum id quod homo factus est, dixisse accipiatur :
+								<hi rend="italic">Dc­ <lb/> scendi de caelo, non</hi> ut <hi
+								rend="italic">faciam voluntatem meam, sed vo­ <lb/> luntatem ejus
+								qui me misit.</hi> Secundus enim Adam, qui <lb/> tollit peccatum
+							mundi, isto modo se discrevit a pri­ <lb/> mo Adam , per quem peccatum
+							intravit in mundum <lb/>
+							<hi rend="italic">(Rom.</hi> v, t2) : quia iste non fecit voluntatem
+							suam, <lb/> sed ejus a quo missus est; cum ille fecerit suam, non <lb/>
+							ejus a quo creatus est. Nee moveat quomodo Christus <lb/> secundum id
+							quod homo- est, descenderit de cœlo, <lb/> cum de matre quae in terra
+							erat factus sit homo. Hoc <lb/> enim propter unitatem personae dictum
+							est, quoniam <lb/> una persona est Christus Deus et homo. Propter quod
+							<lb/> etiam : <hi rend="italic">Nemo,</hi> inquit, <hi rend="italic"
+								>ascendit</hi> in <hi rend="italic">caelum,</hi> nisi <hi
+								rend="italic">qui de <lb/> cœlo descendit. Filius hominis, qui eat
+								in caelo (Joan.</hi>
+							<lb/> III, 13). Si ergo attendas distinctionem substantiarum, <lb/>
+							Filius Dei de coelo descendit, Filius hominis cruci­ <lb/> fixus est :
+							si nnitatem personae, et Filius hominis de­ <lb/> scendit de caelo, et
+							Filius Dei est crucifhus. Ipso <lb/> est enim Dominus gloriae, de quo
+							ait Apostolus : <hi rend="italic">Si<lb/> enim cognovissent,</hi>
+							nunquam Dominum <hi rend="italic">gloriae crucifixi<lb/> sent (I
+								Cor.</hi> II, 8). Propter hanc ergo unitatem perso­ <lb/> nae, non
+							solum Filium hominis dixit descendisse de <lb/> cœlo, sed esse dixit in
+							coelo, cum loquerctur in terra. <lb/> Non ergo voluntatem suam fecit,
+							quia peccatum non <lb/> fecit: sed voluntatem fecit illius qui eum
+							misit. Tunc <lb/> enim facit homo voluntatem Dei, quando facit. justi.
+							<lb/> tiam qua: ex Deo est.</p>
+						<p>4. Nec sic arbitremur a Patre missum. esse Filium, <lb/> ut non sit
+							missus ab Spiritu sancto; cum vox ipsius <lb/> sit per prophetam, <hi
+								rend="italic">Et nunc</hi> Dominus misit <hi rend="italic">me, et
+								Spi.</hi>
+							<lb/> ritus <hi rend="italic">ejus.</hi> Hoc enim Filium dixisse,
+							indicant ea quai <lb/> sunt dicta superius. Nam sic ad ista verba
+							perventum <lb/> est : <hi rend="italic">Audite me,</hi> inquit, <hi
+								rend="italic">Jacob,</hi> et <hi rend="italic">Israel quem ego to
+								<lb/> cabo. Ego sum</hi> primus, <hi rend="italic">et ego</hi> sum
+							in <hi rend="italic">aeternum ; et</hi> ma <lb/> nus <hi rend="italic"
+								>mea</hi> fundavit <hi rend="italic">terram, dextera mea solidavit
+								ccelum. <lb/> Yocabo illos, et astabunt simul ; convenient
+								etiam</hi> uni­ <lb/>
+							<hi rend="italic">versi, et audient. Quis illi. nuntiavit haec?</hi>
+							Diligens te <lb/>
+							<hi rend="italic">feci voluntatem tuam</hi> super <hi rend="italic"
+								>Babylonia, ut</hi> tollatur semen <lb/>
+							<hi rend="italic">Chaldaeorum. Ego locutus sum, ego</hi> vocavi; <hi
+								rend="italic">adduri<lb/> illum, et prosperam</hi> viam <hi
+								rend="italic">ejus feci. Convenite ad me, ei<lb/> audite ista. Nec
+								enim ab initio in obscuro locutus sum : <lb/> cum
+									<unclear>fiebant</unclear>, ibi eram; et nunc Dominus misit</hi>
+							me, et <lb/>
+							<hi rend="italic">Spiritus ejus (Isai.</hi> XLVIII, 12-16). Quid hoc
+							apertius? <lb/> Nee sic a Patre et Spiritu sancto missus est. ut se ipse
+							<lb/> non miserit : sicut a Patre ostenditur traditus, ubi <lb/>
+							legitur, Qui <hi rend="italic">Filio proprio non pepercit, scd pro
+								nobis<lb/> omnibus tradidit eum (Rom.</hi> VIII, 32) ; alio autem
+							loco de <lb/> ipso Filio dicitur, <hi rend="italic">Qui me dilexit, et
+								tradidit scipsum<lb/> pro me (Galat.</hi> II. 20). Quomodo autem non
+							facit va­ <lb/> luntatem suam, qui dixit, Sicut <hi rend="italic"
+								>Pater</hi> suscitatmortuos <lb/>
+							<hi rend="italic">et vivificat, sic et Filius quos vult vivificat
+								(Joan.</hi> V, 21); <lb/> et cum ei dictuin esset <hi rend="italic"
+								>Si vis, potes me mundare;</hi>
+							<lb/> respondit, <hi rend="italic">Volo, mundare;</hi> et ad verbum
+							continuo <lb/> f. ctum est quod velle se dixit <hi rend="italic"
+								>(Matth.</hi> VIII, 2, 3) ? Sicci <lb/> autcm Filias facit
+							voluntatem Patris, sic et Pater facit <lb/> voluntatem Filii. Nam Filius
+							dicit: <hi rend="italic">Pater, volo</hi> ut <hi rend="italic">ubi <lb/>
+								ego</hi> sum, <hi rend="italic">et isti sint mecum (Joan.</hi> XVII,
+							24). Non dixit <lb/> Peto, vel, Rogo; sed, vo!o : ut isto volente
+							faceret <lb/> ille, sicut illo volente faciebat iste : et non alia ille,
+							<lb/> alia istc; sed quae ille, haec etiam iste. <hi rend="italic"
+								>Quaecumque<lb/> enim Pater facit, haec et</hi> Filiussimiliter
+							facit <hi rend="italic">(ld.</hi> v, 19). <lb/> Verba sunt ipsius, verba
+							veritatis suut, falsa esse non <lb/> possunt.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="21">
+						<p>CAPUT XXI. — 1. Suscipere tc dicis quod protuli, <lb/>
+							<hi rend="italic">Nescitis quia templum DA estis, et Spiritus Dei
+								habitat</hi>
+							<lb/> in <hi rend="italic">vobis</hi> (I <hi rend="italic">Cor.</hi>
+							III, 16) ? Quod proposuisti 1 dicere idoo <lb/> dictum esse, quia <hi
+								rend="italic">in nemine habitat Deus, quem non<lb/> ante Spiritus
+								sanctus sanctificaverit, atque purgaverit;</hi>
+							<lb/> quasi templum Den habitaturo, non sibi, sanctificet et <lb/>
+							purget Spiritus sanctus : cum Apostolus hincostenderit <lb/> ipsum esse
+							Deum, cujus nos dixcrat templum : quia <lb/> non ait,. et Spiritus Dei
+							sanctificat et purgat vos, ut <lb/> Deus habitet in vobis, sed ait, <hi
+								rend="italic">Spiritus Dei</hi> habitat in <note type="footnote">*
+								Sic aliquot Mss. At editi, <hi rend="italic">qvod potuisti.</hi>
+							</note>
+							<lb/>
+							<pb n="791"/> tobia. Uliqne in templo suo Deus habitat : nam quid <lb/>
+							est templum Dei, nisi habitaculum Dei ? Vidisti autem <lb/> etiam tu
+							consequenter esse Deum nostrum cujus StI­ <lb/> mus templum : et
+							noluisti aliud testimonium comme­ <lb/> morare quod protuli, <hi
+								rend="italic">Nescitis qnia corpus vestrum <lb/> templum in vobis
+								Spiritus sancti est, quem habetis</hi> n Deo? <lb/> Jam ergo
+							confitere Dcum esse Spiritum sanctum. <lb/> Neque enim, nisi esset Deus,
+							haberet templum, et <lb/> templum non manufactum, sed aedificatum
+							dememhris <lb/> Dei : <hi rend="italic">Christus</hi> enim <hi
+								rend="italic">super omnia est Deus benedictus in</hi>
+							<lb/> saecula <hi rend="italic">(Rom.</hi> IX, 5), cujus membra sunt
+							nostra cor­ <lb/> pora. Qui enim dixit, <hi rend="italic">Nescitis quia
+								corpus vestrum <lb/> templum</hi> in vobis <hi rend="italic"
+								>Spiritus sancti est?</hi> ipse dixit, <hi rend="italic">Ne­ <lb/>
+								scitis quia corpora vestra membra sunt Christi (I</hi> Cor. VI,
+							<lb/> 19, 15) ? Itane vero cui de lignis lapidibus Salemon <lb/>
+							aedificavit templum, Deus est, et cui templum
+								<unclear>aedilica­</unclear>
+							<lb/> tur de membris Christi, hoc est, de membris Dei, <lb/> D:iis uon
+							est? cum loquens de Deo beatissimus mar­ <lb/> tyr Stephanus dixerit :
+							Salomon <hi rend="italic">aedificavit ei</hi> domum ; <lb/>
+							<hi rend="italic">sed Summus non</hi> in <hi rend="italic">manufactis
+								templis inhabitat (Act.</hi> VII, <lb/> 47. 48). Et tamen Christi
+							membra, quorum caput eat <lb/> super omnes cœlos, templum sunt Spiritus
+							sain ti, <lb/> quem constat venisse de coelo. Istum negare Deum <lb/>
+							quid est, nisi non esse et nolle esae templum ejus? <lb/> Alloquitur nos
+							Apostolus dicens : Obsecro autem <hi rend="italic">vos.<unclear/><lb/>
+								fiatres, per miserationes Dei, ut exhibeatis corpora</hi> vestru <lb/>
+							<hi rend="italic">hostiam vivam,</hi> sanctam, Deo <hi rend="italic"
+								>placentem (Rom.</hi> XII, 1). <lb/> Corpora itaque fidelium hostia
+							sunt Deo, membra <lb/> Christi, templum Spiritus sancti, et Deus non est
+							<lb/> Spiritus sanctus! Quis hoc dicit, nisi in quo non inha­ <lb/>
+							hilal? Quoniam in quo habitat, utique templum ejus <lb/> cst. Denique
+							cum dixisset Apostolus : <hi rend="italic">Nescitis quia <lb/>
+								corpus</hi> vestrum templum <hi rend="italic">in vobis Spiritus
+								sancti est, <lb/> quem habetis a Deu, et non estis</hi> vestri? <hi
+								rend="italic">empti</hi> enim <lb/>
+							<hi rend="italic">estis pretio magno ;</hi> continuo secutus adjunxit,
+								<hi rend="italic">Clorifi­<lb/> cale</hi> ergo <hi rend="italic"
+								>Deum</hi> in <hi rend="italic">corpore vestro</hi> (I <hi
+								rend="italic">Cor.</hi> VI, 19, 20). <lb/> Ubi dilucido ostendit
+							Deum esse Spiritum sanctum, <lb/> glorificandum scilicet in corporc
+							nostro, tanquam in <lb/> templo suo. Et qnod Ananiae, dixit apostolus
+							Petrus, <lb/> Ausus <hi rend="italic">es mentiri Spiritui sancto?</hi>
+							atque ostendens <lb/> Deum esse Spiritum sanctum, <hi rend="italic">Non
+								es,</hi> inquit, <hi rend="italic">homi­ <lb/> nibus mentitus, sed
+								Deo (Act.</hi> v, 3, 4).</p>
+						<p>2. Miror autem cor vestrum, quantum sermone <lb/> explicare uon possum,
+							quomodo cum sic laudctis" <lb/> Spiritum sanctum, ut eum sanctificandis
+							fidelibus <lb/> ubique asseratis esse praesentem, tamen negare att­
+							<lb/> deatis Deum. Itane Deus non est, qui replevit orb m <lb/>
+							terrarum? Scriptura enim dicit: <hi rend="italic">Spiritus</hi> Domini
+								<hi rend="italic">re­</hi>
+							<lb/> plevit <hi rend="italic">orbem</hi> terrarum <hi rend="italic"
+								>(Sap.</hi> I, 7). Sed quid dicamus <lb/> quod replevit orbem, qui
+							replevit urbis etiam Re­ <lb/> demptorem ? Dominus enim <hi
+								rend="italic">Jesus plenus Spiritu<lb/> sancto regressus</hi> est
+								<hi rend="italic">a Jordane (Luc.</hi> IV, 1) : et praesu­ <lb/>
+							mitis dicere, quia ipse Dominus Jesus Deus erat, et <lb/> SpiritUs
+							sanctus quo plenus erat, non erat Deus; tam <lb/> male sentientes de
+							Spiritu sancto, ul non ci tribuatis <lb/> saltum quod tributum est Moysi
+							famulo Dci, qii non <lb/> munera gratiarum, scd plagaruin prodigia in
+							eodem <lb/> Spiritu sancto, quia ipse est <hi rend="italic">digitus
+								Dei(Exod.</hi> VIII, 19), <lb/> aegyptiis ingerebat, et tamen
+							Phar.toni deus erat. <lb/> Uno luco erat ad affligendos aegyptios, et
+							Pharaoni <lb/> deus erat ( Exod. VII, 1): ubique adest Spiritus sanctus
+							<lb/> ad homines in aeternam vitam regenerandos, et non <lb/> est eis
+							Deus! lino vero est, et Deus verus est, quia <lb/> vcri Dei membra
+							templum ejus est. Et uiiquc sub­ <lb/> jectum est templum illi cujus est
+							templum : qUomodo <lb/> ergo Deus non cst, cui sunt membra Dei subjecta'
+							<lb/> Ac per hoC et Dominus est templi sui : qnis enim hoc <lb/> neget,
+							quis ila desipiat, ut dicat non esse aliquem <lb/> dominum domus suae?
+							Quomodo ergo Spiritus sanctus <lb/> non est Dominus, qui Dominus est
+							membrorum Do­ <lb/> mini ? Ipse cst quippe Spiritus Domini, de quo uno
+							<lb/> codemque loco dictum est : Cum <hi rend="italic">autem</hi>
+							conversus <lb/>
+							<hi rend="italic">fuerit ad Dominum, auferetur velamen. Dominus
+								autem<lb/> Spiritus est ;</hi> ubi <hi rend="italic">autem Spiritus
+								Domini, ibi libertas</hi>
+							<lb/> (II Cor. III, 16, 17).</p>
+						<p>3. Jam creatorcm superius demonstravi Spiritum <lb/> sanctum: quomodo
+							autem rex non est, cujus templum <lb/> est quae membra sunt regis?
+							Quomodo non consedet <lb/> Patri et Filio, qui replevit Filium, qui
+							membra Filii <lb/> suam possidct domum? Nisi forte quando Filius re­
+							<lb/> gressus est a Jordane, plenus erat Spiritu sancto; et <lb/> quando
+							sedere cœpit ad dexteram Patris, exclusit a so <lb/> Spiritum sanctum?
+							Deimle cum de Patre procedat, <lb/> quomodo cum Patre non sedeat? Cuu
+							ipsa sessio non <lb/> sit utique cogitanda carnaliter : alioquin
+							opinaturi <lb/> sumus honorabilius Filium sedere quam Patrem; ho­ <lb/>
+							norabilius quippe scdetur ad dexteram : cl videbitur <lb/> esse
+							consequens ut Pater sedeat ad sinistram. Postremo <lb/> qualis vobis
+							persuaserit spiritus, ut sancto Spiritui <lb/> denegctis quod sanctis
+							hominibus sancta Scriptura <lb/> concedit, vos videritis. Ait enim
+							Apostolus : Cum <lb/>
+							<hi rend="italic">essemus mortui peccatis, convivificavit nos Christo,
+								cujus<lb/> gratia</hi> sumus salvi facti ; <hi rend="italic">et
+								simul excitavit, et simul se­<lb/> dere fecit</hi> in <hi
+								rend="italic">caelestibus</hi> in <hi rend="italic">Christo Jesu
+								(Ephes.</hi> II, 5, 6). <lb/> Sancti ergo quos sanctificat Spiritus
+							sanctus, convivi­ <lb/> ficati Christo, ita simul sessuri praedestinati
+							sunt, ut <lb/> jam factum dicat Apostolus, quod certum est adfutu •
+							<lb/> rum : et ipsi Spiritui sancto subtrahitur a vobis quis­ <lb/> quis
+							est ille consessus, taoquam sedere cum Patre vel <lb/> Filio sit
+							indignus, qui eadem sede efficit dignos. Cui <lb/> movetis etiam
+							quaestionem quod non adoretur, et hoc <lb/> utique simillimo errore, cum
+							legatis, ut jam supra <lb/> docui, a sanctis ctiam homines adoratos. Et
+							tamen ut <lb/> invidiam blaspbemantis evites; ita laudas Spiritum <lb/>
+							sanctum, ut tribuas ei quod non habet ulla creatura, <lb/> et detrahas
+							ei quod adipiscitur et humana creatura.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="22">
+						<p>CAPUT XXII. — i. Dixisse me quod commemo­ <lb/> ras, fateor, et nunc dico
+							, quod Salvator noster non <lb/> dixerit, Ut ipsi et nos unum ; sed, <hi
+								rend="italic">Ut ipsi sint unum</hi>
+							<lb/> Et de his evangelicis verbis satis a ure rccolo jani <lb/> fuisse
+							responsum, cum ostenderem refellere te ion <lb/> potuisse quae dixi.
+							Quoniam poposci ut proferres ubi <lb/> legeris. <hi rend="italic">Unum
+								sunt,</hi> dictum esse de alquibus rebus <lb/> quae non essent unius
+							ejusdemque substantiae : <unclear>neque</unclear>
+							<lb/> protulisti. Quid enim te adjuvat, quod dilectionis <lb/>
+							consensione affirmas dictum esse de Paulo et Apollo, <lb/>
+							<hi rend="italic">Qui plantat autem et qui rigat, unum sunt (I Cor.</hi>
+							III, 8), <lb/> cum eos non ostendas diversae fuisse substantiae? <lb/>
+							<pb n="793"/> Ambo quippe homines crant. Si enim non diligerent <lb/>
+							invicem, natura unum essent. dileclione non essent : <lb/> si anilem
+							unum natura uon essent, unum dici dile­ <lb/> ctione non possent. Poscit
+							ergo Filius ut ita sint <lb/> unum,quomodo ipse ct Pater unum sunt; id
+							est , <lb/> non solum natura, quod jam erant ; verum eliain <lb/>
+							perfectione charitatis atque justitiae, pro suae capaci­ <lb/> late
+							naturae, quantum in Dei regno esse potuerint: <lb/> ut etiam ipsi summe
+							unum sint in natura sua, quem­ <lb/> admodum Pater et Filius summe unum
+							sunt, quamvis <lb/> in excellentiore atque incomparabiliter meliore na­
+							<lb/> tura sua. Dixit ergo ad Patrem Filius : <hi rend="italic">Pater
+								sancte, <lb/> serva eos</hi> in <hi rend="italic">nomine</hi> tuo,
+								<hi rend="italic">quos dedisti mihi ;</hi> ut <hi rend="italic">ant
+								unum, <lb/> sicut et nos.</hi> Non dixit, Ut sint unum nobiscum;
+							<lb/> aut, Ut simus unum ipsi et nos. Item pauk) post : <lb/>
+							<hi rend="italic">Non</hi> pro <hi rend="italic">Itis autem rogo
+								tantum,</hi> sed <hi rend="italic">et pro</hi> eia <hi rend="italic"
+								>qui cre.</hi>
+							<lb/> dituri <hi rend="italic">sunt</hi> per verbum ipsorum in <hi
+								rend="italic">me;</hi> ut <hi rend="italic">omnes</hi> unum <hi
+								rend="italic">sint,<lb/> sicut</hi> tu <hi rend="italic">Pater in
+								me, et ego</hi> in te, ut <hi rend="italic">et</hi> ipsi in nobis
+							unum <lb/>
+							<hi rend="italic">sint.</hi> Neque hic dixit, Ut ipsi et nos unum simus,
+							sed, <lb/>
+							<hi rend="italic">unum sint in nobis.</hi> Quoniam homines qni natura
+							unum <lb/> suni, summe atque perfecte secundum suum modum <lb/> unum
+							esse non possunt justitiae plenitudine , nisi in <lb/> Deo perficiantur,
+							ut unum sint in Patre et Filio; id <lb/> est, in ipsis unum, non cum
+							ipsis unum. Adhuc se­ <lb/> quitur, et adjungit : <hi rend="italic">Ut
+								mundus credat</hi> quia <hi rend="italic">tu me mi- <lb/> sisti, et
+								ego</hi> claritatem quam mihi <hi rend="italic">dedisti, dedi
+								illis</hi> , ut <lb/> sint unum, sicut nos unum sumus: <hi
+								rend="italic">ego</hi> in <hi rend="italic">eis,</hi> et tu <hi
+								rend="italic">in</hi>
+							<lb/> me, <hi rend="italic">ut sint consummati</hi> in unum. Neque hie
+							dixit, Ut <lb/> nobiscum sint unum, ant, Ut ipsi et nos simus unum.
+							<lb/> Deinde cum addidisset, <hi rend="italic">Ut cognoscat mundus quia
+								tu</hi>
+							<lb/> me <hi rend="italic">misisti, et</hi> dilexisti <hi rend="italic"
+								>eos</hi> sicut <hi rend="italic">et</hi> me <hi rend="italic"
+								>dilexisti;</hi> seculus <lb/> adjunxit, <hi rend="italic">Pater,
+								volo</hi> ut <hi rend="italic">ubi ego</hi> sum, <hi rend="italic"
+								>et</hi> ipsi <hi rend="italic">sint</hi> me­ <lb/> cum (Joan. XVII,
+								11-24).<hi rend="italic">Ubi</hi> sum,inquit, <hi rend="italic"
+								>mecum</hi> sint : <lb/> non ait, Unum mecum sint 1. Hoc ergo
+							voluit, ut cum <lb/> illo essent, non ut illi et ipse unum essent. Quid
+							est <lb/> quod dicere voluisti 4 <hi rend="italic">Dilectionis fecit
+								mentionem,</hi> et <lb/> non substantiae ? Quamvis tu non eo loco
+							ista Domini <lb/> verba posueris, quo ab ipso sunt posita. Sed qnid
+							<lb/> ad Hos ? quandoquidem non ipsos et se, vel ipsos et <lb/> Patrem
+							dixit aut voluit unam esse; sed ipsos unum <lb/> esse voluit, quos
+							noverat unius esse substantiae. Sic­ <lb/> ut <hi rend="italic">ei
+								nos</hi> , inquit unum sumus : quos identidem no­ <lb/> verat unius
+							essp substantia.</p>
+						<p>2. Tu si vis aliquid respondere, ostende secundum <lb/> Scripturam
+							sanctam de aliquibus rebus dici, Unum <lb/> sunt, quarum est diversa
+							substantia. Hoc enim Chri­ <lb/> stus non dixit, quod tamen tu ausus es
+							dicere, id est, <lb/>
+							<hi rend="italic">Apostolos</hi> unum esse <hi rend="italic">cum Patre
+								et</hi> Filio , <hi rend="italic">in eo quod</hi> in <lb/> amnilus
+								<hi rend="italic">ad voluntatem</hi> Dei <hi rend="italic">Patris
+								respicientes, ad</hi> imi­ <lb/>
+							<hi rend="italic">tationem Filii subditi uni Deo Patri et ipsi</hi>
+							inveniun­ <lb/>
+							<hi rend="italic">tur</hi> (a). Haec dicens, Deum et homines sanctos
+							unum <lb/> esse fecisti. Potest ergo quisquam sanctorum dicere , <lb/>
+							Ego et Dens unum sumus? Absit hoc a cordibus et <lb/> oribus sanctis.
+							Puto autem qnod et vos a quocumque <lb/> hoc audiatis, horrescilis , nec
+							fertis quemquam ho­ <lb/> minem, quantolibet munere sanctitatis
+							excellat, di­ <lb/> contem , Ego et Deus unum sumus. Sed forte arro-
+								<note type="footnote">4 I.ov. etquidain Mss. omitlunt, <hi
+									rend="italic">yon ait, vnum mecum sint</hi>
+							</note>
+							<note type="footnote"> !aj vide serm. i tO, n. ł, tom </note>
+							<lb/> gantiae videatur, si hoc de seipso aliquis dicat. Itane <lb/> vcro
+							quisquam vestrum etsi non audet dicere, Ego et <lb/> Deus unum sumus;
+							saltem audet dicere, Paulus et <lb/> Deus unum sunt; sicut incunctanter
+							dicimus, Paulus <lb/> et Apollo unum sunt; Deus Pater et Deus Filius
+							<lb/> unum sunt? Porro, si non audetis dicere , Quilihet <lb/> hono
+							sanctus, quilibet propheta , quilibet apostolus, <lb/> et Deus, unum
+							sunt; quis te urgebal, quis te impin­ <lb/> gebat, quis te praecipitabat
+							1, ut diceres, <hi rend="italic">Apostoli<lb/> unum sunt cum Patre et
+								Filio? Unum sunt,</hi> inquis, <lb/>
+							<hi rend="italic">Pater et Filius, non tamen</hi> unus : continuoque sub
+							<lb/> jungis, <hi rend="italic">Unum ad concordiam pertinet; Unus,
+								ad</hi> nu­ <lb/>
+							<hi rend="italic">merum singularitatis.</hi> Volebas autem dicere , Unum
+							<lb/> sunt, ad concordiam pertinet; Unus est, ad numerum <lb/>
+							singularitatis : sed te a consideratione verborum tuo­ <lb/> rum impetus
+							disputationis avertit. Nam et Unum et <lb/> Unus utique ad numerum
+							pertinet singularem. Scd <lb/> quod verum I est; Unum sunt, propter id
+							quod ad­ <lb/> dilum est, Sunt, pluralem indicat numerum , qua­ <lb/>
+							dam singularitate connexum : Unus est autem , aper­ <lb/> tissime est
+							numerus singularis. Sed numquid Aposto­ <lb/> lus diceret, Qui antem
+							adhaeret Domino, unum sunt? <lb/> Quid enim aliud diccret, si hoc
+							diceret, nisi, Homo <lb/> sanctus, et Deus, unum sunt? Sed ahsit, absit
+							ab illa <lb/> sapientia ista sententia : et tamen dixit, Qui <hi
+								rend="italic">autem<lb/> adhœret Domno,</hi> unus <hi rend="italic"
+								>spiritus</hi> eat (I <hi rend="italic">Cor.</hi> VI, 47); ut <lb/>
+							noveris de his dici, Unum sunt, qaae unius sunt ejus­ <lb/> demque
+							substantiae : sient quibusdam bominibus di­ <lb/> etum est, <hi
+								rend="italic">Omnes enim</hi> vos <hi rend="italic">unum estis in
+								Christo</hi> Jesu <lb/>
+							<hi rend="italic">(Galat.</hi> III, 28); et sicut. ait Ipse Christus,
+								<hi rend="italic">Ego et Pa­ <lb/> ter</hi> unum sumus <hi
+								rend="italic">(Joan.</hi> x, 30). Cum autem unns dici­ <lb/> tur, et
+							qmd unus dicitur 3 : et de diversis substantiis <lb/> dici potest, sicut
+							dictum est, Qui adhaeret Domino % <lb/>
+							<hi rend="italic">unus</hi> spiritus <hi rend="italic">est;</hi> et de
+							rebus unius substantiae, sient, <lb/> dictum est, <hi rend="italic">Erat
+								eis anima et cor unum (Act.</hi> IV, 32). <lb/>
+							<hi rend="italic">Erat,</hi> dixit; non dixit, Erant: quoniam dixit et
+							quid <lb/> crat; id est, <hi rend="italic">anima et cor.</hi> Sic etiam
+							de Patre et Filio, <lb/> et, Unum sunt, dicimus, quia unius substantiae
+							duo <lb/> sunt : et, Unus est, dicimus, sed addimus quid unus; <lb/> id
+							est, unusDeus, unus Dominus , unus Omnipotens, <lb/> et si quid
+							hujusmodi, Satis me vobis duarum istarum <lb/> locutionum arbitror
+							inculcasse distantiam. Scrutare <lb/> itaque Scripturas canonicas
+							veteres et novas, et in­ <lb/> vcni, si potes, ubi dicta sunt aliqua,
+							Unum sunt, quae <lb/> sunt diversae paturae atque substantiae.</p>
+						<p>3. Sane falli te nolo in Epistola Joannis apostoli, <lb/> ubi ait: <hi
+								rend="italic">Tres sunt testes; spiritus, et aqua, et sanguis;<lb/>
+								et tres unum sunt</hi> (I <hi rend="italic">Joan.</hi> v, 8). Ne
+							forte dicas spiri­ <lb/> tum et aquam et sanguinem diversas esse
+							substantias, <lb/> et tamen dictum esse , <hi rend="italic">tres unum
+								sunt :</hi> propter hoc <lb/> admonui ne fallaris. Haec enim
+							sacramenta sunt, in <lb/> quibus non quid sint, sed quid ostendant
+							semper at<lb/>tenditur : quoniam signa sunt rerum , alind existen
+							<lb/>tia, et aliud significanlia. Si ergo illa quae bis signifi <lb/>
+							canlur, intelligantur, ipsa inveniuntur unius esse sub- <note
+								type="footnote">1 Apud Er. Lugd. et ven., <hi rend="italic">quis te
+									wgebat, quis</hi> pr(r' <lb/>
+								<hi rend="italic">cipitahat ?</hi> M. </note><note type="footnote">
+								' Apud Lov. et quosdam Mss., <hi rend="italic">verbum.</hi>
+							</note><note type="footnote"> a sic Mss. Kdili auicm, <hi rend="italic"
+									>ct quid unus naturaj ct quid</hi> :&lt;&lt; <lb/>
+								<hi rend="italic">ndjicitur.</hi>
+							</note>
+							<lb/>
+							<pb n="795"/> stantiae ; tanquam si dicamus , Petra et aqua unum <lb/>
+							sunt, volentes per petram significare Christum ; per <lb/> aquam,
+							Spiritum sanctum : quis dubitat petram et <lb/> aquam diversas esse
+							naturas ? Sed quia Christus et <lb/> Spiritus sanctus unius sunt
+							ejusdemque naturae ; idco <lb/> cum dicitur Petra et aqua unum sunt; ex
+							ea parte <lb/> recie accipi potest , qua istae duae res quarum est di­
+							<lb/> versa natura, aliarum quoque signa sunt rerum qua­ <unclear/>
+							<lb/> rumest una natura. Tria itaque novimus de corpor- <lb/> Domini
+							exisse, cum penderet in ligno : primo, spiri­ <lb/> tum ; unde scriptum
+							est, <hi rend="italic">Et inclinato capite tradidit</hi>
+							<lb/> spiritum ; deinde , quando latus ejus lancca perfora­ <lb/> tum
+							est, sanguinem et aquom <hi rend="italic">(Joan.</hi> XIX, 50, 34).
+							<lb/> Quae tria si per se ipsa intueamur , diversas habent <lb/> singula
+							quaeque substantias; ac per hoc non sunt <lb/> unum. Si vero ea, quae
+							his significata sunt, velimus <lb/> inquirere , non absurde occurrit
+							ipsa Trinitas , qui <lb/> unus, solus , verus, summus est Deus, Pater et
+							Fi­ <lb/> lius et Spiritus sanctus, de quibus verissime dici. po­ <lb/>
+							tuit, <hi rend="italic">Tres</hi> sunt testes , <hi rend="italic">et
+								tres</hi> unum <hi rend="italic">sunt</hi> : ut nomine <lb/>
+							spiritus significatum accipiamus Deum Patrem : de <lb/> ipso quippe
+							adorando loquebamur Dominus, ubi ait, <lb/> Spiritus <hi rend="italic"
+								>eat Deus (Id.</hi> IV, 24). Nomine autem sangui­ <lb/> nis, Filium
+							: quia, <hi rend="italic">Verbum caro factum est (Id.</hi> I, 14). <lb/>
+							Et nomine aquae Spiritum sanctum : cum enim de <lb/> aqua loqueretur
+							Jesus, quam daturus erat sitientibus, <lb/> ait evangelista, <hi
+								rend="italic">Hoc autem dixit de Spiritu, quem ac­</hi>
+							<lb/> cepturi <hi rend="italic">erant credentes</hi> in <hi
+								rend="italic">eum (Id.</hi> VII, 39). Tesles <lb/> vero esse Patrem
+							et Filium et Spiritum sanctum , <lb/> quis Evangelio credit, et dubitat,
+							dicente Filio, <hi rend="italic">Ego</hi>
+							<lb/> sum <hi rend="italic">qui testimonium perhibeo de me: et
+								testimonium <lb/> perhibet de</hi> me, <hi rend="italic">qui misit
+								me, Pater (Jd.</hi> VIII, 18)? Ubi <lb/> etsi non est commemoratus
+							Spiritus sanctus, non ta­ <lb/> men intelligitur separatus. Sed nec de
+							ipso alihi ta­ <lb/> cua, eumque testem satis aperteque monstravit. Nam
+							<lb/> curi illum promitteret, ait : <hi rend="italic">Ipse testimonium
+								perhibebit <lb/> de me.</hi> Hi <hi rend="italic">sunt tres testes:
+								et tres unum sunt (Id.</hi> xv, <lb/> 26), quia unius substantiae
+							sunt. Quod antemi signa <lb/> quibus significati sunt, de corpore Domini
+							exierunt, <lb/> figuraverunt Ecclesiam praedicantem Trinitatis unam
+							<lb/> eamdemque naturam : quoniam hi tres qui trino mo* <lb/> do
+							significati sunt, unum sunt; Ecclesia vero eos <lb/> praedicans, corpus
+							est Christi. Si ergo. Ires res quibus <lb/> significati sunt, ex corpore
+							Domini exierunt : sicut <lb/> ex corpore Domini sonuit, ut baptizarentur
+							gentes <hi rend="italic">in <lb/> nomine Patris et Filii et Spiritus
+								sancti (Matth.</hi> XXVIII, <lb/> 19). <hi rend="italic">In</hi>
+							nomine; non, In nominibus : hi enim tres <lb/> unum sunt, et hi tres
+							unus est Deus. Si quo autem <lb/> ano modo tanti sacramenti ista
+							profunditas , quae in <lb/> Epistola Joannis legitur, exponi et
+							intelligi potest <lb/> secundum catholicam fidem, quae nec confundit nec
+							<lb/> separat Ti iuitatem , nec abnuit tres personas , nec <lb/>
+							diversas credit esse substantias, nulla ratione respu­ <lb/> endum est.
+							Quod enim ad exercendas mentes fide­ <lb/> lium in Scripturis sanctis
+							obscure ponitur,gratulan­ <lb/> dum cst, si multis modis, non tamen
+							insipienter ex­ <lb/> punitur.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="23">
+						<p>CAPUT XXIII. — 1. Quid est autem quod po<lb/>Mis ut astruam , <hi
+								rend="italic">Si pater et Filias et Spiritus san­<lb/> ctus</hi>
+							unus <hi rend="italic">est Deus</hi> ; cum hoe astruat voce clarissima
+							<lb/> Scriptura divina dicens , <hi rend="italic">Audi, Israel; Dominus
+								Deus</hi>
+							<lb/> tuus, <hi rend="italic">Dominus</hi> unus <hi rend="italic">est (
+								Deut,</hi> VI, 4)? Quod et vos <lb/> uiiquc audiretis, si Israel
+							esse velletis, non carnali­ <lb/> ter ut Judaeri, sed spiritualiter ut
+							Christiani. Qui enim <lb/> non vult fideliter audire quod dictum est,
+								<hi rend="italic">Audi, Israel; <lb/> Dominus Deus tuus, Dominus
+								unus est;</hi> superest ut <lb/> eum qui hoc dixit, credat esse
+							mendacem. Si autem <lb/> mendax ille non est, vox ista vera est : si vox
+							ista <lb/> vera est, quaestio ista finita est. Procul dubio quippe <lb/>
+							vos veritascogit Patrem aL Filium et Spiritum sanctum <lb/> confiteri
+							unum Dominum Deum. Sed Spiritum san­ <lb/> ctum, cujus templum non
+							manufactum, sed corpus <lb/> est nostrum , cujus templum non ligna et
+							lapides, sed <lb/> membra sunt Christi, negatis Deum : de ipso Christo
+							<lb/> quid dicturi estis, quem Deum et Dominum confite­ <lb/> mini?
+							Respondete itaque nobis, utrum Pater et Filius <lb/> unus sit Dominus
+							Deus. Si cnim non est <unclear>mius</unclear>, duo <lb/> sunt : si duo
+							sunt, mentitur qui dicit, <hi rend="italic">Audi , Israel; <lb/> Dominus
+								Deus tuus, Dominus unus est ;</hi> mentitur qui <lb/> dicit, <hi
+								rend="italic">Videte quoniam ego sum Deus , et non cst</hi>
+							<unclear>otius</unclear>
+							<lb/>
+							<hi rend="italic">praeter me (Id.</hi> XXIII, 39). Sed quia illum
+								<unclear>menten­</unclear>
+							<lb/> tem dicere non audetis, quare vos corrigere dubita­ <lb/> tis, et
+							venire vel redire ad catholicam fidem , quae <lb/> Patrem et Filium et
+							Spiritum sanctum non tres do­ <lb/> minos deos, sed unum Dominum Dcum
+							credit et <lb/> audit clamantem populo suo, <hi rend="italic">Audi,
+								Israel; Dominus, <lb/> Deus</hi> tuus, Dominus <hi rend="italic"
+								>unus est;</hi> et, <hi rend="italic">Videte quoniam egu</hi>
+							<lb/> sum <hi rend="italic">Dominus, et non est alius praeter me ?</hi>
+							Si te dicam <lb/> surdum et caecum, qui nec audis ista, nec vides, con­
+							<lb/> tumeliosum sine dubio me putabis. Ecce non dico : <lb/> expone
+							nobis quomodo accipias, <hi rend="italic">Audi, Israel ; Do­ <lb/> minus
+								Deus</hi> tuus , <hi rend="italic">Dominus</hi> unus <hi
+								rend="italic">est :</hi> utrum ibi sit <lb/> intelligendus et
+							Christus, an non sit. Si enim dixeris, <lb/> Ibi est; confiteberis mecum
+							Patrem et Filium unum <lb/> esse Dominum Deum. Si autem responderis,
+							Christum <lb/> non esse ibi intelligendum , duos contra vocem divi­
+							<lb/> nam introducturus es dominos deos, quoniam non <lb/> nogas etiam
+							Christum esse Dominum Deum. Similiter <lb/> abs te quaero quomodo
+							accipias, <hi rend="italic">Videte quoniam ego<lb/> sum Dominus, et non
+								est alius pr</hi>ae<hi rend="italic">ter</hi> me. Ibi est et <lb/>
+							Christus, an non est? Si ibi est, profecto Pater ct <lb/> Filius unus
+							est Dominus : si autem ibi non est, et <lb/> tamen Dominus est; mentitur
+							qui dicit, <hi rend="italic">Non est alius <lb/> praeter me.</hi> Est
+							enim alius Dominus Filius, si non <lb/> unus est Domninus Pater et
+							Filius. Quantumlibet enim <lb/> excellentius laudes Patrem, et infra cum
+							deprimas <lb/> Filium, id agis , ut aequales non sint, non ut duo non
+							<lb/> sint. Clama , quantum vis, Pater est major, Filius <lb/> minor :
+							respondetur tibi, Duo sunt tamen major ct <lb/> minor. Nec dictum cst,
+							Dominus Dens tuus major, <lb/> Dominus unus est : sed dictum est , <hi
+								rend="italic">Dominus</hi> Deus <lb/>
+							<hi rend="italic">tuus, Dominus unus est.</hi> Neque dictum est, Non est
+							<lb/> alius aequalis mihi : sed diclum est, <hi rend="italic">Non est
+								alius <lb/> Dominus praeter me.</hi> Aut ergo confitere Patrem et
+							<lb/> Filium unum esse Dominum Dcum , aut apene nega <lb/> Dominum Deum
+							esse Christum , sicut aperte negas <lb/> Dominum Deum esse Spiritum
+							sanctum. Quod si <lb/> . leceris , istis quidem te divinis vocibus non
+							urgebo, <lb/>
+							<pb n="797"/> sedalia testimonia divina proferam, quibus te et iii <lb/>
+							isto errore detestabiliorem convincam 1. Nunc autem <lb/> et si negas
+							Dominum Deum e se Spiritum sancium, <lb/> tamen ut istis Dei vocibus
+							conteraris, satis est quod <lb/> Christum Dominum Deum confiteris : qui
+							si non est <lb/> cum Patre unus Dominus Ocus, duo domini dii nostri
+							<lb/> erunt, et falsae illae Dei voces erunt, <hi rend="italic">Dominus
+								Deus <lb/> tuus, Dominus unus est ;</hi> et, <hi rend="italic">Non
+								eat alius</hi> praeter <hi rend="italic">me.</hi>
+							<lb/> Scd quanto melius erunt vestra verba emendata, quam <lb/> pei
+							verba mendacia ?</p>
+						<p>i. Quaeris a me utrum , <hi rend="italic">Judaico modo te horter</hi>
+							pro­ <lb/>
+							<hi rend="italic">fiteri</hi> unum <hi rend="italic">Denm; an de
+								subjectione Filii potius secun­<lb/> dum quod fides habet</hi>
+							Christiana , <hi rend="italic">ostendatur unus esse<lb/> Deus, cujus
+								Filius noster est Deus.</hi> Ita hoc dicis, quasi <lb/> Judaeorum
+							sil vox, <hi rend="italic">Audi, Israel; Dominus Deus</hi> tuus, <lb/>
+							<hi rend="italic">Dominus unus est ;</hi> aut, <hi rend="italic">Ego sum
+								Dominus, et non eat <lb/> alius prœter me.</hi> Ipse Deus hoc dixit:
+							agnosce, et <lb/> tace ; vel potius edissere quomodo ,'crum dixerit,
+							<lb/> quem nullus nostrum andet affirmare mentitum. <lb/> Edissere,
+							inquam, quomodo verum st, <hi rend="italic">Dominus Deus</hi>
+							<lb/> tuus, <hi rend="italic">Dominus unus est ;</hi> si domini dii
+							nostri, nt di­ <lb/> citis, duo sunt, unus major , alius minor :
+							edissere <lb/> quomodo verum sit, <hi rend="italic">Ego sum Dominus, et
+								non est</hi>
+							<lb/> alius <hi rend="italic">prœter me.</hi> Quis enim hoc dixcril
+							qu;cro, utrum <lb/> pater, an Filius. Si Pater dixit, <hi rend="italic"
+								>Ego</hi> sum Dominus, <lb/> et <hi rend="italic">non est alius
+								praeter me;</hi> non verum dixit, quia <lb/> est alius Dominus
+							Filius. Si Filius hoc dixit: nee ipse <lb/> verum dixit, quia est alius
+							Dominus Pater. Si autem <lb/> hoc dixit Trinitas ; profecto et verum
+							dixit, et vos <lb/> falsum diccre ostendit. Trinitas quippe secundum
+							<lb/> rectam fidcm , id cst, Pater et Filius et Spiritus san­ <lb/>
+							ctus, in cujus nomine baptizamur, et unus Dominus <lb/> Deus noster est,
+							ct praeter ipsum alius non est. Ipse <lb/> est enim Deus de quo dicit
+							Apostolus : <hi rend="italic">Nullus</hi><hi rend="italic">est<lb/>
+								Deus,</hi> nisi unus (I <hi rend="italic">Cor.</hi> VIII , 4). Nam
+							si hoc de Patre <lb/> acceperis dictum , non tibi ent Deus Christus ,
+							quia <lb/> nun potest solvi Scriptura , dicens, <hi rend="italic">Nullus
+								Deus, nisi</hi>
+							<lb/> unus : ut lic vobis taceam de Spiritu sancto , quem <lb/> superius
+							Dominum Deum ostendimus, vobis neganti­ <lb/> bus. Quapropter si
+							Macedoniani haeretici essetis, qui <lb/> de solo Spiritu sancto
+							catholicae fidei consentire de­ <lb/> trectant, Patrem vero et Filium
+							duos quidem esse, <lb/> id est, illum Patrem , illum Filium , et
+							aequales esse, <lb/> atque unius ejusdemque substantiae, nec tamen duos
+							<lb/> dominos deos, sed ambos simul unum Dominum <lb/> Deum essc
+							consentiunt : si ergo et vos saltem harte­ <lb/> nus erraretis, noh
+							utique his divinis vocibus urgerc­ <lb/> mini. Patrem quippe et Filium
+							assereretis unum Do­ <lb/> minum Deum dixisse , <hi rend="italic">Non
+								est alius prœter me.</hi> Uti­ <lb/> nam non restaret agere
+							vobiscum, nisi ut adjungere­ <lb/> tis Spiritum sanctum, et non
+							dualitatem , sed Trini <lb/> tatem diceretis unum Dominum Deum. Nunc
+							vcro <lb/> cum sic asseritis Patrem Dominum Deum , et Filium <lb/>
+							Dominum Deum , ut simul ambos non dicatis unum <lb/> Dominum Deum, sed
+							duos, majorem unum,minorem <lb/> alterum ;prorsus confodimini gladio
+							veritatis dicentis, <lb/>
+							<hi rend="italic">Audi, Israel ;</hi>Dominus <hi rend="italic">Deus
+								tuus, Dominus unus est:</hi>
+							<lb/> qui clamat, <hi rend="italic">Ego</hi> sum <hi rend="italic"
+								>Dominus, et non est alius</hi> praeter <note type="footnote">I f.r.
+								Usyl. v en., <hi rend="italic">destestabiliorem</hi><hi
+									rend="italic">comincam.</hi> M. </note>
+							<lb/> me. Neque enim Dom Pater sic rellet Israelitas a <lb/> cultu
+							deorum revocare multorum atque falsorum , ut <lb/> eis de uno Deo ac
+							Domino mentiretur, et diceret non <lb/> esse praeter se alium Dominum,
+							cnm sciret Deum et <lb/> Dominum esse suum Filium. Absit ut veritas et
+							veri­ <lb/> tatis Pater mendacio deciperet populum suum : hae­ <lb/>
+							reticorum sit haec , uon catholicorum tam horrenda <lb/> et detestanda
+							blasphemia. Prorsus Deus verum dicit, <lb/> cum dicit, <hi rend="italic"
+								>Audi, Israel; Dominus Dcus tuus, Dominus<lb/> unus est:</hi> quia
+							Patcr ct Filius et Sp ritus sanctus, non <lb/> tres dii, sed unus Deus ;
+							nec tres domini, sed unus <lb/> Dominus est. Prorsus verum dicit, <hi
+								rend="italic">Ego sum Dominus, <lb/> et non estalius prœter me
+								;</hi> quia non hoc Pater tan­ <lb/> lum, sed ipsa Trinitas dicit :
+							hic est Dominus unus, <lb/> ct non alius praeter ipsum, Nam si Pater
+							diceret, <hi rend="italic">Ego <lb/> sum Dominus, et non ert alius
+								prœter me;</hi> negaretuti­ <lb/> que Dominum esse unigenitum
+							Filium. Et quis no­ <lb/> strum auderet eum Dominum confiteri,
+							contradicente <lb/> Patre atquc dicente, <hi rend="italic">Ego sum
+								Dominus, et non eat alius <lb/> prater me?</hi> Ac per boc
+							secundumrectam fidem , non <lb/> Patris, sed T riniiatis haec vox cst:
+							et Patris ergo, et Filii, <lb/> et Spiritus sancti. Obticescant igitur
+							linguae ignoran­ <lb/> tium vcritatcm : haec Trinitas Deus unus est. De
+							hoc <lb/> uno Deo dicitur, Audi, <hi rend="italic">Israel; Dominus Deus
+								tuus,</hi>
+							<lb/> Dominus unus <hi rend="italic">est.</hi> llic Deus unus dicit, <hi
+								rend="italic">Ego</hi> sum <hi rend="italic">Do­ <lb/> minus, et non
+								est alius praeter me.</hi> Subjectus est quidem <lb/> Patri filius
+							secundumformam hominis : non tamen <lb/> sunt duo dii ct duo domini
+							secundum formam De!; <lb/> sed ambo cum Spirilu suo unus cst
+							Dominus.</p>
+						<p>3. Testimonia quae de Paulo apostolo protulisti, <lb/> contra te
+							loquuntur, ct nescis. Dicit enim ille : <hi rend="italic">Gra­<lb/> tia
+								vobis et pax a Deu Patre nostro et Domino</hi> Jesu <lb/>
+							<hi rend="italic">Christo (Rom.</hi> I, 7; I <hi rend="italic">Cor.</hi>
+							I, 3; II <hi rend="italic">Cor.</hi> I, 2; <hi rend="italic">Gulat.</hi>
+							i, <lb/> 3, <hi rend="italic">et Ephes.</hi> I, 2). Quomodo est autem
+							Dominus Je<lb/>sus Christus, si Pater dicit, <hi rend="italic">Ego sum
+								Dominus,</hi> et non <lb/>
+							<hi rend="italic">eat</hi> alius <hi rend="italic">praeter me?</hi> Non
+							ergo solius Patris, ut dixi, <lb/> sed Trinitatis haec vox est. Adhibes
+							alterurn testimo­ <lb/> nium, et ipsum contra te ipsum, ubi ait
+							Apostolus, <lb/>
+							<hi rend="italic">Unus Deus</hi> Puter , <hi rend="italic">ex quo omnia,
+								et noa in ipso ;</hi> et <lb/>
+							<hi rend="italic">unus Dominus</hi> Jesus <hi rend="italic">Christus,
+								per quem omnia, et <lb/> noa in ipso,</hi> sicut tu loculus es :
+							Apostolus autem, <hi rend="italic">a</hi>
+							<lb/> noa <hi rend="italic">per ipsum</hi> ait; non ait, in <hi
+								rend="italic">ipso.</hi> Sed hoc quid ad <lb/> causam ? Solent ista
+							contingere ex memoria proferen <lb/> tibus testimonia, non ex codice
+							illa legentibus : quod <lb/> ad rem pertinet potius intuere. Ecce, dixit
+							Aposto­ <lb/> lus, <hi rend="italic">Unus Deus Pater, ex quo omnia, et
+								nos in</hi> ipso, <lb/>
+							<hi rend="italic">et unus Dominus Jesus Christus,</hi><hi rend="italic"
+								>per quem omnia, et</hi>
+							<lb/> noa <hi rend="italic">per</hi> ipsum <hi rend="italic">Cor.</hi>
+							VIII, 6). Omnino duas personas, <lb/> unam Patris, alteram Filii, sine
+							ulla confusione et <lb/> sine ullo errore distinxit. Neque enim duo sunt
+							dii <lb/> patres, sed unus Deus Pater : nec duo sunt domini <lb/> Jesu
+							Christi, sed unus Dominus Jesus Christus. In <lb/> illa quippe Trinitate
+							quaeDeus cst, unus est Pater, <lb/> non duo vel tres; et unus Filius,
+							non duo vel tres; <lb/> et unus amborum Spiritus, non duo vel tres : ct
+							ipse <lb/> unus Pater utique Deus est, et ipse unus Filius etiam <lb/>
+							vobis fatentibus Deus cst, et ipse amborum Spiritus <lb/> etiam vobis
+							negantibus Deus cst. Sic et Dominiun s <lb/> quaeras, singulum quemque
+							respondeo ; sed simu! <lb/>
+							<pb n="799"/> omnes non Ires dominos tlcos, sud unum Domiuum <lb/> Deum
+							dico. Haec est fides nostra, qnoniam haec fides <lb/> est recta, quae
+							fides etiam catholica nuncupatur. Tu <lb/> antem qui huic fidei
+							contradicis, quaeso te, expone <lb/> nobis, eliam Josus Christus quomodo
+							sit Dominus, <lb/> qui non Trinitatis, sed solius Patris esse asseris
+							vo­ <lb/> cem, <hi rend="italic">Ego sum Dominus, et non est alius
+								praeter me.</hi>
+							<lb/> Nempe turbaris ; nempe quid respondeas non invenis, <lb/> nisi
+							quia tacere, quando convinceris, non vis. Si enim <lb/> non Deus
+							Trinitas, sed Pater tantum dixit, <hi rend="italic">Ego sum <lb/>
+								Dominus, et non est alius prœter me :</hi> procul dubio ne­ <lb/>
+							gavit esse Dominum Filium; quoniam si Dominus est <lb/> pt Filius, falso
+							dictum est, <hi rend="italic">Non eat alius Dominus<lb/> prœter me.</hi>
+							Non enim agitur de Domino, quales sunt <lb/> homines domini hominum
+							servorum, quos Apostolus <lb/> secundum carnem dominos esse dicit <hi
+								rend="italic">(Ephes.</hi> VI, 5 ): <lb/> sed de Domino agitur, cui
+							servitus illa debetur, quae <lb/> graece <foreign xml:lang="grc"
+								>λατρεία</foreign> dicitur, secundum quam dictum est, <lb/>
+							<hi rend="italic">Dominum Deum</hi> tuum <hi rend="italic">adorabis, et
+								illi soli servies (Deut,</hi>
+							<lb/> VI, 13). Qui Dominus Deus si non Trinitas, sed solus <lb/> est
+							Pater : prohibemur utique Domino Cbristo tali <lb/> servitude servire,
+							in <hi rend="italic">eo</hi> quod audimus, <hi rend="italic">Illi soli
+								aer­</hi>
+							<lb/> vies ; si ita dictum est, ac si diccrelur, Deo Patri soli <lb/>
+							servies. Qui profecto si solus, et non ipsa Trinitas <lb/> dixit, <hi
+								rend="italic">Ego</hi> sum DorMiMus, <hi rend="italic">et</hi> non
+								<hi rend="italic">eat alius</hi> prœter <hi rend="italic">me;</hi>
+							<lb/> negavit csse Filium Dominum talem, quali domino <lb/> servitus
+							illa debetur, qua nonnisi Deo cum vera ret!­ <lb/> gione servitur. Non
+							enim dixit, Ego sum Dominus <lb/> majoraut melior*et non est tantus aut
+							talis praeter <lb/> ine : sed volens sibi soli ea quae Domino Deo
+							debetur <lb/> servitute serviri, <hi rend="italic">Ego sum,</hi> inquit,
+								<hi rend="italic">Dominus, et non est<lb/> alius</hi> praeter <hi
+								rend="italic">me.</hi> Porro si vox ista, sicut catholica fi­ <lb/>
+							des dicit, unius Dei est, quod est ipsa Trinitas; sine <lb/> ulla
+							dubitatione huic soli serviendam est ea servitute, <lb/> quae nonnisi
+							Domino Deo debetur, quia ipse est Do­ <lb/> minus, et non est alius
+							praeter ipsum.</p>
+						<p>4. Deinde quaero quomodo accipias quod dictum <lb/> est, Unus <hi
+								rend="italic">Deus Pater, ex quo omnia, et nos</hi> in <hi
+								rend="italic">ipso; <lb/> et</hi> unus <hi rend="italic">Dominus
+								Jesus</hi> Christ: s, <hi rend="italic">per quem omnia, et noa <lb/>
+								per</hi> ipsum. Numquid non et ex Filio sunt omnia : <lb/>
+							quandoquidem ipse dicit, <hi rend="italic">Quœcumque Pater facit,
+								haec<lb/> et</hi> Filius <hi rend="italic">similiter facit
+								(Joan.</hi> v, 19)? Si autem ita dis­ <lb/> linguis, ut non sint per
+							Patrem omnia, sed ex Patre; <lb/> nec omnia sint ex Filio, sed per
+							Filium : quis eorum <lb/> tihi vidctur esse illc de quo idem apostolus
+							dicit, 0 <lb/>
+							<hi rend="italic">altitudo diritiarum</hi><hi rend="italic">sapientiœ et
+								scientiœ Dei ! quam in­ <lb/> scrutabilia sunt judicia ejus, et
+								investigabiles viœ ejus ! <lb/> Quis enim cognovit sensum</hi>
+							Domini ? <hi rend="italic">Aut quis consilia­</hi>
+							<lb/> rius <hi rend="italic">ejus</hi> fuit ? <hi rend="italic">Aut quis
+								prior dcdit illi, et retribuetur ei? <lb/> Quoniam ex</hi> ipso, <hi
+								rend="italic">et per ipsum, et in ipso</hi> sunt <hi rend="italic"
+								>omnia : <lb/> ip1i gloria in sœcula</hi> sœculorum. Amen <hi
+								rend="italic">(Rom.</hi>XI, 33-36). <lb/> Utrum Pater eat
+							intelligondus, an Filius? Deum nam­ <lb/> que prius nominavit, dicens :
+							0 <hi rend="italic">allitudo divitiarum sa­</hi>
+							<lb/> pientiae <hi rend="italic">et scientia Dei!</hi> Postea vcro eum
+							Dominum ap­ <lb/> pellait. ubi ait: <hi rend="italic">Quis enim</hi>
+							cognovit sensum <hi rend="italic">Domini?</hi> Sed <lb/> hocnon habet
+							controversiam :utrumque eniin nomen <lb/> etiam vos et Patri assigNatis
+							et Filio. Neque enim sic <lb/> dicitis DeumPatrem, ut negetis esse Deum
+							Filium; <lb/> tut sic dicitis Deum Filium, ut negetis esse Dcum Pa­
+							<lb/> trem. Quatnvis in hoc ap ostolico testimonio quod ad­ <lb/>
+							hibuisti, Deus dicatur Pater, Do t imis Filius, id est, <lb/>
+							<hi rend="italic">Unus Deus</hi> Pater, <hi rend="italic">ex quo omnia;
+								et</hi> unus Dominus <hi rend="italic">Je­ <lb/> sus Christus, per
+								quem omnia.</hi> Sed illud attende abi di­ <lb/> ctum est. <hi
+								rend="italic">0 altitudo divitiarum</hi><hi rend="italic">sapientiae
+								et</hi> scientiae <lb/>
+							<hi rend="italic">Dei!</hi> Nam sive Pater sit iste, sive Filius, <hi
+								rend="italic">ex ipso, et <lb/> per</hi> ipsum, <hi rend="italic"
+								>et</hi> in <hi rend="italic">ipso sunt omnia.</hi> Quomodo ergo ex
+							<lb/> Patre omnia, non ex Filio; et per Filium omnia, non <lb/> per
+							Patrem : quandoquidem quemlibet eorum Apo­ <lb/> stolus voluerit hoc
+							loco intelligi, <hi rend="italic">Ex</hi> ipso , inquit, <hi
+								rend="italic">et</hi>
+							<lb/> per ipsum, <hi rend="italic">et</hi> in <hi rend="italic">ipso
+								sunt omnia?</hi> Si ergo sive de Pa­ <lb/> tre sive de Filio,
+							verissime tamen dicitur, quod ex <lb/> ipso <hi rend="italic">et per
+								ipsum, et in ipso sunt</hi> omnia; sine dubio <lb/> Patris et Filii
+							demonstratur aequalitas. Si autem quo­ <lb/> niam non nominavit Patrem
+							et Filium et Spiritum <lb/> sanctum, sed Dcum et Dominum, quod et ipsa
+							Trini­ <lb/> tas dici potest, singula horum trium referri ad singu­
+							<lb/> los voluit : <hi rend="italic">ex ipso</hi> dicens, propter
+							Patrem; <hi rend="italic">et per <lb/> ipsum,</hi> propter <hi
+								rend="italic">Filium ; in ipso,</hi> propter Spiritum san­ <lb/>
+							ctum : cur hanc Trinitatem unum DominumDeum <lb/> non vultis agnoscere?
+							Quandoquidem non ait, Ex <lb/> ipsis, et per ipsos, et in ipsis; sed
+							ait, <hi rend="italic">ex ipso; et per</hi>
+							<lb/> ipsum, <hi rend="italic">et in ipso sunt</hi> omnia : nec ait,
+							Ipsis gloria; sed, <lb/>
+							<hi rend="italic">ipsi gloria</hi> in saecula sPeculorum. <hi
+								rend="italic">Amen.</hi>
+						</p>
+						<p>5. Falleris sane, qui putas de Patre solo esse di­ <lb/> ctum, <hi
+								rend="italic">Nemo bonus, nisi unus Deus.</hi> Si enim dixisset,
+							<lb/> Nemo bonus, nisi unus Patcr; nee sic exclusum Fi­ <lb/> lium et
+							Spiritum sanctum ab ista unitate bonitatis vo­ <lb/> luisset intelligi :
+							quia et illud quod simili locutiono <lb/> dictum est, quam supra
+							commemoravi, <hi rend="italic">Ea quœ</hi><hi rend="italic">Dei <lb/>
+								sunt, nemo scit, nisi Spiritus Dei (I Cor.</hi> n, 41): non <lb/>
+							excludit ab hac scientia Filium Dei. Quanto ergo no­ <lb/> bis latitudo
+							intelligentiae magis patet, quia non dixit, <lb/> Nemo bonus, nisi unus
+							Pater; sed, <hi rend="italic">Nemo bonus,</hi> nisi <lb/> unus <hi
+								rend="italic">Deus;</hi> quod est ipsa Trinitas. Quaerebat quippe
+							<lb/> ille cui hoc respondit Jesus, non bonum qualecumque, <lb/> sed
+							bonum quo fieret beatus; imo ipsam beatitudinem <lb/> veram, id est,
+							vitam desiderabat aeternam : et inter­ <lb/> pellaverat tanquam hominem
+							Christum, nescicns eum <lb/> esse etiam Deum. Dixerat enim : <hi
+								rend="italic">Magister bone, quid <lb/> faciam, ut vitam</hi>
+							aeternam consequar ? Tunc ait ille: <lb/>
+							<hi rend="italic">Quid me dicis bonum? Nemo bonus,</hi> nisi unus <hi
+								rend="italic">Deus <lb/> (Marc.</hi> x, 17, 18). Vel, sicut legitur
+							apud alium evan­ <lb/> gelistam, qnod tantumdem valet, <hi rend="italic"
+								>Nemo bonus,</hi> nisi <lb/>
+							<hi rend="italic">solus Deus (Luc.</hi> XVIII, 19). Tanquam diceret :
+							Recte <lb/> mc appellabis bonum, si me noveris Deum. Nam <lb/> qnando me
+							nihil aliud quam hominem putas, quid me <lb/> dicis bonum ?Non te facit
+							bonum nec bcatum, nisi <lb/> bonum immutabile quod solus est Deus. Nam
+							bonus <lb/> angelus, bonus homo, bona caetera creatura : haec <lb/> non
+							ita bona sunt, ut ea quisquis adeptus fuerit, sit <lb/> beatus; nec ulla
+							est beata vita, si non sit aeterna. <lb/> Quomodo autem non est tale
+							bonum Dei Filius ve­ <lb/> rus, cumsit verus Deus et vita aeterna, ad
+							quam cu­ <lb/> piebat ille qui interrogaverat pervenire ?</p>
+						<p>6. Proinde cum ego asseram, <hi rend="italic">Nemo bonus,</hi> nisi unus
+							<lb/> et <hi rend="italic">solus Deus,</hi> de ipsa Trinitate dictum
+							esse, qui Deus <lb/> unus et solus est; tu autcm asseras de solo Dco Pa­
+							<lb/> tre dictum esse, quia ipse de nullo alio Deus, de nullo <lb/>
+							<pb n="801"/> alio honus est ; Filius autem de Patre Dcus, de Patre
+							<lb/> magnus et bonus est diligenter attende quis nostrum <lb/> bene
+							sentiat de Deo Patre et de Deo Filio; utrum <lb/> ego qui dico, Dens
+							quidem Pater, non de alio Dco <lb/> Deus est, Deus autem Filius de Patre
+							Deo Deus est, <lb/> sed tantus iste de illo, quantus ille de nullo ; et
+							bo­ <lb/> nus Pater non de alio bono bonus est, Filius vero de <lb/>
+							Pairc buno bonus est, sed tam bonus hic de illo, <lb/> quam bonus ille
+							de nullo : an tu qui propterea dicis <lb/> solum esse Patrem Deum bonum,
+							quia nec Deus est <lb/> de alio Dco,nec bonus de alio bono; Filium vero
+							<lb/> idco Patri non esse cocequandum, quia de illo Deus <lb/> est, de
+							illo bonus est? In qua sententia utrumque <lb/> blasphemas : et Patrem
+							scilicet, quia non tantum ge­ <lb/> nuit quantus cet ipse, nec talem
+							qualis est ipse; et <lb/> Filium, quia talis tantusque nasci non meruit,
+							qualis <lb/> quantusque est ille qui genuit. Denique ista ipsa duo <lb/>
+							de quibus agimus, hoc cst, dcitas et bonitas, quoniam <lb/> dictum est,
+								<hi rend="italic">Nemo</hi> bonus, nisi <hi rend="italic">unus
+								Deus,</hi> in hac tua <lb/> opinione deficiunt. Tantum enim quantus
+							est ipse, et <lb/> talem qualis est ipse, si non potuit gignere, quomodo
+							<lb/> Dens est? si noluit, quomodo bonus cst?</p>
+						<p>7. <hi rend="italic">Pater,</hi> inquis, <hi rend="italic">fons</hi>
+							bonitatis <hi rend="italic">est, qui quod est</hi> bo­ <lb/> nIs <hi
+								rend="italic">a nemine accepit.</hi> Numquid ideo minus bonus est
+							<lb/> Filius, quoniam quod bonus est, ab eo Patrc accepit, <lb/> qui
+							naseenli Filio tantam bonitatem quantacumque <lb/> illi est, quia Deus
+							est, dare potuit; et dedit, quia bo­ <lb/> nus invidere non potuit ? Nam
+							si minus bonitatis, <lb/> quam quod ipse habet unico dedit, minus bonus
+							est <lb/> et ipse quam debuit : quod sentire dementiae est. Er­ <lb/> go
+							quantum ipse habet bonitatis, tantum F:lio de­ <lb/> dit *. Et quia
+							natura est, non gratia Filius, na­ <lb/> scenti, non indigenti dedit; et
+							plenus plenum, fons <lb/> bonitatis fontem genuit bonitatis. Ac per boc
+							nec <lb/> auxit in se hic quod accepit, nec minuit in se ille qui <lb/>
+							dedit 2: quia non habet immutabilitas unde defi­ <lb/> ciat, non habet
+							plenitudo quo crescat. Quid est <lb/> autem ipsa bonitas , nisi vita
+							vivificans ? Proin­ <lb/> de quia fons fontem genuit, <hi rend="italic"
+								>sicut Pater suscitat mor­ <lb/> tuos et vivificat, sic et Filius
+								quos vult vivificat</hi> (Joan. <lb/> v , 21). Hoc ipse Filius
+							dixit, non ego. Unde merito <lb/> Deo Patri dicitur, <hi rend="italic"
+								>Quoniam apud te eat fons vitae.</hi> Quis <lb/> est autem iste fons
+							vitae apud Patrem, nisi de quo di­ <lb/> citur, In <hi rend="italic"
+								>principio erat</hi> Verbum, <hi rend="italic">et</hi> Verbum <hi
+								rend="italic">erat apud <lb/> Deum, et Deus erat Verbum; hoc
+								erat</hi> in <hi rend="italic">principio apud <lb/> Deum</hi> : de
+							quo etiam paulo post dictum est, <hi rend="italic">Et tila<lb/> erat
+								lux</hi> hominum <hi rend="italic">(Id.</hi> i, 1, 2, 4)? Haec vita
+							fons vitae <lb/> est, et lux ista lux lucis est. Unde cum dictum esset, <lb/>
+							<hi rend="italic">Apud te est fons vitae;</hi> continuo subjunctum est,
+								<hi rend="italic">In <lb/> lumine tuo videbimus lumen</hi> (Psal.
+							XXXV, 10), hoc est, <lb/> in Filio luo Spiritum sanctum ; quem tu quoque
+							esse <lb/> illuminatorem in Collationis nostrae priina parte nrm <lb/>
+							fessus es. Fons ergo de fonte, Filius de Patra, et si­ <lb/> mul ambo
+							fons unus: lux de luce, Filius de Patre, et <lb/> simul ambo lux una :
+							sicut Dcus de Dco, et simul <lb/> ambo utique Deus unus: et hoc totum
+							non sine Spi­ <lb/> ritu amborum. Ex hoc fonte bonitatis, ex hoc fonte
+								<note type="footnote">* ouxlam Mss., <hi rend="italic">tantfui Vmco
+									dedit.</hi>
+							</note><note type="footnote"> 'sic Myg. Editi vcro, <hi rend="italic"
+									>quod dedit.</hi>
+							</note>
+							<lb/> vitae, ex hoc immutabili lumine, ex hac indeficiente <lb/>
+							plenitudine, id est, Patre, et Filio, et Spiritu sancto, <lb/> uno
+							Domino Dco solo, sccundum mensuram fidei su:e <lb/> quicumque veraciter
+							credunt, sumentes boni fiunt, vi­ <lb/> vificantur, illuminantur,
+							implentur. Quibus tu unige <lb/> nilum Filium, pace tua dixcrim, nescio
+							qua incredi­ <lb/> bili temeritate junxisti. Tua quippe ista sunl verba
+							: <lb/>
+							<hi rend="italic">Sive,</hi> inquis, <hi rend="italic">Filius, sive qui
+								per Filium sunt facti, de <lb/> illo uno fonte bonitatis unusquisque
+								secundum mensu­ <lb/> ram fidei suae assumpserunt ut essent
+								boni.</hi> Ubi est ergo <lb/> quod fueras ante confessus, illum
+							natura Filium esse, <lb/> non gratia 1? Ecce contra sententiam luam
+							venis: ecce <lb/> jam prodis nefarium secretum haeresis vestrae, quia
+							<lb/> unigenitum verum Dei Filium, verum Dcum, non na­ <lb/> tura
+							Filium, sed gratia profitemini. Si enim et ipse, <lb/> sicut verba tua
+							clamant, secundum mensuram fidei <lb/> SUm, ut bonus esset, assumpsit;
+							gratia est ergo Fi­ <lb/> lius, non natura : cL fuit aliquando non
+							bonus, et cre­ <lb/> dendo factus est bonus; quia ut esset bonus,
+							quemad­ <lb/> modum dicis, secundum mensuram fidei suae de illo <lb/>
+							qui Pater est, fonte bonitatis assumpsit. Legimus qui­ <lb/> dcm quod
+								<hi rend="italic">Jesus</hi> proficiebat aetate et <hi rend="italic"
+								>sapientia, et gratia <lb/> Dei erat</hi> in <hi rend="italic">illo
+								(Luc.</hi> II, 52) : sed secundum formaro <lb/> hominis quam pro
+							nobis accepit ex nobis, non secun­ <lb/> dum formam Dei, in qua non
+							alienam arbitratus est <lb/> esse aequalis Deo <hi rend="italic"
+								>(Philipp.</hi> II, 6). Verumtamen etiam <lb/> in ipsa forma hominis
+							legimus eum aetate et sapientia <lb/> profccissc, non tamen ut ex non
+							bono bonus fieret <lb/> credendo meruisse. Neque nunc inter nos quaestio
+							<lb/> vertitur de natura filii hominis, in qua Dei Filius mi­ <lb/> nor
+							cst Patre: sed de natura Filii Dei, in qua, ut nos <lb/> dicimus, vos
+							negatis, aequalis es. Patri : quia Filius <lb/> verus, Filius unicus,
+							Filius de vero Deo verus Dcus, <lb/> in nullo degeneravit a Patre.
+							Proinde incomparabi­ <lb/> lem Patrem Filio, nec in Scripturis sanctis
+							alicubi <lb/> legere potuisti. Nec sana fide ipse dixisti immensum <lb/>
+							etiam Patrem; quoniam propterea dicis, ut Filium <lb/> non pariter
+							immensum, sed mensura existimes ter­ <lb/> minatum. Tecum habeto
+							mensuram tuam, qua <lb/> tuum falsum dominum metiaris, et de vero Domino
+							<lb/> mentiaris.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="24">
+						<p>CAPUT XXIV. — Bene confiteris quod et Pater <lb/> diligat Filium, et
+							Filius diligat Patrem : sed si et hoc <lb/> confitcaris, quia non est
+							major dilectio in Patre quam <lb/> in Filio. Quia cnim natura
+							divinitatis a quales sunt, <lb/> aequaliter se invicem diligunt. Facit
+							autem Filius sic­ <lb/> ut homo mandatum Patris. Nani sicut Deus, ipse
+							Fr- <lb/>
+							<lb/> lius est mandatum Patris, quia ipse est Verbum Pa­ <lb/> tris.
+							Unde alio loco de mandato Patris, hoc est, de se <lb/> ipso dicit : <hi
+								rend="italic">Scio quia mandatum ejus vita aeterna est <lb/>
+								(Joan.</hi> XII, 50). Quod autem ipse Dei Filius sit vin <lb/>
+							aeterna, Scriptura divina testatur. Ubi autem ait, <hi rend="italic">Qni
+								<lb/> me vidit, vidit et Patrem (Id.</hi> XIV, 9); quis nesciat ideo
+							<lb/> dictum, quoniam quisquis per intelligentiam videt Fi­ <lb/> lium,
+							Patri utique videt aequalem? Quod vos ideo non <lb/> vultis, quia per
+							oculos cordis, quantum ia bac <unclear>vita­</unclear>
+							<lb/> viden potest, Filium non videtis. <note type="footnote">* Plores
+								Mss., <hi rend="italic">nvs gratia.</hi>
+							</note></p>
+						<pb n="803"/>
+					</div>
 
-				<div type="textpart" subtype="chapter" n="25">
-					<p>CAPUT XXV. — Putas non recte a me dictum esse, <lb/> qnod propter formam servi
-					quam suscepit Filius (Phi­ <lb/>
-					<hi rend="italic">lipp.</hi> II, 7), major sil Palcr. Tu enim secundum hae­
-					<lb/> resim vestram, in ipsa Dei forma Patrem Filio vis esse <lb/> majorem : cui
-					paternam sic invides formam, ut ideo <lb/> perfectum velis natum esse Filium
-					aeterna perfectio­ <lb/> ne, ne ad paternam formam saltem crescendo valcai <lb/>
-					pervenire. Sed inaniter invidet homo paternam for­ <lb/> mam Dei Filio, cui
-					Pater eam non invidit, quia aequa­ <lb/> lem sibi unicum genuit. Sed dicis non
-					esse Patris <lb/> . magnam gloriam, si ea forma servi major est, qua <lb/> forma
-					sunt majores et Angeli. Vide si aliud conaris, <lb/> nisi ad unius Patris
-					gloriam, per unici Filii contume­ <lb/> liam pervenire, ut sciliccl non augeatur
-					Pater in glo. <lb/> ria, nisi minuatur Filius in natura. Cohibe te: nescis <lb/>
-					et Patri et Filio te ingerere contumeliam, si nec ille <lb/> potuit aut noluit
-					gignere aequalem sibi, nec iste nasci <lb/> aequalis Puni? Non sc vult Deus ita
-					laudari Patrem, <lb/> ut Filimn dicatur de se ipso generasse degenerem. <lb/>
-					Non vult bonus Filii dilector iia praedicari formam <lb/> suam, ut eam non
-					polucril unicus (jus vcl nascendo <lb/> sumere, vel crescendo comprehendere.
-					Quod autem <lb/> libi videtur nihil magnum de Dco Patrc dici, si forma <lb/>
-					servi major est; qua majores videntur et Angeli: non <lb/> recte cogitas quem
-					locum in rebus habeat humana <lb/> natura, quae condita esi ad imaginem Dei.
-					Majores <lb/> Angeli dici possunt homine, quia majores sunt homi­ <lb/> nis
-					corpore: majores sunt et animo, sed in forma <lb/> quam peccati originalis
-					merito <unclear>curruptihile</unclear> aggravat <lb/> corpus. Natura vero
-					humana, qualem naturam Chri­ <lb/> stus humanae mentis assumpsit, quae nullo
-					peccato <lb/> potuit depravari, solus major est Deus. Denique pro­ <lb/> pler
-					quid dictum sit, <hi rend="italic">Minorasti eum modico</hi> minus <hi
-						rend="italic">quam</hi>
-					<lb/> angelos <hi rend="italic">(Psal.</hi> VIII, 6); apcruit Scriptura, ubi
-					legitur, <lb/>
-					<hi rend="italic">Eum</hi> autem modico minus <hi rend="italic">quam
-						angelos</hi> minoratum <hi rend="italic">vi­ <lb/> dimus</hi> Jesum <hi
-						rend="italic">propter passionem</hi> mortis <hi rend="italic">(llebr.</hi>
-					II, 9). <lb/> Non ergo propter naturam hominis; sed, <hi rend="italic">propter
-						pas­<lb/> sionem mortis.</hi> Natura vero hominis, quae mente ra­ <lb/>
-					tionali et intellectuali creaturas caeteras antecedit, <lb/> Deus solus est
-					niajor: cui utique injuria facta non <lb/> est, ubi scriptum est, <hi
-						rend="italic">Major est Deus corde</hi> nostro <lb/> (I <hi rend="italic"
-						>Joan.</hi> III, 20). Filius ergo Dci susceptum hominem <lb/> levaturus ad
-					Patrem quando dicebat, <hi rend="italic">Si diligeretis me,</hi>
-					<lb/> I gauderetis <hi rend="italic">utique, quia t'ado ad Patrem; quia
-						Pater</hi>
-					<lb/> major <hi rend="italic">me eat (Joan.</hi> xiv, 28); non carni suae solum,
-					sed <lb/> eliam menti, quam gerebat, humanae Deum Patrem <lb/> utique
-					praeferebat : quae tota sine dubio forma agno­ <lb/> scitur servi, quoniam tota
-					servit creatura Creatori.</p>
+					<div type="textpart" subtype="chapter" n="25">
+						<p>CAPUT XXV. — Putas non recte a me dictum esse, <lb/> qnod propter formam
+							servi quam suscepit Filius (Phi­ <lb/>
+							<hi rend="italic">lipp.</hi> II, 7), major sil Palcr. Tu enim secundum
+							hae­ <lb/> resim vestram, in ipsa Dei forma Patrem Filio vis esse <lb/>
+							majorem : cui paternam sic invides formam, ut ideo <lb/> perfectum velis
+							natum esse Filium aeterna perfectio­ <lb/> ne, ne ad paternam formam
+							saltem crescendo valcai <lb/> pervenire. Sed inaniter invidet homo
+							paternam for­ <lb/> mam Dei Filio, cui Pater eam non invidit, quia
+							aequa­ <lb/> lem sibi unicum genuit. Sed dicis non esse Patris <lb/> .
+							magnam gloriam, si ea forma servi major est, qua <lb/> forma sunt
+							majores et Angeli. Vide si aliud conaris, <lb/> nisi ad unius Patris
+							gloriam, per unici Filii contume­ <lb/> liam pervenire, ut sciliccl non
+							augeatur Pater in glo. <lb/> ria, nisi minuatur Filius in natura. Cohibe
+							te: nescis <lb/> et Patri et Filio te ingerere contumeliam, si nec ille
+							<lb/> potuit aut noluit gignere aequalem sibi, nec iste nasci <lb/>
+							aequalis Puni? Non sc vult Deus ita laudari Patrem, <lb/> ut Filimn
+							dicatur de se ipso generasse degenerem. <lb/> Non vult bonus Filii
+							dilector iia praedicari formam <lb/> suam, ut eam non polucril unicus
+							(jus vcl nascendo <lb/> sumere, vel crescendo comprehendere. Quod autem
+							<lb/> libi videtur nihil magnum de Dco Patrc dici, si forma <lb/> servi
+							major est; qua majores videntur et Angeli: non <lb/> recte cogitas quem
+							locum in rebus habeat humana <lb/> natura, quae condita esi ad imaginem
+							Dei. Majores <lb/> Angeli dici possunt homine, quia majores sunt homi­
+							<lb/> nis corpore: majores sunt et animo, sed in forma <lb/> quam
+							peccati originalis merito <unclear>curruptihile</unclear> aggravat <lb/>
+							corpus. Natura vero humana, qualem naturam Chri­ <lb/> stus humanae
+							mentis assumpsit, quae nullo peccato <lb/> potuit depravari, solus major
+							est Deus. Denique pro­ <lb/> pler quid dictum sit, <hi rend="italic"
+								>Minorasti eum modico</hi> minus <hi rend="italic">quam</hi>
+							<lb/> angelos <hi rend="italic">(Psal.</hi> VIII, 6); apcruit Scriptura,
+							ubi legitur, <lb/>
+							<hi rend="italic">Eum</hi> autem modico minus <hi rend="italic">quam
+								angelos</hi> minoratum <hi rend="italic">vi­ <lb/> dimus</hi> Jesum
+								<hi rend="italic">propter passionem</hi> mortis <hi rend="italic"
+								>(llebr.</hi> II, 9). <lb/> Non ergo propter naturam hominis; sed,
+								<hi rend="italic">propter pas­<lb/> sionem mortis.</hi> Natura vero
+							hominis, quae mente ra­ <lb/> tionali et intellectuali creaturas
+							caeteras antecedit, <lb/> Deus solus est niajor: cui utique injuria
+							facta non <lb/> est, ubi scriptum est, <hi rend="italic">Major est Deus
+								corde</hi> nostro <lb/> (I <hi rend="italic">Joan.</hi> III, 20).
+							Filius ergo Dci susceptum hominem <lb/> levaturus ad Patrem quando
+							dicebat, <hi rend="italic">Si diligeretis me,</hi>
+							<lb/> I gauderetis <hi rend="italic">utique, quia t'ado ad Patrem; quia
+								Pater</hi>
+							<lb/> major <hi rend="italic">me eat (Joan.</hi> xiv, 28); non carni
+							suae solum, sed <lb/> eliam menti, quam gerebat, humanae Deum Patrem
+							<lb/> utique praeferebat : quae tota sine dubio forma agno­ <lb/> scitur
+							servi, quoniam tota servit creatura Creatori.</p>
+					</div>
+					<div type="textpart" subtype="chapter" n="26">
+						<p>CAPUT XXVI. — i. Postrema tibi disputatio fuit, <lb/> quomodo sit Deus
+							patribus visus, quando corpus <lb/> humanum in quo videretur, nondum
+							acceperat Chri­ <lb/> stus, cam invisibilis sit per se ipsa divina
+							natura. <lb/> Quod cum eliam tu ila confessus fueris ut inter c;c- <lb/>
+							tera non solum Patrem, sed nec ipsum Filium in <lb/> substantia
+							divinitatis suae diccres esse visibilem, non <lb/> solum hominibus, sed
+							nee ipsis coelestibus potestati­ <lb/> bus : postea, mutata sententia,
+							dicis eum et ante in­ <lb/> carnationem suam conspectibus apparuisse
+							morta­ <lb/> lium, asserens illud quod ait Apostolus , <hi rend="italic"
+								>Quem nemo <lb/> hominum vidit, nec videre potest</hi> (I <hi
+								rend="italic">Tim.</hi> VI, 16), do <lb/> solo Deo Patre dictum
+							esse; Filium vero ex initic <lb/> generis humani videri solitum esse ab
+							hominibus. <lb/> Quod cum probare voluisses, nulia de Scripturis san­
+							<lb/> ctis testimonia protulisti, quae te nihil adjuvare po­ <lb/>
+							luerunt. Non cnim legis alicubi scripsisse Moyse , <lb/> sicut dicis,
+							quod ab illo primo homine Adam usque <lb/> ad ipsam incarnationem semper
+							Filius visus est. Hoc <lb/> enim cum describere pronuntias in Geneseos
+							libro, <lb/> quod ita falsum est, ut etiam ridiculum sit. Numquid <lb/>
+							eniin liber Geneseos , ab Adam usque ad incarnatio­ <lb/> nem Christi,
+							ea quae gesta sunt continet? aut ipsg <lb/> Moyses usque ad tempora
+							incarnationis Christi, vel in <lb/> carne vixit, vel ea quae facta sunt
+							scripsit? Haec <lb/> dicis, et putas te aliquid dicere, vcl putaris ab
+							cis <lb/> qui nee ista possunt, quae tam manifeste falsa sunt ; <lb/>
+							cernere.</p>
+						<p>2. Deinde quod commemoras Patrem ad Filium di­ <lb/> centem, <hi
+								rend="italic">Faciamus</hi> hominem <hi rend="italic">ad
+								imaginem</hi> et similitudi­ <lb/>
+							<hi rend="italic">nem</hi> nostram ; quid hoc ad rem pertinet, rogo te?
+							quid <lb/> ad rem pertinet? Tantumne tibi vajabat loqui, ut non <lb/>
+							attendens quid probare susceperas , memoritcr nobis <lb/> et inaniter
+							Scripturam Geneseos ventilares? Num­ <lb/> quid hinc probatur ante
+							carnem susceptam visus ab <lb/> hominibus Christus, quia dixit Pater ad
+							Filium, Fa <lb/> ciamus <hi rend="italic">hominem ad imaginem et
+								similitudinem nostram ?</hi>
+							<lb/> Deinde adjungis, ac dicis, <hi rend="italic">Et fecit Deus hominem
+								(Gen.</hi>
+							<lb/> I. 26, 27) : atque addis, <hi rend="italic">Quis Dens, nisi Filius
+								?</hi> Et <lb/> ut mihi de opere quasi praescribas meo, <hi
+								rend="italic">Hoc</hi> utique, <lb/> inquis, <hi rend="italic"
+								>et</hi> tu <hi rend="italic">in tuis tractatibus exposuisti.</hi>
+							Ubi nolo <lb/> quaerere quam verum loquaris, quando video nibil <lb/> ad
+							causam pertinere quod loqueris. Agitur quippe in­ <lb/> ter nos, utrum
+							per suae divinitatis. substantiam <lb/> Christus visibus apparuisset
+							humanis. Et tu dicis, <lb/>
+							<hi rend="italic">Fecit Deus hominem :</hi> et addis, <hi rend="italic"
+								>Quis Deus, nisi</hi>
+							<lb/> Filius ? quasi propterea necesse fuerit ut homo <lb/> Deum
+							opificem suum videret oculis carneis. Hoc si <lb/> ita esset, omnes
+							homines viderent Deum : quit <lb/> enim alius eos facit in uteris matrum
+							? Adhuc ad­ <lb/> jicis talia, et dicis : <hi rend="italic">Iste ergo
+								Filius qui est propheta</hi>
+							<lb/> sui genitoris, <hi rend="italic">dicebut</hi> : « Non est <hi
+								rend="italic">bonum solum esse <lb/> hominem, faciamus</hi> ei
+							adjutorium <hi rend="italic">secundum se</hi> &gt; <hi rend="italic"
+								>(Id.</hi>
+							<lb/> II, 18). Si quaeram , quis tibi indicaverit quia Filius <lb/> hoc
+							dicebat, in quibus angustiis te videbis? Scriptura <lb/> enim qua;
+							dixit, <hi rend="italic">In principio fecit Deus caelum et ter­</hi>
+							<lb/> ram, non exprimens utrum Pater, an Filius, an Spi­ <lb/> ritus
+							sanctus, an ipsa Trinitas fecerit, qui unus est <lb/> Deus; per caetera
+							eliam ita commemorat Deum, nt <lb/> dicat, Et <hi rend="italic">fecit
+								Deus, Et</hi> dixit <hi rend="italic">Deus,</hi> per quaeque opera
+							<lb/> ejus, quorum illum asserit conditorem. Simili ergo <lb/> locutione
+							ait, <hi rend="italic">lit Dixit Deus, Faciamus hominem ud <lb/>
+								imaginem</hi> et similitudinem <hi rend="italic">nostram. Et
+								fecit</hi> Deus homi­ <lb/> nem : nec aliter locuta est, ubi nit,
+								<hi rend="italic">Non eat bonum</hi> esse <lb/>
+							<hi rend="italic">hominem solum; faciamus</hi> ei <hi rend="italic"
+								>adjutorium secundum</hi> st. <lb/> Unde igitur tibi persuasum est,
+							caetera suj eriora Pa­ <lb/> trem dixisse, hoc autem Filium? Unde,
+							quaeso, dis­ <lb/> tinguis, unde discernis Patrem dixisse, <hi
+								rend="italic">Fiat lux (Id.</hi>
+							<lb/> I, 1-27), ct caetera ; Patrem denique dixisse, <hi rend="italic"
+								>Faciamus <lb/> hominem;</hi> ct Filium dixisse, <hi rend="italic"
+								>Faciamus ei adjutorium:</hi>
+							<lb/>
+							<pb n="805"/> rum tibi Scriptura Ubique nob dicat nisi, <hi
+								rend="italic">Dixit Deus ?</hi>
+							<lb/> Quae est ista temeritas ? quae praesumptio ? Dcinde cum <lb/> idco
+							Patrem majorem soleatis asserere, quia dixit, <lb/> Fiat hoc, aut illud,
+							tanquam jubens Filio; Filium <lb/> vero ideo minorem , quia jussa
+							perfecit : quid dicturi <lb/> estis, ubi scriptum est, <hi rend="italic"
+								>Faciamus</hi> hominem ? Non enim <lb/> ait sicut in superioribus,
+							Fiat homo, tanquam id jus <lb/> serit Filio : sed, <hi rend="italic"
+								>Faciamus,</hi> inquit, <hi rend="italic">hominem.</hi> Quod noa
+							<lb/> quaero quem dixisse arbitreris : jam enim verba tua <lb/> tenemus,
+							quod Pater hoc dixerit Filio. Cur ergo non <lb/> ait, Fiat, vel, Fac;
+							sed ait, <hi rend="italic">Faciamus?</hi> An caetera <lb/> Deus
+							imperavit, et Filius fecit; bominem vero ambo <lb/> fecerunt, sed Patre
+							et jubente, et cooperante, Filio <lb/> autem non jubente I, sed tantum
+							jussa faciente ? Sed <lb/> si propterea Patrem jubentem intelligis, quia
+							scriptum <lb/> est, <hi rend="italic">Dixit Deut, Faciamus</hi> hominem
+							: ergo jussit et <lb/> Filius; quia tu ipse non Patrem accipis dixisse,
+							sed <lb/> Filium, <hi rend="italic">Faciamus ei adjulorium.</hi> Et
+							sicut illud uhi di­ <lb/> ctum est, <hi rend="italic">Et fecit Dcus
+								hominem ;</hi> obedisse jubenti l'a<lb/>ri Filium vis videri, quia
+							Pater dixerat, <hi rend="italic">Faciamus <lb/> hominem</hi> : ita eliam
+							ubi legimus, <hi rend="italic">Ei immisit Dominus <lb/> soporem in Adam,
+								et sumpsit unam de costis ejus (Gen.</hi>
+							<lb/> n, 21) , et caetera , quibus oslendilur factum homini <lb/> esse
+							adjutorium, obedisse P.trein jubenti Filio, te <lb/> auctore,
+							intelligamus ; quia non Patrem, sed Filium <lb/> dixisse asseris, <hi
+								rend="italic">Faciamus ei adjutorium.</hi>
+						</p>
+						<p>5. Sed haec ila loquor, quasi ad causam quoe a nobis <lb/> agitur,
+							quidquam pertineat, quodlibet hinc volueris <lb/> credere aut suspicari.
+							Prorsus, sicut dicis, Pater jus­ <lb/> serit, ubi dictum est, <hi
+								rend="italic">Faciamus hominem;</hi> et Filius <lb/> obedierit, ubi
+							dictum est, <hi rend="italic">Et fecit Deus hominem :</hi>
+							<lb/> prorsus sicut te delectat, Filius dixerit, <hi rend="italic">Non
+								est bonum <lb/> solum esse hominem; faciamus</hi> ei <hi
+								rend="italic">adjutorium;</hi> sed talia <lb/> dicens ipse non
+							jusserit, quia hoc vultis : quomodo <lb/> ostendis Filium qui hominem
+							fecerit, ab homine vi­ <lb/> sum ? Quomodo ostendis Filium qui dixit,
+							Non <hi rend="italic">est bo­ <lb/> num hominem esse solum; faciamus ei
+								adjutorium,</hi> ab <lb/> homine visum, vel ab ipsa muliere, si eam
+							factam <lb/> non vis a Patre, ne Filio Pater obedisse videatur; <lb/>
+							scd ipse eam Filius, tanquain sibi jubens sibique obe­ <lb/> diens, et
+							faciendam dixit et fecit? Demonstra Filium <lb/> visum esse a viro,
+							visum esse a mulicre. Demonstra<lb/>turum te quippe promiseras, et
+							antequam incarnare­ <lb/> tur visum fuisse humanis aspeotibus Filium.
+							Ostende <lb/> promissa. Quid pergis in vacua? Quid deludis exspe­ <lb/>
+							ctationem nostram, nec cxhihes pollicitationem tuam? <lb/> Multiplicas
+							verba non necessaria, ut necessaria occu­ <lb/> pes tempora. Si
+							propterea visus est a viro Filius quia <lb/> fecit cum, et propterea
+							visus ab ejus muliere quia te­ <lb/> cit eam ; defini, si audes, non
+							posse Dcum Filium et <lb/> operari videntia, et a suis operibus, quamvis
+							alia yi­ <lb/> dentibus, non videri. Si autein huc j olest Dcus Filius;
+							<lb/> ipse quippe usque nunc operatur cuncta videntia, et <lb/> tamen
+							eorum a se ipso crcatis oculis non videtur; <lb/> quid cst quod dixisti
+							? Cur ista de libro Geneseos in <lb/> tuo sermone posuisti ? cur nobis
+							necessaria tempo­ <lb/> rum spatia superflua loquacitate finisti? <note
+								type="footnote">1 Editi, <hi rend="italic">et cooperante</hi> ttiio,
+									<hi rend="italic">rilio autcm</hi> uon <hi rend="italic"
+									>jubente, etc.</hi>
+								<lb/> Costigantur ex vss. </note>
+						</p>
+						<p>4. <hi rend="italic">Sed iste,</hi> inquli, <hi rend="italic">Filius</hi>
+							visus <hi rend="italic">tit Adae,</hi> secundum <lb/>
+							<hi rend="italic">quod legimus, Adam dicentem,</hi> «<hi rend="italic"
+								>Vocem</hi> tuam audivi <lb/>
+							<hi rend="italic">deambulantis in paradiso; et abscondi</hi> me, <hi
+								rend="italic">quia nudus <lb/> tum</hi> » <hi rend="italic">(
+								Gen.</hi> III, 10). Hoc orgo prius diceres, hom <lb/> bone. inde
+							inciperes promissa nonstrare. Quanivis et <lb/> hic Adam, <hi
+								rend="italic">Vocem tuam,</hi> inquit, <hi rend="italic">audivi</hi>
+							; non ait, F'a . <lb/> ciei vel speciem luam vidi. Et quod ait, <hi
+								rend="italic">Abscondi</hi> me, <lb/>
+							<hi rend="italic">quia nudus sum;</hi> videri se a Deo timuit, non a se
+							Deum <lb/> visum esse monstravit. Nam si vox quando auditur, <lb/>
+							sequitur visio; visus est et Deus Pater quoties voce <lb/> attestatus
+							est Filio. Novimus quippe in Evangelio ver. <lb/> ba Patris sonantis,
+							atque dicentis, <hi rend="italic">Tu es Filius</hi> meus <lb/>
+							<hi rend="italic">dilectus,</hi> etc. <hi rend="italic">(Marc.</hi> i,
+							11), ubi auditus ab hominibus, <lb/> non tamen visus est. Ac per hoc et
+							in illis verbis qua; ł <lb/> adjungis, ubi dicit, <hi rend="italic">Quis
+								nuntiavit tibi quia nudus</hi> es? <lb/> et sequentia ; potuit
+							audiri, et non videri Deus. Non­ <lb/> dum itaque aliquid ex eo quod
+							promiseras dixisse tu <lb/> vide : et dic tandem aliquid quod discutere
+							debeamus, <lb/> aut quod pro tua causa esse fateamur.</p>
+						<p>5. <hi rend="italic">Hic Deus,</hi> inquis, <hi rend="italic">et
+								Abrahae</hi> visus <hi rend="italic">est.</hi> Visum esse <lb/> Deum
+							Abi ahae negare non possumus. Scriptura quip­ <lb/> pe fidelissima
+							apertissime hoc loquitur, dicens : <hi rend="italic">Visus <lb/>
+								eat</hi> autem <hi rend="italic">illi Deus ad quercum Mambre.</hi>
+							Sed neque h:c <lb/> expressum est, utrum Pater an Filius. Cum autem
+							<lb/> narraret Scriptura , quomodo ci visus sit Deus, tres <lb/> viros
+							illi apparuisse declarat, in quibus magis ipsa <lb/> Trinitas, qui unus
+							est Deus, recte intelligi potest. De­ <lb/> nique Ires videt , el non
+							dominos, sed Dominum ap­ <lb/> pellat, quoniam Trinitas tres quidem
+							personae sunt, <lb/> sed unus Dominus Deus. Sic autem narratur quod vi­
+							<lb/> dit Abraham : <hi rend="italic">Respiciens,</hi> inquit, <hi
+								rend="italic">oculis</hi> suis <hi rend="italic">vidit, et<lb/> ecce
+								tres viri stabant super eum; et videns</hi> procurrit in <lb/>
+							<hi rend="italic">obviam</hi> illis <hi rend="italic">ab ostio
+								tabernaculi</hi> sui, <hi rend="italic">et</hi> adoravit super <lb/>
+							<hi rend="italic">terram, et dixit: Domine,</hi> si <hi rend="italic"
+								>inveni gratiam ante</hi> te, ne <lb/>
+							<hi rend="italic">praetereas servum tuum.</hi> Hic videmus tres viros
+							appa­ <lb/> ruisse, et unum Dominum dici, unumque Dominum <lb/> rogari
+							ne praetereat servum suum , quoniam congruit <lb/> Deo visitare famulos
+							suos. Dcinde tres personas plu­ <lb/> raliter alloquitur, dicens : <hi
+								rend="italic">Sumatur nunc aqua, et</hi> la­ <lb/>
+							<hi rend="italic">vem pedes vestros, et refrigerate sub arbore, et
+								sumam<lb/> panem , et manducate, et postea transibitis</hi> in <hi
+								rend="italic">viam</hi> ve­ <lb/>
+							<hi rend="italic">stram, propter quod declinastis ad servum</hi>
+							vestrum. Ma­ <lb/> nifestum est eos tanquam homines invitari : non enim
+							<lb/> tale illis praberetur obsequium, quo indigentia refi­ <lb/> cereut
+							corpora,nisi homines putarentur. Et Scriptura <lb/> pluraliter eos
+							respondisse commemorat : ait enim, Et <lb/>
+							<hi rend="italic">dixerunt, Sic fac quemadmodum dixisti.</hi> Noa ait,
+							Et <lb/> dixit; sed, <hi rend="italic">dixerunt.</hi> Deinde cam esset
+							parata rcfectio, <lb/> dicit Scriptura : <hi rend="italic">Et apposuit
+								ante illos, et ederunt.</hi> Non <lb/> ait, Apposuit anle ilium, et
+							edit. Sed ubi ad id ven­ <lb/> tum est, ut Abrahae filius promitteretur
+							ex Sara, quia <lb/> dirinum offerebatur beneficium, non ut hominibus
+							<lb/> humanum exhibebatur obsequium, unum narrat Scri­ <lb/> ptura
+							dicentem, <hi rend="italic">Ubi eat Sara</hi> uxor <hi rend="italic">tua
+								?</hi> Non euim ait, <lb/> Dixerunt autem ad illum : sed ait, <hi
+								rend="italic">Dixit autem ad il­ <lb/> tum : Ubi est Sara uxor
+								tua?</hi> Quis autcm hoc dixcril , <lb/> postea manifestat ; ubi cum
+							risisset Sara, ait eadem <lb/> Scriptura : <hi rend="italic">Et dixit
+								Dominus ad</hi> Abraham : Quare <hi rend="italic">risit <lb/> Sara
+								in semetipsa?</hi> et caetera usque ad finem, tanquam <lb/>
+							<pb n="807"/> unus Dominus singulariter loquitur. Ac post haec, ut <lb/>
+							homines pluraliter ahirc narrantur, et dicitur : E:c<lb/>
+							<hi rend="italic">surgentes autem inde</hi> vin, <hi rend="italic"
+								>conspexerunt</hi> in faciem Sodo­ <lb/>
+							<hi rend="italic">morum et</hi> Gomorrhae ; <hi rend="italic">Abraham
+								vero ambulabat</hi> cum <lb/> illis,<hi rend="italic">deducens.</hi>
+							Rursus autem redit Scriptura ad sin­ <lb/> gularem numerum, ac dicit :
+								<hi rend="italic">Dominus autem</hi> dixit <hi rend="italic">: <lb/>
+								Numquid celabo ego puero meo Abraham quae ego</hi> facio ? <lb/>
+							Deinde promittitur Abrahae praeclara et copiosa poste. <lb/> ritas, et
+							Sodomorum denuntiatur iuleritus. Sequens <lb/> autem Scriptura dicit :
+								<hi rend="italic">Et conversi inde</hi> viri, <hi rend="italic"
+								>venerunt<lb/> in Sodoma ; Abraham autem erat adhuc stans</hi> ante
+								<hi rend="italic">Do­</hi>
+							<lb/> minum. <hi rend="italic">Et appropians Abraham dixit: Ne simul
+								perdas <lb/> justum cum impio; et erit justus tanquam</hi> impius ?
+							Et <lb/> post collocutionem Domini atque Abrahae, sequitur <lb/>
+							Scriptura, et dicit: <hi rend="italic">Abiit autem Dominus, utdesiit
+								loqui <lb/> ad Abraham,</hi> et <hi rend="italic">Abraham regressus
+								eat in locum</hi> suum. <lb/>
+							<hi rend="italic">Venerunt autem duo angeli in Sodoma ad vesperam.</hi>
+							Hi <lb/> sunt de quibus paulo ante dixerat : <hi rend="italic">Conversi
+								inde viri<lb/> venerunt</hi> in <hi rend="italic">Sodoma.</hi> Sed
+							duos esse non expresserat, <lb/> cum ab initio tres viros dixisset
+							apparuisse Abrahae, <lb/> et hospitaliter ab iRo esse susceptos, quos et
+							abeuntes <lb/> deduXit, ambubns cum eis.</p>
+						<p>6. Fortassis ergo jam pronuntiare festinas, unum <lb/> fuisse in eis
+							Dominum Christum, qui singulariter pro­ <lb/> mittebat et respondebat
+							Abrahft; duos vero illos, an­ <lb/> gelos ejus, qui venerunt in Sodoma
+							tanquam missi <lb/> angeli a Domino suo. Sed exspecta : quid properas?
+							<lb/> Consideremus omnia diligenter, ac prius intueamur <lb/> verba
+							Domini loquentis Abrahae : <hi rend="italic">Clamor Sodomorum,</hi>
+							<lb/> tnquit, <hi rend="italic">et Gomorrhae multiplicatus est, et
+								peccata eorum <lb/> magna valde. Descendens ergo videbo,</hi> si <hi
+								rend="italic">secundum cla­</hi>
+							<lb/> morem ipsorum <hi rend="italic">vanientem ad me</hi> consummant.
+							Hic se <lb/> ipsum descensorum dixit in Sodoma, quo tamen neu <lb/> ipse
+							descendit, sed angeli duo. Ipse quippe <hi rend="italic">abiit, ut</hi>
+							<lb/> desiit <hi rend="italic">loqui ad Abraham; Abraham autem regressus
+								est</hi>
+							<lb/> in <hi rend="italic">locum</hi> suum. <hi rend="italic"
+								>Venerunt</hi> autem, sicut dictum est, <hi rend="italic">duo <lb/>
+								angeli ad vesperam in Sodoma.</hi> Quid, si et in illis duo­ <lb/>
+							bus angelis unus Dominus invenitur, qui secundum <lb/> verbum suum in
+							ipsis angelis descendit in Sodoma ? <lb/> Nonne manifestum erit in
+							tribus illis viris unum Do­ <lb/> minum visum fuisse, ubi quid aliud
+							quam ipsa Trini­ <lb/> tas figurata est? Sed videamus utrum nobis sancta
+							<lb/> Scriptura demonstret, etiam in illis duobus angelis, <lb/> ut
+							dixi, unum Dominum inventum, ne forte haec ex <lb/> nostro corde
+							affirmasse videamur. <hi rend="italic">Venerunt</hi> ergo <hi
+								rend="italic">duo <lb/> angeli in</hi> Sodoma <hi rend="italic"
+								>ad</hi> vesperam; <hi rend="italic">Loth vero sedebat,</hi> ut
+							<lb/> scriptum est, <hi rend="italic">juxta portam</hi> Sodomorum. <hi
+								rend="italic">Videns autem<lb/> Loth,</hi> surrexit in <hi
+								rend="italic">obviam illis, et adoravit in faciem in <lb/>
+								terram.</hi> Vides nempe hic a justo viro angelos adoratos, <lb/> et
+							tu non vis adorari Spiritum sanctum, quem vos quo­ <lb/> que omnibus
+							angelis I sine ambiguitate praeponiłis ? <lb/> Sed dicturus es Homines
+							esse credebat, nam et in <lb/> Hospitium tanquam homines invitavit. Hoc
+							magis est <lb/> contra te, qui dicis non adorari Spiritum sanctum, <lb/>
+							omnibus Angelis praefendum ; cOrn videas et ho­ <lb/> mines inferiores
+							Angelis a justis hominibus adorari. <lb/> Scd adhuc dicturus es, Dominum
+							adoravit : cum <lb/> quippe in duobus illis, quos putabat esse homines,
+								<note type="footnote">1 m t-dilione Lov. deest, angelis. </note>
+							<lb/> tanquam in prophetis esse cognovit. Jam ergo pro­ <lb/> batum est,
+							quod me per Scripturam sanctam de<lb/>monstraturum esse promiseram,
+							eumdem Dominum <lb/> qui dictus fuerat abiisse ut cessavit loqui ad
+							Abra­ <lb/> bam, in illis duobus ange! s descendisse in Sodoma, <lb/>
+							sicut dixerat, et in cis ab homine justo agnitum <lb/> fuisse. Exhibuit
+							itaque hospitalitatem quomodo san­ <lb/> ctis hominibus Dei, in quibus
+							Deum esse cognovit, <lb/> cum eos, sicut etiam ipse Abraham, angelos
+							esse <lb/> nesciret. Hi enim Patriarchae sunt significati in Epi­ <lb/>
+							stola ad Hebraeos, ubi de hospitalitate loquens ait: <lb/>
+							<hi rend="italic">Per hanc quidam</hi> nescientes, <hi rend="italic"
+								>hospitio receperunt an­<lb/> gelos (Hebr.</hi> XIII, 2). Receptis
+							ergo eis Loth, nesciens <lb/> quod angeli essent, cognoscens tamen sicut
+							ipo Do­ <lb/> nrino demonstrante cognoscere potuit, quis in eis <lb/>
+							esset, ut ea quae interca facta sunt taceam, exii', cnm <lb/> eis de
+							Sodomis: qnod antequam fierct, sicut Scri­ <lb/> plura loquitur, <hi
+								rend="italic">dixerunt</hi> viri <hi rend="italic">ad Loth : Sunt
+								tibi hic</hi>
+							<lb/> generi, <hi rend="italic">aut filii, aut</hi> filiae ? <hi
+								rend="italic">aut</hi> si <hi rend="italic">quis</hi> tibi <hi
+								rend="italic">alius eat</hi> in <lb/>
+							<hi rend="italic">civitate, educ de loco</hi> hoc : quoniam perdimus'
+								<hi rend="italic">noa <lb/> locum hunc ; quia exaltatus ese clamor
+								eorum ante Do­ <lb/> minum, et misit</hi> noa <hi rend="italic"
+								>Dominus conterere eum.</hi> Ecce ubi <lb/> apparet illud incendium
+							Sodomorum per angelos fa­ <lb/> ctum, quos misit Dominus; in quibus
+							tamen et ipse <lb/> erat : neque enim sic mittit suos, ut recedat ab
+							eis. <lb/> In eis ergo descendit in Sodoma, quod se facturum <lb/> esse
+							praedixerat, quando cum Abraham loqucbatur: <lb/> quod posteaquam fecit,
+							abiisse ipse dictus est, et an­ <lb/> geli venisse in Sodoma ad
+							vesperam. Deinde paulo <lb/> post, mox ut cduxerunt illum foras, et
+							dixerum, <lb/> sicut eadem Scriptura narrat, <hi rend="italic"
+								>Salvam</hi> fac animan <lb/>
+							<hi rend="italic">tuam; ne respexeris retro, nec steteris in tota
+								regione;</hi> in <lb/>
+							<hi rend="italic">monte salvum te fac, nequando comprehendaris</hi> :
+							dixit <lb/> Loth ad illos, <hi rend="italic">Oro, Domine, quia</hi>
+							invenit <hi rend="italic">puer</hi> tuus <lb/>
+							<hi rend="italic">misericordiam ante te,</hi> etc. Quae cum finisset
+							loquendo, <lb/> et elegisset sibi civitatem pusillam in qua salvaretur,
+							<lb/> seqnitur Scriptura, ct ei dicit esse responsum : <hi rend="italic"
+								>Ecce<lb/> miratus</hi> sum2 <hi rend="italic">faciem tuam et super
+								verbum hoc, ne<lb/> everterem civitatem de qua</hi> locutus ea. <hi
+								rend="italic">Festina ergo ut<lb/> salvus sis ibi : non enim potero
+								facere verbum, donec <lb/> tu illo introeas (Gen.</hi> XVIII <hi
+								rend="italic">et</hi> XIX). Quis hoc ei re­ <lb/> spondit, nisi ille
+							cui dixcrat, Oro, <hi rend="italic">Domine?</hi> Hoc an­ <lb/> tem ad
+							ambos dixerat, non ad unum, sicut apertis­ <lb/> sime scriptum est, <hi
+								rend="italic">Dixit autem Loth ad</hi> illos, Ora, <lb/>
+							<hi rend="italic">Domine.</hi> Agnovit ergo a Loth unum Dominum in an­
+							<lb/> gelis duobus, sicut Abraham unum agnovit in tribus.</p>
+						<p>7. Non est cur dicatur : Ille abierat qui Dominus <lb/> erat et cum
+							Abraham locutus erat; duo vero angeli <lb/> ejus erant qui in Sodoma,
+							illo abeunte 4, venerunt. <lb/> Omnes enim tres viridiclisunl . qui
+							apparuerunt Abra­ <lb/> hae, sicut Scriptura solet viros etiain angelos
+							nuncu­ <lb/> pare. Nee eoruin alicui uni promptius et humilius <lb/>
+							Abraham obsecutus est quam duobus, sed aequaliter <lb/> omnibus pedes
+							lavit, aequaliter omnibus epulas In i- <note type="footnote"> * sic Mss.
+								Editi vero, <hi rend="italic">perdemus.</hi>
+							</note><note type="footnote"> I Editi, <hi rend="italic">miseratus</hi>
+								sum. At Mss., <hi rend="italic">miratus</hi> sum :
+									<unclear>hirc</unclear>
+								<lb/> 16 de civitate Dei, cap. 29, juxta graecum LXX, <hi
+									rend="italic">ethaumasa,</hi>
+								<lb/> quod dici POtest, <hi rend="italic">reveritus sunt,
+									suipexi.</hi>
+							</note><note type="footnote"> I In Mss., <hi rend="italic">jgnovisti
+									ergo.</hi>
+							</note><note type="footnote"> * Sola fere edi lio Lov., <hi
+									rend="italic">jnbente.</hi>
+							</note>
+							<lb/>
+							<pb n="809"/> nistravit. Ergo in omnibus Deum vidit. Propter quod <lb/>
+							Scriptura praedixerat, quod visus fuerat Deus Abrahae <lb/> ad quercum
+							Mambre, sub cujns umbra arboris tres <lb/> viros pavit, quos oculis
+							corporis vidit: in cis vero <lb/> Deum, non corporis, sed cordis oculis
+							vidit, id est, <lb/> intellexit atque cognovit; sicut Loth in duobus,
+							cum <lb/> quo non pluraliter, sed singulariter loquebatur, eique <lb/>
+							respondebat etiam ipse tanquam unus. Primo quippe <lb/> Abraham per tres
+							viros illum audivit, postea per <lb/> unum, qui duobus in Sodoma
+							euntibus manens lo­ <lb/> cuius est cum eo; Loth autem per duos, tamen
+							et <lb/> ipse unum Dominum, quein pro liberatione sua ro­ <lb/> gabat,
+							et qui ei respondebat, audivit : cum ambo, id <lb/> est, et Abraham ct
+							Loth, homines putarent eos qui <lb/> angeli erant; Deum vero in eis
+							intelligerent qui erat, <lb/> non putarent esse qui non erat. Quid sibi
+							ergo vult <lb/> ista visibilis Trinitas et intelligibilis unitas, nisi
+							ut <lb/> nobis insinuaretur quod ita tres essent Pater et Fi­ <lb/> lius
+							ct Spiritus sanctus, ut tamen simul non tres dii <lb/> et domini essent,
+							sed unus Dominus Deus ? Tu autem <lb/> dixisti, <hi rend="italic">Hic
+								Deus visus eat Abrahae :</hi> sciens te legisse <lb/> quod scriptum
+							cst, visum esse Deum Abrahae ad quer­ <lb/> cuin Mambre : et volens
+							quasi probare Dominum <lb/> Filium visum esse illi patriarchae,
+							declinasti ab illis <lb/> tribus viris, ct cos omnino tacuisti, in
+							quibus narrat <lb/> Scriptura Deum visum fuisse Abrahae; ne tu ipse nos
+							<lb/> admoneres unius esse substantiae Trinitatem Deum, <lb/> sicut
+							unius erant substantiae tres viri quos vidit Abra­ <lb/> ham : cum
+							praedixisset Scriptura, <hi rend="italic">Visus est Deus <lb/>
+								Abrahce,</hi> nec tamen tres deos esse, quia et, <hi rend="italic"
+								>Visus eat<lb/> Deus,</hi> dictum est; non, visi sunt dii : et ipse
+							Abra-<lb/> ham tres vidit, et unum adoravit : a quo praeteriri <lb/>
+							noluit; ab uno responsa divinitatis accepit. Nec ali­ <lb/> quos duos
+							eorum duos esse dcos sensit, sed unum in <lb/> omnibus : quia et Loth
+							duos vidit, et tamen unum <lb/> Dominum agnovit. Ubi mihi videntur per
+							angelos si­ <lb/> gnificari Filius et Spiritus sanctus : quoniam se illi
+							<lb/> angeli missos esse dixerunt ; et de Trinitate quae Deus <lb/> est,
+							solus Pater non legitur missus; leguntur autem <lb/> missi et Filius et
+							Spiritus sanctus ; quorum non ideo <lb/> est diversa natura : nam et
+							illi viri per quos signifi­ <lb/> cati sunt, unius erant ejusdemque
+							naturae. Hanc ergo <lb/> Scripturam qua convinci posses, astuto silentio
+							devi­ <lb/> tasti. Et cum dixisses, <hi rend="italic">Hic Deus
+								visus</hi> eat <hi rend="italic">Abrahae :</hi>
+							<lb/> volens Filium solum visum putari in eo quod in Ge­ <lb/> nesi
+							legitur, visum esse Deum Abrah;e, quomodo sit <lb/> visus, dicere
+							noluisti, ne ibi non solus Filius, sed <lb/> Trinitas agnosceretur
+							Deus.</p>
+						<p>8. Dixisti autem : <hi rend="italic">Si vis credere, quia Filius vi,,,.
+								<lb/> est Abrahae, utique ipse Unigenitus</hi> in <hi rend="italic"
+								>sancto affirmavit <lb/> Evangelio sic :</hi> « <hi rend="italic"
+								>Abraham pater vester exsultavit ut</hi> vi-­ <lb/>
+							<hi rend="italic">deret diem</hi> meum; <hi rend="italic">et vidit, et
+								gavisus est. &gt; (Joan.</hi> VIII, <lb/> 56). 0 disputare, o
+							probare promissa I quasi dixerit <lb/> Dei Filius, Abraham pater vester
+							concupivit me vi­ <lb/> dere; et vidit, et gavisus est. Quamvis et hoc
+							sic ad­ <lb/> huc posset intelligi, quod sanctus Patriarcha oculis <lb/>
+							cordis viderit Dei Filium, non oculis carnis, unde <lb/> inter nos
+							vertitur quaestio. Sed cum dixerit Christus, <lb/> Abraham concupivit
+								<hi rend="italic">videre diem</hi> meum ; et <hi rend="italic"
+								>vidit, et</hi>
+							<lb/> gavisus <hi rend="italic">est ;</hi> cur non diem Christi
+							intelligimus tem­ <lb/> pus Christi, quo erat venturus in carne, quod
+							Abra­ <lb/> ham sicut et alii Prophetae in spiritu potuit vidcre <lb/>
+							atque gaudere? Neque hie igitur quod proposueras <lb/> et pollicitus
+							fueras, probare potuisti.</p>
+						<p>9. Post haec venisti ad Jacob, qui luctatus est cum <lb/> Angelo, quem
+							scriptura ipsa Geneseos et hominem <lb/> dicit et Deum. Nam ita legitur
+							: <hi rend="italic">Remansit autem</hi> Ja­ <lb/>
+							<hi rend="italic">cob</hi> solus, <hi rend="italic">et luctabatur hamo
+								cum illo usque</hi> in <hi rend="italic">mane. <lb/> Vidit autem
+								quod non potest ad eum, et tetigit latitudi­</hi>
+							<lb/> nem <hi rend="italic">femoris ejus, et</hi> obstupuit' latitudo
+								<hi rend="italic">femoris Jacob, <lb/> dum luctaretur cum eo; et
+								dixit illi : Dimitte me;</hi> f <lb/>
+							<hi rend="italic">ascendit enim aurora. Ille autem dixit: Non te dimit-
+								<lb/> tam,</hi> nisi <hi rend="italic">me benedixeris. Dixit
+								autem</hi> ei: <hi rend="italic">Quod eat no­ <lb/> men</hi> tuum ?
+								<hi rend="italic">llle autem dixit: Jacob. Et dixit ei: Nan<lb/>
+								vocabitur amplius nomen tuum Jacob; sed Israel erit <lb/> nomen
+								tuum, quia valuisti cum Deo, et cum</hi> hominibus <lb/>
+							<hi rend="italic">potens es. Rogavit autem eum Jacob dicens : Enuntia
+								<lb/> mihi nomen</hi> tuum. <hi rend="italic">Et dixit : Quare hoc
+								interrogas</hi> tu <lb/>
+							<hi rend="italic">nomen meum? Et benedixit eum illic. Et appellavit
+								<lb/> Jacob nomen loci illius, Aspectus Dei : Vtdi</hi> enim <hi
+								rend="italic">Deum <lb/> facie ad</hi> faciem, <hi rend="italic">et
+								salva facta est anima mea</hi> (Gen. <lb/> XXXII, 24-30). Ex ista
+							lectione unicum Dei Filium et <lb/> antequam venisset in carne
+							visibiliter apparuisse co­ <lb/> naris ostendere : ubi etsi non absurde
+							Christus intel­ <lb/> ligitur figuratus, propter prophetiam futura
+							nuntian­ <lb/> tem, quia futurum erat ut Jacob in filiis suis qui cru.
+							<lb/> cifixerunt Christum, praevaluisse Christo videretur; <lb/> et in
+							filiis suis videret Christum facie ad faciem, ct <lb/> salva Geret anima
+							Israelitarum qui fideliter hoc vide­ <lb/> runt: tamen hunc hominem quI
+							luctatus est cum <lb/> Jacob, Osee propheta evidenter angelum dicit. Sic
+							<lb/> enim apud eum scriptum est de Jacob : <hi rend="italic">In
+								utero</hi> sup­ <lb/>
+							<hi rend="italic">plantavit fratrem</hi> suum, <hi rend="italic">et in.
+								labore praevaluit</hi> Deo, et <lb/>
+							<hi rend="italic">confortatus eat cum angelo,</hi> et potuit <hi
+								rend="italic">(Osee</hi> XII, 3, 4). <lb/> Sicut ergo in Genesi ille
+							qui luctatus est cnm Jacob, <lb/> ct homo et Deus dicitur 2 ; ita et ab
+							hoc propheta et <lb/> Deus et. angelus. Ac per hoc ita qui erat angelus,
+							<lb/> dictus est humo, quomodo illi dicti suut viri qui ap­ <lb/>
+							paruerunt Abrahae, qnando nescientes* et ipse et <lb/> Loth hospitio
+							receperunt angelos. Deus ergo erat <lb/> in angelo, sicut est Deus in
+							homine, maxime quan­ <lb/> do pcr hominem loquitur. Ita vero per hunc
+							an. <lb/> gelum figuratus est Christus, sicut per hominem. <lb/> Nam et
+							Isaac filius Abrahae,quid crat in figura, <lb/> nisi Christus, quando
+							sicut ovis ad immolandum <lb/> ductus est <hi rend="italic">( Isai.</hi>
+							LIII, 7), et quando sicut Do­ <lb/> minus erucem suam, ita et ipse sibi
+							quibus fuerct <lb/> imponendus ligna portabat? Postremo, quid nri­ <lb/>
+							ramur per angelum figuratum esse Jcsum, si non <lb/> solum per hominem,
+							verum etiam per pecudem figu­ <lb/> ratus est? Nam quis alius erat ille
+							aries qui cornibus <lb/> tenebatur in vepre, nisi Christus crucifixus,
+							vel spinis <lb/> etiam coronatus. Hunc autem arietem pro filio, cui
+							<lb/> parcere jussus est, immolavit Abraham <hi rend="italic">(
+								Gen.</hi> xxJ, <lb/> 6-13). Ita cnim homini parci Deus jussit, ut
+							tanMn IX <note type="footnote"> 1 ID MSS., <hi rend="italic">obit..</hi>
+								' </note><note type="footnote"> * Mss., et Deus <hi rend="italic"
+									>scitur.</hi>
+							</note><note type="footnote"> * MM., <hi rend="italic">quando</hi>
+								tidentes. </note>
+							<note type="footnote"> PATROL. XLII. </note>
+							<note type="footnote">
+								<hi rend="italic">(Vinyl-siahJ</hi>
+							</note>
+							<lb/>
+							<pb n="811"/> pecore, propter passionem Christi, qua? illo modo <lb/>
+							praenuntiabatur, mysterium sacri sanguinis implore­ <lb/> tur. Si ergo
+							putas proprietate, non figura, Christum <lb/> fuisse angelum, qni
+							luctatus est cum Jacob; potes di­ <lb/> cere proprietate, non figura,
+							Christum fuisse arietem, <lb/> quom patriarcha immolavit Abraham : potes
+							postre­ <lb/> o dicere proprictate, non figura, Christuin fuisse <lb/>
+							petram, quae percussa ligno, sifienli populo potum <lb/> largissimum
+							fudit ( Exod. XVII, G ). Sic enim dicit <lb/> Apostolus : <hi
+								rend="italic">Bibebant enim de spirituali</hi> sequente petra ; <lb/>
+							<hi rend="italic">petra autem erat</hi> Christus ( I <hi rend="italic"
+								>Cor.</hi> x, 4 ). Figure istae <lb/> non res ipsae fuerunt, quibus
+							figuris praecedentibus <lb/> tes significabantur esse ventura;: quae
+							figurae per <lb/> suhjectam Deo creaturam, et maxime per Angelorum <lb/>
+							ministerium, mortalium cxhibebantur aspectibus, Dei <lb/> quidem agente
+							potentia, sed tamen latente natura, <lb/> sive Patris, sive Filii, sive
+							Spiritus sancti.</p>
+						<p>40. Frustra itaque asseris Filium Dei risum fuisse <lb/> ah hominibus,
+							Patrem autem non fuisse visum : cum <lb/> pcr subjectam sibi creaturam
+							et Pater videri potuerit, <lb/> et Filius, et Spiritus sanctus; per suam
+							vero substan<lb/> Ham nullus illurum visus cst. Ergo Deus, sicut infir­
+							<lb/> mis hominum sensibus, magis significatus quam de­ <lb/> monstratus
+							est. Non itaque visus cst sicut est : hoc <lb/> quippe in futura vita
+							promittitur sanctis. Unde dicit <lb/> apostolus Joannes : <hi
+								rend="italic">Dilectissimi, nunc filii Dei</hi> sumus, <lb/> et <hi
+								rend="italic">nondum apparuit quid erimus : scimus autem</hi> quia
+							<lb/> cum apparuerit, <hi rend="italic">similes</hi> ei <hi
+								rend="italic">erimus, quoniam videbimus <lb/> eum sicuti eat</hi> (I
+								<hi rend="italic">Joan.</hi> III, 2). Videruut ergo et in hoc <lb/>
+							saeculo Apostoli Dominum; viderunt, sed non sicut <lb/> est. Denique
+							Moyses eum sibi cupiebat ostendi, quam­ <lb/> vis cum eo facie ad faciem
+							Scriptura indice loquero­ <lb/> tur (Exod. XXXIII, 13, 11). Quod cum in
+							mea superius <lb/> prosecutione dixissem, quasi non audieris
+							praeteristi, <lb/> cnm tibi ejusdem meso prosecutionis recitari ex tabu­
+							<lb/> lis universa voluissem. Non autem discernens quid <lb/> sit videri
+							Dcum per substantiam suam, et quid sit <lb/> videri Deum per subjectam
+							creaturam, in tantam <lb/> blasphemiam decidisti, ut unigenitum Dei
+							Filium per <lb/> hoe ipsum quod Deus est mutabilem diceres : quando­
+							<lb/> quidamsoli Patri putasti esse tribuendum quod scri­ <lb/> pturO
+							osse dixisti, <hi rend="italic">Ego sum qui</hi> sum , <hi rend="italic"
+								>et non</hi> sum <hi rend="italic">mu­ <lb/> tatus;</hi> quasi
+							Filius vel Spiritus sanctus sit mutatus <lb/> quando visibiliter
+							apparuit, vel ille quod constat natus <lb/> ex fcmina , vel iste in
+							specie columbae aut igneis lin­ <lb/> guis se humanis aspectibus
+							monstrans. Unde jam re­ <lb/> spondi tibi in eo sermone, ubi ostendi non
+							te rcfel­ <lb/> lisse quae dili. Nunc vero ut intelligas quomodo <lb/>
+							dixerit Deus,<hi rend="italic">Ego</hi> sum <hi rend="italic">qui sum,
+								et non sum mutatus,</hi>
+							<lb/> vel quod scriptum magis invenitur, <hi rend="italic">Ego</hi> enim
+								<hi rend="italic">Dom­</hi>
+							<lb/> nus, <hi rend="italic">et</hi> non <hi rend="italic">mutor
+								(Id.</hi> 3, 14, <hi rend="italic">et Malach.</hi> 3, 6); quo­ <lb/>
+							niam non solus Pater, sed Deos unus hoc dixit, quod <lb/> est ipsa
+							Trinitas ; Psalmum attende ubi legitur : Tu <lb/> in <hi rend="italic"
+								>principio, Domine, terram</hi> fundasti, <hi rend="italic">et
+								opera</hi> manuum <lb/> tuarum sunt <hi rend="italic">caeli : ipsi
+								peribunt; tu autem permanebis : <lb/> et omnes sicut vestimentum
+								veterascent, et velut tegu­ <lb/> mentum mutabis eos, ct</hi>
+							mutabuntur ; <hi rend="italic">tu autem idem</hi>
+							<unclear/>
+							<lb/> spse es, et anni <hi rend="italic">tui non deficient (Psal.</hi>
+							CI, 25-28). Hoc <lb/> autem ad Filium Dei dictum es n in Epistola qua
+							est <lb/> ad Hebraeos sancta Scriptura .testatur <hi rend="italic"
+								>(Hebr.</hi> I, 10- <lb/> 42). Quis vero non intelligat, uhi
+							dicitur, <hi rend="italic">Caeli muta­ <lb/> buntur; tu autem idem ipse
+								es;</hi> nihil dici animI, nisi, <lb/> TII non mutaris? Ac per hoc
+							etiam Deo Filio convenit <lb/> dicere, <hi rend="italic">Ego sum qui
+								sum, et</hi> non <hi rend="italic">sum mutatus;</hi> vel <lb/>
+							<hi rend="italic">Ego enim Dominus, et non mutor.</hi> Quod tu idco soli
+							<lb/> Patri assignasti, ut in sua substantia crederetur esse <lb/>
+							mutabilis Filius ; tanquam ita susceperit hominem, ut <lb/> in hominem
+							verteretur. iianc tantam blasphamiam <lb/> non emendabis, nisi
+							credideris, in assumpti mehomi <lb/> nis accessisse Filio quud non erat,
+							non autem reces­ <lb/> sisse vcl defecisse quod crat.</p>
+						<p>11. Deinde quaero, quis apparuerit Moysi in igne <lb/> quando rubus
+							iullammabatur, ct non urebatur Quan­ <lb/> quain et illic angelum
+							apparuisse Scriptura ipsa de­ <lb/> clarat , dicens : <hi rend="italic"
+								>Apparuit antem illi angelus Domini in<lb/> flamma ignis de
+								rubo.</hi> In angelo autem Deum fuisse , <lb/> quis dubitet? Sed
+							quis Deuserat ? utrum Pater, an <lb/> Filius? Dicturus es, Filius : non
+							vis enim Patrem <lb/> ullo modo, vel pcr subjectam crcaturam, visibus
+							ap­ <lb/> paruisse mortalium. Sed quodlibet horum eligas, ad <lb/>
+							utrumque respondeo. Si Paler crat, apparuit ct Pater <lb/> hominibus :
+							si Filius erat, non inutatur et Filius. Ibi <lb/> enim cum quaesisset
+							Moyscs, quis esset qui eum mit­ <lb/> tere!; ille respondit : <hi
+								rend="italic">Ego sum qui</hi> sum. Quod quid <lb/> est aliud, nisi,
+							Mutabilis non sum : sicut propheticum <lb/> testimonium ipse posuisti,
+								<hi rend="italic">Ego</hi> sum <hi rend="italic">qui sum, et non
+								<lb/> sum</hi> mutatus ? Dixit etiam rursus ad Moyscn : <hi
+								rend="italic">Ego</hi>
+							<lb/> sum <hi rend="italic">Deus Abraham, et Deus Isaac, et Deus Jacob
+								(Exod.</hi>
+							<lb/> III, 2, 14, 6, 15). Aude, si potes, negare Dcum Patrem <lb/> Dcum
+							esse Abraham, et Isaac, et Jacob; si non i;se <lb/> de ruho, sed Filius
+							loquebatur. Si autem Pater, con­ <lb/> fitere eliam Patrem Deum
+							hominibus visum. Si vero <lb/> uterque est Deus Abraham, et Deus Isaac,
+							et Deus <lb/> Jacob, quod esse annuis ;-quid ambigis utrumque <lb/> unum
+							Deum? Jacob quippe ipse est Israel, cujus filiis <lb/> dicitur : <hi
+								rend="italic">Audi, Israel; Dominus Deus tuus, Dominus <lb/> unus
+								est (Deut.</hi> VI, 4).</p>
+						<p>12. Quapropter verum esse agnosce qnod dixi, di­ <lb/> vinitatem non per
+							substantiam suam, in qua invisi­ <lb/> bilis ct immutabilis est, ped per
+							creaturam sibi subjo<lb/>Clam mortalium oculis apparuisse cum voluit.
+							Non <lb/> itaque sicut accipere vel accipi mea verba voluisti, <lb/> ego
+							divinitatem sic patribus 1 ostendisse se dixi, tan­ <lb/> quan eam
+							voluerim credi visibilem, quati prius <lb/> invisibilem dixeram esse :
+							sed dixi, quando se patri­ <lb/> bus divinitas ostendebat, per subjectam
+							creaturam se <lb/> visibilem demonstrabat. Nam per ipsam suam natu­
+							<lb/> . ram usque adeo invisibilis est, ut ipse Moyscs ei cum <lb/> quo
+							facie ad faciem loquebatur diceret: <hi rend="italic">Si inveni gra.
+								<lb/> tiam ante te, ostende mihi temetipsum manifeste (Exod.</hi>
+							<lb/> XXXIII, 11, 15). Ecce quod dixi : relege, et invenies <lb/> me
+							verum dicere ; te autem non intelligere voluisse, <lb/> vcl non
+							potuisse, quod dixi. Audi ergo idipsum me <lb/> aliquanto planius
+							disserentem. Ego divinitatem Patris <lb/> et Filii et Spiritus sancti in
+							sua natura atque substan­ <lb/> tia mortalibus oculis invisibilem dico.
+							Eam vcro se tu <note type="footnote"> I riure* 'w:SS. J <hi
+									rend="italic">ratru.</hi>
+							</note>
+							<lb/>
+							<pb n="813"/> formas visibiles vertere, absit ut dicam, quia et im­
+							<lb/> mutabilem dico. Restat ergo ut aspcetibus humanis <lb/> quando se
+							ostendit ut voluit, per subjectam intelliga­ <lb/> tur hoc fecisse
+							creaturam, quae potest oculis apparere <lb/> mortilihus.</p>
+						<p>13. Quid est autem quod eumde Patre dixisses, <lb/>
+							<hi rend="italic">Unus est</hi> invisibilis, unde jam salis est
+							disputatum; ad­ <lb/> didisti, Unus <hi rend="italic">etiam incapubilis
+								atque immensus?</hi> Inca­ <lb/> pabilem quidem non legimus Deum.
+							Cur sane dicas <lb/> incapabilem, nescio. Si cnim capi non potest, quo­
+							<lb/> modo non solum Filius, verum eLiam Pater veniunt <lb/> ad hominem,
+							sicut dicit ipse Filius, et mansionem <lb/> apud eum faciunt <hi
+								rend="italic">(Joan.</hi> xiv, 23) ? Puto quod capiat <lb/> eos apud
+							quem faciunt mansionem. An forte dicis, <lb/> Non ex toto, sed ex parte
+							capiuntur? Dic quod vis : <lb/> respondetur enim tibi, Non sunt ergo
+							incapabiles, qui <lb/> sunt xel ex parte capabiles. An ideo tibi non
+							sufficit <lb/> incapabilem dicere, sed addidisti, et immensum, ut <lb/>
+							exponeres quatenus incapabilem dixeris ? id cst, quia <lb/> totius capax
+							non est humana natura; immensus est <lb/> enim ? Verum hoc et de Filio
+							dici potest. Neque enim <lb/> quisquam sic capit unigenitum Verbum, ut
+							ejus ca­ <lb/> pacem se omni modo audeat profiteri. Prorsus etiam <lb/>
+							ipsum non esse dubitamus immensum. Nam quaero <lb/> abs te, de quo
+							accipias quod scriptum est : <hi rend="italic">Magnus <lb/> est, et non
+								habet</hi> finem; <hi rend="italic">excelsus et</hi> immensus. De
+							ipso <lb/> quippc paulo post dicitur : <hi rend="italic">Hic Deus
+								noster,</hi> non <hi rend="italic">aesti­ <lb/> mabitur alius ad eum
+								; hic</hi> invenit <hi rend="italic">omnem viam disci­ <lb/> plinae
+								et dedit eam Jacob puero suo, et Israel dilecto <lb/> suo : post
+								haec super terram</hi> visus <hi rend="italic">eat, ei inter
+								homines<lb/> conversatus eat (Baruch</hi> III, 26, 56, 37, 58) ?
+							Quis est <lb/> iste, responde? Quis est, inquam, <hi rend="italic"
+								>Magnus, et non <lb/> habens finem ; excelsus et immensus; qui super
+								terram</hi>
+							<lb/> visus <hi rend="italic">est, et inter homines conversatus est</hi>
+							? Yidco quos <lb/> aestus, quas patiaris angustias. Times dicere, Pater
+							<lb/> est ; ubi audis, <hi rend="italic">super terram</hi> visus <hi
+								rend="italic">est, et inter homines <lb/> conversatus est.</hi> Tu
+							enim Patrem por suam substan­ <lb/> tiam revera invisihilem, nec per
+							subjectam creaturam <lb/> vis esse ab hominibus visum. Times dicere,
+							Filius <lb/> est ; ubi audis, non <hi rend="italic">habet finem,
+								excelsus et immensus.</hi>
+							<lb/> Tii enim Patrem tantummodo esse contendis immen­ <lb/> sum. Times
+							dicere, Spiritus sanctus est; ubi audis , <lb/>
+							<hi rend="italic">hic Deus noster.</hi> Tu enim nec Deum vis esse
+							Spiritum <lb/> sanctum. Quid es acturus, quid responsurus, homo <lb/>
+							qui non vis esse catholicus, ut Christum sic accipias <lb/> in forma
+							servi super terram visum, et inter homines <lb/> conversatum, ut tamen
+							in forma Dei in qua invisibilis <lb/> mansit, confitearis immensum ? <hi
+								rend="italic">Hic Deus noster, non <lb/> aestimabitur alius ad
+								eum.</hi> Quis alius, nisi Antichristus, <lb/> quem veram Christum
+							fides vera non aestimat, sed <lb/> enim pro vero Christo exsecrabilis
+							Judxorum error <lb/> exspectat ?</p>
+						<p>14. Si oras, et petis, ut dicis, discipulus esse divi­ <lb/> narum
+							Scripturarum. ad rem pertinentia testimonia <lb/> divina considera. Noli
+							per multa quae te nihil adju­ <lb/> vene, evagari: elige prudenter
+							tacere quam inaniter <lb/> loqui, quando non invenis quid respondcas
+							manife­ <lb/> stissimae veritati. Timere te ostendis , nc te nudcm <lb/>
+							discipulis tuis. Utinam tu Chrsio sic induaris, at di­ <lb/> scipulos
+							tuos magis ipsius velis discipulos esse quant <lb/> tuos. Nam me non
+							pœnitet, quantum Dominus donat. <lb/> operam dare ut tu et discipuli tui
+							sub uno magistro <lb/> sitis condiscipuli mei. Tractatui autcm men, cui
+							post <lb/> tantum tempus adhuc te responsurum esse promittis, <lb/> si
+							ita responsurus es, ut modo respondisti vel inter­ <lb/> rogationibus,
+							vel prosecutionibus meis, non plana <lb/> aliquid respondebis: sed ut
+							homines non intelligentes <lb/> quomodocumque dccipias , non tacebis. Ex
+							his ergo <lb/> omnibus, quae sicut potui disputavi, satis apparet <lb/>
+							Patris ct Filii et Spiritus sancti unam esse virtutem, <lb/> unam esse
+							suBstantiam, unam deitatem, unam majo­ <lb/> statcm, unam gloriam; quia
+							ipsa Trinitas est unus <lb/> Dominus Deus noster, de quo dictum ea, <hi
+								rend="italic">Audi, Israel; <lb/> Dominus Deus tuus, Dominus unus
+								eat (Deut.</hi> VI , 4). <lb/> Tunc autem dictum est, quando Dominu;
+							solus dedu­ <lb/> cebat eos, et non fuit in eis deus alienus. Neque cnim
+							<lb/> non cos deducebat et Christus, cum dicat Apostolus, <lb/>
+							<hi rend="italic">Neque tentemus Christum, sicut quidam illorum tenta­
+								<lb/> verunt</hi> (I <hi rend="italic">Cor.</hi> x, 9); aut
+							Christus1 non cst Deus, aut <lb/> Christus Deus est alienus. Hic est
+							ergo Deus Pater <lb/> et Filius et Spiritus sanctus, Trinitas unus Deus
+							: cul <lb/> uni jubemur ea quae non nisi Deo debetur servitute <lb/>
+							servire, cum audimus , Dominum <hi rend="italic">Deum tuum</hi> adora­ <lb/>
+							<hi rend="italic">bis, et illi soli servies (Deut,</hi> VI, 43). Neque
+							enim hac <lb/> servitute non servimus Christo, cUjus membra su­ <lb/>
+							mus; aut Spiritui sancto, cujus templuuf sumus. Haec <lb/> Trinitas unus
+							Deus <hi rend="italic">dicit: Ego 4um Dominus, et non<lb/> est
+								alius</hi> praeter <hi rend="italic">me ( Id.</hi> XXXII, 59). Neque
+							enim nun <lb/> est Dominus Christo!, quem vos quoque Deum et Do­ <lb/>
+							minum confitcmini; aut Spiritus sanctus uon est Do­ <lb/> minus domus
+							suae, hoc est templi sui. Ipse est quippe <lb/> Spiritus Domini de quo
+							dicitur: <hi rend="italic">Dominus autem spiri­ <lb/> tua</hi> eat ; <hi
+								rend="italic">ubi autem spiritus Domini, ibi libertas</hi> (II <hi
+								rend="italic">Cor.</hi>
+							<lb/> iiT, 17). Haec est Trinitas unus Deus, de. quo dicit <lb/>
+							Apostolus : <hi rend="italic">Nullus Deus, nisi unus</hi> (I <hi
+								rend="italic">Cor.</hi> VIII , 4). <lb/> Non enim cum haec ,tuditis,
+							Deum negare unigeuitum <lb/> audetis. Hic Deus Trinitas dicit; <hi
+								rend="italic">Ego</hi> sum <hi rend="italic">qui</hi> sum, et <lb/>
+							non <hi rend="italic">sum mutatus (Exod.</hi> III, 14, <hi rend="italic"
+								>et Malach.</hi> III, 6). Non <lb/> enim mutatus est Christus, cui
+							dicitur : <hi rend="italic">Mutabis</hi> cae­ <lb/> los, <hi
+								rend="italic">et mutabuntur; tu autem idem ipse es</hi> ( <hi
+								rend="italic">Psat.</hi> CI. <lb/> 27, 28): aut mutabitur Spiritus
+							veritatis, cum sit <lb/> immutabilis vcritas, cui tantum honorem dat
+							ipse <lb/> Christus, ut dicat, <hi rend="italic">Expedit tobis ut ego
+								eam;</hi> nisi <lb/>
+							<hi rend="italic">enim ego</hi>
+							<unclear>abiers</unclear>, <hi rend="italic">Paracletus non veniet
+								ad</hi> vos <hi rend="italic">(Joan.</hi>
+							<lb/> xvi, 7): et, <hi rend="italic">Quicumque dixerit blasphemiam</hi>
+							in <hi rend="italic">Filium <lb/> hominis, dimittetur ei; qui autem
+								dixerit in Spiritum <lb/> sanctum, noM dimittetur ei (Matth.</hi>
+							XII. 52 ). Et cum d&lt;: <lb/> se ipso dixerit, <hi rend="italic">Ecce
+								ego vobiscum sum usque ad con­<lb/> summationem saeculi (Id.</hi>
+							XXVIII , 20); de illo dixit <lb/>
+							<hi rend="italic">Ut vobiscum sit</hi> in <hi rend="italic">aeternum
+								(Joan.</hi> XIV, 16). Hisatque <lb/> hujusmodi testimoniis, quae
+							omnia quaerere et colli­ <lb/> gere longum est, si pacifice acquiescas ,
+							eris, quod <lb/> orare et optare te dicis, divinarum Scripturarum di­
+							<lb/> scipulus, ut de tua fraternitate gaudeamus. <note type="footnote">
+								1 Kdili, <hi rend="italic">qitibus</hi> c fr::tus. Vclius Mss., <hi
+									rend="italic">ntd</hi> (Christus. </note></p>
+					</div>
 				</div>
-				<div type="textpart" subtype="chapter" n="26">
-					<p>CAPUT XXVI. — i. Postrema tibi disputatio fuit, <lb/> quomodo sit Deus patribus
-					visus, quando corpus <lb/> humanum in quo videretur, nondum acceperat Chri­
-					<lb/> stus, cam invisibilis sit per se ipsa divina natura. <lb/> Quod cum eliam
-					tu ila confessus fueris ut inter c;c- <lb/> tera non solum Patrem, sed nec ipsum
-					Filium in <lb/> substantia divinitatis suae diccres esse visibilem, non <lb/>
-					solum hominibus, sed nee ipsis coelestibus potestati­ <lb/> bus : postea, mutata
-					sententia, dicis eum et ante in­ <lb/> carnationem suam conspectibus apparuisse
-					morta­ <lb/> lium, asserens illud quod ait Apostolus , <hi rend="italic">Quem
-						nemo <lb/> hominum vidit, nec videre potest</hi> (I <hi rend="italic"
-						>Tim.</hi> VI, 16), do <lb/> solo Deo Patre dictum esse; Filium vero ex
-					initic <lb/> generis humani videri solitum esse ab hominibus. <lb/> Quod cum
-					probare voluisses, nulia de Scripturis san­ <lb/> ctis testimonia protulisti,
-					quae te nihil adjuvare po­ <lb/> luerunt. Non cnim legis alicubi scripsisse
-					Moyse , <lb/> sicut dicis, quod ab illo primo homine Adam usque <lb/> ad ipsam
-					incarnationem semper Filius visus est. Hoc <lb/> enim cum describere pronuntias
-					in Geneseos libro, <lb/> quod ita falsum est, ut etiam ridiculum sit. Numquid
-					<lb/> eniin liber Geneseos , ab Adam usque ad incarnatio­ <lb/> nem Christi, ea
-					quae gesta sunt continet? aut ipsg <lb/> Moyses usque ad tempora incarnationis
-					Christi, vel in <lb/> carne vixit, vel ea quae facta sunt scripsit? Haec <lb/>
-					dicis, et putas te aliquid dicere, vcl putaris ab cis <lb/> qui nee ista
-					possunt, quae tam manifeste falsa sunt ; <lb/> cernere.</p>
-					<p>2. Deinde quod commemoras Patrem ad Filium di­ <lb/> centem, <hi rend="italic"
-						>Faciamus</hi> hominem <hi rend="italic">ad imaginem</hi> et similitudi­ <lb/>
-					<hi rend="italic">nem</hi> nostram ; quid hoc ad rem pertinet, rogo te? quid
-					<lb/> ad rem pertinet? Tantumne tibi vajabat loqui, ut non <lb/> attendens quid
-					probare susceperas , memoritcr nobis <lb/> et inaniter Scripturam Geneseos
-					ventilares? Num­ <lb/> quid hinc probatur ante carnem susceptam visus ab <lb/>
-					hominibus Christus, quia dixit Pater ad Filium, Fa <lb/> ciamus <hi
-						rend="italic">hominem ad imaginem et similitudinem nostram ?</hi>
-					<lb/> Deinde adjungis, ac dicis, <hi rend="italic">Et fecit Deus hominem
-						(Gen.</hi>
-					<lb/> I. 26, 27) : atque addis, <hi rend="italic">Quis Dens, nisi Filius ?</hi>
-					Et <lb/> ut mihi de opere quasi praescribas meo, <hi rend="italic">Hoc</hi>
-					utique, <lb/> inquis, <hi rend="italic">et</hi> tu <hi rend="italic">in tuis
-						tractatibus exposuisti.</hi> Ubi nolo <lb/> quaerere quam verum loquaris,
-					quando video nibil <lb/> ad causam pertinere quod loqueris. Agitur quippe in­
-					<lb/> ter nos, utrum per suae divinitatis. substantiam <lb/> Christus visibus
-					apparuisset humanis. Et tu dicis, <lb/>
-					<hi rend="italic">Fecit Deus hominem :</hi> et addis, <hi rend="italic">Quis
-						Deus, nisi</hi>
-					<lb/> Filius ? quasi propterea necesse fuerit ut homo <lb/> Deum opificem suum
-					videret oculis carneis. Hoc si <lb/> ita esset, omnes homines viderent Deum :
-					quit <lb/> enim alius eos facit in uteris matrum ? Adhuc ad­ <lb/> jicis talia,
-					et dicis : <hi rend="italic">Iste ergo Filius qui est propheta</hi>
-					<lb/> sui genitoris, <hi rend="italic">dicebut</hi> : « Non est <hi
-						rend="italic">bonum solum esse <lb/> hominem, faciamus</hi> ei adjutorium
-						<hi rend="italic">secundum se</hi> &gt; <hi rend="italic">(Id.</hi>
-					<lb/> II, 18). Si quaeram , quis tibi indicaverit quia Filius <lb/> hoc dicebat,
-					in quibus angustiis te videbis? Scriptura <lb/> enim qua; dixit, <hi
-						rend="italic">In principio fecit Deus caelum et ter­</hi>
-					<lb/> ram, non exprimens utrum Pater, an Filius, an Spi­ <lb/> ritus sanctus, an
-					ipsa Trinitas fecerit, qui unus est <lb/> Deus; per caetera eliam ita commemorat
-					Deum, nt <lb/> dicat, Et <hi rend="italic">fecit Deus, Et</hi> dixit <hi
-						rend="italic">Deus,</hi> per quaeque opera <lb/> ejus, quorum illum asserit
-					conditorem. Simili ergo <lb/> locutione ait, <hi rend="italic">lit Dixit Deus,
-						Faciamus hominem ud <lb/> imaginem</hi> et similitudinem <hi rend="italic"
-						>nostram. Et fecit</hi> Deus homi­ <lb/> nem : nec aliter locuta est, ubi
-					nit, <hi rend="italic">Non eat bonum</hi> esse <lb/>
-					<hi rend="italic">hominem solum; faciamus</hi> ei <hi rend="italic">adjutorium
-						secundum</hi> st. <lb/> Unde igitur tibi persuasum est, caetera suj eriora
-					Pa­ <lb/> trem dixisse, hoc autem Filium? Unde, quaeso, dis­ <lb/> tinguis, unde
-					discernis Patrem dixisse, <hi rend="italic">Fiat lux (Id.</hi>
-					<lb/> I, 1-27), ct caetera ; Patrem denique dixisse, <hi rend="italic">Faciamus
-						<lb/> hominem;</hi> ct Filium dixisse, <hi rend="italic">Faciamus ei
-						adjutorium:</hi>
-					<lb/>
-					<pb n="805"/> rum tibi Scriptura Ubique nob dicat nisi, <hi rend="italic">Dixit
-						Deus ?</hi>
-					<lb/> Quae est ista temeritas ? quae praesumptio ? Dcinde cum <lb/> idco Patrem
-					majorem soleatis asserere, quia dixit, <lb/> Fiat hoc, aut illud, tanquam jubens
-					Filio; Filium <lb/> vero ideo minorem , quia jussa perfecit : quid dicturi <lb/>
-					estis, ubi scriptum est, <hi rend="italic">Faciamus</hi> hominem ? Non enim
-					<lb/> ait sicut in superioribus, Fiat homo, tanquam id jus <lb/> serit Filio :
-					sed, <hi rend="italic">Faciamus,</hi> inquit, <hi rend="italic">hominem.</hi>
-					Quod noa <lb/> quaero quem dixisse arbitreris : jam enim verba tua <lb/>
-					tenemus, quod Pater hoc dixerit Filio. Cur ergo non <lb/> ait, Fiat, vel, Fac;
-					sed ait, <hi rend="italic">Faciamus?</hi> An caetera <lb/> Deus imperavit, et
-					Filius fecit; bominem vero ambo <lb/> fecerunt, sed Patre et jubente, et
-					cooperante, Filio <lb/> autem non jubente I, sed tantum jussa faciente ? Sed
-					<lb/> si propterea Patrem jubentem intelligis, quia scriptum <lb/> est, <hi
-						rend="italic">Dixit Deut, Faciamus</hi> hominem : ergo jussit et <lb/>
-					Filius; quia tu ipse non Patrem accipis dixisse, sed <lb/> Filium, <hi
-						rend="italic">Faciamus ei adjulorium.</hi> Et sicut illud uhi di­ <lb/> ctum
-					est, <hi rend="italic">Et fecit Dcus hominem ;</hi> obedisse jubenti l'a<lb/>ri Filium vis videri, quia Pater dixerat, <hi rend="italic">Faciamus <lb/>
-						hominem</hi> : ita eliam ubi legimus, <hi rend="italic">Ei immisit Dominus
-						<lb/> soporem in Adam, et sumpsit unam de costis ejus (Gen.</hi>
-					<lb/> n, 21) , et caetera , quibus oslendilur factum homini <lb/> esse
-					adjutorium, obedisse P.trein jubenti Filio, te <lb/> auctore, intelligamus ;
-					quia non Patrem, sed Filium <lb/> dixisse asseris, <hi rend="italic">Faciamus ei
-						adjutorium.</hi>
-					</p>
-					<p>5. Sed haec ila loquor, quasi ad causam quoe a nobis <lb/> agitur, quidquam
-					pertineat, quodlibet hinc volueris <lb/> credere aut suspicari. Prorsus, sicut
-					dicis, Pater jus­ <lb/> serit, ubi dictum est, <hi rend="italic">Faciamus
-						hominem;</hi> et Filius <lb/> obedierit, ubi dictum est, <hi rend="italic"
-						>Et fecit Deus hominem :</hi>
-					<lb/> prorsus sicut te delectat, Filius dixerit, <hi rend="italic">Non est bonum
-						<lb/> solum esse hominem; faciamus</hi> ei <hi rend="italic"
-						>adjutorium;</hi> sed talia <lb/> dicens ipse non jusserit, quia hoc vultis
-					: quomodo <lb/> ostendis Filium qui hominem fecerit, ab homine vi­ <lb/> sum ?
-					Quomodo ostendis Filium qui dixit, Non <hi rend="italic">est bo­ <lb/> num
-						hominem esse solum; faciamus ei adjutorium,</hi> ab <lb/> homine visum, vel
-					ab ipsa muliere, si eam factam <lb/> non vis a Patre, ne Filio Pater obedisse
-					videatur; <lb/> scd ipse eam Filius, tanquain sibi jubens sibique obe­ <lb/>
-					diens, et faciendam dixit et fecit? Demonstra Filium <lb/> visum esse a viro,
-					visum esse a mulicre. Demonstra<lb/>turum te quippe promiseras, et antequam
-					incarnare­ <lb/> tur visum fuisse humanis aspeotibus Filium. Ostende <lb/>
-					promissa. Quid pergis in vacua? Quid deludis exspe­ <lb/> ctationem nostram, nec
-					cxhihes pollicitationem tuam? <lb/> Multiplicas verba non necessaria, ut
-					necessaria occu­ <lb/> pes tempora. Si propterea visus est a viro Filius quia
-					<lb/> fecit cum, et propterea visus ab ejus muliere quia te­ <lb/> cit eam ;
-					defini, si audes, non posse Dcum Filium et <lb/> operari videntia, et a suis
-					operibus, quamvis alia yi­ <lb/> dentibus, non videri. Si autein huc j olest
-					Dcus Filius; <lb/> ipse quippe usque nunc operatur cuncta videntia, et <lb/>
-					tamen eorum a se ipso crcatis oculis non videtur; <lb/> quid cst quod dixisti ?
-					Cur ista de libro Geneseos in <lb/> tuo sermone posuisti ? cur nobis necessaria
-					tempo­ <lb/> rum spatia superflua loquacitate finisti? <note type="footnote">1
-						Editi, <hi rend="italic">et cooperante</hi> ttiio, <hi rend="italic">rilio
-							autcm</hi> uon <hi rend="italic">jubente, etc.</hi>
-						<lb/> Costigantur ex vss. </note>
-					</p>
-					<p>4. <hi rend="italic">Sed iste,</hi> inquli, <hi rend="italic">Filius</hi> visus
-						<hi rend="italic">tit Adae,</hi> secundum <lb/>
-					<hi rend="italic">quod legimus, Adam dicentem,</hi> «<hi rend="italic"
-						>Vocem</hi> tuam audivi <lb/>
-					<hi rend="italic">deambulantis in paradiso; et abscondi</hi> me, <hi
-						rend="italic">quia nudus <lb/> tum</hi> » <hi rend="italic">( Gen.</hi> III,
-					10). Hoc orgo prius diceres, hom <lb/> bone. inde inciperes promissa nonstrare.
-					Quanivis et <lb/> hic Adam, <hi rend="italic">Vocem tuam,</hi> inquit, <hi
-						rend="italic">audivi</hi> ; non ait, F'a . <lb/> ciei vel speciem luam vidi.
-					Et quod ait, <hi rend="italic">Abscondi</hi> me, <lb/>
-					<hi rend="italic">quia nudus sum;</hi> videri se a Deo timuit, non a se Deum
-					<lb/> visum esse monstravit. Nam si vox quando auditur, <lb/> sequitur visio;
-					visus est et Deus Pater quoties voce <lb/> attestatus est Filio. Novimus quippe
-					in Evangelio ver. <lb/> ba Patris sonantis, atque dicentis, <hi rend="italic">Tu
-						es Filius</hi> meus <lb/>
-					<hi rend="italic">dilectus,</hi> etc. <hi rend="italic">(Marc.</hi> i, 11), ubi
-					auditus ab hominibus, <lb/> non tamen visus est. Ac per hoc et in illis verbis
-					qua; ł <lb/> adjungis, ubi dicit, <hi rend="italic">Quis nuntiavit tibi quia
-						nudus</hi> es? <lb/> et sequentia ; potuit audiri, et non videri Deus. Non­
-					<lb/> dum itaque aliquid ex eo quod promiseras dixisse tu <lb/> vide : et dic
-					tandem aliquid quod discutere debeamus, <lb/> aut quod pro tua causa esse
-					fateamur.</p>
-					<p>5. <hi rend="italic">Hic Deus,</hi> inquis, <hi rend="italic">et Abrahae</hi>
-					visus <hi rend="italic">est.</hi> Visum esse <lb/> Deum Abi ahae negare non
-					possumus. Scriptura quip­ <lb/> pe fidelissima apertissime hoc loquitur, dicens
-					: <hi rend="italic">Visus <lb/> eat</hi> autem <hi rend="italic">illi Deus ad
-						quercum Mambre.</hi> Sed neque h:c <lb/> expressum est, utrum Pater an
-					Filius. Cum autem <lb/> narraret Scriptura , quomodo ci visus sit Deus, tres
-					<lb/> viros illi apparuisse declarat, in quibus magis ipsa <lb/> Trinitas, qui
-					unus est Deus, recte intelligi potest. De­ <lb/> nique Ires videt , el non
-					dominos, sed Dominum ap­ <lb/> pellat, quoniam Trinitas tres quidem personae
-					sunt, <lb/> sed unus Dominus Deus. Sic autem narratur quod vi­ <lb/> dit Abraham
-					: <hi rend="italic">Respiciens,</hi> inquit, <hi rend="italic">oculis</hi> suis
-						<hi rend="italic">vidit, et<lb/> ecce tres viri stabant super eum; et
-						videns</hi> procurrit in <lb/>
-					<hi rend="italic">obviam</hi> illis <hi rend="italic">ab ostio tabernaculi</hi>
-					sui, <hi rend="italic">et</hi> adoravit super <lb/>
-					<hi rend="italic">terram, et dixit: Domine,</hi> si <hi rend="italic">inveni
-						gratiam ante</hi> te, ne <lb/>
-					<hi rend="italic">praetereas servum tuum.</hi> Hic videmus tres viros appa­
-					<lb/> ruisse, et unum Dominum dici, unumque Dominum <lb/> rogari ne praetereat
-					servum suum , quoniam congruit <lb/> Deo visitare famulos suos. Dcinde tres
-					personas plu­ <lb/> raliter alloquitur, dicens : <hi rend="italic">Sumatur nunc
-						aqua, et</hi> la­ <lb/>
-					<hi rend="italic">vem pedes vestros, et refrigerate sub arbore, et sumam<lb/>
-						panem , et manducate, et postea transibitis</hi> in <hi rend="italic"
-						>viam</hi> ve­ <lb/>
-					<hi rend="italic">stram, propter quod declinastis ad servum</hi> vestrum. Ma­
-					<lb/> nifestum est eos tanquam homines invitari : non enim <lb/> tale illis
-					praberetur obsequium, quo indigentia refi­ <lb/> cereut corpora,nisi homines
-					putarentur. Et Scriptura <lb/> pluraliter eos respondisse commemorat : ait enim,
-					Et <lb/>
-					<hi rend="italic">dixerunt, Sic fac quemadmodum dixisti.</hi> Noa ait, Et <lb/>
-					dixit; sed, <hi rend="italic">dixerunt.</hi> Deinde cam esset parata rcfectio,
-					<lb/> dicit Scriptura : <hi rend="italic">Et apposuit ante illos, et
-						ederunt.</hi> Non <lb/> ait, Apposuit anle ilium, et edit. Sed ubi ad id
-					ven­ <lb/> tum est, ut Abrahae filius promitteretur ex Sara, quia <lb/> dirinum
-					offerebatur beneficium, non ut hominibus <lb/> humanum exhibebatur obsequium,
-					unum narrat Scri­ <lb/> ptura dicentem, <hi rend="italic">Ubi eat Sara</hi> uxor
-						<hi rend="italic">tua ?</hi> Non euim ait, <lb/> Dixerunt autem ad illum :
-					sed ait, <hi rend="italic">Dixit autem ad il­ <lb/> tum : Ubi est Sara uxor
-						tua?</hi> Quis autcm hoc dixcril , <lb/> postea manifestat ; ubi cum
-					risisset Sara, ait eadem <lb/> Scriptura : <hi rend="italic">Et dixit Dominus
-						ad</hi> Abraham : Quare <hi rend="italic">risit <lb/> Sara in
-						semetipsa?</hi> et caetera usque ad finem, tanquam <lb/>
-					<pb n="807"/> unus Dominus singulariter loquitur. Ac post haec, ut <lb/> homines
-					pluraliter ahirc narrantur, et dicitur : E:c<lb/>
-					<hi rend="italic">surgentes autem inde</hi> vin, <hi rend="italic"
-						>conspexerunt</hi> in faciem Sodo­ <lb/>
-					<hi rend="italic">morum et</hi> Gomorrhae ; <hi rend="italic">Abraham vero
-						ambulabat</hi> cum <lb/> illis,<hi rend="italic">deducens.</hi> Rursus autem
-					redit Scriptura ad sin­ <lb/> gularem numerum, ac dicit : <hi rend="italic"
-						>Dominus autem</hi> dixit <hi rend="italic">: <lb/> Numquid celabo ego puero
-						meo Abraham quae ego</hi> facio ? <lb/> Deinde promittitur Abrahae praeclara
-					et copiosa poste. <lb/> ritas, et Sodomorum denuntiatur iuleritus. Sequens <lb/>
-					autem Scriptura dicit : <hi rend="italic">Et conversi inde</hi> viri, <hi
-						rend="italic">venerunt<lb/> in Sodoma ; Abraham autem erat adhuc stans</hi>
-					ante <hi rend="italic">Do­</hi>
-					<lb/> minum. <hi rend="italic">Et appropians Abraham dixit: Ne simul perdas
-						<lb/> justum cum impio; et erit justus tanquam</hi> impius ? Et <lb/> post
-					collocutionem Domini atque Abrahae, sequitur <lb/> Scriptura, et dicit: <hi
-						rend="italic">Abiit autem Dominus, utdesiit loqui <lb/> ad Abraham,</hi> et
-						<hi rend="italic">Abraham regressus eat in locum</hi> suum. <lb/>
-					<hi rend="italic">Venerunt autem duo angeli in Sodoma ad vesperam.</hi> Hi <lb/>
-					sunt de quibus paulo ante dixerat : <hi rend="italic">Conversi inde viri<lb/>
-						venerunt</hi> in <hi rend="italic">Sodoma.</hi> Sed duos esse non
-					expresserat, <lb/> cum ab initio tres viros dixisset apparuisse Abrahae, <lb/>
-					et hospitaliter ab iRo esse susceptos, quos et abeuntes <lb/> deduXit, ambubns
-					cum eis.</p>
-					<p>6. Fortassis ergo jam pronuntiare festinas, unum <lb/> fuisse in eis Dominum
-					Christum, qui singulariter pro­ <lb/> mittebat et respondebat Abrahft; duos vero
-					illos, an­ <lb/> gelos ejus, qui venerunt in Sodoma tanquam missi <lb/> angeli a
-					Domino suo. Sed exspecta : quid properas? <lb/> Consideremus omnia diligenter,
-					ac prius intueamur <lb/> verba Domini loquentis Abrahae : <hi rend="italic"
-						>Clamor Sodomorum,</hi>
-					<lb/> tnquit, <hi rend="italic">et Gomorrhae multiplicatus est, et peccata eorum
-						<lb/> magna valde. Descendens ergo videbo,</hi> si <hi rend="italic"
-						>secundum cla­</hi>
-					<lb/> morem ipsorum <hi rend="italic">vanientem ad me</hi> consummant. Hic se
-					<lb/> ipsum descensorum dixit in Sodoma, quo tamen neu <lb/> ipse descendit, sed
-					angeli duo. Ipse quippe <hi rend="italic">abiit, ut</hi>
-					<lb/> desiit <hi rend="italic">loqui ad Abraham; Abraham autem regressus
-						est</hi>
-					<lb/> in <hi rend="italic">locum</hi> suum. <hi rend="italic">Venerunt</hi>
-					autem, sicut dictum est, <hi rend="italic">duo <lb/> angeli ad vesperam in
-						Sodoma.</hi> Quid, si et in illis duo­ <lb/> bus angelis unus Dominus
-					invenitur, qui secundum <lb/> verbum suum in ipsis angelis descendit in Sodoma ?
-					<lb/> Nonne manifestum erit in tribus illis viris unum Do­ <lb/> minum visum
-					fuisse, ubi quid aliud quam ipsa Trini­ <lb/> tas figurata est? Sed videamus
-					utrum nobis sancta <lb/> Scriptura demonstret, etiam in illis duobus angelis,
-					<lb/> ut dixi, unum Dominum inventum, ne forte haec ex <lb/> nostro corde
-					affirmasse videamur. <hi rend="italic">Venerunt</hi> ergo <hi rend="italic">duo
-						<lb/> angeli in</hi> Sodoma <hi rend="italic">ad</hi> vesperam; <hi
-						rend="italic">Loth vero sedebat,</hi> ut <lb/> scriptum est, <hi
-						rend="italic">juxta portam</hi> Sodomorum. <hi rend="italic">Videns
-						autem<lb/> Loth,</hi> surrexit in <hi rend="italic">obviam illis, et
-						adoravit in faciem in <lb/> terram.</hi> Vides nempe hic a justo viro
-					angelos adoratos, <lb/> et tu non vis adorari Spiritum sanctum, quem vos quo­
-					<lb/> que omnibus angelis I sine ambiguitate praeponiłis ? <lb/> Sed dicturus es
-					Homines esse credebat, nam et in <lb/> Hospitium tanquam homines invitavit. Hoc
-					magis est <lb/> contra te, qui dicis non adorari Spiritum sanctum, <lb/> omnibus
-					Angelis praefendum ; cOrn videas et ho­ <lb/> mines inferiores Angelis a justis
-					hominibus adorari. <lb/> Scd adhuc dicturus es, Dominum adoravit : cum <lb/>
-					quippe in duobus illis, quos putabat esse homines, <note type="footnote">1 m
-						t-dilione Lov. deest, angelis. </note>
-					<lb/> tanquam in prophetis esse cognovit. Jam ergo pro­ <lb/> batum est, quod me
-					per Scripturam sanctam de<lb/>monstraturum esse promiseram, eumdem Dominum
-					<lb/> qui dictus fuerat abiisse ut cessavit loqui ad Abra­ <lb/> bam, in illis
-					duobus ange! s descendisse in Sodoma, <lb/> sicut dixerat, et in cis ab homine
-					justo agnitum <lb/> fuisse. Exhibuit itaque hospitalitatem quomodo san­ <lb/>
-					ctis hominibus Dei, in quibus Deum esse cognovit, <lb/> cum eos, sicut etiam
-					ipse Abraham, angelos esse <lb/> nesciret. Hi enim Patriarchae sunt significati
-					in Epi­ <lb/> stola ad Hebraeos, ubi de hospitalitate loquens ait: <lb/>
-					<hi rend="italic">Per hanc quidam</hi> nescientes, <hi rend="italic">hospitio
-						receperunt an­<lb/> gelos (Hebr.</hi> XIII, 2). Receptis ergo eis Loth,
-					nesciens <lb/> quod angeli essent, cognoscens tamen sicut ipo Do­ <lb/> nrino
-					demonstrante cognoscere potuit, quis in eis <lb/> esset, ut ea quae interca
-					facta sunt taceam, exii', cnm <lb/> eis de Sodomis: qnod antequam fierct, sicut
-					Scri­ <lb/> plura loquitur, <hi rend="italic">dixerunt</hi> viri <hi
-						rend="italic">ad Loth : Sunt tibi hic</hi>
-					<lb/> generi, <hi rend="italic">aut filii, aut</hi> filiae ? <hi rend="italic"
-						>aut</hi> si <hi rend="italic">quis</hi> tibi <hi rend="italic">alius
-						eat</hi> in <lb/>
-					<hi rend="italic">civitate, educ de loco</hi> hoc : quoniam perdimus' <hi
-						rend="italic">noa <lb/> locum hunc ; quia exaltatus ese clamor eorum ante
-						Do­ <lb/> minum, et misit</hi> noa <hi rend="italic">Dominus conterere
-						eum.</hi> Ecce ubi <lb/> apparet illud incendium Sodomorum per angelos fa­
-					<lb/> ctum, quos misit Dominus; in quibus tamen et ipse <lb/> erat : neque enim
-					sic mittit suos, ut recedat ab eis. <lb/> In eis ergo descendit in Sodoma, quod
-					se facturum <lb/> esse praedixerat, quando cum Abraham loqucbatur: <lb/> quod
-					posteaquam fecit, abiisse ipse dictus est, et an­ <lb/> geli venisse in Sodoma
-					ad vesperam. Deinde paulo <lb/> post, mox ut cduxerunt illum foras, et dixerum,
-					<lb/> sicut eadem Scriptura narrat, <hi rend="italic">Salvam</hi> fac animan <lb/>
-					<hi rend="italic">tuam; ne respexeris retro, nec steteris in tota regione;</hi>
-					in <lb/>
-					<hi rend="italic">monte salvum te fac, nequando comprehendaris</hi> : dixit
-					<lb/> Loth ad illos, <hi rend="italic">Oro, Domine, quia</hi> invenit <hi
-						rend="italic">puer</hi> tuus <lb/>
-					<hi rend="italic">misericordiam ante te,</hi> etc. Quae cum finisset loquendo,
-					<lb/> et elegisset sibi civitatem pusillam in qua salvaretur, <lb/> seqnitur
-					Scriptura, ct ei dicit esse responsum : <hi rend="italic">Ecce<lb/> miratus</hi>
-					sum2 <hi rend="italic">faciem tuam et super verbum hoc, ne<lb/> everterem
-						civitatem de qua</hi> locutus ea. <hi rend="italic">Festina ergo ut<lb/>
-						salvus sis ibi : non enim potero facere verbum, donec <lb/> tu illo introeas
-						(Gen.</hi> XVIII <hi rend="italic">et</hi> XIX). Quis hoc ei re­ <lb/>
-					spondit, nisi ille cui dixcrat, Oro, <hi rend="italic">Domine?</hi> Hoc an­
-					<lb/> tem ad ambos dixerat, non ad unum, sicut apertis­ <lb/> sime scriptum est,
-						<hi rend="italic">Dixit autem Loth ad</hi> illos, Ora, <lb/>
-					<hi rend="italic">Domine.</hi> Agnovit ergo a Loth unum Dominum in an­ <lb/>
-					gelis duobus, sicut Abraham unum agnovit in tribus.</p>
-					<p>7. Non est cur dicatur : Ille abierat qui Dominus <lb/> erat et cum Abraham
-					locutus erat; duo vero angeli <lb/> ejus erant qui in Sodoma, illo abeunte 4,
-					venerunt. <lb/> Omnes enim tres viridiclisunl . qui apparuerunt Abra­ <lb/> hae,
-					sicut Scriptura solet viros etiain angelos nuncu­ <lb/> pare. Nee eoruin alicui
-					uni promptius et humilius <lb/> Abraham obsecutus est quam duobus, sed
-					aequaliter <lb/> omnibus pedes lavit, aequaliter omnibus epulas In i- <note
-						type="footnote"> * sic Mss. Editi vero, <hi rend="italic">perdemus.</hi>
-					</note><note type="footnote"> I Editi, <hi rend="italic">miseratus</hi> sum. At
-						Mss., <hi rend="italic">miratus</hi> sum : <unclear>hirc</unclear>
-						<lb/> 16 de civitate Dei, cap. 29, juxta graecum LXX, <hi rend="italic"
-							>ethaumasa,</hi>
-						<lb/> quod dici POtest, <hi rend="italic">reveritus sunt, suipexi.</hi>
-					</note><note type="footnote"> I In Mss., <hi rend="italic">jgnovisti ergo.</hi>
-					</note><note type="footnote"> * Sola fere edi lio Lov., <hi rend="italic"
-							>jnbente.</hi>
-					</note>
-					<lb/>
-					<pb n="809"/> nistravit. Ergo in omnibus Deum vidit. Propter quod <lb/>
-					Scriptura praedixerat, quod visus fuerat Deus Abrahae <lb/> ad quercum Mambre,
-					sub cujns umbra arboris tres <lb/> viros pavit, quos oculis corporis vidit: in
-					cis vero <lb/> Deum, non corporis, sed cordis oculis vidit, id est, <lb/>
-					intellexit atque cognovit; sicut Loth in duobus, cum <lb/> quo non pluraliter,
-					sed singulariter loquebatur, eique <lb/> respondebat etiam ipse tanquam unus.
-					Primo quippe <lb/> Abraham per tres viros illum audivit, postea per <lb/> unum,
-					qui duobus in Sodoma euntibus manens lo­ <lb/> cuius est cum eo; Loth autem per
-					duos, tamen et <lb/> ipse unum Dominum, quein pro liberatione sua ro­ <lb/>
-					gabat, et qui ei respondebat, audivit : cum ambo, id <lb/> est, et Abraham ct
-					Loth, homines putarent eos qui <lb/> angeli erant; Deum vero in eis
-					intelligerent qui erat, <lb/> non putarent esse qui non erat. Quid sibi ergo
-					vult <lb/> ista visibilis Trinitas et intelligibilis unitas, nisi ut <lb/> nobis
-					insinuaretur quod ita tres essent Pater et Fi­ <lb/> lius ct Spiritus sanctus,
-					ut tamen simul non tres dii <lb/> et domini essent, sed unus Dominus Deus ? Tu
-					autem <lb/> dixisti, <hi rend="italic">Hic Deus visus eat Abrahae :</hi> sciens
-					te legisse <lb/> quod scriptum cst, visum esse Deum Abrahae ad quer­ <lb/> cuin
-					Mambre : et volens quasi probare Dominum <lb/> Filium visum esse illi
-					patriarchae, declinasti ab illis <lb/> tribus viris, ct cos omnino tacuisti, in
-					quibus narrat <lb/> Scriptura Deum visum fuisse Abrahae; ne tu ipse nos <lb/>
-					admoneres unius esse substantiae Trinitatem Deum, <lb/> sicut unius erant
-					substantiae tres viri quos vidit Abra­ <lb/> ham : cum praedixisset Scriptura,
-						<hi rend="italic">Visus est Deus <lb/> Abrahce,</hi> nec tamen tres deos
-					esse, quia et, <hi rend="italic">Visus eat<lb/> Deus,</hi> dictum est; non, visi
-					sunt dii : et ipse Abra-<lb/> ham tres vidit, et unum adoravit : a quo
-					praeteriri <lb/> noluit; ab uno responsa divinitatis accepit. Nec ali­ <lb/>
-					quos duos eorum duos esse dcos sensit, sed unum in <lb/> omnibus : quia et Loth
-					duos vidit, et tamen unum <lb/> Dominum agnovit. Ubi mihi videntur per angelos
-					si­ <lb/> gnificari Filius et Spiritus sanctus : quoniam se illi <lb/> angeli
-					missos esse dixerunt ; et de Trinitate quae Deus <lb/> est, solus Pater non
-					legitur missus; leguntur autem <lb/> missi et Filius et Spiritus sanctus ;
-					quorum non ideo <lb/> est diversa natura : nam et illi viri per quos signifi­
-					<lb/> cati sunt, unius erant ejusdemque naturae. Hanc ergo <lb/> Scripturam qua
-					convinci posses, astuto silentio devi­ <lb/> tasti. Et cum dixisses, <hi
-						rend="italic">Hic Deus visus</hi> eat <hi rend="italic">Abrahae :</hi>
-					<lb/> volens Filium solum visum putari in eo quod in Ge­ <lb/> nesi legitur,
-					visum esse Deum Abrah;e, quomodo sit <lb/> visus, dicere noluisti, ne ibi non
-					solus Filius, sed <lb/> Trinitas agnosceretur Deus.</p>
-					<p>8. Dixisti autem : <hi rend="italic">Si vis credere, quia Filius vi,,,. <lb/> est
-						Abrahae, utique ipse Unigenitus</hi> in <hi rend="italic">sancto affirmavit
-						<lb/> Evangelio sic :</hi> « <hi rend="italic">Abraham pater vester
-						exsultavit ut</hi> vi-­ <lb/>
-					<hi rend="italic">deret diem</hi> meum; <hi rend="italic">et vidit, et gavisus
-						est. &gt; (Joan.</hi> VIII, <lb/> 56). 0 disputare, o probare promissa I
-					quasi dixerit <lb/> Dei Filius, Abraham pater vester concupivit me vi­ <lb/>
-					dere; et vidit, et gavisus est. Quamvis et hoc sic ad­ <lb/> huc posset
-					intelligi, quod sanctus Patriarcha oculis <lb/> cordis viderit Dei Filium, non
-					oculis carnis, unde <lb/> inter nos vertitur quaestio. Sed cum dixerit Christus,
-					<lb/> Abraham concupivit <hi rend="italic">videre diem</hi> meum ; et <hi
-						rend="italic">vidit, et</hi>
-					<lb/> gavisus <hi rend="italic">est ;</hi> cur non diem Christi intelligimus
-					tem­ <lb/> pus Christi, quo erat venturus in carne, quod Abra­ <lb/> ham sicut
-					et alii Prophetae in spiritu potuit vidcre <lb/> atque gaudere? Neque hie igitur
-					quod proposueras <lb/> et pollicitus fueras, probare potuisti.</p>
-					<p>9. Post haec venisti ad Jacob, qui luctatus est cum <lb/> Angelo, quem scriptura
-					ipsa Geneseos et hominem <lb/> dicit et Deum. Nam ita legitur : <hi
-						rend="italic">Remansit autem</hi> Ja­ <lb/>
-					<hi rend="italic">cob</hi> solus, <hi rend="italic">et luctabatur hamo cum illo
-						usque</hi> in <hi rend="italic">mane. <lb/> Vidit autem quod non potest ad
-						eum, et tetigit latitudi­</hi>
-					<lb/> nem <hi rend="italic">femoris ejus, et</hi> obstupuit' latitudo <hi
-						rend="italic">femoris Jacob, <lb/> dum luctaretur cum eo; et dixit illi :
-						Dimitte me;</hi> f <lb/>
-					<hi rend="italic">ascendit enim aurora. Ille autem dixit: Non te dimit- <lb/>
-						tam,</hi> nisi <hi rend="italic">me benedixeris. Dixit autem</hi> ei: <hi
-						rend="italic">Quod eat no­ <lb/> men</hi> tuum ? <hi rend="italic">llle
-						autem dixit: Jacob. Et dixit ei: Nan<lb/> vocabitur amplius nomen tuum
-						Jacob; sed Israel erit <lb/> nomen tuum, quia valuisti cum Deo, et cum</hi>
-					hominibus <lb/>
-					<hi rend="italic">potens es. Rogavit autem eum Jacob dicens : Enuntia <lb/> mihi
-						nomen</hi> tuum. <hi rend="italic">Et dixit : Quare hoc interrogas</hi> tu <lb/>
-					<hi rend="italic">nomen meum? Et benedixit eum illic. Et appellavit <lb/> Jacob
-						nomen loci illius, Aspectus Dei : Vtdi</hi> enim <hi rend="italic">Deum
-						<lb/> facie ad</hi> faciem, <hi rend="italic">et salva facta est anima
-						mea</hi> (Gen. <lb/> XXXII, 24-30). Ex ista lectione unicum Dei Filium et
-					<lb/> antequam venisset in carne visibiliter apparuisse co­ <lb/> naris
-					ostendere : ubi etsi non absurde Christus intel­ <lb/> ligitur figuratus,
-					propter prophetiam futura nuntian­ <lb/> tem, quia futurum erat ut Jacob in
-					filiis suis qui cru. <lb/> cifixerunt Christum, praevaluisse Christo videretur;
-					<lb/> et in filiis suis videret Christum facie ad faciem, ct <lb/> salva Geret
-					anima Israelitarum qui fideliter hoc vide­ <lb/> runt: tamen hunc hominem quI
-					luctatus est cum <lb/> Jacob, Osee propheta evidenter angelum dicit. Sic <lb/>
-					enim apud eum scriptum est de Jacob : <hi rend="italic">In utero</hi> sup­ <lb/>
-					<hi rend="italic">plantavit fratrem</hi> suum, <hi rend="italic">et in. labore
-						praevaluit</hi> Deo, et <lb/>
-					<hi rend="italic">confortatus eat cum angelo,</hi> et potuit <hi rend="italic"
-						>(Osee</hi> XII, 3, 4). <lb/> Sicut ergo in Genesi ille qui luctatus est cnm
-					Jacob, <lb/> ct homo et Deus dicitur 2 ; ita et ab hoc propheta et <lb/> Deus
-					et. angelus. Ac per hoc ita qui erat angelus, <lb/> dictus est humo, quomodo
-					illi dicti suut viri qui ap­ <lb/> paruerunt Abrahae, qnando nescientes* et ipse
-					et <lb/> Loth hospitio receperunt angelos. Deus ergo erat <lb/> in angelo, sicut
-					est Deus in homine, maxime quan­ <lb/> do pcr hominem loquitur. Ita vero per
-					hunc an. <lb/> gelum figuratus est Christus, sicut per hominem. <lb/> Nam et
-					Isaac filius Abrahae,quid crat in figura, <lb/> nisi Christus, quando sicut ovis
-					ad immolandum <lb/> ductus est <hi rend="italic">( Isai.</hi> LIII, 7), et
-					quando sicut Do­ <lb/> minus erucem suam, ita et ipse sibi quibus fuerct <lb/>
-					imponendus ligna portabat? Postremo, quid nri­ <lb/> ramur per angelum figuratum
-					esse Jcsum, si non <lb/> solum per hominem, verum etiam per pecudem figu­ <lb/>
-					ratus est? Nam quis alius erat ille aries qui cornibus <lb/> tenebatur in vepre,
-					nisi Christus crucifixus, vel spinis <lb/> etiam coronatus. Hunc autem arietem
-					pro filio, cui <lb/> parcere jussus est, immolavit Abraham <hi rend="italic">(
-						Gen.</hi> xxJ, <lb/> 6-13). Ita cnim homini parci Deus jussit, ut tanMn IX
-						<note type="footnote"> 1 ID MSS., <hi rend="italic">obit..</hi> '
-						</note><note type="footnote"> * Mss., et Deus <hi rend="italic">scitur.</hi>
-					</note><note type="footnote"> * MM., <hi rend="italic">quando</hi> tidentes. </note>
-					<note type="footnote"> PATROL. XLII. </note>
-					<note type="footnote">
-						<hi rend="italic">(Vinyl-siahJ</hi>
-					</note>
-					<lb/>
-					<pb n="811"/> pecore, propter passionem Christi, qua? illo modo <lb/>
-					praenuntiabatur, mysterium sacri sanguinis implore­ <lb/> tur. Si ergo putas
-					proprietate, non figura, Christum <lb/> fuisse angelum, qni luctatus est cum
-					Jacob; potes di­ <lb/> cere proprietate, non figura, Christum fuisse arietem,
-					<lb/> quom patriarcha immolavit Abraham : potes postre­ <lb/> o dicere
-					proprictate, non figura, Christuin fuisse <lb/> petram, quae percussa ligno,
-					sifienli populo potum <lb/> largissimum fudit ( Exod. XVII, G ). Sic enim dicit
-					<lb/> Apostolus : <hi rend="italic">Bibebant enim de spirituali</hi> sequente
-					petra ; <lb/>
-					<hi rend="italic">petra autem erat</hi> Christus ( I <hi rend="italic">Cor.</hi>
-					x, 4 ). Figure istae <lb/> non res ipsae fuerunt, quibus figuris praecedentibus
-					<lb/> tes significabantur esse ventura;: quae figurae per <lb/> suhjectam Deo
-					creaturam, et maxime per Angelorum <lb/> ministerium, mortalium cxhibebantur
-					aspectibus, Dei <lb/> quidem agente potentia, sed tamen latente natura, <lb/>
-					sive Patris, sive Filii, sive Spiritus sancti.</p>
-					<p>40. Frustra itaque asseris Filium Dei risum fuisse <lb/> ah hominibus, Patrem
-					autem non fuisse visum : cum <lb/> pcr subjectam sibi creaturam et Pater videri
-					potuerit, <lb/> et Filius, et Spiritus sanctus; per suam vero substan<lb/> Ham
-					nullus illurum visus cst. Ergo Deus, sicut infir­ <lb/> mis hominum sensibus,
-					magis significatus quam de­ <lb/> monstratus est. Non itaque visus cst sicut est
-					: hoc <lb/> quippe in futura vita promittitur sanctis. Unde dicit <lb/>
-					apostolus Joannes : <hi rend="italic">Dilectissimi, nunc filii Dei</hi> sumus,
-					<lb/> et <hi rend="italic">nondum apparuit quid erimus : scimus autem</hi> quia
-					<lb/> cum apparuerit, <hi rend="italic">similes</hi> ei <hi rend="italic"
-						>erimus, quoniam videbimus <lb/> eum sicuti eat</hi> (I <hi rend="italic"
-						>Joan.</hi> III, 2). Videruut ergo et in hoc <lb/> saeculo Apostoli Dominum;
-					viderunt, sed non sicut <lb/> est. Denique Moyses eum sibi cupiebat ostendi,
-					quam­ <lb/> vis cum eo facie ad faciem Scriptura indice loquero­ <lb/> tur
-					(Exod. XXXIII, 13, 11). Quod cum in mea superius <lb/> prosecutione dixissem,
-					quasi non audieris praeteristi, <lb/> cnm tibi ejusdem meso prosecutionis
-					recitari ex tabu­ <lb/> lis universa voluissem. Non autem discernens quid <lb/>
-					sit videri Dcum per substantiam suam, et quid sit <lb/> videri Deum per
-					subjectam creaturam, in tantam <lb/> blasphemiam decidisti, ut unigenitum Dei
-					Filium per <lb/> hoe ipsum quod Deus est mutabilem diceres : quando­ <lb/>
-					quidamsoli Patri putasti esse tribuendum quod scri­ <lb/> pturO osse dixisti,
-						<hi rend="italic">Ego sum qui</hi> sum , <hi rend="italic">et non</hi> sum
-						<hi rend="italic">mu­ <lb/> tatus;</hi> quasi Filius vel Spiritus sanctus
-					sit mutatus <lb/> quando visibiliter apparuit, vel ille quod constat natus <lb/>
-					ex fcmina , vel iste in specie columbae aut igneis lin­ <lb/> guis se humanis
-					aspectibus monstrans. Unde jam re­ <lb/> spondi tibi in eo sermone, ubi ostendi
-					non te rcfel­ <lb/> lisse quae dili. Nunc vero ut intelligas quomodo <lb/>
-					dixerit Deus,<hi rend="italic">Ego</hi> sum <hi rend="italic">qui sum, et non
-						sum mutatus,</hi>
-					<lb/> vel quod scriptum magis invenitur, <hi rend="italic">Ego</hi> enim <hi
-						rend="italic">Dom­</hi>
-					<lb/> nus, <hi rend="italic">et</hi> non <hi rend="italic">mutor (Id.</hi> 3,
-					14, <hi rend="italic">et Malach.</hi> 3, 6); quo­ <lb/> niam non solus Pater,
-					sed Deos unus hoc dixit, quod <lb/> est ipsa Trinitas ; Psalmum attende ubi
-					legitur : Tu <lb/> in <hi rend="italic">principio, Domine, terram</hi> fundasti,
-						<hi rend="italic">et opera</hi> manuum <lb/> tuarum sunt <hi rend="italic"
-						>caeli : ipsi peribunt; tu autem permanebis : <lb/> et omnes sicut
-						vestimentum veterascent, et velut tegu­ <lb/> mentum mutabis eos, ct</hi>
-					mutabuntur ; <hi rend="italic">tu autem idem</hi>
-					<unclear/>
-					<lb/> spse es, et anni <hi rend="italic">tui non deficient (Psal.</hi> CI,
-					25-28). Hoc <lb/> autem ad Filium Dei dictum es n in Epistola qua est <lb/> ad
-					Hebraeos sancta Scriptura .testatur <hi rend="italic">(Hebr.</hi> I, 10- <lb/>
-					42). Quis vero non intelligat, uhi dicitur, <hi rend="italic">Caeli muta­ <lb/>
-						buntur; tu autem idem ipse es;</hi> nihil dici animI, nisi, <lb/> TII non
-					mutaris? Ac per hoc etiam Deo Filio convenit <lb/> dicere, <hi rend="italic">Ego
-						sum qui sum, et</hi> non <hi rend="italic">sum mutatus;</hi> vel <lb/>
-					<hi rend="italic">Ego enim Dominus, et non mutor.</hi> Quod tu idco soli <lb/>
-					Patri assignasti, ut in sua substantia crederetur esse <lb/> mutabilis Filius ;
-					tanquam ita susceperit hominem, ut <lb/> in hominem verteretur. iianc tantam
-					blasphamiam <lb/> non emendabis, nisi credideris, in assumpti mehomi <lb/> nis
-					accessisse Filio quud non erat, non autem reces­ <lb/> sisse vcl defecisse quod
-					crat.</p>
-					<p>11. Deinde quaero, quis apparuerit Moysi in igne <lb/> quando rubus
-					iullammabatur, ct non urebatur Quan­ <lb/> quain et illic angelum apparuisse
-					Scriptura ipsa de­ <lb/> clarat , dicens : <hi rend="italic">Apparuit antem illi
-						angelus Domini in<lb/> flamma ignis de rubo.</hi> In angelo autem Deum
-					fuisse , <lb/> quis dubitet? Sed quis Deuserat ? utrum Pater, an <lb/> Filius?
-					Dicturus es, Filius : non vis enim Patrem <lb/> ullo modo, vel pcr subjectam
-					crcaturam, visibus ap­ <lb/> paruisse mortalium. Sed quodlibet horum eligas, ad
-					<lb/> utrumque respondeo. Si Paler crat, apparuit ct Pater <lb/> hominibus : si
-					Filius erat, non inutatur et Filius. Ibi <lb/> enim cum quaesisset Moyscs, quis
-					esset qui eum mit­ <lb/> tere!; ille respondit : <hi rend="italic">Ego sum
-						qui</hi> sum. Quod quid <lb/> est aliud, nisi, Mutabilis non sum : sicut
-					propheticum <lb/> testimonium ipse posuisti, <hi rend="italic">Ego</hi> sum <hi
-						rend="italic">qui sum, et non <lb/> sum</hi> mutatus ? Dixit etiam rursus ad
-					Moyscn : <hi rend="italic">Ego</hi>
-					<lb/> sum <hi rend="italic">Deus Abraham, et Deus Isaac, et Deus Jacob
-						(Exod.</hi>
-					<lb/> III, 2, 14, 6, 15). Aude, si potes, negare Dcum Patrem <lb/> Dcum esse
-					Abraham, et Isaac, et Jacob; si non i;se <lb/> de ruho, sed Filius loquebatur.
-					Si autem Pater, con­ <lb/> fitere eliam Patrem Deum hominibus visum. Si vero
-					<lb/> uterque est Deus Abraham, et Deus Isaac, et Deus <lb/> Jacob, quod esse
-					annuis ;-quid ambigis utrumque <lb/> unum Deum? Jacob quippe ipse est Israel,
-					cujus filiis <lb/> dicitur : <hi rend="italic">Audi, Israel; Dominus Deus tuus,
-						Dominus <lb/> unus est (Deut.</hi> VI, 4).</p>
-					<p>12. Quapropter verum esse agnosce qnod dixi, di­ <lb/> vinitatem non per
-					substantiam suam, in qua invisi­ <lb/> bilis ct immutabilis est, ped per
-					creaturam sibi subjo<lb/>Clam mortalium oculis apparuisse cum voluit. Non
-					<lb/> itaque sicut accipere vel accipi mea verba voluisti, <lb/> ego divinitatem
-					sic patribus 1 ostendisse se dixi, tan­ <lb/> quan eam voluerim credi visibilem,
-					quati prius <lb/> invisibilem dixeram esse : sed dixi, quando se patri­ <lb/>
-					bus divinitas ostendebat, per subjectam creaturam se <lb/> visibilem
-					demonstrabat. Nam per ipsam suam natu­ <lb/> . ram usque adeo invisibilis est,
-					ut ipse Moyscs ei cum <lb/> quo facie ad faciem loquebatur diceret: <hi
-						rend="italic">Si inveni gra. <lb/> tiam ante te, ostende mihi temetipsum
-						manifeste (Exod.</hi>
-					<lb/> XXXIII, 11, 15). Ecce quod dixi : relege, et invenies <lb/> me verum
-					dicere ; te autem non intelligere voluisse, <lb/> vcl non potuisse, quod dixi.
-					Audi ergo idipsum me <lb/> aliquanto planius disserentem. Ego divinitatem Patris
-					<lb/> et Filii et Spiritus sancti in sua natura atque substan­ <lb/> tia
-					mortalibus oculis invisibilem dico. Eam vcro se tu <note type="footnote"> I
-						riure* 'w:SS. J <hi rend="italic">ratru.</hi>
-					</note>
-					<lb/>
-					<pb n="813"/> formas visibiles vertere, absit ut dicam, quia et im­ <lb/>
-					mutabilem dico. Restat ergo ut aspcetibus humanis <lb/> quando se ostendit ut
-					voluit, per subjectam intelliga­ <lb/> tur hoc fecisse creaturam, quae potest
-					oculis apparere <lb/> mortilihus.</p>
-					<p>13. Quid est autem quod eumde Patre dixisses, <lb/>
-					<hi rend="italic">Unus est</hi> invisibilis, unde jam salis est disputatum; ad­
-					<lb/> didisti, Unus <hi rend="italic">etiam incapubilis atque immensus?</hi>
-					Inca­ <lb/> pabilem quidem non legimus Deum. Cur sane dicas <lb/> incapabilem,
-					nescio. Si cnim capi non potest, quo­ <lb/> modo non solum Filius, verum eLiam
-					Pater veniunt <lb/> ad hominem, sicut dicit ipse Filius, et mansionem <lb/> apud
-					eum faciunt <hi rend="italic">(Joan.</hi> xiv, 23) ? Puto quod capiat <lb/> eos
-					apud quem faciunt mansionem. An forte dicis, <lb/> Non ex toto, sed ex parte
-					capiuntur? Dic quod vis : <lb/> respondetur enim tibi, Non sunt ergo
-					incapabiles, qui <lb/> sunt xel ex parte capabiles. An ideo tibi non sufficit
-					<lb/> incapabilem dicere, sed addidisti, et immensum, ut <lb/> exponeres
-					quatenus incapabilem dixeris ? id cst, quia <lb/> totius capax non est humana
-					natura; immensus est <lb/> enim ? Verum hoc et de Filio dici potest. Neque enim
-					<lb/> quisquam sic capit unigenitum Verbum, ut ejus ca­ <lb/> pacem se omni modo
-					audeat profiteri. Prorsus etiam <lb/> ipsum non esse dubitamus immensum. Nam
-					quaero <lb/> abs te, de quo accipias quod scriptum est : <hi rend="italic"
-						>Magnus <lb/> est, et non habet</hi> finem; <hi rend="italic">excelsus
-						et</hi> immensus. De ipso <lb/> quippc paulo post dicitur : <hi
-						rend="italic">Hic Deus noster,</hi> non <hi rend="italic">aesti­ <lb/>
-						mabitur alius ad eum ; hic</hi> invenit <hi rend="italic">omnem viam disci­
-						<lb/> plinae et dedit eam Jacob puero suo, et Israel dilecto <lb/> suo :
-						post haec super terram</hi> visus <hi rend="italic">eat, ei inter
-						homines<lb/> conversatus eat (Baruch</hi> III, 26, 56, 37, 58) ? Quis est
-					<lb/> iste, responde? Quis est, inquam, <hi rend="italic">Magnus, et non <lb/>
-						habens finem ; excelsus et immensus; qui super terram</hi>
-					<lb/> visus <hi rend="italic">est, et inter homines conversatus est</hi> ? Yidco
-					quos <lb/> aestus, quas patiaris angustias. Times dicere, Pater <lb/> est ; ubi
-					audis, <hi rend="italic">super terram</hi> visus <hi rend="italic">est, et inter
-						homines <lb/> conversatus est.</hi> Tu enim Patrem por suam substan­ <lb/>
-					tiam revera invisihilem, nec per subjectam creaturam <lb/> vis esse ab hominibus
-					visum. Times dicere, Filius <lb/> est ; ubi audis, non <hi rend="italic">habet
-						finem, excelsus et immensus.</hi>
-					<lb/> Tii enim Patrem tantummodo esse contendis immen­ <lb/> sum. Times dicere,
-					Spiritus sanctus est; ubi audis , <lb/>
-					<hi rend="italic">hic Deus noster.</hi> Tu enim nec Deum vis esse Spiritum <lb/>
-					sanctum. Quid es acturus, quid responsurus, homo <lb/> qui non vis esse
-					catholicus, ut Christum sic accipias <lb/> in forma servi super terram visum, et
-					inter homines <lb/> conversatum, ut tamen in forma Dei in qua invisibilis <lb/>
-					mansit, confitearis immensum ? <hi rend="italic">Hic Deus noster, non <lb/>
-						aestimabitur alius ad eum.</hi> Quis alius, nisi Antichristus, <lb/> quem
-					veram Christum fides vera non aestimat, sed <lb/> enim pro vero Christo
-					exsecrabilis Judxorum error <lb/> exspectat ?</p>
-					<p>14. Si oras, et petis, ut dicis, discipulus esse divi­ <lb/> narum Scripturarum.
-					ad rem pertinentia testimonia <lb/> divina considera. Noli per multa quae te
-					nihil adju­ <lb/> vene, evagari: elige prudenter tacere quam inaniter <lb/>
-					loqui, quando non invenis quid respondcas manife­ <lb/> stissimae veritati.
-					Timere te ostendis , nc te nudcm <lb/> discipulis tuis. Utinam tu Chrsio sic
-					induaris, at di­ <lb/> scipulos tuos magis ipsius velis discipulos esse quant
-					<lb/> tuos. Nam me non pœnitet, quantum Dominus donat. <lb/> operam dare ut tu
-					et discipuli tui sub uno magistro <lb/> sitis condiscipuli mei. Tractatui autcm
-					men, cui post <lb/> tantum tempus adhuc te responsurum esse promittis, <lb/> si
-					ita responsurus es, ut modo respondisti vel inter­ <lb/> rogationibus, vel
-					prosecutionibus meis, non plana <lb/> aliquid respondebis: sed ut homines non
-					intelligentes <lb/> quomodocumque dccipias , non tacebis. Ex his ergo <lb/>
-					omnibus, quae sicut potui disputavi, satis apparet <lb/> Patris ct Filii et
-					Spiritus sancti unam esse virtutem, <lb/> unam esse suBstantiam, unam deitatem,
-					unam majo­ <lb/> statcm, unam gloriam; quia ipsa Trinitas est unus <lb/> Dominus
-					Deus noster, de quo dictum ea, <hi rend="italic">Audi, Israel; <lb/> Dominus
-						Deus tuus, Dominus unus eat (Deut.</hi> VI , 4). <lb/> Tunc autem dictum
-					est, quando Dominu; solus dedu­ <lb/> cebat eos, et non fuit in eis deus
-					alienus. Neque cnim <lb/> non cos deducebat et Christus, cum dicat Apostolus, <lb/>
-					<hi rend="italic">Neque tentemus Christum, sicut quidam illorum tenta­ <lb/>
-						verunt</hi> (I <hi rend="italic">Cor.</hi> x, 9); aut Christus1 non cst
-					Deus, aut <lb/> Christus Deus est alienus. Hic est ergo Deus Pater <lb/> et
-					Filius et Spiritus sanctus, Trinitas unus Deus : cul <lb/> uni jubemur ea quae
-					non nisi Deo debetur servitute <lb/> servire, cum audimus , Dominum <hi
-						rend="italic">Deum tuum</hi> adora­ <lb/>
-					<hi rend="italic">bis, et illi soli servies (Deut,</hi> VI, 43). Neque enim hac
-					<lb/> servitute non servimus Christo, cUjus membra su­ <lb/> mus; aut Spiritui
-					sancto, cujus templuuf sumus. Haec <lb/> Trinitas unus Deus <hi rend="italic"
-						>dicit: Ego 4um Dominus, et non<lb/> est alius</hi> praeter <hi
-						rend="italic">me ( Id.</hi> XXXII, 59). Neque enim nun <lb/> est Dominus
-					Christo!, quem vos quoque Deum et Do­ <lb/> minum confitcmini; aut Spiritus
-					sanctus uon est Do­ <lb/> minus domus suae, hoc est templi sui. Ipse est quippe
-					<lb/> Spiritus Domini de quo dicitur: <hi rend="italic">Dominus autem spiri­
-						<lb/> tua</hi> eat ; <hi rend="italic">ubi autem spiritus Domini, ibi
-						libertas</hi> (II <hi rend="italic">Cor.</hi>
-					<lb/> iiT, 17). Haec est Trinitas unus Deus, de. quo dicit <lb/> Apostolus : <hi
-						rend="italic">Nullus Deus, nisi unus</hi> (I <hi rend="italic">Cor.</hi>
-					VIII , 4). <lb/> Non enim cum haec ,tuditis, Deum negare unigeuitum <lb/>
-					audetis. Hic Deus Trinitas dicit; <hi rend="italic">Ego</hi> sum <hi
-						rend="italic">qui</hi> sum, et <lb/> non <hi rend="italic">sum mutatus
-						(Exod.</hi> III, 14, <hi rend="italic">et Malach.</hi> III, 6). Non <lb/>
-					enim mutatus est Christus, cui dicitur : <hi rend="italic">Mutabis</hi> cae­
-					<lb/> los, <hi rend="italic">et mutabuntur; tu autem idem ipse es</hi> ( <hi
-						rend="italic">Psat.</hi> CI. <lb/> 27, 28): aut mutabitur Spiritus
-					veritatis, cum sit <lb/> immutabilis vcritas, cui tantum honorem dat ipse <lb/>
-					Christus, ut dicat, <hi rend="italic">Expedit tobis ut ego eam;</hi> nisi <lb/>
-					<hi rend="italic">enim ego</hi>
-					<unclear>abiers</unclear>, <hi rend="italic">Paracletus non veniet ad</hi> vos
-						<hi rend="italic">(Joan.</hi>
-					<lb/> xvi, 7): et, <hi rend="italic">Quicumque dixerit blasphemiam</hi> in <hi
-						rend="italic">Filium <lb/> hominis, dimittetur ei; qui autem dixerit in
-						Spiritum <lb/> sanctum, noM dimittetur ei (Matth.</hi> XII. 52 ). Et cum
-					d&lt;: <lb/> se ipso dixerit, <hi rend="italic">Ecce ego vobiscum sum usque ad
-						con­<lb/> summationem saeculi (Id.</hi> XXVIII , 20); de illo dixit <lb/>
-					<hi rend="italic">Ut vobiscum sit</hi> in <hi rend="italic">aeternum (Joan.</hi>
-					XIV, 16). Hisatque <lb/> hujusmodi testimoniis, quae omnia quaerere et colli­
-					<lb/> gere longum est, si pacifice acquiescas , eris, quod <lb/> orare et optare
-					te dicis, divinarum Scripturarum di­ <lb/> scipulus, ut de tua fraternitate
-					gaudeamus. <note type="footnote"> 1 Kdili, <hi rend="italic">qitibus</hi> c
-						fr::tus. Vclius Mss., <hi rend="italic">ntd</hi> (Christus. </note></p></div>
 			</div>
 		</body>
 	</text>

--- a/data/stoa0040/stoa028/stoa0040.stoa028.opp-lat1.xml
+++ b/data/stoa0040/stoa028/stoa0040.stoa028.opp-lat1.xml
@@ -148,7 +148,10 @@
 				<language ident="la">Latin</language>
 			</langUsage>
 		</profileDesc>
-
+		<revisionDesc>
+			<change who="Lauryne Lemosquet" when="2019-02-19">Correction de l'OCR.</change>
+			<change who="Lauryne Lemosquet" when="2019-03-31">Structuration du fichier afin de respecter les guidelines du project CapiTainS.</change>
+		</revisionDesc>
 	</teiHeader>
 	<text>
 		<body>

--- a/data/stoa0040/stoa028/stoa0040.stoa028.opp-lat1.xml
+++ b/data/stoa0040/stoa028/stoa0040.stoa028.opp-lat1.xml
@@ -130,10 +130,16 @@
 		<encodingDesc>
 			<p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture.</p>
+			<projectDesc>
+				<p>This document is compatible with <ref target="http://capitains.github.io">CapiTainS Guidelines</ref></p>
+			</projectDesc>
 			<refsDecl n="CTS">
-				<cRefPattern n="no citable units founds" matchPattern="(.+)"
-					replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"
-				/>
+				<cRefPattern n="chapter" matchPattern="(\w+).(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1']/tei:div[@n='$2'])">
+					<p>This pointer pattern extracts books and chapters.</p>
+				</cRefPattern>
+				<cRefPattern n="book" matchPattern="(\w+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
+					<p>This pointer pattern extracts books.</p>
+				</cRefPattern>
 			</refsDecl>
 		</encodingDesc>
 

--- a/data/stoa0040/stoa028/stoa0040.stoa028.opp-lat1.xml
+++ b/data/stoa0040/stoa028/stoa0040.stoa028.opp-lat1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:lang="eng">
 	<teiHeader>
 		<fileDesc>
 			<titleStmt>
@@ -146,7 +146,7 @@
 	</teiHeader>
 	<text>
 		<body>
-			<div type="edition" n="urn:cts:latinLit:stoa0040.stoa028.opp-lat1">
+			<div type="edition" n="urn:cts:latinLit:stoa0040.stoa028.opp-lat1" xml:lang="la">
 				<head>
 					<title type="main">S. AURELII AUGUSTINI HIPPONENSIS EPISCOPI CONTRA MAXIMINUM
 						HaeRETICUM Arianorum Episcopum LIBRI DUO (a).</title>

--- a/data/stoa0040/stoa028/stoa0040.stoa028.opp-lat1.xml
+++ b/data/stoa0040/stoa028/stoa0040.stoa028.opp-lat1.xml
@@ -167,7 +167,8 @@
 					hoc sit n spondete posse, quod est tacere non posse? <lb/> Prius itaque ostendam
 					refellere te non potuisse quae <lb/> dixi : deinde, quantum nccessarium
 					videbitur, ego <lb/> refellam qu:c ipse dixisti.</p>
-				<p>CAPUT PIUMUM. — <hi rend="italic">De duobus diis.</hi> De duobus <lb/> diis quae
+				<div type="textpart" subtype="chapter" n="1">
+					<p>CAPUT PIUMUM. — <hi rend="italic">De duobus diis.</hi> De duobus <lb/> diis quae
 					ipse dixisti, ego certe respondens verbis <lb/> tuis, ubi aisti a vobis unum
 					Deum colatis : <hi rend="italic">Consequens <lb/> est,</hi> inquam, <hi
 						rend="italic">ut aut</hi> non <hi rend="italic">colatis</hi> Christum, <hi
@@ -205,7 +206,9 @@
 					etiam Filio ea quae <lb/> uni Deo debetur servitute servire. Memento ergo te
 					<lb/> non respondisse ad illud quod objeceram , non a vo­ <lb/> bis coli unum
 					Dcum, sed duos.</p>
-				<p>CAPUT II. — <hi rend="italic">De humanis contagiis.</hi> Secundo loco <lb/> egi
+				</div>
+				<div type="textpart" subtype="chapter" n="2">
+					<p>CAPUT II. — <hi rend="italic">De humanis contagiis.</hi> Secundo loco <lb/> egi
 					tecum de verbis tuis, ubi dixeras, <hi rend="italic">Deum Patrem</hi>
 					<lb/> ad <hi rend="italic">humana</hi> non <hi rend="italic">descendisse
 						contagia;</hi> quasi Christus <lb/> illa in carne perpessus sit : et
@@ -255,7 +258,9 @@
 					non esse contagia. Sed <lb/> quid ad nos , si more tuo loquens, contactum forte
 					<lb/> mortalium voluisti appellare contagium; cum tamen <lb/> nobiscum sentias,
 					Dominum Jesum, nec in spiritu, <lb/> nec in carne ullum habuisse peccatum?</p>
-				<p>CAPUT III. — <hi rend="italic">De invisibili Deo.</hi> Tertio loco de in­ <lb/>
+				</div>
+				<div type="textpart" subtype="chapter" n="3">
+					<p>CAPUT III. — <hi rend="italic">De invisibili Deo.</hi> Tertio loco de in­ <lb/>
 					visibili Deo cum agerem, admonui ul crederes invisi­ <lb/> bilem , non solum
 					Patrem, sed etiam Filium secun­ <lb/> dun. divinit item, non secundum carnem, in
 					qua eum <lb/> visibilem mortalibus apparuisse quis negat? undeot <lb/> alio loco
@@ -298,7 +303,9 @@
 					de capabili et incapabili, sed <lb/> de visibili et invisibili inter nos
 					quaestio versabatur : <lb/> in qua quaestione si libi ipsi tu ip e visibilis es,
 					vi. <lb/> ctum te esse vides.</p>
-				<p>CAPUT IV. — <hi rend="italic">De immortali</hi>
+				</div>
+				<div type="textpart" subtype="chapter" n="4">
+					<p>CAPUT IV. — <hi rend="italic">De immortali</hi>
 					<unclear/><hi rend="italic">Deo.</hi> Quarto loco egi <lb/> tecum de immortali
 					Den etiam Filio. Quoniam tu il­ <lb/> lud quod ait Apostolus , <hi rend="italic"
 						>Qui solus habet immortalita­<lb/> tem</hi> (I <hi rend="italic">Tim.</hi>
@@ -332,7 +339,9 @@
 					nobis, quod ad ea quae dixi, nihii respon­ <lb/> dere potuisti, ct non solum
 					Patrem ; sed quamvis ab <lb/> ipso, habere tamen , immortalitatem etiam Filium
 					<lb/> coactus es confiteri.</p>
-				<p>CAPUT V. — <hi rend="italic">Unde major sit Pater.</hi> Quinto loco <lb/>
+				</div>
+				<div type="textpart" subtype="chapter" n="5">
+					<p>CAPUT V. — <hi rend="italic">Unde major sit Pater.</hi> Quinto loco <lb/>
 					ostendi, unde major sit Pater Filio : quia nou Den <lb/> major est, unde illi
 					coaeternus est Filius; sed homine <lb/> major est, quod ex tempore ,factus est
 					Filius. Ibi <lb/> commemoravi apostolicum testimonium : <hi rend="italic"
@@ -424,7 +433,9 @@
 					Dei <lb/> Patris esse non potest inaequalis. Proinde nee hu'c <lb/> loco
 					prosecutionis meae, ubi de verbis Apostoli aequa­ <lb/> lem Patri Filium
 					comptobavi, respondere aliquid pro <lb/> vestra intentione potuisti.</p>
-				<p>CAPUT VI. — <hi rend="italic">De veris filiis animalium.</hi> Sexto loco <lb/> ut
+				</div>
+				<div type="textpart" subtype="chapter" n="6">
+					<p>CAPUT VI. — <hi rend="italic">De veris filiis animalium.</hi> Sexto loco <lb/> ut
 					ejusdem naturae cujus ct Pater est, ostenderem <lb/> Filium, etiam mortalium
 					fctus animalium immanitati <lb/> vestri crroris objeci, increpans cor vestrum,
 					qui ejus­ <lb/> dem nature cujus est Pater, negatis esse Deum Fi­ <lb/> lium,
@@ -470,7 +481,9 @@
 					verum Filium qua fronte dicatis : nisi quia in­ <lb/> fclicissimo errore non vos
 					putatis ad unius Patris glo­ <lb/> riam, nisi per unici Filii contumeliam
 					pervenire (a).</p>
-				<p>CAPUT VII. — <hi rend="italic">De magnitudine Filii.</hi> Septimo loco <lb/> dixi
+				</div>
+				<div type="textpart" subtype="chapter" n="7">
+					<p>CAPUT VII. — <hi rend="italic">De magnitudine Filii.</hi> Septimo loco <lb/> dixi
 					: <hi rend="italic">Usque adeo autem Filium agnoscimus magnum <lb/> Deum , ut
 						Patri dicamus aequalem. Itaque</hi> sine <hi rend="italic">causa,</hi>
 					<lb/> inquam, nobis <hi rend="italic">quod valde profitemur, testimoniis, et
@@ -513,7 +526,9 @@
 					<lb/> vetbis ad rem non necessariis conari operire res cla<lb/>ras. Qui est
 					Pater Filio ex utero suo, de vontre ma­ <lb/> tris Deus ejus est, non de suo. Ad
 					hoc ergo prorsus <lb/> nihil respondere po:uisti.</p>
-				<p>CAPUT VIII. — <hi rend="italic">De subjectione Filii</hi> Octavo loco de <lb/>
+				</div>
+				<div type="textpart" subtype="chapter" n="8">
+					<p>CAPUT VIII. — <hi rend="italic">De subjectione Filii</hi> Octavo loco de <lb/>
 					subjectione qua subjectus est Patri Filius, respondi <lb/> libi : quoniam
 					dixeras, <hi rend="italic">De sua subjectione unum sta­<lb/> tuit Deum.</hi>
 					Respondi ergo ellam hoc secundum homi­ <lb/> nen recte accipi, quod Filius
@@ -542,7 +557,9 @@
 					legentibus, evidenter appareret tc illa dixisse. Quis <lb/> enim crederet,
 					consentire posse vos nobis, secundum <lb/> formam servi, ac per hoc non secundum
 					formam Det <lb/> Christum esse subjectum ?</p>
-				<p>CAPUT IX. — <hi rend="italic">Utrum adoret Patrem Spiritus san­<lb/> ctus.</hi>
+				</div>
+				<div type="textpart" subtype="chapter" n="9">
+					<p>CAPUT IX. — <hi rend="italic">Utrum adoret Patrem Spiritus san­<lb/> ctus.</hi>
 					Nono loco abs te quaesivimus, ut per Scripturas <lb/> divinas ostenderes, si
 					valeres, utrum adoret Patrem <lb/> Spiritus sanctus. Iloc cniin dixeras : sed
 					sicut ipsi <lb/> tua prosccutio, cui respondi, satis indicat, non pro­ <lb/>
@@ -583,7 +600,9 @@
 					consuctudincm regum, qni plerumque adorantur, <lb/> ct non rogantur ; aliquando
 					rogantur, et non adora n<lb/>tur. Ac pcr hoc a Spiritu sancto adorari Patrem
 					<lb/> nullo modo demonstrarc potuisti.</p>
-				<p>CAPUTX.— <hi rend="italic">Quomodo sit unus Deus Pater et Filius <lb/> et</hi>
+				</div>
+				<div type="textpart" subtype="chapter" n="10">
+					<p>CAPUTX.— <hi rend="italic">Quomodo sit unus Deus Pater et Filius <lb/> et</hi>
 					Spiritus <hi rend="italic">sanctus.</hi> Decimo loco egi lecum ut intelli­ <lb/>
 					geres, quomodo per ineffabilem copulationem sit unus <lb/> Deus ipsa
 					Trinitas,quam dicimusunius esse substan­ <lb/> tiae : quandoquidem ctiam
@@ -633,7 +652,9 @@
 						>qui</hi> adhaeret <hi rend="italic">Domino,</hi> unus <lb/>
 					<hi rend="italic">spiritus</hi> est : si contentionem deposueris, non
 					negabis.</p>
-				<p>CAPUT XI. — <hi rend="italic">De templo Spiritus sancti.</hi> Undecimo <lb/>
+				</div>
+				<div type="textpart" subtype="chapter" n="11">
+					<p>CAPUT XI. — <hi rend="italic">De templo Spiritus sancti.</hi> Undecimo <lb/>
 					loco, Deum esse Spiritum sanctum, de templo ejus <lb/> quod nos ipsi sumus,
 					teste Apostolo, ostendi , ubi <lb/> ait, <hi rend="italic">Nescitis quia templum
 						Dei estis, et</hi> Spiritus <hi rend="italic">Dei <lb/> habitat</hi> in <hi
@@ -686,7 +707,9 @@
 					qui templtum nos <lb/> ipsos haberet: quem sine dubio Deam cognoscere­ <lb/>
 					mus, si ei templum de lignis et lapidibus per divinam <lb/> Scripturam faccre
 					juberemur?</p>
-				<p>CAPUT XII. — <hi rend="italic">De eo quod Pater et Filius unum<lb/> sint.</hi>
+				</div>
+				<div type="textpart" subtype="chapter" n="12">
+					<p>CAPUT XII. — <hi rend="italic">De eo quod Pater et Filius unum<lb/> sint.</hi>
 					Duodecimo loco admonui te, ut proferres, si <lb/> posses, qua divina auctorilate
 					sit dictum, quod unum <lb/> sint, ubi substantiae sunt diversae. Tu autem
 					respon­ <lb/> dcre ad hoc volens, nihil tale proferre potuisti; sed <lb/> magnis
@@ -747,7 +770,9 @@
 					quoniam, Ut ipsi <lb/> et nos unum simus, aut, Nobiscum sint unum, nus­ <lb/>
 					quam Christum dixisse manifestum est; te quoque <lb/> nobis respondere non
 					potuisse, et fraudern facere vo­ <lb/> luisse manifestum sit.</p>
-				<p>CAPUT XIII. — <hi rend="italic">De testimonio quod Pater perhibuit<lb/>
+				</div>
+				<div type="textpart" subtype="chapter" n="13">
+					<p>CAPUT XIII. — <hi rend="italic">De testimonio quod Pater perhibuit<lb/>
 						Filio.</hi> Tertio decimo loco te commonui, non ideo Pa­ <lb/> irem Filio
 					esse majorem, quia testimonium perhibuit <lb/> Pater Filio. Nam et Propbetas ei
 					testimonium perhi­ <lb/> buisse memoravi, quos majores illo esse non potes <lb/>
@@ -762,7 +787,9 @@
 					Sabellianos <lb/> est dogma commune. Illi enim dicunt, nonalium, sed <lb/>
 					eumdem Filium esse qui est Pater : nos autem alium <lb/> quidem esse Patrem, et
 					alium Filium; sed tamen <lb/> quod Pater est, hoc esse dicimus Filium.</p>
-				<p>CAPUT XIV. — <hi rend="italic">De dilectione Patris et Filii.</hi> Quarto <lb/>
+				</div>
+				<div type="textpart" subtype="chapter" n="14">
+					<p>CAPUT XIV. — <hi rend="italic">De dilectione Patris et Filii.</hi> Quarto <lb/>
 					decimo loco ad illud quod dixeras, <hi rend="italic">Dilectum lego, et <lb/>
 						credo quod Pater eat qui diligit , et Filius qui diligitur;</hi>
 					<lb/> respondens dixi : <hi rend="italic">Sic autem dicis hinc inter Patrem et
@@ -776,7 +803,9 @@
 					tanquam Filius ita diligat Patrem, sicut creatura <lb/> Crratorcm , non sicut
 					unigenitus geuitorcm, quem <lb/> diversitate substantiae vultis esse
 					degenerem.</p>
-				<p>CAPUT XV. — <hi rend="italic">De invisibilitate Trinitatis.</hi> Quinto <lb/>
+				</div>
+				<div type="textpart" subtype="chapter" n="15">
+					<p>CAPUT XV. — <hi rend="italic">De invisibilitate Trinitatis.</hi> Quinto <lb/>
 					decimo loco dixi pariter esse invisibilem Trinitatem, <note type="footnote"> *
 						ALD, fcr. et Mas., <hi rend="italic">tanquam.</hi>
 					</note>
@@ -803,7 +832,9 @@
 					fuisse visihilcm; quem <lb/> tupcrius in formi servi viden potuisse , in
 					substantia <lb/> vero suie divinitatis esse invisibilem, jam fueras et <lb/>
 					ipse confessus.</p>
-				<p>CAPUT XVI. — <hi rend="italic">De solo sapiente Deo.</hi> Sexto de­ <lb/> cimo
+				</div>
+				<div type="textpart" subtype="chapter" n="16">
+					<p>CAPUT XVI. — <hi rend="italic">De solo sapiente Deo.</hi> Sexto de­ <lb/> cimo
 					loco; quia de Patre tantum dixissc Apostolum <lb/> dixeras, <hi rend="italic"
 						>Soli sapienti Deo (Rom.</hi> xvi, 27); ego dixi : <lb/>
 					<hi rend="italic">Ergo solus Pater est Deus sapiens, et non est sapiens<lb/>
@@ -836,7 +867,9 @@
 						rend="italic">Sed</hi> vere <hi rend="italic">solus sapiens</hi> Pater ?
 					Nempe <lb/> quo per veneris , et a quanta blasphemia te debeas re­ <lb/> yovare,
 					jam sentis.</p>
-				<p>CAPUT XVII. — <hi rend="italic">De infecto Deo.</hi> Septimo decimo <lb/> loco
+				</div>
+				<div type="textpart" subtype="chapter" n="17">
+					<p>CAPUT XVII. — <hi rend="italic">De infecto Deo.</hi> Septimo decimo <lb/> loco
 					egi tecum, quod etiam Filius , non solus Pater, <lb/> infectus sit, hoc est,
 					factus non sit. Dixeras enim ideo <lb/> a vobis unum Deum pronuntiari, quia <hi
 						rend="italic">unus est super<lb/> omnia innatus,</hi> infectus. Respondens
@@ -851,8 +884,9 @@
 						ipse factus</hi> eat, in­ <lb/> quam, <hi rend="italic">non per illum facta
 						sunt omnia, aed</hi> caetera. Ad <lb/> haec tu cum tota hii prolixitate
 					sermonis, ita nihil <lb/> quod diceres invenisti , ut hinc omnino, tanquam id
-					<lb/> non audieris, conticesceres.</p>
-				<p>CAPUT XVIII. <hi rend="italic">- De ingenito Patre.</hi> Octavo decimo <lb/> loco
+					<lb/> non audieris, conticesceres.</p></div>
+				<div type="textpart" subtype="chapter" n="18">
+					<p>CAPUT XVIII. <hi rend="italic">- De ingenito Patre.</hi> Octavo decimo <lb/> loco
 					etiam de innato Patre , id est ingenito , quia ct <lb/> hoc dixcras, tccum
 					agendum putavi, et dixi: <hi rend="italic">Non <lb/> itoque dico Filium
 						ingenitum; aed Patrem genitorem, <lb/> Filium genitum. Hoc tamen genuit
@@ -860,7 +894,9 @@
 						rend="italic">qnod est Pater non est <lb/> Filius ; sicut de partubus
 						animalium supra jam diximus.</hi>
 					<lb/> Eliam ad hoc In nee verum nec falsum ali quid protulisti.</p>
-				<p>CAPUT XIX. — <hi rend="italic">De aequalitate Spiritus sancti cum Pa.<lb/>
+				</div>
+				<div type="textpart" subtype="chapter" n="19">
+					<p>CAPUT XIX. — <hi rend="italic">De aequalitate Spiritus sancti cum Pa.<lb/>
 						tre.</hi> Nonodccimo loco, quia poposceras a mc, ut osten­ <lb/> derem
 					aequalem esse I'atri i Spiritum sanctum ; respondi <lb/> tibi dicens: <hi
 						rend="italic">Quid est autem quod</hi> poscis, <hi rend="italic">ut ostendam
@@ -962,7 +998,9 @@
 					fideliter. Memento tamen, nec majorem Pa<lb/> Irem Spiritu sancto, nec
 					adoratum Patrem ab Spiritu <lb/> sancto, ullis divinis testimoniis contra
 					propositionem <lb/> meam te demonstrare potuisse.</p>
-				<p>CAPUT XX. — <hi rend="italic">Licet ingenitus Pater,</hi> aequalis <hi
+				</div>
+				<div type="textpart" subtype="chapter" n="20">
+					<p>CAPUT XX. — <hi rend="italic">Licet ingenitus Pater,</hi> aequalis <hi
 						rend="italic">ta­<lb/> men Filius.</hi> Vigesimo loco, quoniam dixeras de
 					Filio, <lb/> Si <hi rend="italic">aequalis. Patri, utique talis:</hi> si <hi
 						rend="italic">talis, utique innatus;</hi>
@@ -982,7 +1020,8 @@
 					summo silentio praeterire. <note type="footnote"> I Apud Lov., <hi rend="italic"
 							>plene.</hi>
 					</note>
-				</p>
+					</p>
+				</div>
 				<ab>
 					<title type="sub">
 						<hi rend="italic">LIBER SECUNDUS (a).</hi>
@@ -991,7 +1030,7 @@
 				<p>Refelluntur singillatim quae in Collatione Maximinus dixit ultima sua
 					disputatione, cujus disputationis suae prolixitato <lb/> respondendi tempus tunc
 					eripuit Augustino.</p>
-				<p>PRaeFATIO. - Res jam postulat ut in eoquod reliquum <lb/> est, opitulante Domino,
+				<p>PRAEFATIO. - Res jam postulat ut in eoquod reliquum <lb/> est, opitulante Domino,
 					impleam promissionem meam. <lb/> In operis quippe hujus exordio, Prius,
 					inquam,ostendam <lb/>
 					<hi rend="italic">refellere te non potuisse quae dixi: deinde, quantum<lb/>
@@ -1027,7 +1066,8 @@
 					tanquam repugnemus. Haec et alia quae suis <lb/> ostendam locis, in quibus
 					operam supervacuam con­ <lb/> trivisti, ut moras necteres, tempusque produceres,
 					<lb/> commemorando attingere debeo, non redarguere <lb/> disputando.</p>
-				<p>CAPUT PRIMUM. — Dicis me <hi rend="italic">auxilio</hi> principum mu­ <lb/>
+				<div type="textpart" subtype="chapter" n="1">
+					<p>CAPUT PRIMUM. — Dicis me <hi rend="italic">auxilio</hi> principum mu­ <lb/>
 					<hi rend="italic">nitum, non loqui secundum timorem Dei;</hi> cum scias nobis
 					<lb/> esse praeceptum orare pro regibus, ut in agnitionem <lb/> veniant
 					veritatis (I Tim. II, i, 4): quod in quibusdam <lb/> esse impletum, nos Deo
@@ -1037,7 +1077,9 @@
 					xqualem; an qui sic geni­ <lb/> torem debonestat et genitum, ut et illum dicat
 					non <lb/> potuisse gignere per omnia sui similem filium, et <lb/> isium dicat
 					non dcgenerasse jam natum, sed dcgeae­ <lb/> rem natum.</p>
-				<p>CAPUT II. — Dicis <hi rend="italic">vos Christum colere, ut Deum <lb/> omnis
+				</div>
+				<div type="textpart" subtype="chapter" n="2">
+					<p>CAPUT II. — Dicis <hi rend="italic">vos Christum colere, ut Deum <lb/> omnis
 						creaturae cui flectitur</hi> omne <hi rend="italic">genu, cœlestium, ter­
 						<lb/> restrium et infernorum</hi> : quem tamen Deo Patri esse <lb/> non
 					vultis aequalem, quia <hi rend="italic">hoc Pater ei donavit:</hi> ait <lb/>
@@ -1060,7 +1102,9 @@
 					<lb/> pientissimus dixerit? Hoc illi ergo donatum est ut ho­ <lb/> mini,
 					secundum quem Filius factus est obediens usque <lb/> ad mortem crucis, quod jam
 					habebat idem ipse Dei <lb/> Filius, Deus de Deo natus aequalis.</p>
-				<p>CAPUT III. — Objicis mihi, quod dicam Spiritum <lb/> sanctum aequalem esse Filio.
+				</div>
+				<div type="textpart" subtype="chapter" n="3">
+					<p>CAPUT III. — Objicis mihi, quod dicam Spiritum <lb/> sanctum aequalem esse Filio.
 					Dico plane. <hi rend="italic">Da,</hi> inquis, <lb/>
 					<hi rend="italic">testimonia ubi adoratur Spiritus sanctus.</hi> Ut video, hinc
 					<lb/> eam vis ostendi aequalem Christo, si adoratur ut Chri­ <lb/> stus. Jam
@@ -1100,14 +1144,17 @@
 						<hi rend="italic">Act.</hi> XVII, 24 ), sed corpus no­ <lb/> strum templum
 					est Spiritus sancti. Et ne corpora no­ <lb/> stra contemnas, membra sunt Christi
 					( I <hi rend="italic">Cor.</hi> vi, 19, <lb/> 15). Qualis ergo Deus, cui templum
-					aedificatur, et a <lb/> Deo, et de membris Dei ?</p>
-				<p>CAPUT IV. — Dicis <hi rend="italic">Christum esse</hi> in <hi rend="italic"
+					aedificatur, et a <lb/> Deo, et de membris Dei ?</p></div>
+				<div type="textpart" subtype="chapter" n="4">
+					<p>CAPUT IV. — Dicis <hi rend="italic">Christum esse</hi> in <hi rend="italic"
 						>dextera Dei,<lb/> et interpellare pro nobis (Rom.</hi> VIII, 34). Quod cur
 					no­ <lb/> bis objicis, si eum non solum Deum, verum etiam <lb/> hominem
 					agnoscis? Quid te igitur adjuvat, quod se­ <lb/> dere ad dexteram Patris assidue
 					legitur ? Quid nobis, <lb/> non quidem inanibus testimoniis, sed tamen inaniler,
 					<lb/> probare niteris quod fatemur.</p>
-				<p>CAPUT V. — Dicis <hi rend="italic">vos Spiritum sanctum</hi> compe­ <lb/>
+				</div>
+				<div type="textpart" subtype="chapter" n="5">
+					<p>CAPUT V. — Dicis <hi rend="italic">vos Spiritum sanctum</hi> compe­ <lb/>
 					<hi rend="italic">tenter honorare ut doctorem, ut ducatorem,</hi> ut <hi
 						rend="italic">illumina­</hi>
 					<lb/> torem, ut <hi rend="italic">sanctificatorem; Christum colere, ut
@@ -1135,7 +1182,9 @@
 						rend="italic">de philosophicas artis<lb/> instructione venire</hi>
 					arbitraris. Sufficit mihi quod ita <lb/> putasti Christum ad terrena descendisse
 					contagia, <lb/> ut tamen confitereris nullum habuisse peccatum.</p>
-				<p>CAPUT VI. — Illud sane quod commemoravi, <lb/> partus animalium, quae cum terrena
+				</div>
+				<div type="textpart" subtype="chapter" n="6">
+					<p>CAPUT VI. — Illud sane quod commemoravi, <lb/> partus animalium, quae cum terrena
 					sint atque mor­ <lb/> talia, hoc tamen gignunt quod ipsa sunt, ut homo ho­ <lb/>
 					minem, canis canem; puto quod non aspernatus hor­ <lb/> ruisti, sed te aspernari
 					atque horrere finixisti, dicens, <lb/>
@@ -1146,7 +1195,9 @@
 					creaturam corruptibilem cernitis , hoc <lb/> quod ipsa est gignere fetum situm,
 					et Deum Patrem <lb/> omnipotentem creditis non potuisse nisi ejus dege­ <lb/>
 					nerante natura g:gnerc unicum suum.</p>
-				<p>CAPUT VII. — Sed dicis: <hi rend="italic">Dominus Dominum ge­<lb/> nuit,
+				</div>
+				<div type="textpart" subtype="chapter" n="7">
+					<p>CAPUT VII. — Sed dicis: <hi rend="italic">Dominus Dominum ge­<lb/> nuit,
 						Deus</hi> Den. <hi rend="italic">genuit, Rex Regem genuit, Creator <lb/>
 						Creatorem</hi> genuit, <hi rend="italic">bonus bonum genuit, sapiens
 						sapien­<lb/> tem genuit, clemens clementem, potens potentem.</hi> Si sub
@@ -1190,11 +1241,15 @@
 					nativitatem . <lb/> veri Filii Dei, ne Deum Patrem dicas id quod non est <lb/>
 					ipse gcnuisse. Si autem hoc genuit quod est ipse; <lb/> unam Patris et Filii
 					esse substantiam negare nolite.</p>
-				<p>CAPUT VIII. — Jam vero sequentia, quae sic con­ <lb/> nexuisti, ut de cruce vel
+				</div>
+				<div type="textpart" subtype="chapter" n="8">
+					<p>CAPUT VIII. — Jam vero sequentia, quae sic con­ <lb/> nexuisti, ut de cruce vel
 					incarnatione Christi probare <lb/> nobis velles quod pariter credimus; servasti
 					morem <lb/> mum : sed nihil tibi ad ista respondens, etiam ego <lb/> servo
 					promissum meum.</p>
-				<p>CAPUT IX. — 1. De iuvisibili Filio cum agere­ <lb/> mus, quem consensisti esse
+				</div>
+				<div type="textpart" subtype="chapter" n="9">
+					<p>CAPUT IX. — 1. De iuvisibili Filio cum agere­ <lb/> mus, quem consensisti esse
 					invisibilem secundum di­ <lb/> vinitatem, qui prius solum Patrem invisibilem
 					esse <lb/> praesumpseras, ad rem non pertinentia multa dixisti <lb/> de
 					invisibilibus creaturis : quod poterunt judicare qui <lb/> legerint. De
@@ -1264,7 +1319,7 @@
 					semper vident faciem Dei <lb/> Patris? Numquid propter regulam tuam, quam sine
 					<lb/> consideratione fixisti, putandi sunt Angeli Patre Deo <lb/> esse
 					majores?</p>
-				<p>2. Scd eleganter te existimas invenisse quod diceres, <lb/> ubi :isti de Filio:
+					<p>2. Scd eleganter te existimas invenisse quod diceres, <lb/> ubi :isti de Filio:
 						<hi rend="italic">Vidit ergo Patrem, sed vidit incapa­ <lb/> bilem.</hi> Nec
 					attendis, quia ctsi vidit incapabilcm, quem <lb/> sicut putas, capere non
 					putuit; non tamen invisibilcm, <lb/> quem videre potuit. Tu autem nobiscum non
@@ -1307,7 +1362,9 @@
 					invisibilem esse concesseris ? Sed quod­ <lb/> libet sentias de universa
 					invisibili creatura, quantum <lb/> ad Dcum pertinet, de quo inter nos agitur,
 					satis tibi <lb/> demonstratum est non esse solum invisibilem Pa­ <lb/> trem.</p>
-				<p>CAPUT X. — i. Putas Dcum Patrem cum F'ilio ct <lb/> Spirilu sancto unum Deum esse
+				</div>
+				<div type="textpart" subtype="chapter" n="10">
+					<p>CAPUT X. — i. Putas Dcum Patrem cum F'ilio ct <lb/> Spirilu sancto unum Deum esse
 					non possc : timcs <lb/> cnim ne Palcr solus non sit unus Dcus, sed pars
 						<unclear>umus</unclear>
 					<lb/> Dei qui constat ex tribus. Noli liincre, nulla fit pur­ <lb/> tium in
@@ -1339,7 +1396,7 @@
 					quicumque ipsam <lb/> Trinitatem unum Dominum Deum esse nostrum di­ <lb/>
 					dicimus, profecto cum ei soli ea quas Deo dcbelur <lb/> servitute servimus,
 					Domino Deo soli nos servire con­ <lb/> fidimus.</p>
-				<p>2. <hi rend="italic">Ergo</hi> , inquis, <hi rend="italic">Deus Puler pars est
+					<p>2. <hi rend="italic">Ergo</hi> , inquis, <hi rend="italic">Deus Puler pars est
 						Dei.</hi> Absit. <lb/> Tres enim personae sunt Pater et Filius et Spiri­
 					<lb/> tus sanctus : et hi tres quia unius substantiae sunt, <lb/> unum sunt, ct
 					summc unum sunt, ubi nulla natura­ <lb/> rum, nulla cst diversitas voluntatum.
@@ -1366,7 +1423,7 @@
 					intelligat. Verum cst enim quod dicitur per <lb/> prophetam, Nisi <hi
 						rend="italic">credidcritis , non intelligetis ( Isa;.</hi>
 					<lb/> VII, 9 ).</p>
-				<p>5. Tu nempe dixisti; <hi rend="italic">unum Deum</hi> non <hi rend="italic">ex
+					<p>5. Tu nempe dixisti; <hi rend="italic">unum Deum</hi> non <hi rend="italic">ex
 						partibus <lb/> esse compositum.</hi> Et quia de Patre hoc vis intelligi, <lb/>
 					<hi rend="italic">Ille,</hi> innuis , <hi rend="italic">quod est, virtus est
 						ingenita,</hi> simplex. <lb/> £t tamen in hac simplici virtute quam multa
@@ -1395,7 +1452,9 @@
 					virtutem de virtute gcnitam, et virtutem de virtute <lb/> procedentem non vis
 					eamdem habere naturam, hoc <lb/> falsum dicis, hoc contra fidem rectam et
 					catholicam <lb/> dicis.</p>
-				<p>CAPUT XI. — Redis ut quaeras a me, quomodo <lb/> sit invisibilis Filius, unde jam
+				</div>
+				<div type="textpart" subtype="chapter" n="11">
+					<p>CAPUT XI. — Redis ut quaeras a me, quomodo <lb/> sit invisibilis Filius, unde jam
 					dixi superius, quod <lb/> visum est dicendum. Sed si <hi rend="italic">ob
 						hoc,</hi> inquis, <hi rend="italic">Filius</hi> in­ <lb/>
 					<hi rend="italic">visibilis a te pronuntiatur, eo quod oculis humanis con­ <lb/>
@@ -1417,7 +1476,9 @@
 					<lb/> quod non sit Filii, mendacem facias cumdem Filium <lb/> dicentem, <hi
 						rend="italic">Omnia quae habet Pater, mea suni (Joan.</hi>
 					<lb/> XVI, 15).</p>
-				<p>CAPUT XII. — i. HInc et de potentia sapis, quod <lb/> scilicet sit quidem potens
+				</div>
+				<div type="textpart" subtype="chapter" n="12">
+					<p>CAPUT XII. — i. HInc et de potentia sapis, quod <lb/> scilicet sit quidem potens
 					ct Filius, sed potentior Pa­ <lb/> ter Filio : ulauctoribus et doctoribus vobis
 					potuerit <lb/> potentem potens, nee potuerit omnipotcntem gignere <lb/>
 					omnipotens. Ac per hoc si habct Pater omnipoten<lb/>liam quam non habet
@@ -1443,7 +1504,7 @@
 					<hi rend="italic">Pater facit, h</hi>ae<hi rend="italic">c et Filius</hi>
 					similiter <hi rend="italic">facit</hi> ? quod ulique <lb/> non potest, si
 					omnipotens non est.</p>
-				<p>2. Ac per hoc quod ait Apostolus , <hi rend="italic">Beatus et solus</hi>
+					<p>2. Ac per hoc quod ait Apostolus , <hi rend="italic">Beatus et solus</hi>
 					<lb/> potens : non cogor de Patre tantummodo accipere; <lb/> sed de Deo, quod
 					est ipsa Trinitas. Loquens enim <lb/> ad Timotheum : Praecipio, inquit, tibi <hi
 						rend="italic">coram Deo, <lb/> qui vivificat omnia, et Christo Jesu qui</hi>
@@ -1521,7 +1582,7 @@
 					<hi rend="italic">videbunt (Matth.</hi> v, 8). Cui Deo, id est Patri et Filio
 					<lb/> et Spiritui sancio, qua; Trinitas unus est Deus, honor <lb/> et gloria in
 					s;rcula saeculorum; Amen.</p>
-				<p>3. Absit autem ut, quomodo putas, ideo sit Pater <lb/> potentior Filio, quia
+					<p>3. Absit autem ut, quomodo putas, ideo sit Pater <lb/> potentior Filio, quia
 					creatorem genuit Pater, Filius <lb/> autem non genuit creatorem. Neque enim non
 					po­ <lb/> luit <hi rend="italic">(a),</hi> sed non oportuit. Immoderata enim
 					esset <lb/> divina generatio , si genitus Filius nepotem gigneret <lb/> Patri :
@@ -1544,7 +1605,9 @@
 						>quaecumque Pater facit, h</hi>aec <hi rend="italic">et Filius simili­<lb/>
 						ter facil.</hi> Filiurn quippe ipsum genuit utique Pall'is <lb/> natura, non
 					fecit.</p>
-				<p>CAPUT XIII. — i. In illo etiam testimonio, ubi <lb/> ait Apostulus, <hi
+				</div>
+				<div type="textpart" subtype="chapter" n="13">
+					<p>CAPUT XIII. — i. In illo etiam testimonio, ubi <lb/> ait Apostulus, <hi
 						rend="italic">Soli sapienti Deo;</hi> non dissimilis error <lb/> est vester
 					: sed quod vobis respondimus de potentia, <lb/> hoc etiam de sapientia
 					respondemus. Si cnim dixis­ <lb/> set Apostolus, Soli sapienti Patri; nec sic
@@ -1574,7 +1637,7 @@
 					alterum dicitis : et reos vos, secundum errorem ve­ <lb/> strum, praecepti hujus
 					violati esse monstratis, quia <lb/> non solum majori, verum etiam minori, ea
 					quae Do­ <lb/> mino Deo debetur servitute servitis.</p>
-				<p>i. Ubi autem dixit Apostolus, <hi rend="italic">Soli sapienti Deo;</hi>
+					<p>i. Ubi autem dixit Apostolus, <hi rend="italic">Soli sapienti Deo;</hi>
 					<lb/> cum scriberet ad Romanos, in fine Epistolae sic Io­ <lb/> quitur: <hi
 						rend="italic">Ei autem</hi> qui <hi rend="italic">potens est,</hi> inquit,
 					vos <hi rend="italic">confirmare<lb/> secundum Evangelium</hi> meum, <hi
@@ -1613,8 +1676,9 @@
 					deperit, <lb/> si dicatur, Ei gloria , cui per Cbrislum gloria ? Hoc <lb/> est
 					namque, <hi rend="italic">per Jesum Christum cui gloria;</hi> quod est, <lb/>
 					cui per Jesum Christum gloria. Sed horum alter in­ <lb/> usitatus, alter
-					usitatus est ordo verborum.</p>
-				<p>CAPUT XIV. — 1. Quaeris a me, Si <hi rend="italic">de</hi> substantia <lb/>
+					usitatus est ordo verborum.</p></div>
+				<div type="textpart" subtype="chapter" n="14">
+					<p>CAPUT XIV. — 1. Quaeris a me, Si <hi rend="italic">de</hi> substantia <lb/>
 					<hi rend="italic">Patris eat Filius, de substantia Patris eat etiam Spiritus
 						<lb/> sanctus; cur unus Filius sit, et alius non sit filius.</hi>
 					<lb/> Ecce respondeo, sive capias, sive non capias. De <lb/> Patre est Filius,
@@ -1659,7 +1723,7 @@
 						rend="italic">Spiritum</hi> potavi­ <lb/> mus (I <hi rend="italic">Cor.</hi>
 					XII, 13). Et alio ioco : <hi rend="italic">Unum corpus et</hi>
 					<lb/> unus <hi rend="italic">Spiritus (Ephes.</hi> IV, 4).</p>
-				<p>2. Quid ergo haec Trinitas, nisi unius ejosdemque <lb/> substantiae est?
+					<p>2. Quid ergo haec Trinitas, nisi unius ejosdemque <lb/> substantiae est?
 					Quandoquidem non de aliqua materia <lb/> vel de nihilo est Filius, sed de quo
 					cst genitus : item­ <lb/> que Spiritus sanctus non de aliqua maleria, vcl de
 					<lb/> nihilo, sed indc est unde proccdiL. Vos autem nec <lb/> Filium de Patris
@@ -1692,7 +1756,7 @@
 					aliqua ergo substantia <lb/> est. Si non de Patris; de qua? Dicite. Sed non in­
 					<lb/> venitis. Jam igitur unigenitum Dei Filium Jesum Chri­ <lb/> stum Dominum
 					nostrum de Patris esse substantia non <lb/> vos nobiscum pigeat conteri.</p>
-				<p>5. Pater crgo et Filius unius sunt ejusdemquc sub­ <lb/> stantiae. noc est illud
+					<p>5. Pater crgo et Filius unius sunt ejusdemquc sub­ <lb/> stantiae. noc est illud
 					Homousion, quod in concilio <lb/> Nicaeno adversus haereticos Arianos a
 					catholicis Pa­ <lb/> tribus veritatis anctoritate et auctoritatis veritate fir­
 					<lb/> matum est : quod postea in concilio Ariminensi, <lb/> propter novitatem
@@ -1729,7 +1793,7 @@
 					, multo magis potuisse <lb/> verum gignere Filium de sua substantia, et unam cum
 					<lb/> vero Filio habere substantiam, manente incorruptione <lb/> spirituali, ct
 					longissime hinc alicna corruptione car­ <lb/> nali.</p>
-				<p>4. Nam de anima quid dixeris, nescio. Verba enim <lb/> tua sunt, ubi dicis : <hi
+					<p>4. Nam de anima quid dixeris, nescio. Verba enim <lb/> tua sunt, ubi dicis : <hi
 						rend="italic">Nee enim ad</hi> animae <hi rend="italic">ingenuitatem <lb/>
 						comparatis tantam illam magnificentiam, sed ad fragili­ <lb/> tatem
 						corporis. De corpore utique,</hi> inquis, <hi rend="italic">nascitur
@@ -1778,11 +1842,11 @@
 					unius ejusdemque substantiae sunt Pater et Filius. <lb/> Quomodo autcm nihil
 					Filio subtraxit, ut dicis, si <lb/> ejusdem substantiae est, et tamen minor est,
 					nec sicut <lb/> infans crescere potest ?</p>
-				<p>5. Jam vero de immortalitate Dei, quia non Pa­ <lb/> irem, sed Deum qui et Patcr
+					<p>5. Jam vero de immortalitate Dei, quia non Pa­ <lb/> irem, sed Deum qui et Patcr
 					est et Filius et Spiritus <lb/> sanctus , solum habere immortalitatem dixit
 					Aposto­ <lb/> lus, satis superius disputavi, quando ipsum aposto­ <lb/> icum
 					testimonium et posui totum , et exposui.</p>
-				<p>6. Displicet tibi , quod aequalem Patri asserimus <lb/> Filium : quasi possit
+					<p>6. Displicet tibi , quod aequalem Patri asserimus <lb/> Filium : quasi possit
 					esse inaequalis, qui verus est <lb/> Filius, non natus ex tempore, sed gignenti
 					coaeternus, <lb/> sicut splendor ab igne genitus gignenti manifestatur <lb/>
 					aequaevus. Sed <hi rend="italic">habet,</hi> inquis , <hi rend="italic">Dei
@@ -1805,7 +1869,7 @@
 					humana longe melior ct <lb/> excellentior divina nativitas, incorruptibili et
 					invio­ <lb/> labili generatione : non tamen sit deterior, diversi­ <lb/> late
 					naturae.</p>
-				<p>7. Sed <hi rend="italic">vitam Filius,</hi> inquit, <hi rend="italic">accepit a
+					<p>7. Sed <hi rend="italic">vitam Filius,</hi> inquit, <hi rend="italic">accepit a
 						Patre.</hi> Acce­ <lb/> pit sicut genitus a gignente. <hi rend="italic"
 						>Omnia,</hi> inquit, <hi rend="italic">quae ha­<lb/> bet Pater,mea sunt.
 						(Joan.</hi> xvi, 15). Omnia ergo quae <lb/> habet Pater, dedit ille
@@ -1863,7 +1927,7 @@
 					<lb/> i, 8), in qua paulo minus minoratus est ab Angelis <lb/>
 					<hi rend="italic">( f'Bal.</hi> VIII, C), ut Patri in forma Dei maneret
 					aequalis: <lb/> quia non est forma illa mutabilis.</p>
-				<p>8. Quid itaque mirum est, si na quae commemoras, <lb/> dicit, <hi rend="italic"
+					<p>8. Quid itaque mirum est, si na quae commemoras, <lb/> dicit, <hi rend="italic"
 						>Ego quae plucila sunt Patri, facio semper ( Joan.</hi>
 					<lb/> VIII, 29) : ct ad monumentum Lazari, <hi rend="italic">Pater. gratias<lb/>
 						ago tibi, qnia audisti me; et ego sciebam quia semper</hi> me <lb/>
@@ -1918,7 +1982,7 @@
 					<lb/> statim in tantum sacrilcgium corde atque ore prorui­ <lb/> tis, ut veri
 					Filii Dei unam eamdemque cum Patre <lb/> substantiam non esse credatis atque
 					dicatis ?</p>
-				<p>9. Quid quod etiam illud commemorandum putasti, <lb/> quod manifestissime ut homo
+					<p>9. Quid quod etiam illud commemorandum putasti, <lb/> quod manifestissime ut homo
 					loquitur: <hi rend="italic">Potestatem ha­ <lb/> beo ponendi animam meam, et
 						potestatem habeo iterum <lb/> sumendi eam. Hoc</hi> enim praeceptum <hi
 						rend="italic">accepi a Patre meo?</hi>
@@ -1972,8 +2036,9 @@
 					lium, de Dco Patrc natum Deum, qui utique imper­ <lb/> fectus est natus, si
 					praeceptum accepit indoctus. Quia <lb/> vero perfectus est natus, praeceptum
 					dedit ille gi­ <lb/> gnendo, accepit iste nascendo. Nunquam enim verus <lb/> Dei
-					Filius indoctus fuit : filius autem numquam non fuit.</p>
-				<p>CAPUT XV. — i. In forma Dei Filium esse non <lb/> negas, et Dco Patri aequalem
+					Filius indoctus fuit : filius autem numquam non fuit.</p></div>
+				<div type="textpart" subtype="chapter" n="15">
+					<p>CAPUT XV. — i. In forma Dei Filium esse non <lb/> negas, et Dco Patri aequalem
 					negas, majorem Patris <lb/> iormam putans esse quam Filii : tanquam non ha­
 					<lb/> buerit Pater unde formam suam compleret in Filio, <lb/> quem de se ipso
 					genuit ,non fecit ex nihilo, non ex <lb/> alio. Aut si formam suam in unico
@@ -2012,7 +2077,7 @@
 							aetatis accessu</hi></note>
 					<lb/> attendis ? Nunnc regis <unclear>Dei</unclear> Filio paternum regnum au
 					<lb/> ferres tolerabilius quam naturam?</p>
-				<p>2, Dc Spiritu autem sancto, quomodo e' ipse de <lb/> Deo sit, nec tamen et ipse
+					<p>2, Dc Spiritu autem sancto, quomodo e' ipse de <lb/> Deo sit, nec tamen et ipse
 					filius sit, quoniam proce­ <lb/> dendo, non nascendo legitur esse de Deo, jam
 					supe­ <lb/> rius, quantum satis visum est, disputavi. Nos, inquis, <lb/>
 					<hi rend="italic">in Patrem Deum innatum,</hi> naturam non <hi rend="italic"
@@ -2077,7 +2142,7 @@
 					substantiae qui­ <lb/> dem unius esse cum Palrc, sed non per omina <lb/> similem
 					Patri. Nicaenum igitur tenete nobiscum con­ <lb/> cilium , si voltis Christum
 					dicere verum Dei Filium.</p>
-				<p>5. <hi rend="italic">Diversas,</hi> inquis, <hi rend="italic">accusamur dicere
+					<p>5. <hi rend="italic">Diversas,</hi> inquis, <hi rend="italic">accusamur dicere
 						natura.</hi> Et <lb/> quid aliud dicis de Den Patre ct Dco Filio? quid aliud
 					<lb/> dicis? An idco putas ab isia accusatione purgari% <lb/> quia continuo
 					subjungis dicens : <hi rend="italic">Hoc scito quod nos <lb/> dicimus, quod
@@ -2111,7 +2176,7 @@
 					Verus <hi rend="italic">innatus Pater <lb/> verum genuit Filium;</hi> cum procul
 					dubio verus Filius <lb/> ton sit, si non est unius ejusdemque substantiae eum
 					<lb/> illo qui genuit ?</p>
-				<p>4. Dicit quidem Filius ad Patrem , <hi rend="italic">Haec</hi> est <hi
+					<p>4. Dicit quidem Filius ad Patrem , <hi rend="italic">Haec</hi> est <hi
 						rend="italic">autem<lb/> vita œterna,</hi> ut cognoscant te solum terum <hi
 						rend="italic">Deum, et <lb/> quem misisti</hi> Jesum <hi rend="italic"
 						>Christum (Joan.</hi> XVII, 5) : Id est, . <lb/> te et quem misisti Jesum
@@ -2146,7 +2211,7 @@
 					<lb/> bonum <hi rend="italic">Patrem</hi> dicit <hi rend="italic">esse
 						Deum.</hi> Deus autem unus ct <lb/> solus est ipsa Trinitas, ut ostendunt ea
 					quae superius <lb/> jam saepissime diximus.</p>
-				<p>5. Quod autem <hi rend="italic">non</hi> proficientem , <hi rend="italic">sed
+					<p>5. Quod autem <hi rend="italic">non</hi> proficientem , <hi rend="italic">sed
 						perfectum <lb/> Deus Pater genuerit Filium Deum;</hi> verum dicis. Sed <lb/>
 					quod ipsam Filii perfectionem, perfectioni Patris non <lb/> vis aquare; hoc
 					falsum dicis, ct vcritati qua verus <lb/> cst Filius contradicis. <hi
@@ -2194,8 +2259,9 @@
 					cxposilio­ <lb/> nem meam, qua ostendi sic obedientem fuisse in for­ <lb/> nia
 					servi, ut formam non amitteret Dei, in qua :'qua­ <lb/> lis est Patri. Tu vero
 					vide quam contumeliose Filio <lb/> Dci tribuas obedientiam , cujus minuis in
-					divinitate <lb/> naturam.</p>
-				<p>CAPUT XVI. - !. Quando autem a me audisti <lb/> prop. r Judaeos , <hi
+					divinitate <lb/> naturam.</p></div>
+				<div type="textpart" subtype="chapter" n="16">
+					<p>CAPUT XVI. - !. Quando autem a me audisti <lb/> prop. r Judaeos , <hi
 						rend="italic">humilitatis, non veritatis gratia , <lb/> dixisse Filium quod
 						Deus ejus sit Puter ejus ?</hi> Hoc a <lb/> me ita nunquam audire potuisti,
 					sicut nunquam dixi: <lb/> sed plane dili, propter formam servi dictum esse.
@@ -2224,7 +2290,7 @@
 					<lb/> quibus probares dictum esse Deum Christi, eum qui <lb/> Pater est Christi,
 					discutere quemadmodum dicta sint, <lb/> superfluum judico : sed a te frustra
 					commemorata <lb/> esse, puto quod nec tu dcbeas dubitare.</p>
-				<p>2. Jam vero illud ubi Dominos in eadem carne <lb/> quam resuscitaverat
+					<p>2. Jam vero illud ubi Dominos in eadem carne <lb/> quam resuscitaverat
 					constitutus, et eumdem homincm <lb/> g<unclear>erens</unclear> , ait ad
 					discipulos suos, <hi rend="italic">Data</hi> est <hi rend="italic">mihi</hi>
 					omnis <lb/>
@@ -2246,7 +2312,7 @@
 					quaestionis? An forte nos admo­ <lb/> ncre voluisti, quod baptizari Dominus
 					jusserit gculcs <lb/> in nominc Patris ct Filii ct Spiritus sancti ? Ubi au­
 					<lb/> dis unum nomen , ct unam non vis intelligere dcila­ <lb/> tem.</p>
-				<p>3. Quod autem dicisv ct ante incarnationem Chri­ <lb/> sti , Patrem dictuin csse
+					<p>3. Quod autem dicisv ct ante incarnationem Chri­ <lb/> sti , Patrem dictuin csse
 					Dum ejus, quoniam scri. <lb/> ptum est \ Unxit <hi rend="italic">te, Deus,
 						Deus</hi> tuus; longe antequam <lb/> Christus venisset in carne : itane Ron
 					intelligis in <lb/> prophetia esse praed clum , tanquam fucrit factum <lb/> quod
@@ -2290,7 +2356,9 @@
 					id est, Spiritu sancto. Propter quod de <lb/> illo scriptum cst : Jesus <hi
 						rend="italic">autem plenus Spiritu sancto, <lb/> reversus est a Jordanc
 						(Luc.</hi> iv, 1).</p>
-				<p>CAPUT XVII.— 1. Dicis in persona Spiritus sancti <lb/> non posse suscipi quod de
+				</div>
+				<div type="textpart" subtype="chapter" n="17">
+					<p>CAPUT XVII.— 1. Dicis in persona Spiritus sancti <lb/> non posse suscipi quod de
 					Filio dictum est, <hi rend="italic">Omnia <lb/> per ipsum fucta sunt</hi> , et
 						<hi rend="italic">sine ipso</hi> facturi <hi rend="italic">est nihil <lb/>
 						(Joan.</hi> I, 3). Et hoc ideo hidis, ut quibus potueris <lb/> persuadeas,
@@ -2315,7 +2383,7 @@
 					Spiritus sanct! : cur non sic <lb/> audis de Filio Dei, Omnia pur <hi
 						rend="italic">ipsum facta sunt;</hi> ut <lb/> et non nominatum intellig
 						<unclear>as</unclear> ibi ctiam Spiritum san­ <lb/> cium?</p>
-				<p>2. NaiD quid excellentius in creaturis quam virtu­ <lb/> tes cœlorum? Scriptum
+					<p>2. NaiD quid excellentius in creaturis quam virtu­ <lb/> tes cœlorum? Scriptum
 					est autem : <hi rend="italic">Verbo DOli,;,. i <lb/> cœli firmati sunt; et</hi>
 					Spiritu <hi rend="italic">oris ejus, omnis virtus eo­ <lb/> rum (Psal.</hi>
 					XXXII, 6). Dixeras nempe non me talia re­ <lb/> perire in Scripturis divinis,
@@ -2361,7 +2429,7 @@
 					iniqua ( <hi rend="italic">PsaL</hi> LXII, 12 ). Si ergo cogitas os veraciter
 					<lb/> aperire, n on solum Filium , verum etiam Spiritum <lb/> sanctum creatorem
 					carnis Filii confitere.</p>
-				<p>3. An f orte dicturus es, ea facta esse per Spiritum <lb/> sanctum quae
+					<p>3. An f orte dicturus es, ea facta esse per Spiritum <lb/> sanctum quae
 					commemoravi, id est, quod omnis virtus <lb/> coelorum per eum firmata sit, quod
 					per cum creaban­ <lb/> tur homines denuo, qni primo ita creantur ut conver­
 					<lb/> tantur in pulverem suum ; quod ipse carnem opera­ <lb/> tus est Christi
@@ -2377,7 +2445,7 @@
 						operatur unus atque</hi> idem <hi rend="italic">Spiritus</hi> (1 <hi
 						rend="italic">Cor.</hi> XII, i 1); nec <lb/> tamen ab hac operatione Filius
 					separatur.</p>
-				<p>4. Magnum sane aliquid tibi dicere videris, quia di­ <lb/> cis : Filius <hi
+					<p>4. Magnum sane aliquid tibi dicere videris, quia di­ <lb/> cis : Filius <hi
 						rend="italic">erat</hi> in <hi rend="italic">principio antequam aliquid
 						esset; <lb/> Pater vero, ante principium</hi> Ubi legisti, ut iirc cre
 					<lb/>dcres? Unde praesumpsisti ut haec diceres , ubi nec <lb/> auctoritas ulla,
@@ -2395,7 +2463,9 @@
 					<lb/>
 					<pb n="785"/> ab utroque procedentem negabo esse principium : <lb/> sed haec
 					tria simul sicut unum Deum, ita unum dico <lb/> esse principium.</p>
-				<p>CAPUT XVIII — i. Quid, si <hi rend="italic">audierit,</hi> inquis, Pa­ <lb/> trem
+				</div>
+				<div type="textpart" subtype="chapter" n="18">
+					<p>CAPUT XVIII — i. Quid, si <hi rend="italic">audierit,</hi> inquis, Pa­ <lb/> trem
 						<hi rend="italic">dicentem,</hi> « <hi rend="italic">Tecum</hi> principium
 					in <hi rend="italic">die</hi> virtuti, <hi rend="italic">tum, <lb/> in
 						splendoribus tanctorum, ex utero ante luciferum</hi> ge­ <lb/> nui <hi
@@ -2421,7 +2491,7 @@
 					qui dicere audctis ex utero. <lb/> Dei processisse diversam naturam? Si antem
 					hoc, sic­ <lb/> ut debclis, horretis, respuilaque nobiscum, jam tnn­ <lb/> dem
 					concilium Nicaenum et Homousion laudate ac <lb/> tenete nobiscum.</p>
-				<p>2. Quis autem nou videat defectum tuum, ubi cum. <lb/> andisses, me
+					<p>2. Quis autem nou videat defectum tuum, ubi cum. <lb/> andisses, me
 					commemorante,1 in prophetia dixisse <lb/> Christum suo Patri, De <hi
 						rend="italic">ventre</hi> matris meae <hi rend="italic">Deus</hi> meus <lb/>
 					<hi rend="italic">es tu (Psal</hi> xxi, ii ); ut intelligeremus ejus na­ <lb/>
@@ -2452,7 +2522,7 @@
 					diceres, <lb/> aliam nativitatem quae Dei de Deo. est, interponem <lb/> dam
 					putasti qua fugeres. Rogo te; quando quid rc­ <lb/> spondeas non habes, quanto
 					melius taceres?</p>
-				<p>3. Si propter <hi rend="italic">corpus,</hi> inquis, in <hi rend="italic">quo
+					<p>3. Si propter <hi rend="italic">corpus,</hi> inquis, in <hi rend="italic">quo
 						se</hi> exinanivit, <lb/>
 					<hi rend="italic">debitorem</hi> te <hi rend="italic">sentit</hi> suo <hi
 						rend="italic">genitori;</hi> multo magis qui illum <lb/>
@@ -2487,7 +2557,7 @@
 					obsequium : si autem per obsequium mino­ <lb/> rem natura1 vultis credere,
 					prohibemus: nullo modo <lb/> enim Deus Pater ut babcre unici Filii posset obse­
 					<lb/> quium, vellet denegare naturam.</p>
-				<p>4. Par entibus autom ut esset subditus Christus , <lb/> non dvinae majestatis
+					<p>4. Par entibus autom ut esset subditus Christus , <lb/> non dvinae majestatis
 					fuit, sed aetatis humanae Fru­ <lb/> stra itaque dixisti : <hi rend="italic">Si
 						parentibus fuit subditus quot<lb/> creavit</hi> ( <hi rend="italic"
 						>Luc.</hi> II, 51 ), <hi rend="italic">quanto magis suo genitori qui <lb/>
@@ -2505,7 +2575,7 @@
 					gignere aequalem; ut ipsi Filio qni unicus <lb/> Patri non est generatus
 					aequalis. et idco perfectus est <lb/> natus, ne unquam vel crescendo fieret,
 					quod non po­ <lb/> tuit esse nascendo.</p>
-				<p>5. Non autem, ut putas, corpus tantum Filii, id est, <lb/> corpus hominis, verum
+					<p>5. Non autem, ut putas, corpus tantum Filii, id est, <lb/> corpus hominis, verum
 					etiam buinanum spiritum Pa­ <lb/> tri dicimus esse subjectum : et secundum id
 					quod <lb/> botro factus est intelligimus dictum. <hi rend="italic">Cnm antem
 						omnia<lb/> tlli</hi> subjecta fuerint <hi rend="italic">tunc et ipse Filius
@@ -2518,7 +2588,7 @@
 					omuia Christo subjecta fuerint, et capiti <lb/> et corpori erunt sinc
 					dubitatione subjecta. Nam secun­ <lb/> dum id quod sine tempore Deus natus est,
 					nihil un­ <lb/> qnam potuit ei non esse subjectum.</p>
-				<p>6. Scimus, quod nos commemoraridos putasti, <hi rend="italic">quia <lb/>
+					<p>6. Scimus, quod nos commemoraridos putasti, <hi rend="italic">quia <lb/>
 						Pater</hi> non <hi rend="italic">judicat quemquam, sed omne judicium
 						dedit</hi>
 					<lb/> Filio <hi rend="italic">(Joan.</hi> v, 22). Vellem tamen diceres nobis,
@@ -2551,8 +2621,9 @@
 					<lb/> tris <hi rend="italic">mei percipite regnum</hi> ( <hi rend="italic"
 						>Matth.</hi> xxv, 34 ). Quo tu <lb/> testimonio non hominem, sed Deum
 					minorem suo <lb/> Patre quasi probare voluisti : sed sicut ab eit qui in­ <lb/>
-					telligunt perspicitur, nun probasti.</p>
-				<p>CAPUT XIX. — De Spiritus sancti autem gemiii­ <lb/> bus, quia non ipse gemit, sed
+					telligunt perspicitur, nun probasti.</p></div>
+				<div type="textpart" subtype="chapter" n="19">
+					<p>CAPUT XIX. — De Spiritus sancti autem gemiii­ <lb/> bus, quia non ipse gemit, sed
 					inspirans nobis deside­ <lb/> rium sanctum nos facit gemere quamdiu peregrina­
 					<lb/> mur a Domino, jam tibi sunicienter respondisse me <lb/> existimo. £t tales
 					de Scripturis sanctis locutiones, <lb/> quantum satis videbatur ostendi, quoniam
@@ -2561,7 +2632,9 @@
 					<lb/> gnoscere hominem fecit. Non eqim tunc cognoverat <lb/> quod tunc se
 					dixerat cognovisse, qni omnia scit an­ <lb/> tequam fiant. Ad quod te respondere
 					non potuisse, <lb/> quid predest quia scutis, quando non consentis ?</p>
-				<p>CAPUT XX. — i. Jam eliam de verbis Domini <lb/> ubi ait, <hi rend="italic"
+				</div>
+				<div type="textpart" subtype="chapter" n="20">
+					<p>CAPUT XX. — i. Jam eliam de verbis Domini <lb/> ubi ait, <hi rend="italic"
 						>Ego</hi> et <hi rend="italic">Pater</hi> unum sumus <hi rend="italic"
 						>(Joan.</hi> x, 30); nihil <lb/> te respondere potuisse monstravi. Sed ut
 					hic quoquo <lb/> ostendam, si exemplis, ut dicis, quibus ego usus sum, <lb/> vis
@@ -2612,7 +2685,7 @@
 					sunt. Haec si discre­ <lb/> veris, et contentiosus esse nolueris, non te ad ea
 					re­ <lb/> spondisse aliquid jam videbis, et de hac quaestione <lb/> procul dubio
 					jam tacebis.</p>
-				<p>2, Ubi autem dixil Eilius Patri, <hi rend="italic">Verum non quod</hi>
+					<p>2, Ubi autem dixil Eilius Patri, <hi rend="italic">Verum non quod</hi>
 					<lb/> ego <hi rend="italic">volo, sed quod. tu vis;</hi> quid te adjuvat quod
 					tua <lb/> verba subjungis ctdicis, <hi rend="italic">Ostendit vere voluntatem
 						suam <lb/> subjectam</hi> suo genitori : quasi nos. negemus, hominis <lb/>
@@ -2635,7 +2708,7 @@
 					<lb/> Nunquam enim posset immutabilis illa natura quid­ <lb/> quam
 						<unclear>aliud</unclear> velle quam Pater. Haec si distingueretis, <lb/>
 					Ariani haeretici non essetis.</p>
-				<p>3. Nam et illud quod dictum est, Descendi <hi rend="italic">de cœ­<lb/> to, non
+					<p>3. Nam et illud quod dictum est, Descendi <hi rend="italic">de cœ­<lb/> to, non
 						ut faciam volunlatem meam, sed voluntatem ejus</hi>
 					<lb/> qui <hi rend="italic">me misit (Joan.</hi> V!, 58) : potest quidem accipi
 					<lb/> etiam secundum id quod est unigenitum Verbum ; ut <lb/> ideo voluntatem
@@ -2672,7 +2745,7 @@
 					voluntatem suam fecit, quia peccatum non <lb/> fecit: sed voluntatem fecit
 					illius qui eum misit. Tunc <lb/> enim facit homo voluntatem Dei, quando facit.
 					justi. <lb/> tiam qua: ex Deo est.</p>
-				<p>4. Nec sic arbitremur a Patre missum. esse Filium, <lb/> ut non sit missus ab
+					<p>4. Nec sic arbitremur a Patre missum. esse Filium, <lb/> ut non sit missus ab
 					Spiritu sancto; cum vox ipsius <lb/> sit per prophetam, <hi rend="italic">Et
 						nunc</hi> Dominus misit <hi rend="italic">me, et Spi.</hi>
 					<lb/> ritus <hi rend="italic">ejus.</hi> Hoc enim Filium dixisse, indicant ea
@@ -2712,8 +2785,9 @@
 					<lb/> alia istc; sed quae ille, haec etiam iste. <hi rend="italic"
 						>Quaecumque<lb/> enim Pater facit, haec et</hi> Filiussimiliter facit <hi
 						rend="italic">(ld.</hi> v, 19). <lb/> Verba sunt ipsius, verba veritatis
-					suut, falsa esse non <lb/> possunt.</p>
-				<p>CAPUT XXJ. — 1. Suscipere tc dicis quod protuli, <lb/>
+					suut, falsa esse non <lb/> possunt.</p></div>
+				<div type="textpart" subtype="chapter" n="21">
+					<p>CAPUT XXI. — 1. Suscipere tc dicis quod protuli, <lb/>
 					<hi rend="italic">Nescitis quia templum DA estis, et Spiritus Dei habitat</hi>
 					<lb/> in <hi rend="italic">vobis</hi> (I <hi rend="italic">Cor.</hi> III, 16) ?
 					Quod proposuisti 1 dicere idoo <lb/> dictum esse, quia <hi rend="italic">in
@@ -2770,7 +2844,7 @@
 					atque ostendens <lb/> Deum esse Spiritum sanctum, <hi rend="italic">Non es,</hi>
 					inquit, <hi rend="italic">homi­ <lb/> nibus mentitus, sed Deo (Act.</hi> v, 3,
 					4).</p>
-				<p>2. Miror autem cor vestrum, quantum sermone <lb/> explicare uon possum, quomodo
+					<p>2. Miror autem cor vestrum, quantum sermone <lb/> explicare uon possum, quomodo
 					cum sic laudctis" <lb/> Spiritum sanctum, ut eum sanctificandis fidelibus <lb/>
 					ubique asseratis esse praesentem, tamen negare att­ <lb/> deatis Deum. Itane
 					Deus non est, qui replevit orb m <lb/> terrarum? Scriptura enim dicit: <hi
@@ -2799,7 +2873,7 @@
 						Spiritus est ;</hi> ubi <hi rend="italic">autem Spiritus Domini, ibi
 						libertas</hi>
 					<lb/> (II Cor. III, 16, 17).</p>
-				<p>3. Jam creatorcm superius demonstravi Spiritum <lb/> sanctum: quomodo autem rex
+					<p>3. Jam creatorcm superius demonstravi Spiritum <lb/> sanctum: quomodo autem rex
 					non est, cujus templum <lb/> est quae membra sunt regis? Quomodo non consedet
 					<lb/> Patri et Filio, qui replevit Filium, qui membra Filii <lb/> suam possidct
 					domum? Nisi forte quando Filius re­ <lb/> gressus est a Jordane, plenus erat
@@ -2825,7 +2899,9 @@
 					Et tamen ut <lb/> invidiam blaspbemantis evites; ita laudas Spiritum <lb/>
 					sanctum, ut tribuas ei quod non habet ulla creatura, <lb/> et detrahas ei quod
 					adipiscitur et humana creatura.</p>
-				<p>CAPUT XXII. — i. Dixisse me quod commemo­ <lb/> ras, fateor, et nunc dico , quod
+				</div>
+				<div type="textpart" subtype="chapter" n="22">
+					<p>CAPUT XXII. — i. Dixisse me quod commemo­ <lb/> ras, fateor, et nunc dico , quod
 					Salvator noster non <lb/> dixerit, Ut ipsi et nos unum ; sed, <hi rend="italic"
 						>Ut ipsi sint unum</hi>
 					<lb/> Et de his evangelicis verbis satis a ure rccolo jani <lb/> fuisse
@@ -2883,7 +2959,7 @@
 					unum <lb/> esse voluit, quos noverat unius esse substantiae. Sic­ <lb/> ut <hi
 						rend="italic">ei nos</hi> , inquit unum sumus : quos identidem no­ <lb/>
 					verat unius essp substantia.</p>
-				<p>2. Tu si vis aliquid respondere, ostende secundum <lb/> Scripturam sanctam de
+					<p>2. Tu si vis aliquid respondere, ostende secundum <lb/> Scripturam sanctam de
 					aliquibus rebus dici, Unum <lb/> sunt, quarum est diversa substantia. Hoc enim
 					Chri­ <lb/> stus non dixit, quod tamen tu ausus es dicere, id est, <lb/>
 					<hi rend="italic">Apostolos</hi> unum esse <hi rend="italic">cum Patre et</hi>
@@ -2940,7 +3016,7 @@
 					locutionum arbitror inculcasse distantiam. Scrutare <lb/> itaque Scripturas
 					canonicas veteres et novas, et in­ <lb/> vcni, si potes, ubi dicta sunt aliqua,
 					Unum sunt, quae <lb/> sunt diversae paturae atque substantiae.</p>
-				<p>3. Sane falli te nolo in Epistola Joannis apostoli, <lb/> ubi ait: <hi
+					<p>3. Sane falli te nolo in Epistola Joannis apostoli, <lb/> ubi ait: <hi
 						rend="italic">Tres sunt testes; spiritus, et aqua, et sanguis;<lb/> et tres
 						unum sunt</hi> (I <hi rend="italic">Joan.</hi> v, 8). Ne forte dicas spiri­
 					<lb/> tum et aquam et sanguinem diversas esse substantias, <lb/> et tamen dictum
@@ -3007,7 +3083,9 @@
 					substantias, nulla ratione respu­ <lb/> endum est. Quod enim ad exercendas
 					mentes fide­ <lb/> lium in Scripturis sanctis obscure ponitur,gratulan­ <lb/>
 					dum cst, si multis modis, non tamen insipienter ex­ <lb/> punitur.</p>
-				<p>CAPUT XXIII. — 1. Quid est autem quod po<lb/>Mis ut astruam , <hi
+				</div>
+				<div type="textpart" subtype="chapter" n="23">
+					<p>CAPUT XXIII. — 1. Quid est autem quod po<lb/>Mis ut astruam , <hi
 						rend="italic">Si pater et Filias et Spiritus san­<lb/> ctus</hi> unus <hi
 						rend="italic">est Deus</hi> ; cum hoe astruat voce clarissima <lb/>
 					Scriptura divina dicens , <hi rend="italic">Audi, Israel; Dominus Deus</hi>
@@ -3074,7 +3152,7 @@
 						<hi rend="italic">Non eat alius</hi> praeter <hi rend="italic">me.</hi>
 					<lb/> Scd quanto melius erunt vestra verba emendata, quam <lb/> pei verba
 					mendacia ?</p>
-				<p>i. Quaeris a me utrum , <hi rend="italic">Judaico modo te horter</hi> pro­ <lb/>
+					<p>i. Quaeris a me utrum , <hi rend="italic">Judaico modo te horter</hi> pro­ <lb/>
 					<hi rend="italic">fiteri</hi> unum <hi rend="italic">Denm; an de subjectione
 						Filii potius secun­<lb/> dum quod fides habet</hi> Christiana , <hi
 						rend="italic">ostendatur unus esse<lb/> Deus, cujus Filius noster est
@@ -3145,7 +3223,7 @@
 						alius praeter me.</hi> Subjectus est quidem <lb/> Patri filius
 					secundumformam hominis : non tamen <lb/> sunt duo dii ct duo domini secundum
 					formam De!; <lb/> sed ambo cum Spirilu suo unus cst Dominus.</p>
-				<p>3. Testimonia quae de Paulo apostolo protulisti, <lb/> contra te loquuntur, ct
+					<p>3. Testimonia quae de Paulo apostolo protulisti, <lb/> contra te loquuntur, ct
 					nescis. Dicit enim ille : <hi rend="italic">Gra­<lb/> tia vobis et pax a Deu
 						Patre nostro et Domino</hi> Jesu <lb/>
 					<hi rend="italic">Christo (Rom.</hi> I, 7; I <hi rend="italic">Cor.</hi> I, 3;
@@ -3211,7 +3289,7 @@
 					<lb/> ulla dubitatione huic soli serviendam est ea servitute, <lb/> quae nonnisi
 					Domino Deo debetur, quia ipse est Do­ <lb/> minus, et non est alius praeter
 					ipsum.</p>
-				<p>4. Deinde quaero quomodo accipias quod dictum <lb/> est, Unus <hi rend="italic"
+					<p>4. Deinde quaero quomodo accipias quod dictum <lb/> est, Unus <hi rend="italic"
 						>Deus Pater, ex quo omnia, et nos</hi> in <hi rend="italic">ipso; <lb/>
 						et</hi> unus <hi rend="italic">Dominus Jesus</hi> Christ: s, <hi
 						rend="italic">per quem omnia, et noa <lb/> per</hi> ipsum. Numquid non et ex
@@ -3264,8 +3342,8 @@
 					gloria; sed, <lb/>
 					<hi rend="italic">ipsi gloria</hi> in saecula sPeculorum. <hi rend="italic"
 						>Amen.</hi>
-				</p>
-				<p>5. Falleris sane, qui putas de Patre solo esse di­ <lb/> ctum, <hi rend="italic"
+					</p>
+					<p>5. Falleris sane, qui putas de Patre solo esse di­ <lb/> ctum, <hi rend="italic"
 						>Nemo bonus, nisi unus Deus.</hi> Si enim dixisset, <lb/> Nemo bonus, nisi
 					unus Patcr; nee sic exclusum Fi­ <lb/> lium et Spiritum sanctum ab ista unitate
 					bonitatis vo­ <lb/> luisset intelligi : quia et illud quod simili locutiono
@@ -3293,7 +3371,7 @@
 					<lb/> Quomodo autem non est tale bonum Dei Filius ve­ <lb/> rus, cumsit verus
 					Deus et vita aeterna, ad quam cu­ <lb/> piebat ille qui interrogaverat pervenire
 					?</p>
-				<p>6. Proinde cum ego asseram, <hi rend="italic">Nemo bonus,</hi> nisi unus <lb/> et
+					<p>6. Proinde cum ego asseram, <hi rend="italic">Nemo bonus,</hi> nisi unus <lb/> et
 						<hi rend="italic">solus Deus,</hi> de ipsa Trinitate dictum esse, qui Deus
 					<lb/> unus et solus est; tu autcm asseras de solo Dco Pa­ <lb/> tre dictum esse,
 					quia ipse de nullo alio Deus, de nullo <lb/>
@@ -3314,7 +3392,7 @@
 						rend="italic">unus Deus,</hi> in hac tua <lb/> opinione deficiunt. Tantum
 					enim quantus est ipse, et <lb/> talem qualis est ipse, si non potuit gignere,
 					quomodo <lb/> Dens est? si noluit, quomodo bonus cst?</p>
-				<p>7. <hi rend="italic">Pater,</hi> inquis, <hi rend="italic">fons</hi> bonitatis
+					<p>7. <hi rend="italic">Pater,</hi> inquis, <hi rend="italic">fons</hi> bonitatis
 						<hi rend="italic">est, qui quod est</hi> bo­ <lb/> nIs <hi rend="italic">a
 						nemine accepit.</hi> Numquid ideo minus bonus est <lb/> Filius, quoniam quod
 					bonus est, ab eo Patrc accepit, <lb/> qui naseenli Filio tantam bonitatem
@@ -3382,8 +3460,9 @@
 					alicubi <lb/> legere potuisti. Nec sana fide ipse dixisti immensum <lb/> etiam
 					Patrem; quoniam propterea dicis, ut Filium <lb/> non pariter immensum, sed
 					mensura existimes ter­ <lb/> minatum. Tecum habeto mensuram tuam, qua <lb/> tuum
-					falsum dominum metiaris, et de vero Domino <lb/> mentiaris.</p>
-				<p>CAPUT XXIV. — Bene confiteris quod et Pater <lb/> diligat Filium, et Filius
+					falsum dominum metiaris, et de vero Domino <lb/> mentiaris.</p></div>
+				<div type="textpart" subtype="chapter" n="24">
+					<p>CAPUT XXIV. — Bene confiteris quod et Pater <lb/> diligat Filium, et Filius
 					diligat Patrem : sed si et hoc <lb/> confitcaris, quia non est major dilectio in
 					Patre quam <lb/> in Filio. Quia cnim natura divinitatis a quales sunt, <lb/>
 					aequaliter se invicem diligunt. Facit autem Filius sic­ <lb/> ut homo mandatum
@@ -3400,8 +3479,10 @@
 							rend="italic">nvs gratia.</hi>
 					</note></p>
 				<pb n="803"/>
+				</div>
 
-				<p>CAPUT XXV. — Putas non recte a me dictum esse, <lb/> qnod propter formam servi
+				<div type="textpart" subtype="chapter" n="25">
+					<p>CAPUT XXV. — Putas non recte a me dictum esse, <lb/> qnod propter formam servi
 					quam suscepit Filius (Phi­ <lb/>
 					<hi rend="italic">lipp.</hi> II, 7), major sil Palcr. Tu enim secundum hae­
 					<lb/> resim vestram, in ipsa Dei forma Patrem Filio vis esse <lb/> majorem : cui
@@ -3446,7 +3527,9 @@
 					sed <lb/> eliam menti, quam gerebat, humanae Deum Patrem <lb/> utique
 					praeferebat : quae tota sine dubio forma agno­ <lb/> scitur servi, quoniam tota
 					servit creatura Creatori.</p>
-				<p>CAPUT XXVI. — i. Postrema tibi disputatio fuit, <lb/> quomodo sit Deus patribus
+				</div>
+				<div type="textpart" subtype="chapter" n="26">
+					<p>CAPUT XXVI. — i. Postrema tibi disputatio fuit, <lb/> quomodo sit Deus patribus
 					visus, quando corpus <lb/> humanum in quo videretur, nondum acceperat Chri­
 					<lb/> stus, cam invisibilis sit per se ipsa divina natura. <lb/> Quod cum eliam
 					tu ila confessus fueris ut inter c;c- <lb/> tera non solum Patrem, sed nec ipsum
@@ -3467,7 +3550,7 @@
 					Christi, vel in <lb/> carne vixit, vel ea quae facta sunt scripsit? Haec <lb/>
 					dicis, et putas te aliquid dicere, vcl putaris ab cis <lb/> qui nee ista
 					possunt, quae tam manifeste falsa sunt ; <lb/> cernere.</p>
-				<p>2. Deinde quod commemoras Patrem ad Filium di­ <lb/> centem, <hi rend="italic"
+					<p>2. Deinde quod commemoras Patrem ad Filium di­ <lb/> centem, <hi rend="italic"
 						>Faciamus</hi> hominem <hi rend="italic">ad imaginem</hi> et similitudi­ <lb/>
 					<hi rend="italic">nem</hi> nostram ; quid hoc ad rem pertinet, rogo te? quid
 					<lb/> ad rem pertinet? Tantumne tibi vajabat loqui, ut non <lb/> attendens quid
@@ -3536,8 +3619,8 @@
 					adjutorium, obedisse P.trein jubenti Filio, te <lb/> auctore, intelligamus ;
 					quia non Patrem, sed Filium <lb/> dixisse asseris, <hi rend="italic">Faciamus ei
 						adjutorium.</hi>
-				</p>
-				<p>5. Sed haec ila loquor, quasi ad causam quoe a nobis <lb/> agitur, quidquam
+					</p>
+					<p>5. Sed haec ila loquor, quasi ad causam quoe a nobis <lb/> agitur, quidquam
 					pertineat, quodlibet hinc volueris <lb/> credere aut suspicari. Prorsus, sicut
 					dicis, Pater jus­ <lb/> serit, ubi dictum est, <hi rend="italic">Faciamus
 						hominem;</hi> et Filius <lb/> obedierit, ubi dictum est, <hi rend="italic"
@@ -3566,8 +3649,8 @@
 						Editi, <hi rend="italic">et cooperante</hi> ttiio, <hi rend="italic">rilio
 							autcm</hi> uon <hi rend="italic">jubente, etc.</hi>
 						<lb/> Costigantur ex vss. </note>
-				</p>
-				<p>4. <hi rend="italic">Sed iste,</hi> inquli, <hi rend="italic">Filius</hi> visus
+					</p>
+					<p>4. <hi rend="italic">Sed iste,</hi> inquli, <hi rend="italic">Filius</hi> visus
 						<hi rend="italic">tit Adae,</hi> secundum <lb/>
 					<hi rend="italic">quod legimus, Adam dicentem,</hi> «<hi rend="italic"
 						>Vocem</hi> tuam audivi <lb/>
@@ -3589,7 +3672,7 @@
 					<lb/> dum itaque aliquid ex eo quod promiseras dixisse tu <lb/> vide : et dic
 					tandem aliquid quod discutere debeamus, <lb/> aut quod pro tua causa esse
 					fateamur.</p>
-				<p>5. <hi rend="italic">Hic Deus,</hi> inquis, <hi rend="italic">et Abrahae</hi>
+					<p>5. <hi rend="italic">Hic Deus,</hi> inquis, <hi rend="italic">et Abrahae</hi>
 					visus <hi rend="italic">est.</hi> Visum esse <lb/> Deum Abi ahae negare non
 					possumus. Scriptura quip­ <lb/> pe fidelissima apertissime hoc loquitur, dicens
 					: <hi rend="italic">Visus <lb/> eat</hi> autem <hi rend="italic">illi Deus ad
@@ -3656,7 +3739,7 @@
 					expresserat, <lb/> cum ab initio tres viros dixisset apparuisse Abrahae, <lb/>
 					et hospitaliter ab iRo esse susceptos, quos et abeuntes <lb/> deduXit, ambubns
 					cum eis.</p>
-				<p>6. Fortassis ergo jam pronuntiare festinas, unum <lb/> fuisse in eis Dominum
+					<p>6. Fortassis ergo jam pronuntiare festinas, unum <lb/> fuisse in eis Dominum
 					Christum, qui singulariter pro­ <lb/> mittebat et respondebat Abrahft; duos vero
 					illos, an­ <lb/> gelos ejus, qui venerunt in Sodoma tanquam missi <lb/> angeli a
 					Domino suo. Sed exspecta : quid properas? <lb/> Consideremus omnia diligenter,
@@ -3737,7 +3820,7 @@
 						<hi rend="italic">Dixit autem Loth ad</hi> illos, Ora, <lb/>
 					<hi rend="italic">Domine.</hi> Agnovit ergo a Loth unum Dominum in an­ <lb/>
 					gelis duobus, sicut Abraham unum agnovit in tribus.</p>
-				<p>7. Non est cur dicatur : Ille abierat qui Dominus <lb/> erat et cum Abraham
+					<p>7. Non est cur dicatur : Ille abierat qui Dominus <lb/> erat et cum Abraham
 					locutus erat; duo vero angeli <lb/> ejus erant qui in Sodoma, illo abeunte 4,
 					venerunt. <lb/> Omnes enim tres viridiclisunl . qui apparuerunt Abra­ <lb/> hae,
 					sicut Scriptura solet viros etiain angelos nuncu­ <lb/> pare. Nee eoruin alicui
@@ -3792,7 +3875,7 @@
 					<lb/> volens Filium solum visum putari in eo quod in Ge­ <lb/> nesi legitur,
 					visum esse Deum Abrah;e, quomodo sit <lb/> visus, dicere noluisti, ne ibi non
 					solus Filius, sed <lb/> Trinitas agnosceretur Deus.</p>
-				<p>8. Dixisti autem : <hi rend="italic">Si vis credere, quia Filius vi,,,. <lb/> est
+					<p>8. Dixisti autem : <hi rend="italic">Si vis credere, quia Filius vi,,,. <lb/> est
 						Abrahae, utique ipse Unigenitus</hi> in <hi rend="italic">sancto affirmavit
 						<lb/> Evangelio sic :</hi> « <hi rend="italic">Abraham pater vester
 						exsultavit ut</hi> vi-­ <lb/>
@@ -3808,7 +3891,7 @@
 					tem­ <lb/> pus Christi, quo erat venturus in carne, quod Abra­ <lb/> ham sicut
 					et alii Prophetae in spiritu potuit vidcre <lb/> atque gaudere? Neque hie igitur
 					quod proposueras <lb/> et pollicitus fueras, probare potuisti.</p>
-				<p>9. Post haec venisti ad Jacob, qui luctatus est cum <lb/> Angelo, quem scriptura
+					<p>9. Post haec venisti ad Jacob, qui luctatus est cum <lb/> Angelo, quem scriptura
 					ipsa Geneseos et hominem <lb/> dicit et Deum. Nam ita legitur : <hi
 						rend="italic">Remansit autem</hi> Ja­ <lb/>
 					<hi rend="italic">cob</hi> solus, <hi rend="italic">et luctabatur hamo cum illo
@@ -3879,7 +3962,7 @@
 					creaturam, et maxime per Angelorum <lb/> ministerium, mortalium cxhibebantur
 					aspectibus, Dei <lb/> quidem agente potentia, sed tamen latente natura, <lb/>
 					sive Patris, sive Filii, sive Spiritus sancti.</p>
-				<p>40. Frustra itaque asseris Filium Dei risum fuisse <lb/> ah hominibus, Patrem
+					<p>40. Frustra itaque asseris Filium Dei risum fuisse <lb/> ah hominibus, Patrem
 					autem non fuisse visum : cum <lb/> pcr subjectam sibi creaturam et Pater videri
 					potuerit, <lb/> et Filius, et Spiritus sanctus; per suam vero substan<lb/> Ham
 					nullus illurum visus cst. Ergo Deus, sicut infir­ <lb/> mis hominum sensibus,
@@ -3931,7 +4014,7 @@
 					blasphamiam <lb/> non emendabis, nisi credideris, in assumpti mehomi <lb/> nis
 					accessisse Filio quud non erat, non autem reces­ <lb/> sisse vcl defecisse quod
 					crat.</p>
-				<p>11. Deinde quaero, quis apparuerit Moysi in igne <lb/> quando rubus
+					<p>11. Deinde quaero, quis apparuerit Moysi in igne <lb/> quando rubus
 					iullammabatur, ct non urebatur Quan­ <lb/> quain et illic angelum apparuisse
 					Scriptura ipsa de­ <lb/> clarat , dicens : <hi rend="italic">Apparuit antem illi
 						angelus Domini in<lb/> flamma ignis de rubo.</hi> In angelo autem Deum
@@ -3954,7 +4037,7 @@
 					annuis ;-quid ambigis utrumque <lb/> unum Deum? Jacob quippe ipse est Israel,
 					cujus filiis <lb/> dicitur : <hi rend="italic">Audi, Israel; Dominus Deus tuus,
 						Dominus <lb/> unus est (Deut.</hi> VI, 4).</p>
-				<p>12. Quapropter verum esse agnosce qnod dixi, di­ <lb/> vinitatem non per
+					<p>12. Quapropter verum esse agnosce qnod dixi, di­ <lb/> vinitatem non per
 					substantiam suam, in qua invisi­ <lb/> bilis ct immutabilis est, ped per
 					creaturam sibi subjo<lb/>Clam mortalium oculis apparuisse cum voluit. Non
 					<lb/> itaque sicut accipere vel accipi mea verba voluisti, <lb/> ego divinitatem
@@ -3977,7 +4060,7 @@
 					mutabilem dico. Restat ergo ut aspcetibus humanis <lb/> quando se ostendit ut
 					voluit, per subjectam intelliga­ <lb/> tur hoc fecisse creaturam, quae potest
 					oculis apparere <lb/> mortilihus.</p>
-				<p>13. Quid est autem quod eumde Patre dixisses, <lb/>
+					<p>13. Quid est autem quod eumde Patre dixisses, <lb/>
 					<hi rend="italic">Unus est</hi> invisibilis, unde jam salis est disputatum; ad­
 					<lb/> didisti, Unus <hi rend="italic">etiam incapubilis atque immensus?</hi>
 					Inca­ <lb/> pabilem quidem non legimus Deum. Cur sane dicas <lb/> incapabilem,
@@ -4019,7 +4102,7 @@
 						aestimabitur alius ad eum.</hi> Quis alius, nisi Antichristus, <lb/> quem
 					veram Christum fides vera non aestimat, sed <lb/> enim pro vero Christo
 					exsecrabilis Judxorum error <lb/> exspectat ?</p>
-				<p>14. Si oras, et petis, ut dicis, discipulus esse divi­ <lb/> narum Scripturarum.
+					<p>14. Si oras, et petis, ut dicis, discipulus esse divi­ <lb/> narum Scripturarum.
 					ad rem pertinentia testimonia <lb/> divina considera. Noli per multa quae te
 					nihil adju­ <lb/> vene, evagari: elige prudenter tacere quam inaniter <lb/>
 					loqui, quando non invenis quid respondcas manife­ <lb/> stissimae veritati.
@@ -4078,7 +4161,7 @@
 					<lb/> gere longum est, si pacifice acquiescas , eris, quod <lb/> orare et optare
 					te dicis, divinarum Scripturarum di­ <lb/> scipulus, ut de tua fraternitate
 					gaudeamus. <note type="footnote"> 1 Kdili, <hi rend="italic">qitibus</hi> c
-						fr::tus. Vclius Mss., <hi rend="italic">ntd</hi> (Christus. </note></p>
+						fr::tus. Vclius Mss., <hi rend="italic">ntd</hi> (Christus. </note></p></div>
 			</div>
 		</body>
 	</text>


### PR DESCRIPTION
En réponse au ticket #152 que j'ai ouvert, je me permets de vous soumettre mon travail.

Pour mettre en place la "capitanisation du texte" j'ai réorganisé le texte en plusieurs niveau de \<div\> : chapiter (chapter) et livre (book).

J'ai également ajouter des \<cRefPatter\> pour rendre le texte citable grâce à CapiTainS.

J'ai ajouter les différentes langues dans des xml:lang pour : 
- préciser la langue du texte (latin)
- préciser la langue d'encodage (anglais)

Pour finir, j'ai créé un revisiondesc qui m'a permis de laisser une trace des modifications que j'ai apporté au fichier.