### PR TITLE
Structuration d'un fichier suivant les recommandations des guidelines CapiTains (stoa0040.stoa008)

### DIFF
--- a/data/stoa0040/stoa008/stoa0040.stoa008.opp-lat1.xml
+++ b/data/stoa0040/stoa008/stoa0040.stoa008.opp-lat1.xml
@@ -139,84 +139,84 @@
 								grammaticam</hi> spectat, <hi rend="italic">sed ad musicam.</hi>
 						</title>
 					</ab>
-					<div type="textpart" subtype="dialog" n="1"><p>1. MAGISTER : <hi rend="italic">Modus,</hi> qui pes est? DISCIPULUS 1 : <lb/>
+					<div type="textpart" subtype="dialog" n="1"><p>1. MAGISTER : <hi rend="italic">Modus,</hi> qui pes est? DISCIPULUS 1 :<lb/>
 						Pyrrhichius. <hi rend="italic">M.</hi> Quot temporum est? <hi rend="italic"
-							>D.</hi> Duum. <lb/>
+							>D.</hi> Duum.<lb/>
 						<hi rend="italic">II. Bonus,</hi> qui pes est ? D. Idem qui ct modus. <hi
-							rend="italic">M.</hi> Hoc <lb/> est ergo <hi rend="italic">modus,</hi>
-						quod <hi rend="italic">bonus. D.</hi> Non. 3/. Cur ergo <lb/> idem? <hi
-							rend="italic">D.</hi> Quia idem iti sono, in significatione aliud. <lb/>
+							rend="italic">M.</hi> Hoc<lb/>est ergo <hi rend="italic">modus,</hi>
+						quod <hi rend="italic">bonus. D.</hi> Non. 3/. Cur ergo<lb/>idem? <hi
+							rend="italic">D.</hi> Quia idem iti sono, in significatione aliud.<lb/>
 						<hi rend="italic">M.</hi> Concedis ergo cumdem sonum esse cum dici.mus,
 							<note type="footnote"> ADMONITIO PP. BENEDICTINORUM. </note><note
 							type="footnote"> ,mendis i ropc innumeris expuvgati sunt (Libri
-							deMusica) ad Mss. Corbeiensem 01 tinae notæ, Arnulfensem, Albinensem,
-							<lb/> victorinum, regium, vaticanum ; ad lectiones ex Helgicis quatuor
-							per Lovanienses collectas; et ad editiones Am. Fr. ct Lov. <lb/>
-							Præterea libri quinque priores ad alium victorinum et ad Navarricum Mss.
-							collati sunt; sextus demum liber ad alium <lb/> Navar. et alium Victor.
+							deMusica) ad Mss. Corbeiensem 01 tinae notae, Arnulfensem, Albinensem,
+							<lb/>victorinum, regium, vaticanum ; ad lectiones ex Helgicis quatuor
+							per Lovanienses collectas; et ad editiones Am. Fr. ct Lov.<lb/>
+							Praeterea libri quinque priores ad alium victorinum et ad Navarricum Mss.
+							collati sunt; sextus demum liber ad alium<lb/>Navar. et alium Victor.
 							ad unum majoris conventus Augustinianoium Paris. ctad Benignianum.
-							</note><note type="footnote"><hi rend="italic">comparavimus præterea eas
+							</note><note type="footnote"><hi rend="italic">comparavimus praeterea eas
 								omnes editiones initio</hi> Retractationum et Confessionum <hi
-								rend="italic">memoratas , necnon duos Regiæ<lb/> Bibliothecæ</hi>
+								rend="italic">memoratas , necnon duos Regiae<lb/>Bibliothecae</hi>
 							Mss., numeris A, 7200, <hi rend="italic">et</hi> H, 7231 <hi
 								rend="italic">designatos, ac operis Augustiniani quamdam epitomen
-								ex</hi> ipis <hi rend="italic">potissimum <lb/> Augustini</hi>
+								ex</hi> ipis <hi rend="italic">potissimum<lb/>Augustini</hi>
 							verbis concinnatam, <hi rend="italic">quam ngelus Maius in pervetusto
-								codice B</hi><hi rend="italic">ibliothecæ</hi> V<hi rend="italic"
-								>aticanæ reperit ediditque Romæ,<lb/> anno</hi> 1828, in tomo 5,
+								codice B</hi><hi rend="italic">ibliothecae</hi> V<hi rend="italic"
+								>aticanae reperit ediditque Romae,<lb/>anno</hi> 1828, in tomo 5,
 							parte 3, i ag. 116-134, novie collectionis s:riptorum veterum e
-							vaticanis Cdd. ex; ressæ. M.</note>
+							vaticanis Cdd. ex; ressae. M.</note>
 						<note type="footnote"> s in a; ite operis, apud Albinensem Mss. habctur :
-								<hi rend="italic">Inci­<lb/> frit dwtogoritm</hi> augustini <hi
+								<hi rend="italic">Inci­<lb/>frit dwtogoritm</hi> augustini <hi
 								rend="italic">et Licentii de Musica liber primus.</hi>
-							<lb/> Titulum persinulem j'rn'ferun!. Regius codex et Victorini <lb/>
-							(w' ty v.ss. autem Corb. Aruulf. et aliis tlcrisque, uilerlo <lb/>
-							cutores Au;:,uSlinns' ct Licentius ex nomine designantur |er <lb/>
+							<lb/>Titulum persinulem j'rn'ferun!. Regius codex et Victorini<lb/>
+							(w' ty v.ss. autem Corb. Aruulf. et aliis tlcrisque, uilerlo<lb/>
+							cutores Au;:,uSlinns' ct Licentius ex nomine designantur |er<lb/>
 							t&lt;;Lmn &lt; | ns , ubicumque in uilis nolie anix.e sunt Vagistri
-							<lb/> ac Discipuli. </note>
+							<lb/>ac Discipuli. </note>
 						<note type="footnote">
 							<hi rend="italic">(a)</hi> Inclinati an. Christi oo7, perfecti circiter
 							au. 3SQ. </note>
 						<lb/>
 						<pb n="1083"/>
 						<hi rend="italic">modus,</hi> et, bonus. D. Litterarum sono ista video dis­
-						<lb/> crepare, cætera autem paria csse. <hi rend="italic">M.</hi> Quid? cum
-						enun­ <lb/> tiamus, <hi rend="italic">pone</hi> verbum, ct <hi rend="italic"
-							>pone</hi> adverbium; præter id <lb/> Quod significatio diversa est,
-						nihil libi vidclur sonus <lb/> dustare? <hi rend="italic">D.</hi> Distat
-						omnino. <hi rend="italic">M.</hi> Unde distat, cum et <lb/> iisdem
-						temporibus utrumque, ct iisdem litteris con­ <lb/> stet? D. Eo distat 1 quod
-						in diversis locis habent acu­ <lb/> mcn. <hi rend="italic">Al.</hi> Cujus
-						tandem artis cst ista dignoscere? <hi rend="italic">D.</hi> A <lb/>
-						grammaticis hæc audire soleo, ct ibi ea didici ; sed <lb/> utrumc hoc
-						ejusdem a.-tis sit proprium, an aliunde <lb/> usurpatum , nescio. <hi
-							rend="italic">M.</hi> Post ista videbimus : nunc <lb/> illud quæro,
-						utrum si tympanum vel chordam bis per­ <lb/> cuterem tam raptim et velociter
-						quam cum enuntia­ <lb/> mus <hi rend="italic">modus,</hi> aut <hi
-							rend="italic">bonus;</hi> agnosceres et tibi eadcm <lb/> tempora casu ,
-						an non. D. Agnoscerem. M. Vocarcs <lb/> largo pedem pyrrhicliinm. <hi
-							rend="italic">D.</hi> Vocarem. <hi rend="italic">M.</hi> Nomen <lb/>
+						<lb/>crepare, caetera autem paria csse. <hi rend="italic">M.</hi> Quid? cum
+						enun­<lb/>tiamus, <hi rend="italic">pone</hi> verbum, ct <hi rend="italic"
+							>pone</hi> adverbium; praeter id<lb/>Quod significatio diversa est,
+						nihil libi vidclur sonus<lb/>dustare? <hi rend="italic">D.</hi> Distat
+						omnino. <hi rend="italic">M.</hi> Unde distat, cum et<lb/>iisdem
+						temporibus utrumque, ct iisdem litteris con­<lb/>stet? D. Eo distat 1 quod
+						in diversis locis habent acu­<lb/>mcn. <hi rend="italic">Al.</hi> Cujus
+						tandem artis cst ista dignoscere? <hi rend="italic">D.</hi> A<lb/>
+						grammaticis haec audire soleo, ct ibi ea didici ; sed<lb/>utrumc hoc
+						ejusdem a.-tis sit proprium, an aliunde<lb/>usurpatum , nescio. <hi
+							rend="italic">M.</hi> Post ista videbimus : nunc<lb/>illud quaero,
+						utrum si tympanum vel chordam bis per­<lb/>cuterem tam raptim et velociter
+						quam cum enuntia­<lb/>mus <hi rend="italic">modus,</hi> aut <hi
+							rend="italic">bonus;</hi> agnosceres et tibi eadcm<lb/>tempora casu ,
+						an non. D. Agnoscerem. M. Vocarcs<lb/>largo pedem pyrrhicliinm. <hi
+							rend="italic">D.</hi> Vocarem. <hi rend="italic">M.</hi> Nomen<lb/>
 						hujus pedis a quo, nisi a grammatico, didicisti ? <hi rend="italic">D.</hi>
-						<lb/> Fatcor. <hi rend="italic">M.</hi> Ergo de omnibus hujusmodi sonis
-						gram­ <lb/> maticus judicabit; an per teipsum istos pulsus didi­ <lb/>
-						cisti, sed nomen quod imponeres, a grammatico au­ <lb/> dieras? <hi
+						<lb/>Fatcor. <hi rend="italic">M.</hi> Ergo de omnibus hujusmodi sonis
+						gram­<lb/>maticus judicabit; an per teipsum istos pulsus didi­<lb/>
+						cisti, sed nomen quod imponeres, a grammatico au­<lb/>dieras? <hi
 							rend="italic">D.</hi> Ita est. <hi rend="italic">M.</hi> Et ausus es
-						nomen quod te <lb/> grammatica docuit, transferre ad cam rem, quam non <lb/>
+						nomen quod te<lb/>grammatica docuit, transferre ad cam rem, quam non<lb/>
 						pertiuere ad grammaticam confiteris? <hi rend="italic">D.</hi> Video non
-						<lb/> ob aliud pcdi nomen impositum, quam propter tem­ <lb/> porum
-						dimensionem; quam ubicumque cognovero, eo <lb/> transferrc illud vocabulum
-						cur non audeo? Sed clsi <lb/> alia vocabula sunt imponenda, cum ejusdem
-						dimen­ <lb/> sionis soni sunt, sed ad grammaticos tamen non per­ <lb/>
-						tinent; quid milii est de nominibus laborare, cum res <lb/> aperta sit? <hi
-							rend="italic">31.</hi> Nee ego id volo : sed tamen cum vi­ <lb/> deas
-						innumcrahilia genera sonorum, in quibus certae <lb/> dimensiones observari
-						possunt, qu:e genera fatemur <lb/> grammaticæ disciplinænon case tribuenda ;
-						nonne <lb/> censes case aliam aliquam disciplinam, quæ quidquid <lb/> in
-						hujusmodi sit vocibus numerosum artificiosumque, <lb/> contineat? <hi
+						<lb/>ob aliud pcdi nomen impositum, quam propter tem­<lb/>porum
+						dimensionem; quam ubicumque cognovero, eo<lb/>transferrc illud vocabulum
+						cur non audeo? Sed clsi<lb/>alia vocabula sunt imponenda, cum ejusdem
+						dimen­<lb/>sionis soni sunt, sed ad grammaticos tamen non per­<lb/>
+						tinent; quid milii est de nominibus laborare, cum res<lb/>aperta sit? <hi
+							rend="italic">31.</hi> Nee ego id volo : sed tamen cum vi­<lb/>deas
+						innumcrahilia genera sonorum, in quibus certae<lb/>dimensiones observari
+						possunt, qu:e genera fatemur<lb/>grammaticae disciplinaenon case tribuenda ;
+						nonne<lb/>censes case aliam aliquam disciplinam, quae quidquid<lb/>in
+						hujusmodi sit vocibus numerosum artificiosumque,<lb/>contineat? <hi
 							rend="italic">D.</hi> Probahilc mihi videtur. <hi rend="italic">M.</hi>
-						Qaod cjus <lb/> esse nomen existimas? Nam opinor n &gt;n libi nevum <lb/>
-						esse omnipotentiam quamdam canendi Musis solcre <lb/> concedi. Hac est, nisi
-						fallor, illa quæ Musica nomina­ <lb/> tur. <hi rend="italic">D.</hi> Ei cgo
+						Qaod cjus<lb/>esse nomen existimas? Nam opinor n &gt;n libi nevum<lb/>
+						esse omnipotentiam quamdam canendi Musis solcre<lb/>concedi. Hac est, nisi
+						fallor, illa quae Musica nomina­<lb/>tur. <hi rend="italic">D.</hi> Ei cgo
 						hanc esse existimo.</p>
 					</div>
 				</div>
@@ -225,323 +225,323 @@
 								quid sit.</hi>
 						</title>
 					</ab>
-					<div type="textpart" subtype="dialog" n="2"><p>2. <hi rend="italic">M.</hi> Sed jam placcl nobis dc nomine minine la­ <lb/>
-						borare : modo inquiramus, si videtur, quam diligcn­ <lb/> tissime possumus ,
-						omnem hujus quæcumque cst <lb/> disciplinæ vim atque rationem. <hi
-							rend="italic">D.</hi> Inquiramus sanc : <lb/> nam boc lotuin quidquid
-						csl, mulium nosse desidero. <lb/>
+					<div type="textpart" subtype="dialog" n="2"><p>2. <hi rend="italic">M.</hi> Sed jam placcl nobis dc nomine minine la­<lb/>
+						borare : modo inquiramus, si videtur, quam diligcn­<lb/>tissime possumus ,
+						omnem hujus quaecumque cst<lb/>disciplinae vim atque rationem. <hi
+							rend="italic">D.</hi> Inquiramus sanc :<lb/>nam boc lotuin quidquid
+						csl, mulium nosse desidero.<lb/>
 						<hi rend="italic">M.</hi> Dclini ergo musicam. <hi rend="italic">D.</hi> Non
-						audeo. <hi rend="italic">M.</hi> Potes <lb/> saltem definitionem meam
-						probarc? <hi rend="italic">D.</hi> Experibor, <lb/> si dixeris. <hi
-							rend="italic">Al.</hi> Musica , cst scientia bene modulandi. <lb/> An
-						tibi non videtur? <hi rend="italic">D.</hi> Videretur frtasse, si mihi <lb/>
+						audeo. <hi rend="italic">M.</hi> Potes<lb/>saltem definitionem meam
+						probarc? <hi rend="italic">D.</hi> Experibor,<lb/>si dixeris. <hi
+							rend="italic">Al.</hi> Musica , cst scientia bene modulandi.<lb/>An
+						tibi non videtur? <hi rend="italic">D.</hi> Videretur frtasse, si mihi<lb/>
 						liqueret quid sit ipsa modulatio. <hi rend="italic">M.</hi> Numquidnam hoc
-						<lb/> verbum quod modulari dicitur, aut nunquam audisti, <lb/> aut uspiam
-						nisi in eo quod ad cantandum saltandumve <lb/> pertineret? <hi rend="italic"
-							>D.</hi> Ita cst quidem : sed quia video modu­ <lb/> lari a modo esse
-						dictum, cum in omnibus bene factis <lb/> modus servandua sit, ei multa etiam
-						in canendo ac <lb/> saltando quamvis delectent, vilissima sint; volo plc­
-						<lb/> nissime accipere quid prorsus sii ipsa modulatio, quo <note
+						<lb/>verbum quod modulari dicitur, aut nunquam audisti,<lb/>aut uspiam
+						nisi in eo quod ad cantandum saltandumve<lb/>pertineret? <hi rend="italic"
+							>D.</hi> Ita cst quidem : sed quia video modu­<lb/>lari a modo esse
+						dictum, cum in omnibus bene factis<lb/>modus servandua sit, ei multa etiam
+						in canendo ac<lb/>saltando quamvis delectent, vilissima sint; volo plc­
+						<lb/>nissime accipere quid prorsus sii ipsa modulatio, quo <note
 							type="footnote">
 							<hi rend="italic">1 Itistant,</hi> juxta r.d. Vs. A ct edd. rr. !u.'!.
 							M. </note>
-						<lb/> uno pene verbo tantæ disciplinæ dcfinitio continetur. <lb/> Nan enim
-						tale aliquid hic discendum est, quale qui­ <lb/> libet cantorcs
-						histrionesque novcrunt. <hi rend="italic">M.</hi> Illud supe­ <lb/> rus,
-						quod in omnibus etiam præter musicam faetis <lb/> inodus servandus est, et
-						tamcn in musica modulatio <lb/> dicitur, non te moveat; nisi forte ignoras
-						dictionem <lb/> oratoris proprie nominari. <hi rend="italic">D.</hi> Non
-						ignoro : sed quor­ <lb/> sum istuc? <hi rend="italic">M.</hi> Quia et puer
-						tuus quamlibct impolitis­ <lb/> simus et rusticissimus, cum vcl uno verbo
-						interroganti <lb/> tibi respondet, fateris cum aliquid dicere? <hi
-							rend="italic">D.</hi> Fateor. <lb/>
+						<lb/>uno pene verbo tantae disciplinae dcfinitio continetur.<lb/>Nan enim
+						tale aliquid hic discendum est, quale qui­<lb/>libet cantorcs
+						histrionesque novcrunt. <hi rend="italic">M.</hi> Illud supe­<lb/>rus,
+						quod in omnibus etiam praeter musicam faetis<lb/>inodus servandus est, et
+						tamcn in musica modulatio<lb/>dicitur, non te moveat; nisi forte ignoras
+						dictionem<lb/>oratoris proprie nominari. <hi rend="italic">D.</hi> Non
+						ignoro : sed quor­<lb/>sum istuc? <hi rend="italic">M.</hi> Quia et puer
+						tuus quamlibct impolitis­<lb/>simus et rusticissimus, cum vcl uno verbo
+						interroganti<lb/>tibi respondet, fateris cum aliquid dicere? <hi
+							rend="italic">D.</hi> Fateor.<lb/>
 						<hi rend="italic">M.</hi> Ergo et ille orator est? D. Non. M. Non igitur
-						dictio­ <lb/> ne usus cst cum aliquid dixerit, quamvis dictioncm a <lb/>
+						dictio­<lb/>ne usus cst cum aliquid dixerit, quamvis dictioncm a<lb/>
 						dicendo dictam esse fateamur. <hi rend="italic">D.</hi> Concedo : sed et hoc
-						<lb/> quo pertineat requiro. <hi rend="italic">M.</hi> Ad id scilicet ut
-						intelligas <lb/> modulationem posse ad solam musicam pertinere, <lb/>
-						quamvis nudus unde flexum verbum est, possit etiam <lb/> in aliis rebus
-						esse: quemadmodum dictio proprie tribui­ <lb/> tur oratoribus, quamvis dicat
-						aliquid omnis qui loqui­ <lb/> tur, et a discendo dictio nominata sit. <hi
+						<lb/>quo pertineat requiro. <hi rend="italic">M.</hi> Ad id scilicet ut
+						intelligas<lb/>modulationem posse ad solam musicam pertinere,<lb/>
+						quamvis nudus unde flexum verbum est, possit etiam<lb/>in aliis rebus
+						esse: quemadmodum dictio proprie tribui­<lb/>tur oratoribus, quamvis dicat
+						aliquid omnis qui loqui­<lb/>tur, et a discendo dictio nominata sit. <hi
 							rend="italic">D.</hi> Jam intelligo,</p>
 					</div>
 					<div type="textpart" subtype="dialog" n="3">
-						<p>3. M. Illud ergo quod abs te postea dictum est, multa <lb/> esse in canendo
-						et saltando vilia, in quibus si modula­ <lb/> tionis nomen accipimus, pene
-						divina ista disciplina <lb/> vilescit; cautissime omninoabs te
-						animadversumest. <lb/> Itaque discutiamus primum quid sit modulari, deinde
-						<lb/> quid sit bene modulari : non enim frustra est defini- <lb/> Hon!
-						additum. Postremo etiam quod ibi scientia po­ <lb/> sita est, non est
-						contemnendum : nam bis tribus, nisi <lb/> fallor, definitio illa perfecta
+						<p>3. M. Illud ergo quod abs te postea dictum est, multa<lb/>esse in canendo
+						et saltando vilia, in quibus si modula­<lb/>tionis nomen accipimus, pene
+						divina ista disciplina<lb/>vilescit; cautissime omninoabs te
+						animadversumest.<lb/>Itaque discutiamus primum quid sit modulari, deinde
+						<lb/>quid sit bene modulari : non enim frustra est defini<lb/>Hon!
+						additum. Postremo etiam quod ibi scientia po­<lb/>sita est, non est
+						contemnendum : nam bis tribus, nisi<lb/>fallor, definitio illa perfecta
 						cst. <hi rend="italic">D.</hi> Ila fiat. <hi rend="italic">M.</hi> Igitur
-						<lb/> quoniam fatemur modulationem a modo csse nomina­ <lb/> tam; numquidnam
-						tibi videtur metuendum ne ant <lb/> excedatur modus, aut non impleatur nisi
-						in rebus <lb/> quæ motu aliquo fiunt? aut si nihil moveatur, possu­ <lb/>
-						mus formidare ne præter modum aliquid fiat? D. Nullo <lb/> pacto. <hi
-							rend="italic">M.</hi> Ergo modulatio non incongrue dicitur mo­ <lb/>
-						vendi quædam peritia, vel certe qua fit ut bene ali­ <lb/> quid moveatur.
-						Non cnim possumus dicere bene mo­ <lb/> veri aliquid, si modum non servat.
-							<hi rend="italic">D.</hi> Non possumus <lb/> quidcm : sed necesse crit
-						rursus istam modulationem <lb/> in omnibus bene factis intelligere. Nihil
-						quippe nisi <lb/> bene movendo, bene fieri video. M. Quid si forte ista
-						<lb/> omnia per musicam fiant, quamvis modulationis no­ <lb/> meu in
-						cujuscemodi I organis magis tritum sit, nec <lb/> immerito? Nam credo videri
-						libi aliud esse tornatum <lb/> aliquid ligneum, vel argenteum, vel cujusce
-						matcriae; <lb/> aliud autcm ipsum motum artificis, cum illa tornan­ <lb/>
+						<lb/>quoniam fatemur modulationem a modo csse nomina­<lb/>tam; numquidnam
+						tibi videtur metuendum ne ant<lb/>excedatur modus, aut non impleatur nisi
+						in rebus<lb/>quae motu aliquo fiunt? aut si nihil moveatur, possu­<lb/>
+						mus formidare ne praeter modum aliquid fiat? D. Nullo<lb/>pacto. <hi
+							rend="italic">M.</hi> Ergo modulatio non incongrue dicitur mo­<lb/>
+						vendi quaedam peritia, vel certe qua fit ut bene ali­<lb/>quid moveatur.
+						Non cnim possumus dicere bene mo­<lb/>veri aliquid, si modum non servat.
+							<hi rend="italic">D.</hi> Non possumus<lb/>quidcm : sed necesse crit
+						rursus istam modulationem<lb/>in omnibus bene factis intelligere. Nihil
+						quippe nisi<lb/>bene movendo, bene fieri video. M. Quid si forte ista
+						<lb/>omnia per musicam fiant, quamvis modulationis no­<lb/>meu in
+						cujuscemodi I organis magis tritum sit, nec<lb/>immerito? Nam credo videri
+						libi aliud esse tornatum<lb/>aliquid ligneum, vel argenteum, vel cujusce
+						matcriae;<lb/>aliud autcm ipsum motum artificis, cum illa tornan­<lb/>
 						tar. <hi rend="italic">D.</hi> Assentior multum differre. <hi rend="italic"
-							>M.</hi> Numquidnam <lb/> ergo ipse motus propter se appetitur, et non
-						propter <lb/> id quod vult esse toruatum ? <hi rend="italic">D.</hi>
-						Manifestum est. M. <lb/> Quid ? si membra non ob aliud moveret, nisi ut
-						pulchre <lb/> ac decore moverentur, cum facere aliud nisi saltarcdi­ <lb/>
+							>M.</hi> Numquidnam<lb/>ergo ipse motus propter se appetitur, et non
+						propter<lb/>id quod vult esse toruatum ? <hi rend="italic">D.</hi>
+						Manifestum est. M.<lb/>Quid ? si membra non ob aliud moveret, nisi ut
+						pulchre<lb/>ac decore moverentur, cum facere aliud nisi saltarcdi­<lb/>
 						cercmus ? <hi rend="italic">D.</hi> Ita videtur. <hi rend="italic">M.</hi>
-						Quando ergo censes ali­ <lb/> quam rcm præstare et quasi dominari? cum
-						propter se­ <lb/> ipsam, an cum propter aliud appelitur? <hi rend="italic"
-							>D.</hi> Quis negai <lb/> cum propter scipsam? <hi rend="italic">M.</hi>
-						Repete nunc illud supertus <lb/> quod de modulatione diximus : nam ita cam
-						posuera­ <lb/> mus, quasi quamdam movendi esse pcriliam. ct vide <lb/> uhi
-						magis habere sedem debeat hoc nomen: in eo motu <lb/> qui velut liber cst,
+						Quando ergo censes ali­<lb/>quam rcm praestare et quasi dominari? cum
+						propter se­<lb/>ipsam, an cum propter aliud appelitur? <hi rend="italic"
+							>D.</hi> Quis negai<lb/>cum propter scipsam? <hi rend="italic">M.</hi>
+						Repete nunc illud supertus<lb/>quod de modulatione diximus : nam ita cam
+						posuera­<lb/>mus, quasi quamdam movendi esse pcriliam. ct vide<lb/>uhi
+						magis habere sedem debeat hoc nomen: in eo motu<lb/>qui velut liber cst,
 						id cst propter se ipse appetitur et <note type="footnote"> * sic &gt;:s. B;
 							at Ms. a, hujuscam (ti. Fdd. <hi rend="italic">ejuscemodi.</hi> M. </note>
 						<lb/>
-						<pb n="1085"/> per se ipse delectat; an in eo qui servit quodammode . <lb/>
-						nam quasi serviunt omnia quæ non sibi suni, sed ad <lb/> aliquid aliud
-						referuntur. <hi rend="italic">D.</hi> In eo sciHcet qui propter <lb/> se
-						appetitur. <hi rend="italic">M.</hi> Ergo scientiam modulandi jam pro­ <lb/>
-						babile est esse scientiam bene movendi; ita ut motns <lb/> per se ipse
-						appetatur, atque ob hoc per se ipse de­ <lb/> lectet. <hi rend="italic"
+						<pb n="1085"/> per se ipse delectat; an in eo qui servit quodammode .<lb/>
+						nam quasi serviunt omnia quae non sibi suni, sed ad<lb/>aliquid aliud
+						referuntur. <hi rend="italic">D.</hi> In eo sciHcet qui propter<lb/>se
+						appetitur. <hi rend="italic">M.</hi> Ergo scientiam modulandi jam pro­<lb/>
+						babile est esse scientiam bene movendi; ita ut motns<lb/>per se ipse
+						appetatur, atque ob hoc per se ipse de­<lb/>lectet. <hi rend="italic"
 							>D.</hi> Probabile sane.</p>
 					</div>
 					</div>
 					<div type="textpart" subtype="chapter" n="3"><ab>
 						<title type="sub"><hi rend="italic">Bene</hi> modulari <hi
-								rend="italic">quid sit, et cur in mu­ sicæ definitione</hi>
+								rend="italic">quid sit, et cur in mu­ sicae definitione</hi>
 							positI.</title>
 					</ab>
 					<div type="textpart" subtype="dialog" n="4">
-						<p>4. <hi rend="italic">M.</hi> Cur ergo additum est, bene; cum jam ipsa <lb/>
-						modulatio nisi bene moveatur, esse non possit? D. <lb/> Nescio, et
-						quemadmodum milii ereptam sit ignoro : <lb/> nam hoc requirendum animo
-						hsescrat. M. Poterat <lb/> omnino nulla de hoc verbo controversia fieri, ut
-						jam <lb/> musicam sublato eo quod positum est, bene, tantum <lb/> scientiam
-						modulandi definiremus. <hi rend="italic">D.</hi> Quis cnim ferat, <lb/> si
-						enodare totum ita velis? <hi rend="italic">M.</hi> Musica est scientia <lb/>
-						bene movendi. Sed quia bene moveri jam dici potest, <lb/> quidquid numerose
-						servatis temporum 1 atque inter­ <lb/> vallorum dimensionibus movetur ( jam
-						enim delectat, <lb/> et ob hoc modulatio non incongrue jam vocatur ) ; fieri
-						<lb/> autem potest, ut ista numerositas atque dimensio dc­ <lb/> lectet,
-						quando non opus est; ut si quis suavissime ca­ <lb/> nens, et pulchre
-						saltans, velit eo ipso lascivire, cum <lb/> reS severitatem desidcrat : non
-						bene utique numerosa <lb/> modulatione utitur; id est ea motione quæ jam
-						bona, <lb/> ea eo quia numerosa est, dici potest, male ille, id est <lb/>
-						iaco; grucnter utitur. Unde aliud est modulari, aliud <lb/> bene modulari.
-						Nam modulatio ad quemvis cantorem, <lb/> tantum qui non erret in illis
-						dimensionibus vocum ac <lb/> sonorum ; bona vero modulatio ad hanc libcralcm
-						dis­ <lb/> ciplinam, id est ad musicam, pertinere arbitranda cs t. <lb/>
-						Quod si nec illa bona tibi motio vidctur, ex eo quia <lb/> inepta est,
-						quamvis artificiose numerosam esse fateare; <lb/> teneamus illud nostrum,
-						quod ubique servandum est, <lb/> ne certamen verbi, re satis elucente, nos
-						torqueat ; <lb/> nlhilque curemus, utrum musica modulandi, an bene <lb/>
+						<p>4. <hi rend="italic">M.</hi> Cur ergo additum est, bene; cum jam ipsa<lb/>
+						modulatio nisi bene moveatur, esse non possit? D.<lb/>Nescio, et
+						quemadmodum milii ereptam sit ignoro :<lb/>nam hoc requirendum animo
+						hsescrat. M. Poterat<lb/>omnino nulla de hoc verbo controversia fieri, ut
+						jam<lb/>musicam sublato eo quod positum est, bene, tantum<lb/>scientiam
+						modulandi definiremus. <hi rend="italic">D.</hi> Quis cnim ferat,<lb/>si
+						enodare totum ita velis? <hi rend="italic">M.</hi> Musica est scientia<lb/>
+						bene movendi. Sed quia bene moveri jam dici potest,<lb/>quidquid numerose
+						servatis temporum 1 atque inter­<lb/>vallorum dimensionibus movetur ( jam
+						enim delectat,<lb/>et ob hoc modulatio non incongrue jam vocatur ) ; fieri
+						<lb/>autem potest, ut ista numerositas atque dimensio dc­<lb/>lectet,
+						quando non opus est; ut si quis suavissime ca­<lb/>nens, et pulchre
+						saltans, velit eo ipso lascivire, cum<lb/>reS severitatem desidcrat : non
+						bene utique numerosa<lb/>modulatione utitur; id est ea motione quae jam
+						bona,<lb/>ea eo quia numerosa est, dici potest, male ille, id est<lb/>
+						iaco; grucnter utitur. Unde aliud est modulari, aliud<lb/>bene modulari.
+						Nam modulatio ad quemvis cantorem,<lb/>tantum qui non erret in illis
+						dimensionibus vocum ac<lb/>sonorum ; bona vero modulatio ad hanc libcralcm
+						dis­<lb/>ciplinam, id est ad musicam, pertinere arbitranda cs t.<lb/>
+						Quod si nec illa bona tibi motio vidctur, ex eo quia<lb/>inepta est,
+						quamvis artificiose numerosam esse fateare;<lb/>teneamus illud nostrum,
+						quod ubique servandum est,<lb/>ne certamen verbi, re satis elucente, nos
+						torqueat ;<lb/>nlhilque curemus, utrum musica modulandi, an bene<lb/>
 						modulandi scientia describatur. <hi rend="italic">D.</hi> Amo quidem rixas
-						<lb/> verborum præterire atque contemnere, non tamen <lb/> mihi displicet
+						<lb/>verborum praeterire atque contemnere, non tamen<lb/>mihi displicet
 						ista distinctio.</p>
 					</div>
 					</div>
 					<div type="textpart" subtype="chapter" n="4"><ab>
 						<title type="sub"><hi rend="italic">Scientia cur</hi> in <hi
-								rend="italic">musicæ definitione ponitur.</hi>
+								rend="italic">musicae definitione ponitur.</hi>
 						</title>
 					</ab>
 					<div type="textpart" subtype="dialog" n="5">
-						<p>5. <hi rend="italic">M.</hi> Restat ut quæramus cur sit in definitione <lb/>
+						<p>5. <hi rend="italic">M.</hi> Restat ut quaeramus cur sit in definitione<lb/>
 						scientia. <hi rend="italic">D.</hi> Ita fiat : nam hoc flagitare ordinem me­
-						<lb/> mini. <hi rend="italic">M.</hi> Responde igitur, utrum tihi videatur
-						bene <lb/> modulari vocem luscinia verna parte anni : nam et <lb/> numerosus
-						est et suavissimus ille cantus, et, nisi fal­ <lb/> lor, tempori congruit.
+						<lb/>mini. <hi rend="italic">M.</hi> Responde igitur, utrum tihi videatur
+						bene<lb/>modulari vocem luscinia verna parte anni : nam et<lb/>numerosus
+						est et suavissimus ille cantus, et, nisi fal­<lb/>lor, tempori congruit.
 							<hi rend="italic">D.</hi> Videtur omnino. <hi rend="italic">M.</hi> Num­
-						<lb/> quidnam liberalis hujus disciplinæ perita est? <hi rend="italic"
-							>D.</hi> Non. <lb/> M. Vides igitur nomen scientiae definitioni
-						perneces­ <lb/> sarium. D. Video prorsus. <hi rend="italic">M.</hi> Dic
-						niihi ergo, quæso <lb/> te; nonne tales tibi omnes videntur, qualis illa
-						lusci­ <lb/> nia est, qui sensu quodam ducti bene canunt, hoc est <lb/>
-						numerose id faciunt ac suaviter, quamvis interrogati <lb/> de ipsis numeris,
-						vel de intervallis acutarum gravium­ <lb/> que vocum, respondere non
-						possint? <hi rend="italic">D.</hi> Simillimos <lb/> eos puto. <hi
+						<lb/>quidnam liberalis hujus disciplinae perita est? <hi rend="italic"
+							>D.</hi> Non.<lb/>M. Vides igitur nomen scientiae definitioni
+						perneces­<lb/>sarium. D. Video prorsus. <hi rend="italic">M.</hi> Dic
+						niihi ergo, quaeso<lb/>te; nonne tales tibi omnes videntur, qualis illa
+						lusci­<lb/>nia est, qui sensu quodam ducti bene canunt, hoc est<lb/>
+						numerose id faciunt ac suaviter, quamvis interrogati<lb/>de ipsis numeris,
+						vel de intervallis acutarum gravium­<lb/>que vocum, respondere non
+						possint? <hi rend="italic">D.</hi> Simillimos<lb/>eos puto. <hi
 							rend="italic">M.</hi> Quid ? ii qui illos sine ista scientia liben-
 							<note type="footnote"> I Sic in vss.; at tov., <hi rend="italic"
 								>quidquid numerositatis tmponmi.</hi>
-							<lb/> Ain. ct Kr. habeat, <hi rend="italic">quiaquid numerositatis, ql.æ
+							<lb/>Ain. ct Kr. habeat, <hi rend="italic">quiaquid numerositatis, ql.ae
 								temporum.</hi>
-							<lb/> — BenediclmU a lst:i utatur valic. Cd. M. </note>
-						<lb/> ler audiunt; cum videamus elephantos, <unclear>urs</unclear> os,
-						aliaque <lb/> nonnulla genera bestiarum ad Cantus moveri, avesque <lb/>
-						ipsas delectari suis vocibus (non enim nullo extra <lb/> propasito I commodo
-						tam impense id agerent sine <lb/> quadam libidinc); nonne pecoribns
-						comparandi sunt <lb/>
+							<lb/>— BenediclmU a lst:i utatur valic. Cd. M. </note>
+						<lb/>ler audiunt; cum videamus elephantos, <unclear>urs</unclear> os,
+						aliaque<lb/>nonnulla genera bestiarum ad Cantus moveri, avesque<lb/>
+						ipsas delectari suis vocibus (non enim nullo extra<lb/>propasito I commodo
+						tam impense id agerent sine<lb/>quadam libidinc); nonne pecoribns
+						comparandi sunt<lb/>
 						<hi rend="italic">D.</hi> Censco : sed pene in omne genus humanum tendit
-						<lb/> hæc contumelia. <hi rend="italic">M.</hi> Non cst quod putas. Nani
-						magni <lb/> viri, etsi musicam nesciunt, aut congruere plebi vo­ <lb/> lunt,
-						quæ non mullum a pecoribus distat, ct cujus <lb/> ingens est numerus, quod
-						modestissime ac prudentis­ <lb/> sime faciunt (scd de hoc nunc disserendi
-						locus non <lb/> est); aut post magnas curas relaxandi ao reparandi <lb/>
-						animi gratia moderatissime ab iis aliquid voluptatis <lb/> assumitur. Quam
-						interdum sic capere modestissimumu <lb/> est ; ab ea vero capi vel interdum
-						, turpc atque inde­ <lb/> corum est.</p></div>
+						<lb/>haec contumelia. <hi rend="italic">M.</hi> Non cst quod putas. Nani
+						magni<lb/>viri, etsi musicam nesciunt, aut congruere plebi vo­<lb/>lunt,
+						quae non mullum a pecoribus distat, ct cujus<lb/>ingens est numerus, quod
+						modestissime ac prudentis­<lb/>sime faciunt (scd de hoc nunc disserendi
+						locus non<lb/>est); aut post magnas curas relaxandi ao reparandi<lb/>
+						animi gratia moderatissime ab iis aliquid voluptatis<lb/>assumitur. Quam
+						interdum sic capere modestissimumu<lb/>est ; ab ea vero capi vel interdum
+						, turpc atque inde­<lb/>corum est.</p></div>
 					<div type="textpart" subtype="dialog" n="6">
-						<p>6. Sed quid tibi videtur ? qui vel tibiis canunt vel <lb/> cithara, atque
-						hujusmodi instrumentis, numquidnam <lb/> possunt lusciniæ comparari ? <hi
-							rend="italic">D.</hi> Nou. <hi rend="italic">M.</hi> Quid igitur <lb/>
+						<p>6. Sed quid tibi videtur ? qui vel tibiis canunt vel<lb/>cithara, atque
+						hujusmodi instrumentis, numquidnam<lb/>possunt lusciniae comparari ? <hi
+							rend="italic">D.</hi> Nou. <hi rend="italic">M.</hi> Quid igitur<lb/>
 						distant? <hi rend="italic">D.</hi> Quod in istis artem quamdam esse video,
-						<lb/> in illa vero solam naturam. <hi rend="italic">M.</hi> Verisimile
-						dicis; sed <lb/> ars tibi videtur ista esse dicenda, etiamsi quadam imi­
-						<lb/> tatione id faciunt? <hi rend="italic">D.</hi> Cur non? Nam video
-						tantum <lb/> valcre in artibus imitationem, ut, ea sublata, omnes <lb/> pene
-						perimantur. Præbent cnim se magistri ad imi­ <lb/> tandum, et hoc ipsum est
-						quod vocant docere. M. Vi­ <lb/> detur tibi ars ratio esse quædam, et ii qui
-						ane utun­ <lb/>
-						<lb/> tur, ratione uti: an aliter putas? D. Videtur. M. <lb/> Quisquis
-						igitur ratione uti non potest, arte non utitur. <lb/>
+						<lb/>in illa vero solam naturam. <hi rend="italic">M.</hi> Verisimile
+						dicis; sed<lb/>ars tibi videtur ista esse dicenda, etiamsi quadam imi­
+						<lb/>tatione id faciunt? <hi rend="italic">D.</hi> Cur non? Nam video
+						tantum<lb/>valcre in artibus imitationem, ut, ea sublata, omnes<lb/>pene
+						perimantur. Praebent cnim se magistri ad imi­<lb/>tandum, et hoc ipsum est
+						quod vocant docere. M. Vi­<lb/>detur tibi ars ratio esse quaedam, et ii qui
+						ane utun­<lb/>
+						<lb/>tur, ratione uti: an aliter putas? D. Videtur. M.<lb/>Quisquis
+						igitur ratione uti non potest, arte non utitur.<lb/>
 						<hi rend="italic">D.</hi> Et hoc concedo. <hi rend="italic">M.</hi> Censesne
-						muta animalia, quæ <lb/> etiam irrationalia dicuntur, uti posse ratione? <hi
-							rend="italic">D.</hi> Nullo <lb/> modo. <hi rend="italic">M.</hi> Aut
-						igitur picas et psittacos et corvos ra­ <lb/> tionalia esse dicturus es
-						animalia, aut imitationem <lb/> norninc artis temere vocasti. Videmus enim
-						has aves <lb/> et multa canere ac sonare quodam humano usu, et <lb/> nonnisi
+						muta animalia, quae<lb/>etiam irrationalia dicuntur, uti posse ratione? <hi
+							rend="italic">D.</hi> Nullo<lb/>modo. <hi rend="italic">M.</hi> Aut
+						igitur picas et psittacos et corvos ra­<lb/>tionalia esse dicturus es
+						animalia, aut imitationem<lb/>norninc artis temere vocasti. Videmus enim
+						has aves<lb/>et multa canere ac sonare quodam humano usu, et<lb/>nonnisi
 						imitando facere : nisi tu aliter credis. <hi rend="italic">D.</hi> Quo­
-						<lb/> modo hoc confeceris, et quantum contra responsionem <lb/> meam valeat,
-						nondum plane intelligo. <hi rend="italic">M.</hi> Quæsive­ <lb/> ram ex te,
-						utrum citharistas et tibicines, et hujusmodi <lb/> aliud genus hominum,
-						artem diceres habere, etiamsi <lb/> id quod in canendo faciunt, imitatione
-						assecuti suut. <lb/> Dixisti esse artem , tantumque id valere affirmasti, ut
-						<lb/> omnes pene libi artes periclitari viderentur imitatione <lb/> sublata.
-						Ex quo iam colligi potest, omnem qui imi­ <lb/> tando assequitur aliquid,
-						arte uti; etiamsi forte non <lb/> omnis qui arte utitur, imitando eam
-						perceperit. At 2 <lb/> si omnis imitatio ars est, et ars omnis ratio; omnis
-						<lb/> imitatio ratio : ratione autem non utitur irrationale <lb/> animal;
-						non igitur habet artem : habet autem imita­ <lb/> tionem; non est igitur ars
-						imitatio. <hi rend="italic">D.</hi> Ego multas <lb/> artes imitatione
-						constare dixi, non ipsam imitationem <lb/> artem vocavi. M. Quæ igitur artes
-						imitatione constant, <lb/> non eas censes ratione consLare? <hi
-							rend="italic">D.</hi> Imo utroque <lb/> puto cas constare. <hi
-							rend="italic">M.</hi> Nihil repugno, sed scientiam in <lb/> quo ponis;
-						in ratione, an in imitatione ? <hi rend="italic">D.</hi> Et hoc in <lb/>
+						<lb/>modo hoc confeceris, et quantum contra responsionem<lb/>meam valeat,
+						nondum plane intelligo. <hi rend="italic">M.</hi> Quaesive­<lb/>ram ex te,
+						utrum citharistas et tibicines, et hujusmodi<lb/>aliud genus hominum,
+						artem diceres habere, etiamsi<lb/>id quod in canendo faciunt, imitatione
+						assecuti suut.<lb/>Dixisti esse artem , tantumque id valere affirmasti, ut
+						<lb/>omnes pene libi artes periclitari viderentur imitatione<lb/>sublata.
+						Ex quo iam colligi potest, omnem qui imi­<lb/>tando assequitur aliquid,
+						arte uti; etiamsi forte non<lb/>omnis qui arte utitur, imitando eam
+						perceperit. At 2<lb/>si omnis imitatio ars est, et ars omnis ratio; omnis
+						<lb/>imitatio ratio : ratione autem non utitur irrationale<lb/>animal;
+						non igitur habet artem : habet autem imita­<lb/>tionem; non est igitur ars
+						imitatio. <hi rend="italic">D.</hi> Ego multas<lb/>artes imitatione
+						constare dixi, non ipsam imitationem<lb/>artem vocavi. M. Quae igitur artes
+						imitatione constant,<lb/>non eas censes ratione consLare? <hi
+							rend="italic">D.</hi> Imo utroque<lb/>puto cas constare. <hi
+							rend="italic">M.</hi> Nihil repugno, sed scientiam in<lb/>quo ponis;
+						in ratione, an in imitatione ? <hi rend="italic">D.</hi> Et hoc in<lb/>
 						utroque. <hi rend="italic">hI.</hi> Ergo scientiam illis avibus dabis,
-						quibus <lb/> imitationem non adimis. <hi rend="italic">D.</hi> Non dało ila
+						quibus<lb/>imitationem non adimis. <hi rend="italic">D.</hi> Non dało ila
 						enim dixi <note type="footnote"> I inB., <hi rend="italic">pofito.</hi> vs
 							A, Vatic. C(i., <hi rend="italic">proposito.</hi> Y. </note><note
 							type="footnote"> * In B., al. Mss. A ut B, <hi rend="italic">ut.</hi> M. </note>
 						<lb/>
-						<pb n="1087"/> in utroquc esse scientiam, ut in sola imitatione esse <lb/>
+						<pb n="1087"/> in utroquc esse scientiam, ut in sola imitatione esse<lb/>
 						non possit. <hi rend="italic">M.</hi> Quid? in sola ratione vidctur tibi
-						esse <lb/> posse? <hi rend="italic">D.</hi> Videtur. <hi rend="italic"
-							>M.</hi> Aliud igitur putas esse artem, <lb/> aliud scientiam. Siquidem
-						scientia ct in sola ratione <lb/> esse potest, ars autem rationi jungit
-						imitationem. <lb/>
+						esse<lb/>posse? <hi rend="italic">D.</hi> Videtur. <hi rend="italic"
+							>M.</hi> Aliud igitur putas esse artem,<lb/>aliud scientiam. Siquidem
+						scientia ct in sola ratione<lb/>esse potest, ars autem rationi jungit
+						imitationem.<lb/>
 						<hi rend="italic">D.</hi> Non video esse consequens. Non enim omnes, sed
-						<lb/> multas artes dixeram, simul ratione atque imitatione <lb/> constare.
-							<hi rend="italic">II.</hi> Quid? scientiam vocabisne etiam illam, <lb/>
-						quae his duobus simul constat; an ei solam partem <lb/> rationis attribues?
-							<hi rend="italic">D.</hi> Quid enim me prohibet vocare <lb/> scientiam,
+						<lb/>multas artes dixeram, simul ratione atque imitatione<lb/>constare.
+							<hi rend="italic">II.</hi> Quid? scientiam vocabisne etiam illam,<lb/>
+						quae his duobus simul constat; an ei solam partem<lb/>rationis attribues?
+							<hi rend="italic">D.</hi> Quid enim me prohibet vocare<lb/>scientiam,
 						cum rationi adjungitur imitatio?</p></div>
 					<div type="textpart" subtype="dialog" n="7">
-						<p>7. <hi rend="italic">M.</hi> Quoniam nunc agimus de citharista et tibi­ <lb/>
-						cine, id esi de musicis rebus; volo milii dicas, utrum <lb/> corpori
-						tribuendum sit, id est obtemperationi cuidam <lb/> corporis, si quid isti
-						homines imitatione faciunt. <lb/>
+						<p>7. <hi rend="italic">M.</hi> Quoniam nunc agimus de citharista et tibi­<lb/>
+						cine, id esi de musicis rebus; volo milii dicas, utrum<lb/>corpori
+						tribuendum sit, id est obtemperationi cuidam<lb/>corporis, si quid isti
+						homines imitatione faciunt.<lb/>
 						<hi rend="italic">D.</hi> Ego istam ct animo simul et corpori tribuendam
-						<lb/> puto : quanquam idipsum verbum satis proprie abs te <lb/> positum est,
-						quod obtemperationem corporis appel­ <lb/> lasti : non enim obtemperare nisi
-						animo potest. <lb/> M. Video te cautissime imitationem non soli corpori
-						<lb/> voluisse concedere. Sed numquid scientiam negabis <lb/> ad solum
-						animum pertincre? <hi rend="italic">D.</hi> Quis boc negaverit? <lb/> M.
-						Nullo modo igitur scientiam in sonis nervorum i ct <lb/> tibiarum, simul et
-						rationi et imitationi tribuere sine­ <lb/> lis. Illa enim imitatio non est,
-						ut confessus es, sine <lb/> corpore; scientiam vero solius animi esse
-						dixisti. <lb/> i. Ex iis quidem quae tibi concessi , fateor hoc esse <lb/>
-						confectum : sed quid no rem ? Habebit enim et tibicen <lb/> scientiam in
-						animo. Neque enim cum ei accedit imi­ <lb/> tatio, quam sine corpore dedi
-						esse non posse, adimct <lb/> illud quod animo amplectitur. <hi rend="italic"
-							>M.</hi> Non adimct qui­ <lb/> dem : nee ego affirmo eos, a quibus
-						organa ista tra­ <lb/> ctantur, omnes carere scientia, sed non habere omnes
-						<lb/> dico. Istam cnim ad hoc volvimus quaestionem , ut <lb/> intelligamus,
-						si possumus, quam recte sit scientia in <lb/> illa definitione musicae
-						posita; quam si omnes tibici­ <lb/> nes et fidicines , et id genus alii
-						quilibet habent, nihil <lb/> ista disciplina puto esse vilius, nibil
+						<lb/>puto : quanquam idipsum verbum satis proprie abs te<lb/>positum est,
+						quod obtemperationem corporis appel­<lb/>lasti : non enim obtemperare nisi
+						animo potest.<lb/>M. Video te cautissime imitationem non soli corpori
+						<lb/>voluisse concedere. Sed numquid scientiam negabis<lb/>ad solum
+						animum pertincre? <hi rend="italic">D.</hi> Quis boc negaverit?<lb/>M.
+						Nullo modo igitur scientiam in sonis nervorum i ct<lb/>tibiarum, simul et
+						rationi et imitationi tribuere sine­<lb/>lis. Illa enim imitatio non est,
+						ut confessus es, sine<lb/>corpore; scientiam vero solius animi esse
+						dixisti.<lb/>i. Ex iis quidem quae tibi concessi , fateor hoc esse<lb/>
+						confectum : sed quid no rem ? Habebit enim et tibicen<lb/>scientiam in
+						animo. Neque enim cum ei accedit imi­<lb/>tatio, quam sine corpore dedi
+						esse non posse, adimct<lb/>illud quod animo amplectitur. <hi rend="italic"
+							>M.</hi> Non adimct qui­<lb/>dem : nee ego affirmo eos, a quibus
+						organa ista tra­<lb/>ctantur, omnes carere scientia, sed non habere omnes
+						<lb/>dico. Istam cnim ad hoc volvimus quaestionem , ut<lb/>intelligamus,
+						si possumus, quam recte sit scientia in<lb/>illa definitione musicae
+						posita; quam si omnes tibici­<lb/>nes et fidicines , et id genus alii
+						quilibet habent, nihil<lb/>ista disciplina puto esse vilius, nibil
 						abjectius.</p></div>
 						<div type="textpart" subtype="dialog" n="8">
-							<p>8. Sed attende quam diligentissime, ul quod diu <lb/> jam molimur appareat.
-						Certe enim jam milii dedisti <lb/> in solo animo habitare scientiam. D.
-						Quidni dederim? <lb/> M. Quid? sensum aurium animonc, an corpori, an <lb/>
-						utique concedis? <hi rend="italic">D.</hi> Utrique. M. Quid memoriam? <lb/>
+							<p>8. Sed attende quam diligentissime, ul quod diu<lb/>jam molimur appareat.
+						Certe enim jam milii dedisti<lb/>in solo animo habitare scientiam. D.
+						Quidni dederim?<lb/>M. Quid? sensum aurium animonc, an corpori, an<lb/>
+						utique concedis? <hi rend="italic">D.</hi> Utrique. M. Quid memoriam?<lb/>
 						<hi rend="italic">D.</hi> Animo puto esse tribuendam. Non enin. si per sen­
-						<lb/> sus percipimus aliquid quod memoriæ commenda­ <lb/> mus , idco in
-						corpore memoria esse putanda est. <lb/> II. Magna fortasse ista quæstio est,
-						neque huic oppor­ <lb/> tuna sermoni. Sed quod proposito sat est, puto te
-						<lb/> ncgare non posse, bestias babere memoriam. Nam et <lb/> nidos post
-						annum revisunt hirundines, et de capellis <lb/> verissime dictum est: <lb/>
-						Atque ipse memorcs redeunt in tecta capellæ. <lb/>
-						<hi rend="italic">(Georg. lib.</hi> 5, <hi rend="italic">v.</hi> 310.) <lb/>
-						Et canis heroem dominum, jam suis hominibus obli­ <lb/> lum recognovisse <hi
-							rend="italic">prædicatur (Odysseæ <foreign xml:lang="grc">ρ</foreign>,
+						<lb/>sus percipimus aliquid quod memoriae commenda­<lb/>mus , idco in
+						corpore memoria esse putanda est.<lb/>II. Magna fortasse ista quaestio est,
+						neque huic oppor­<lb/>tuna sermoni. Sed quod proposito sat est, puto te
+						<lb/>ncgare non posse, bestias babere memoriam. Nam et<lb/>nidos post
+						annum revisunt hirundines, et de capellis<lb/>verissime dictum est:<lb/>
+						Atque ipse memorcs redeunt in tecta capellae.<lb/>
+						<hi rend="italic">(Georg. lib.</hi> 5, <hi rend="italic">v.</hi> 310.)<lb/>
+						Et canis heroem dominum, jam suis hominibus obli­<lb/>lum recognovisse <hi
+							rend="italic">praedicatur (Odysseae <foreign xml:lang="grc">ρ</foreign>,
 							v.</hi> 291 <hi rend="italic">seqq.).</hi>
-						<lb/> Et manumerabilia, si velimus, animadvertere possu­ <lb/> mus, quibus
-						id quod dico manifestum est. <hi rend="italic">D.</hi> Nee ego <lb/> istud
+						<lb/>Et manumerabilia, si velimus, animadvertere possu­<lb/>mus, quibus
+						id quod dico manifestum est. <hi rend="italic">D.</hi> Nee ego<lb/>istud
 						nego, et quid te adjuvct, vehementer exspecto. <note type="footnote">
 							<hi rend="italic">1 yeiborum,</hi> juxta diss. A et B. M. </note>
-						<lb/> M. Quid putas, msi quod scientiam qui soli animo <lb/> tribuit, eamque
-						omnibus irrationalibus animantibus <lb/> adimit, neque in sensu eam, neque
-						in memoria ( nam <lb/> illud non est sine corpore, et utrumque etiam in
-						<lb/> bestia est), sed in solo intellectu collocavit? <hi rend="italic"
-							>D.</hi> Et <lb/> boc exspecto quid te adjuvet. <hi rend="italic"
-							>M.</hi> Nihil aliud, nisi <lb/> omnes qui sensum sequuntur, et quod in
-						eo delectat, <lb/> metnoriaj commendant, atque secundum id corpus <lb/>
-						moventes, vim quamdam imitationis adjungunt; non <lb/> eos habere scientiam,
-						quamvis perite ac docte multa <lb/> facere videantur, si rem ipsam quam
-						profitentur aut <lb/> exhibent, intellectus puritate ac veritate non
-						teneant. <lb/> At si tales esse istos theatricos operarios ratio de.. <lb/>
-						monstravcrit; nihil erit, ut opinor, cur dubites eis <lb/> negare scientiam,
-						et ob hoc musicam, quæ scicntia <lb/> modulandi est, nequaquam coucedcre.
-							<hi rend="italic">D.</hi> Explica <lb/> hoc; videamus quale sit.</p></div>
+						<lb/>M. Quid putas, msi quod scientiam qui soli animo<lb/>tribuit, eamque
+						omnibus irrationalibus animantibus<lb/>adimit, neque in sensu eam, neque
+						in memoria ( nam<lb/>illud non est sine corpore, et utrumque etiam in
+						<lb/>bestia est), sed in solo intellectu collocavit? <hi rend="italic"
+							>D.</hi> Et<lb/>boc exspecto quid te adjuvet. <hi rend="italic"
+							>M.</hi> Nihil aliud, nisi<lb/>omnes qui sensum sequuntur, et quod in
+						eo delectat,<lb/>metnoriaj commendant, atque secundum id corpus<lb/>
+						moventes, vim quamdam imitationis adjungunt; non<lb/>eos habere scientiam,
+						quamvis perite ac docte multa<lb/>facere videantur, si rem ipsam quam
+						profitentur aut<lb/>exhibent, intellectus puritate ac veritate non
+						teneant.<lb/>At si tales esse istos theatricos operarios ratio de..<lb/>
+						monstravcrit; nihil erit, ut opinor, cur dubites eis<lb/>negare scientiam,
+						et ob hoc musicam, quae scicntia<lb/>modulandi est, nequaquam coucedcre.
+							<hi rend="italic">D.</hi> Explica<lb/>hoc; videamus quale sit.</p></div>
 					<div type="textpart" subtype="dialog" n="9">
 						<p>9. <hi rend="italic">M.</hi> Mobilitatem digitorum celeriorem vel pigrio-
-						<lb/> rem credo te non scientine, sed usui dare. <hi rend="italic">D.</hi>
-						Cur ita <lb/> credis id? <hi rend="italic">M.</hi> Quia superius soli animo
-						scientiam tri­ <lb/> buebas , hoc autem quanquam imperante animo ta­ <lb/>
+						<lb/>rem credo te non scientine, sed usui dare. <hi rend="italic">D.</hi>
+						Cur ita<lb/>credis id? <hi rend="italic">M.</hi> Quia superius soli animo
+						scientiam tri­<lb/>buebas , hoc autem quanquam imperante animo ta­<lb/>
 						men esse corporis vides. <hi rend="italic">D.</hi> Sed cum scicns animus
-						<lb/> hoc imperat corpori, magis hoc scicnti animo, quan <lb/> servientibus
-						membris tribuendum puto. <hi rend="italic">M.</hi> Nonne <lb/> censes posse
-						fieri ut unus aliam scientia præcedat, <lb/> cum ille imperitior multo
-						facilius et expeditius dig!­ <lb/> tos moveat? <hi rend="italic">D.</hi>
-						Censco. <hi rend="italic">M.</hi> At si motus celer et ex­ <lb/> pedilior
-						digitorum scientiæ tribuendus esset, tanto in <lb/> eo quisque excelleret,
-						quanto esset scientior. <hi rend="italic">D.</hi> Con­ <lb/> cedo. <hi
-							rend="italic">M.</hi> Attende ctiam istud. Nam opinor nonnun­ <lb/> quam
-						te animadvertisse fabros, vel hujusmodi opificcs, <lb/> ascia sive securi
-						cumdem locum feriendo repetere, <lb/> et non alio quam eo quo intendit
-						animus ictum per­ <lb/> ducere; quod nos tentantes cum assequi nequimus,
-						<lb/> ab cis sæpe irridemur. <hi rend="italic">D.</hi> Ila est ut dicis. <hi
-							rend="italic">M.</hi> Ergo <lb/> cum id nos facere non valemus, numquid
-						ignoramus <lb/> quid feriri debeat, vel quantum debeat ampulari? <hi
+						<lb/>hoc imperat corpori, magis hoc scicnti animo, quan<lb/>servientibus
+						membris tribuendum puto. <hi rend="italic">M.</hi> Nonne<lb/>censes posse
+						fieri ut unus aliam scientia praecedat,<lb/>cum ille imperitior multo
+						facilius et expeditius dig!­<lb/>tos moveat? <hi rend="italic">D.</hi>
+						Censco. <hi rend="italic">M.</hi> At si motus celer et ex­<lb/>pedilior
+						digitorum scientiae tribuendus esset, tanto in<lb/>eo quisque excelleret,
+						quanto esset scientior. <hi rend="italic">D.</hi> Con­<lb/>cedo. <hi
+							rend="italic">M.</hi> Attende ctiam istud. Nam opinor nonnun­<lb/>quam
+						te animadvertisse fabros, vel hujusmodi opificcs,<lb/>ascia sive securi
+						cumdem locum feriendo repetere,<lb/>et non alio quam eo quo intendit
+						animus ictum per­<lb/>ducere; quod nos tentantes cum assequi nequimus,
+						<lb/>ab cis saepe irridemur. <hi rend="italic">D.</hi> Ila est ut dicis. <hi
+							rend="italic">M.</hi> Ergo<lb/>cum id nos facere non valemus, numquid
+						ignoramus<lb/>quid feriri debeat, vel quantum debeat ampulari? <hi
 							rend="italic">D.</hi>
-						<lb/> Sæpe ignoramus, sæpe scimus. <hi rend="italic">M.</hi> Fac ergo
-						aliquem <lb/> nosse omnia, quae fabri facere debeant, et perfecte <lb/>
-						nosse, minus tamen valere in opere; sed eisdem <lb/> ipsis qui facillime
-						operantur, multa dictare solertius <lb/> qnam illL per se judicare 1
-						possent; an id usu evenire <lb/> negas? <hi rend="italic">D.</hi> Non nego.
-							<hi rend="italic">M.</hi> Non igitur solum movendi <lb/> celcrilas atque
-						facilitas, sed etiam motionis modus <lb/> ipse in membris, usui potius quam
-						scientiæ tribuen­ <lb/> dus est. Nam si aliter esset, eo quisque manibus me­
-						<lb/> lius uteretur quo esset peritior: quod licet ad tibias <lb/>
-						citharasve referamus, ne quod ibi digiti atque articuli <lb/> faciunt, quia
-						difficile nobis est, scientia potius quam <lb/> usu et sedula imitatione ac
-						meditatione fieri putemus. <lb/>
+						<lb/>Saepe ignoramus, saepe scimus. <hi rend="italic">M.</hi> Fac ergo
+						aliquem<lb/>nosse omnia, quae fabri facere debeant, et perfecte<lb/>
+						nosse, minus tamen valere in opere; sed eisdem<lb/>ipsis qui facillime
+						operantur, multa dictare solertius<lb/>qnam illL per se judicare 1
+						possent; an id usu evenire<lb/>negas? <hi rend="italic">D.</hi> Non nego.
+							<hi rend="italic">M.</hi> Non igitur solum movendi<lb/>celcrilas atque
+						facilitas, sed etiam motionis modus<lb/>ipse in membris, usui potius quam
+						scientiae tribuen­<lb/>dus est. Nam si aliter esset, eo quisque manibus me­
+						<lb/>lius uteretur quo esset peritior: quod licet ad tibias<lb/>
+						citharasve referamus, ne quod ibi digiti atque articuli<lb/>faciunt, quia
+						difficile nobis est, scientia potius quam<lb/>usu et sedula imitatione ac
+						meditatione fieri putemus.<lb/>
 						<hi rend="italic">D.</hi> Non queo resisterc ; nam et medicos audire soleo
-						<lb/> doctissimos viros, sæpe in secandis, vel quoquo modo <lb/>
-						comprimendis membris, in eo quod manu ac ferro <lb/> fiat, ab imperitioribus
-						antecedi : quod genus curandi <lb/> chirurgiam nominant, quo vocabulo satis
-						significatur <lb/> opcraria quaedam in manibus medendi consuetudo. <lb/>
-						Perge itaque ad caetera, et jam istam confice <unclear>cuæstio­</unclear>
-						<lb/> nem. <note type="footnote"> I in R., <hi rend="italic">indicare;</hi>
-							sic etiam -Lov.; at Er. Lugd. ven. MSS. <lb/> A et B. <hi rend="italic"
+						<lb/>doctissimos viros, saepe in secandis, vel quoquo modo<lb/>
+						comprimendis membris, in eo quod manu ac ferro<lb/>fiat, ab imperitioribus
+						antecedi : quod genus curandi<lb/>chirurgiam nominant, quo vocabulo satis
+						significatur<lb/>opcraria quaedam in manibus medendi consuetudo.<lb/>
+						Perge itaque ad caetera, et jam istam confice <unclear>cuaestio­</unclear>
+						<lb/>nem. <note type="footnote"> I in R., <hi rend="italic">indicare;</hi>
+							sic etiam -Lov.; at Er. Lugd. ven. MSS.<lb/>A et B. <hi rend="italic"
 								>judicare.</hi> M. </note></p>
 					<pb n="1089"/>
 					</div>
@@ -551,34 +551,34 @@
 							a natura.</title>
 					</ab>
 					<div type="textpart" subtype="dialog" n="10"><p>10. <hi rend="italic">M.</hi> Illud restat, ut opinor, ut inveniamus, si
-						<lb/> possumus, has ipsas artes quae nobis per manus pla­ <lb/> cent' ut
-						illius usus potentes essent, non continuo <lb/> scientiam, sed sensum ac
-						memoriam secutas : ne <lb/> forte mihi dicas fieri quidem possc, ut scientia
-						sine <lb/> usu sit, et major plerumque quam cst in eis qui usu <lb/>
-						excellunt; sed tamen etiam illos ad usum tantum non <lb/> potuisse sine ulla
-						scientia pervenire. D. Aggredcre : <lb/> nam ita deberi manifestum est. <hi
-							rend="italic">II.</hi> Nunquamne hu­ <lb/> jusmodi histriones audisti
-						studiosius? D. Plus fortasse <lb/> quam vellem. <hi rend="italic">M.</hi>
-						Unde fieri putas, ut imperita multitudo <lb/> explodat saepe tibicinem
-						nugatorios sonos efferentem; <lb/> rursumque plaudat bene canenti, et
-						prorsus quanto <lb/> suavius canitur, tanto amplius et studiosius moveatur ?
-						<lb/> Numquidnam id a vulgo per artem musicam fieri cre­ <lb/> dendum est?
-						D. Non. <hi rend="italic">M.</hi> Quid igitur? D. Natura id <lb/> fieri
-						puto, quae omnibus dedit sensum audiendi, quo <lb/> ista judicantur. ii.
-						Recte putas. Sed jam etiam illud <lb/> vide, utrum et tibicen ipse hoc sensu
-						praeditus sit. <lb/> Quod si ita est, potest ejus sequens judicium movcre
-						<lb/> digitos cum tibias inflaverit, et quod satis commode <lb/> . pro
-						arbitrio sonuerit, id notare ac mandare memoriæ, <lb/> atque id repetendo
-						consuefacere digitos eo ferri sine <lb/> ulla trepidatione et errore, sive
-						ab alio accipiat id <lb/> quod cauLet, sive ipse inveniat, illa de qua
-						dictum est <lb/> ducente atque approbante natura. Itaque cum sensum <lb/>
-						memoria, et articuli memoriam sequuntur, usu jam <lb/> edomiti atque
-						præparati; canit cum vult lauto mclius <lb/> atque jucundius, quanto illis
-						omnibus præstat qua; <lb/> superius ratio docuit cum bestiis nos habere
-						commu­ <lb/> nia, appetitum scilicet imitandi, sensum atque mcmo­ <lb/>
+						<lb/>possumus, has ipsas artes quae nobis per manus pla­<lb/>cent' ut
+						illius usus potentes essent, non continuo<lb/>scientiam, sed sensum ac
+						memoriam secutas : ne<lb/>forte mihi dicas fieri quidem possc, ut scientia
+						sine<lb/>usu sit, et major plerumque quam cst in eis qui usu<lb/>
+						excellunt; sed tamen etiam illos ad usum tantum non<lb/>potuisse sine ulla
+						scientia pervenire. D. Aggredcre :<lb/>nam ita deberi manifestum est. <hi
+							rend="italic">II.</hi> Nunquamne hu­<lb/>jusmodi histriones audisti
+						studiosius? D. Plus fortasse<lb/>quam vellem. <hi rend="italic">M.</hi>
+						Unde fieri putas, ut imperita multitudo<lb/>explodat saepe tibicinem
+						nugatorios sonos efferentem;<lb/>rursumque plaudat bene canenti, et
+						prorsus quanto<lb/>suavius canitur, tanto amplius et studiosius moveatur ?
+						<lb/>Numquidnam id a vulgo per artem musicam fieri cre­<lb/>dendum est?
+						D. Non. <hi rend="italic">M.</hi> Quid igitur? D. Natura id<lb/>fieri
+						puto, quae omnibus dedit sensum audiendi, quo<lb/>ista judicantur. ii.
+						Recte putas. Sed jam etiam illud<lb/>vide, utrum et tibicen ipse hoc sensu
+						praeditus sit.<lb/>Quod si ita est, potest ejus sequens judicium movcre
+						<lb/>digitos cum tibias inflaverit, et quod satis commode<lb/>. pro
+						arbitrio sonuerit, id notare ac mandare memoriae,<lb/>atque id repetendo
+						consuefacere digitos eo ferri sine<lb/>ulla trepidatione et errore, sive
+						ab alio accipiat id<lb/>quod cauLet, sive ipse inveniat, illa de qua
+						dictum est<lb/>ducente atque approbante natura. Itaque cum sensum<lb/>
+						memoria, et articuli memoriam sequuntur, usu jam<lb/>edomiti atque
+						praeparati; canit cum vult lauto mclius<lb/>atque jucundius, quanto illis
+						omnibus praestat qua;<lb/>superius ratio docuit cum bestiis nos habere
+						commu­<lb/>nia, appetitum scilicet imitandi, sensum atque mcmo­<lb/>
 						riam. Numquid habes adversum ista quod dicas? <hi rend="italic">D.</hi>
-						<lb/> Ego vero nihil habeo. Jam audire cupio cujusmodi sit <lb/> illa
-						disciplina, quam profecto a cognitione vilissimo­ <lb/> rum aniniorum video
+						<lb/>Ego vero nihil habeo. Jam audire cupio cujusmodi sit<lb/>illa
+						disciplina, quam profecto a cognitione vilissimo­<lb/>rum aniniorum video
 						subtilissime vindicatam.</p></div>
 					</div>
 			</div> 
@@ -588,74 +588,74 @@
 						</title>
 					</ab>
 					<div type="textpart" subtype="dialog" n="11">
-						<p>11. M. Nondum est satis quod factum est, nec ad ejus <lb/> explicationem
-						transire nos sinam, nisi quemadmodum <lb/> constitit inter nos posse
-						histriones sine ista scientia <lb/> satisfacere voluptati aurium popularium;
-						ita etiam <lb/> nullo modo esse posse hislrioncs musicae studiosos <lb/>
+						<p>11. M. Nondum est satis quod factum est, nec ad ejus<lb/>explicationem
+						transire nos sinam, nisi quemadmodum<lb/>constitit inter nos posse
+						histriones sine ista scientia<lb/>satisfacere voluptati aurium popularium;
+						ita etiam<lb/>nullo modo esse posse hislrioncs musicae studiosos<lb/>
 						peritosque constiterit. <hi rend="italic">D.</hi> Mirum si hoc effeceris. M.
-						<lb/> Facile id quidem, sed attentiore te milii opus est. <hi rend="italic"
+						<lb/>Facile id quidem, sed attentiore te milii opus est. <hi rend="italic"
 							>D.</hi>
-						<lb/> Nunquam equidem, quod sciam, rcmissior in audien­ <lb/> do fui, ab
-						usque sermo iste sumpsit cxordium : sed <lb/> nunc me, fateor, multo
-						erectiorem reddidisti. M. Gra­ <lb/> tum habeo, quanquam tibi te commodes
-						magis. Itaque <lb/> responde, si placet, utrum tibi vidcatur scire quid
-						<lb/> vil aureus solidus, qui eum æquo pretio vendere cu­ <lb/> piens,
-						decent nummus eum valerc putaverit? <hi rend="italic">D.</hi> Cui <lb/> hoc
-						videatur? <hi rend="italic">Al.</hi> Nunc age, dic mihi, quid charius <lb/>
-						habendum sit, quod nostra intelligentia comminetur, <lb/> an quod nobis
-						fortuito imperitorum judicio lribuitur? <lb/>
-						<hi rend="italic">D.</hi> Nulli dubium est, longe illud priulum præstare
-						<lb/> cæteris omnibus, quoe ne nostra quidem putanda sunt. <note
+						<lb/>Nunquam equidem, quod sciam, rcmissior in audien­<lb/>do fui, ab
+						usque sermo iste sumpsit cxordium : sed<lb/>nunc me, fateor, multo
+						erectiorem reddidisti. M. Gra­<lb/>tum habeo, quanquam tibi te commodes
+						magis. Itaque<lb/>responde, si placet, utrum tibi vidcatur scire quid
+						<lb/>vil aureus solidus, qui eum aequo pretio vendere cu­<lb/>piens,
+						decent nummus eum valerc putaverit? <hi rend="italic">D.</hi> Cui<lb/>hoc
+						videatur? <hi rend="italic">Al.</hi> Nunc age, dic mihi, quid charius<lb/>
+						habendum sit, quod nostra intelligentia comminetur,<lb/>an quod nobis
+						fortuito imperitorum judicio lribuitur?<lb/>
+						<hi rend="italic">D.</hi> Nulli dubium est, longe illud priulum praestare
+						<lb/>caeteris omnibus, quoe ne nostra quidem putanda sunt. <note
 							type="footnote"> ' tis. A, <hi rend="italic">has</hi> tpsas <hi
-								rend="italic">quæ nobis perplacenI</hi> manus. u. </note>
+								rend="italic">quae nobis perplacenI</hi> manus. u. </note>
 						<lb/>
-						<hi rend="italic">M.</hi> Num ergo negas omnem scientiam intelligentia <lb/>
+						<hi rend="italic">M.</hi> Num ergo negas omnem scientiam intelligentia<lb/>
 						contineri? <hi rend="italic">D.</hi> Quis negat ? M. Et musica igitur ibi
-						est. <lb/> D. Video ex ejus definitione id esse consequens. <hi
+						est.<lb/>D. Video ex ejus definitione id esse consequens. <hi
 							rend="italic">M.</hi>
-						<lb/> Quid? plausus populi et omnia illa theatrica præmia, <lb/> nonne tibi
-						ex eo genere videntur, quod in potestate <lb/> fortunæ et imperitorum
-						judicio positum est? <hi rend="italic">D.</hi> Nihil <lb/> magis arbitror
-						esse fortuitum obnoxiumquc casibus et <lb/> plebeiæ dominationi nutibusque
-						subjectum, quam illa <lb/> sunt omnia. <hi rend="italic">M.</hi> Hoccine
-						igitur pretio cantus suus vcn <lb/> derent histriones, si musicam scirent ?
-							<hi rend="italic">D.</hi> Non parum <lb/> quidem bac conclusione
-						commoveor, sed nonnilul <lb/> habeo quod contradicam. Nam ille venditor
-						solidi cum <lb/> isto comparandus non videtur : non enim accepto <lb/>
-						plausu aut qualibet sibi largita pecunia scientiam, si <lb/> quam forte
-						habet qua populum delectavit, amittit; sed <lb/> onustior nummo, et laude
-						hominum latior, cum ea­ <lb/> dem disciplina incolumi atque integra domum
-						discc­ <lb/> dit: stultus autcm esset, si commoda illa contemne­ <lb/> ret,
-						quæ non adeptus multo esset ignobilior atque <lb/> pauperior; adeptus autem
+						<lb/>Quid? plausus populi et omnia illa theatrica praemia,<lb/>nonne tibi
+						ex eo genere videntur, quod in potestate<lb/>fortunae et imperitorum
+						judicio positum est? <hi rend="italic">D.</hi> Nihil<lb/>magis arbitror
+						esse fortuitum obnoxiumquc casibus et<lb/>plebeiae dominationi nutibusque
+						subjectum, quam illa<lb/>sunt omnia. <hi rend="italic">M.</hi> Hoccine
+						igitur pretio cantus suus vcn<lb/>derent histriones, si musicam scirent ?
+							<hi rend="italic">D.</hi> Non parum<lb/>quidem bac conclusione
+						commoveor, sed nonnilul<lb/>habeo quod contradicam. Nam ille venditor
+						solidi cum<lb/>isto comparandus non videtur : non enim accepto<lb/>
+						plausu aut qualibet sibi largita pecunia scientiam, si<lb/>quam forte
+						habet qua populum delectavit, amittit; sed<lb/>onustior nummo, et laude
+						hominum latior, cum ea­<lb/>dem disciplina incolumi atque integra domum
+						discc­<lb/>dit: stultus autcm esset, si commoda illa contemne­<lb/>ret,
+						quae non adeptus multo esset ignobilior atque<lb/>pauperior; adeptus autem
 						nihilo esset indoctior.</p></div>
-					<div type="textpart" subtype="dialog" n="12"><p>12. <hi rend="italic">M.</hi> Vide ergo utrum vel isto conficiamus qnod <lb/>
-						volumus. Nam credo videri tibi multo esse praestan - <lb/> tius, id propter
-						quod aliquid facimus, quam idipsum <lb/> quod facimus. <hi rend="italic"
-							>D.</hi> Manifestum est. <hi rend="italic">M.</hi> Qui ergo can­ <lb/>
-						tat vel cantare discit, non ob aliud nisi ut laudetur :t <lb/> populo, vel
-						omnino abs quovis homine, nonne judi­ <lb/> cat meliorem laudem illam esse
+					<div type="textpart" subtype="dialog" n="12"><p>12. <hi rend="italic">M.</hi> Vide ergo utrum vel isto conficiamus qnod<lb/>
+						volumus. Nam credo videri tibi multo esse praestan<lb/>tius, id propter
+						quod aliquid facimus, quam idipsum<lb/>quod facimus. <hi rend="italic"
+							>D.</hi> Manifestum est. <hi rend="italic">M.</hi> Qui ergo can­<lb/>
+						tat vel cantare discit, non ob aliud nisi ut laudetur :t<lb/>populo, vel
+						omnino abs quovis homine, nonne judi­<lb/>cat meliorem laudem illam esse
 						quam cantum? <hi rend="italic">D.</hi>
-						<lb/> Negare non possum. <hi rend="italic">M.</hi> Quid? ille qui male de
-						aliqua <lb/> re judicat, videtur tibi cam scire? D. Nullo modo, <lb/> nisi
-						forte quoquo modo corruptus. <hi rend="italic">M.</hi> Ergo qui vcre <lb/>
-						putat melius esse aliquid quod deterius est, nullo du­ <lb/> bitante
-						scientia ejus caret. D. Ila est. <hi rend="italic">M.</hi> Quando igi­ <lb/>
-						tur milii vel persuaseris vel ostenderis quemlibet hi. <lb/> strionum non
-						ideo iilam, si quam habet facultatem, <lb/> vel assecutum esse vel exhibere
-						ut populo placeat <lb/> propter quaestum ant famam; concedam posse quem­
-						<lb/> quam et musicæ habere scientiam, et esse histrionem. <lb/> v Si autem
-						perprohabile est, neminem esse histrionum <lb/> qui non sibi professionis
-						finem in pecunia seu gloria <lb/> constituat ac proponat, fateare necesse
-						est aut musi­ <lb/> cam nescire histriones, aut magis expetendam esse ab
-						<lb/> aliis laudem, vel quæque ałia fortuita commoda, quam <lb/> a
-						nobismetipsis inteliigentiam 1. D. Video me, qui su­ <lb/> pcriora
-						concesserim, eliam istis cedere debcre. Non <lb/> enim mihi ullo modo videri
-						potest de scena inveniri <lb/> posse talem virum, qui artem suam propter
-						seipsam, <lb/> non propter extra posita commoda diligat; cum de <lb/>
-						gymnasio vix talis inveniatur : quanquam si quis exi. <lb/> stit, vel
-						exstiterit, non eo contemnendi musici, sed <lb/> honorandi aliquando
-						histriones possint videri. Quam­ <lb/> obrem explica jam, si placet, tantam
-						istam, quae jam <lb/> vilis mihi videri non potest, disciplinam.</p>
+						<lb/>Negare non possum. <hi rend="italic">M.</hi> Quid? ille qui male de
+						aliqua<lb/>re judicat, videtur tibi cam scire? D. Nullo modo,<lb/>nisi
+						forte quoquo modo corruptus. <hi rend="italic">M.</hi> Ergo qui vcre<lb/>
+						putat melius esse aliquid quod deterius est, nullo du­<lb/>bitante
+						scientia ejus caret. D. Ila est. <hi rend="italic">M.</hi> Quando igi­<lb/>
+						tur milii vel persuaseris vel ostenderis quemlibet hi.<lb/>strionum non
+						ideo iilam, si quam habet facultatem,<lb/>vel assecutum esse vel exhibere
+						ut populo placeat<lb/>propter quaestum ant famam; concedam posse quem­
+						<lb/>quam et musicae habere scientiam, et esse histrionem.<lb/>v Si autem
+						perprohabile est, neminem esse histrionum<lb/>qui non sibi professionis
+						finem in pecunia seu gloria<lb/>constituat ac proponat, fateare necesse
+						est aut musi­<lb/>cam nescire histriones, aut magis expetendam esse ab
+						<lb/>aliis laudem, vel quaeque ałia fortuita commoda, quam<lb/>a
+						nobismetipsis inteliigentiam 1. D. Video me, qui su­<lb/>pcriora
+						concesserim, eliam istis cedere debcre. Non<lb/>enim mihi ullo modo videri
+						potest de scena inveniri<lb/>posse talem virum, qui artem suam propter
+						seipsam,<lb/>non propter extra posita commoda diligat; cum de<lb/>
+						gymnasio vix talis inveniatur : quanquam si quis exi.<lb/>stit, vel
+						exstiterit, non eo contemnendi musici, sed<lb/>honorandi aliquando
+						histriones possint videri. Quam­<lb/>obrem explica jam, si placet, tantam
+						istam, quae jam<lb/>vilis mihi videri non potest, disciplinam.</p>
 					</div>
 					</div>
 					<div type="textpart" subtype="chapter" n="7"><ab>
@@ -663,31 +663,31 @@
 							motu.</title>
 					</ab>
 					<div type="textpart" subtype="dialog" n="13"><p>13. <hi rend="italic">M.</hi> Faciam, imo tu facies. Nam ego nihil aliud
-						<lb/> quam rogabo te ac percontabor : tu vero totum hoc <lb/> quidquid est,
-						et quod nunc nesciens quærere videris, <note type="footnote"> I Ms. A addit:
-								<hi rend="italic">Ft q,ria ab atiis expetunt laudem et covt­ <lb/>
+						<lb/>quam rogabo te ac percontabor : tu vero totum hoc<lb/>quidquid est,
+						et quod nunc nesciens quaerere videris, <note type="footnote"> I Ms. A addit:
+								<hi rend="italic">Ft q,ria ab atiis expetunt laudem et covt­<lb/>
 								moda, et a nobis intelligentiam non</hi> ejyrelrrut, <hi
-								rend="italic">cum prarjiuli­ <lb/> cant id quod lilivs e: t, eo</hi>
-							qvod <hi rend="italic">est citi ins. constat, qttii ejm <lb/> scienti an
+								rend="italic">cum prarjiuli­<lb/>cant id quod lilivs e: t, eo</hi>
+							qvod <hi rend="italic">est citi ins. constat, qttii ejm<lb/>scienti an
 								n(:M habent;</hi> addita saue j eri eram. Y. </note>
 						<lb/>
-						<pb n="1091"/> respondendo explicabis Itaque jain ex te quæro, utrum <lb/>
+						<pb n="1091"/> respondendo explicabis Itaque jain ex te quaero, utrum<lb/>
 						quisquam p ussit, et diu et volociter currere. <hi rend="italic">D.</hi> Po­
-						<lb/> test. <hi rend="italic">M.</hi> Quid, tarde et velociter ? D. Nullo
+						<lb/>test. <hi rend="italic">M.</hi> Quid, tarde et velociter ? D. Nullo
 						modo. <hi rend="italic">M.</hi>
-						<lb/> Aliud ergo cst diu, aHud tarde. <hi rend="italic">D.</hi> Aliud
+						<lb/>Aliud ergo cst diu, aHud tarde. <hi rend="italic">D.</hi> Aliud
 						omnino. <hi rend="italic">M.</hi>
-						<lb/> Item quæro, quid putes diuturnitati esse contrarium, <lb/> sicuti est
-						tarditati velocitas. <hi rend="italic">D.</hi> Non mihi occurrii usi­ <lb/>
-						tatum nomen. Itaque diuturno nihil video quod op­ <lb/> ponam, nisi non
-						diuturnum, ut ei quod dicitur, diu, <lb/> contrarium sit non diu, quia et
-						vclocitcr si nollem <lb/> dicere, et pro eo non tarde dicercm,ni!iil aliud
-						signi­ <lb/> licarctur. <hi rend="italic">M.</hi> Verum dicis. Nihil enim
-						deperit, cum <lb/> ita loquimur, veritati. Nam et mihi si est hoc nomen,
-						<lb/> quod tibi non occurrisse dicis, aut ignoratur a me, aut <lb/> in
-						pr;vsentia non vcnit in luentem. Quamobrem sic <lb/> agamus, ut hæc bina
-						contraria appellemus hoc modo, <lb/> diu et non diu, tarde et velociter. Ac
-						primum de diu­ <lb/> turno et non diuturno disseramus, si placet. <hi
+						<lb/>Item quaero, quid putes diuturnitati esse contrarium,<lb/>sicuti est
+						tarditati velocitas. <hi rend="italic">D.</hi> Non mihi occurrii usi­<lb/>
+						tatum nomen. Itaque diuturno nihil video quod op­<lb/>ponam, nisi non
+						diuturnum, ut ei quod dicitur, diu,<lb/>contrarium sit non diu, quia et
+						vclocitcr si nollem<lb/>dicere, et pro eo non tarde dicercm,ni!iil aliud
+						signi­<lb/>licarctur. <hi rend="italic">M.</hi> Verum dicis. Nihil enim
+						deperit, cum<lb/>ita loquimur, veritati. Nam et mihi si est hoc nomen,
+						<lb/>quod tibi non occurrisse dicis, aut ignoratur a me, aut<lb/>in
+						pr;vsentia non vcnit in luentem. Quamobrem sic<lb/>agamus, ut haec bina
+						contraria appellemus hoc modo,<lb/>diu et non diu, tarde et velociter. Ac
+						primum de diu­<lb/>turno et non diuturno disseramus, si placet. <hi
 							rend="italic">D.</hi> Ila fiat.</p>
 					</div>
 					</div>
@@ -697,51 +697,51 @@
 					</ab>
 					<div type="textpart" subtype="dialog">
 						<p>14. <hi rend="italic">M.</hi> Manifestumne tibi est, id dici diu fieri qnod
-						<lb/> per longum, id autem non diu quod per breve tempus <lb/> fit ? <hi
+						<lb/>per longum, id autem non diu quod per breve tempus<lb/>fit ? <hi
 							rend="italic">D.</hi> Manifestum. <hi rend="italic">M.</hi> Motus igitur
-						qui fit, verbi gra­ <lb/> tia, duabus horis, nonne ad eum qui una hora lit,
-						du­ <lb/> plum habet temporis? <hi rend="italic">D.</hi> Quis binc
-						dubitaverit ? M. <lb/> Recipit ergo id quod diu vel non diu dicimus dinlcu­
-						<lb/> siones hujusmodi ct numeros, ut alius motus ad alium, <lb/> tanquam
-						duo ad unum sit; id cst ut bis tantum habeat <lb/> alius quantum semel 1 :
-						alius item ad alium tanquam <lb/> tria ad duo, id est ut tantas tres partes
-						temporis ha­ <lb/> beat, quantas alius duas: atque ila per cæteros nume­
-						<lb/> ros licet currere, ut non sint spatia indefinita et inde­ <lb/>
-						terminata, sed habeant ad se duo motus aliquem nu­ <lb/> merum ; aut eumdem,
-						velut unum ad unum, ad duo <lb/> duo, ad tria uia, quatuor ad quatuor*: aut
-						non eum­ <lb/> dem, ut unum ad duo, duo ad tria, tria ad quatuor ; <lb/> aut
-						unum ad tria, duo ad sex, et quidquid potest 3 ali­ <lb/> quid ad sese
-						dimensionis obtinere. <hi rend="italic">D.</hi> Planius ista <lb/> qusrso.
-						M. Revertere ergo ad illas horas, et quod <lb/> satis putabam dictum, cum
-						.de una hora et de dua­ <lb/> bus dixissem, per omnia considera. Certe enim
-						non <lb/> ncgasposse fieri aliqucm motum tempore unius. ho. <lb/> rx&gt; et
+						qui fit, verbi gra­<lb/>tia, duabus horis, nonne ad eum qui una hora lit,
+						du­<lb/>plum habet temporis? <hi rend="italic">D.</hi> Quis binc
+						dubitaverit ? M.<lb/>Recipit ergo id quod diu vel non diu dicimus dinlcu­
+						<lb/>siones hujusmodi ct numeros, ut alius motus ad alium,<lb/>tanquam
+						duo ad unum sit; id cst ut bis tantum habeat<lb/>alius quantum semel 1 :
+						alius item ad alium tanquam<lb/>tria ad duo, id est ut tantas tres partes
+						temporis ha­<lb/>beat, quantas alius duas: atque ila per caeteros nume­
+						<lb/>ros licet currere, ut non sint spatia indefinita et inde­<lb/>
+						terminata, sed habeant ad se duo motus aliquem nu­<lb/>merum ; aut eumdem,
+						velut unum ad unum, ad duo<lb/>duo, ad tria uia, quatuor ad quatuor*: aut
+						non eum­<lb/>dem, ut unum ad duo, duo ad tria, tria ad quatuor ;<lb/>aut
+						unum ad tria, duo ad sex, et quidquid potest 3 ali­<lb/>quid ad sese
+						dimensionis obtinere. <hi rend="italic">D.</hi> Planius ista<lb/>qusrso.
+						M. Revertere ergo ad illas horas, et quod<lb/>satis putabam dictum, cum
+						.de una hora et de dua­<lb/>bus dixissem, per omnia considera. Certe enim
+						non<lb/>ncgasposse fieri aliqucm motum tempore unius. ho.<lb/>rx&gt; et
 						alium duarum. <hi rend="italic">D.</hi> Verum est. <hi rend="italic">M.</hi>
-						Quid? <lb/> . alimn duarum, alium trium non fateris? D. Fatcor. <lb/>
+						Quid?<lb/>. alimn duarum, alium trium non fateris? D. Fatcor.<lb/>
 						<hi rend="italic">M.</hi> Et alium tribus horis fieri, alium quatuor; rursus
-						<lb/> alium una, alium tribus; aut alium duabus, alium sex, <lb/> norne
-						manifestum est ? <hi rend="italic">D.</hi> Manifestum. M. Cur ergo <lb/> et
-						illud non manifestum sit ? Nam hoc dicebam cum <lb/> duos motus habere ad se
-						posse aliquem numerum di­ <lb/> cerem, velut unum ad duo, duo ad tria, tria
-						ad qua­ <lb/> tuor; unum ad tria, duo ad sex, et si quos al os re­ <lb/>
-						censere volueris. Ilis enim coguitis, est et 4 potestatis <lb/> persequi
+						<lb/>alium una, alium tribus; aut alium duabus, alium sex,<lb/>norne
+						manifestum est ? <hi rend="italic">D.</hi> Manifestum. M. Cur ergo<lb/>et
+						illud non manifestum sit ? Nam hoc dicebam cum<lb/>duos motus habere ad se
+						posse aliquem numerum di­<lb/>cerem, velut unum ad duo, duo ad tria, tria
+						ad qua­<lb/>tuor; unum ad tria, duo ad sex, et si quos al os re­<lb/>
+						censere volueris. Ilis enim coguitis, est et 4 potestatis<lb/>persequi
 						caetera, sive septem ad decem, sive quinque <note type="footnote"> 1 Mss. A
-							et B ac Edd. omnes non habent, <hi rend="italic">alius qucnilum <lb/>
+							et B ac Edd. omnes non habent, <hi rend="italic">alius qucnilum<lb/>
 								semet.</hi> sic legit vatic. Cd. : f t <hi rend="italic">bis tantum
-								iuibeai spuii,<lb/> quantum habet ille qui una</hi> hora <hi
+								iuibeai spuii,<lb/>quantum habet ille qui una</hi> hora <hi
 								rend="italic">fit.</hi> it. </note><note type="footnote"> * sic
 							veteres MSS.; at Faci. habent: <hi rend="italic">Aut</hi> eumdem, <hi
-								rend="italic">tit</hi> ,nan­ <lb/>
+								rend="italic">tit</hi> ,nan­<lb/>
 							<hi rend="italic">tum</hi> temporis <hi rend="italic">unus, latiium
-								tencat liller, aut non cumdem,</hi> etc. <lb/> — sic etiam MS. A et
+								tencat liller, aut non cumdem,</hi> etc.<lb/>— sic etiam MS. A et
 							cd. vatic. M. </note><note type="footnote">a cd. vatic., <hi
 								rend="italic">potest onmirrl.,</hi> addita voce <hi rend="italic"
 								>omnino.</hi> M. </note><note type="footnote"> 4 Cd. vatic. legit
-							simpliciter, eat poleatutis, subluta vocula <lb/>
+							simpliciter, eat poleatutis, subluta vocula<lb/>
 							<hi rend="italic">et.</hi> 51. </note>
-						<lb/> ad octo, et quidquid omnino cst in duobus motibus ita <lb/> partes
-						dimensas habentibus ad invicem, ut possint <lb/> dici tot ad tot; sivc
-						æquales numeri sint, sive alius <lb/> major, alius minor. <hi rend="italic"
-							>D.</hi> Jam intelligo, et fieri posse <lb/> concedo.</p>
+						<lb/>ad octo, et quidquid omnino cst in duobus motibus ita<lb/>partes
+						dimensas habentibus ad invicem, ut possint<lb/>dici tot ad tot; sivc
+						aequales numeri sint, sive alius<lb/>major, alius minor. <hi rend="italic"
+							>D.</hi> Jam intelligo, et fieri posse<lb/>concedo.</p>
 					</div>
 					</div>
 					<div type="textpart" subtype="chapter" n="9"><ab>
@@ -749,67 +749,67 @@
 								irrationabiles, connumerati et dinumerati.</hi>
 						</title>
 					</ab>
-					<div type="textpart" subtype="dialog" n="15"><p>15. <hi rend="italic">M.</hi> Illud etiam, ut opinor, intelligis, omnem <lb/>
-						mensuram et modum immoderationi et infinitati 1 <lb/> recte anteponi. D.
-						Manifestissimum est. <hi rend="italic">M.</hi> Duo igitur <lb/> motus qui ad
-						sese, ut dictum est, habent aliquam nu­ <lb/> merosam dimensionem, iis qui
-						cain non habent ante­ <lb/> ponendi sunt. D. Et hoc manifestum est atque
-						conse­ <lb/> quens : illos enim certus quidam modus, atque men­ <lb/> sura
-						quæ in numeris est, sibimet copulal; qua qui <lb/> carent, non utique'sibi
-						aliqua ratione junguntur. <lb/>
+					<div type="textpart" subtype="dialog" n="15"><p>15. <hi rend="italic">M.</hi> Illud etiam, ut opinor, intelligis, omnem<lb/>
+						mensuram et modum immoderationi et infinitati 1<lb/>recte anteponi. D.
+						Manifestissimum est. <hi rend="italic">M.</hi> Duo igitur<lb/>motus qui ad
+						sese, ut dictum est, habent aliquam nu­<lb/>merosam dimensionem, iis qui
+						cain non habent ante­<lb/>ponendi sunt. D. Et hoc manifestum est atque
+						conse­<lb/>quens : illos enim certus quidam modus, atque men­<lb/>sura
+						quae in numeris est, sibimet copulal; qua qui<lb/>carent, non utique'sibi
+						aliqua ratione junguntur.<lb/>
 						<hi rend="italic">M.</hi> Appellemus ergo, si placet, illos . qui inter se
-						di­ <lb/> mensi sunt, rationabiles; illos autem qui ea dimen­ <lb/> sione
+						di­<lb/>mensi sunt, rationabiles; illos autem qui ea dimen­<lb/>sione
 						carent, irrationabiles. <hi rend="italic">D.</hi> Placet vero. <hi
-							rend="italic">M.</hi> Jam <lb/> illud attende, utrurn tibi videatur
-						major concordia in <lb/> motibus rationabilibus eorum qui æquales sunt inter
-						<lb/> se, quam eorum qui sunt illæquales. <hi rend="italic">D.</hi> Cui hoc
-						nou <lb/> videatur? II. Porro inæqualium, nonne alii sunt in <lb/> quibus
-						possumus dicere, quota parte sua major aut <lb/> coæquetur minori, aut eum
-						cxcedat, ut duo et quatuor, <lb/> vel sex et octo; alii autem in quibus non
-						idem dici <lb/> potest, sicut in his numeris, tria et decem, vel qua­ <lb/>
-						tuor et undecim I? ? Cernis profecto in illis duobus no­ <lb/> meris
-						superioribus dimidia parte majorem minori <lb/> coa'quan ; in iis rursum
-						quos posterius dixi, minorem <lb/> a majore quarta parte majoris excedi : in
-						his autem <lb/> aliis, qualcs sunt tria et decem, vel quatuor et unde­ <lb/>
-						cini, videmus quidem nonnullam convenientiam, quia <lb/> partes ad se
-						habent, de quibus dici possit, tot ad tot; <lb/> scd numquid talem , qualis
-						est in superioribus? Nam <lb/> neque quota parte minori major aequetur,
-						neque quota <lb/> parte minorcm major excedat, dici ullo modo potest. <lb/>
-						Nam neque tria quota pars sit denarii numeri, neque <lb/> quatuor quota pars
-						sit undenarii, dixerit quispiam. <lb/> Cum autem dico ut consideres quota
-						sit pars, liqui­ <lb/> dam dico, ct sinc ullo additamento; sicuti est dimi­
-						<lb/> dia, tertia, quarta, quinta, sexta, et deinceps; non ut <lb/> trientes
-						et semiunciae, et boc genus præcisionum ali­ <lb/> quid addatur. <hi
+							rend="italic">M.</hi> Jam<lb/>illud attende, utrurn tibi videatur
+						major concordia in<lb/>motibus rationabilibus eorum qui aequales sunt inter
+						<lb/>se, quam eorum qui sunt illaequales. <hi rend="italic">D.</hi> Cui hoc
+						nou<lb/>videatur? II. Porro inaequalium, nonne alii sunt in<lb/>quibus
+						possumus dicere, quota parte sua major aut<lb/>coaequetur minori, aut eum
+						cxcedat, ut duo et quatuor,<lb/>vel sex et octo; alii autem in quibus non
+						idem dici<lb/>potest, sicut in his numeris, tria et decem, vel qua­<lb/>
+						tuor et undecim I? ? Cernis profecto in illis duobus no­<lb/>meris
+						superioribus dimidia parte majorem minori<lb/>coa'quan ; in iis rursum
+						quos posterius dixi, minorem<lb/>a majore quarta parte majoris excedi : in
+						his autem<lb/>aliis, qualcs sunt tria et decem, vel quatuor et unde­<lb/>
+						cini, videmus quidem nonnullam convenientiam, quia<lb/>partes ad se
+						habent, de quibus dici possit, tot ad tot;<lb/>scd numquid talem , qualis
+						est in superioribus? Nam<lb/>neque quota parte minori major aequetur,
+						neque quota<lb/>parte minorcm major excedat, dici ullo modo potest.<lb/>
+						Nam neque tria quota pars sit denarii numeri, neque<lb/>quatuor quota pars
+						sit undenarii, dixerit quispiam.<lb/>Cum autem dico ut consideres quota
+						sit pars, liqui­<lb/>dam dico, ct sinc ullo additamento; sicuti est dimi­
+						<lb/>dia, tertia, quarta, quinta, sexta, et deinceps; non ut<lb/>trientes
+						et semiunciae, et boc genus praecisionum ali­<lb/>quid addatur. <hi
 							rend="italic">D.</hi> Jam intelligo.</p>
 					</div>
-					<div type="textpart" subtype="dialog" n="16"><p>16. M. Ergo ex his inæqualibus motibus rationabili­
-						<lb/> bus, quoniam duo genera subjectis etiam numerorum <lb/> cxemplis
-						proposui, quos quibus -anteponendos arbi.. <lb/> traris? illosne in quibus
-						illa quota pars dici potes!, an <lb/> in quibus non potest? <hi
-							rend="italic">D.</hi> Illos mihi ratio vidctur ante­ <lb/> ponendos
-						jubere, in quibus potest dici, ut demon­ <lb/> stratum est, quota parte sui
-						major aut coaequetur mi- <lb/> Dori, aut eum excedat, iis in quibus idem non
-						evenit. <lb/> M. Recte. Sed visne etiam his nomina imponamus, <lb/> ut cum
+					<div type="textpart" subtype="dialog" n="16"><p>16. M. Ergo ex his inaequalibus motibus rationabili­
+						<lb/>bus, quoniam duo genera subjectis etiam numerorum<lb/>cxemplis
+						proposui, quos quibus -anteponendos arbi..<lb/>traris? illosne in quibus
+						illa quota pars dici potes!, an<lb/>in quibus non potest? <hi
+							rend="italic">D.</hi> Illos mihi ratio vidctur ante­<lb/>ponendos
+						jubere, in quibus potest dici, ut demon­<lb/>stratum est, quota parte sui
+						major aut coaequetur mi<lb/>Dori, aut eum excedat, iis in quibus idem non
+						evenit.<lb/>M. Recte. Sed visne etiam his nomina imponamus,<lb/>ut cum
 						cos deinceps commemorare necesse fuerit, <note type="footnote">1 *:ss.
 							plures, <hi rend="italic">ct informitati recte anteponi.—</hi> Quod
-							etiam <lb/> ferunt Mss. nostri ct vatic. cd. M. </note><note
+							etiam<lb/>ferunt Mss. nostri ct vatic. cd. M. </note><note
 							type="footnote">4 In B. : <hi rend="italic">inaiquulium, nonne alii sunt
-								in qitibaj possu­ <lb/> mus dicere, auota parte sua major aut
-								cocequetnr nrvw;i<lb/> cut cum excedal; atri aiitcm in qtibus non
-								iitem dici potest, <lb/> Mcut in his</hi> nnmerh, <hi rend="italic"
+								in qitibaj possu­<lb/>mus dicere, auota parte sua major aut
+								cocequetnr nrvw;i<lb/>cut cum excedal; atri aiitcm in qtibus non
+								iitem dici potest,<lb/>Mcut in his</hi> nnmerh, <hi rend="italic"
 								>dr,o ct qlw,kor,</hi> vel <hi rend="italic">sex ct octo.</hi> Locum
-							<lb/> liuuc dainus ensentJatuuj ex vatic. Ai </note>
+							<lb/>liuuc dainus ensentJatuuj ex vatic. Ai </note>
 						<lb/>
 						<pb n="1093"/> expeditius loquamur? <hi rend="italic">D.</hi> Volo sane. M.
-						Appellemus <lb/> crgo istos quos præponimus, connumeratos ; illos au­ <lb/>
-						tem qnibus hos præponimus, dinumeratos : propterea <lb/> quia isti
-						superiores non solum singuli numerantur, <lb/> sed etiam ea parte qua major
-						minori æquatur vel eum <lb/> excedit, se metiuntur et numerant; illi autem
-						poste­ <lb/> riores singillatim tantummodo ad sc numerantur, ca <lb/> vero
-						parte qua vel aequatur minori major, vel cxcedit <lb/> non se metiuntur et
-						numerant. Non eniin potest in eis <lb/> dici, aut qnoties habeat minorem
-						major; aut illud quo <lb/> Excedit major minorem quoties habeat et major et
-						<lb/> minor. D. Accipio et ista vocabula, et quantum valco, <lb/> faciam ut
+						Appellemus<lb/>crgo istos quos praeponimus, connumeratos ; illos au­<lb/>
+						tem qnibus hos praeponimus, dinumeratos : propterea<lb/>quia isti
+						superiores non solum singuli numerantur,<lb/>sed etiam ea parte qua major
+						minori aequatur vel eum<lb/>excedit, se metiuntur et numerant; illi autem
+						poste­<lb/>riores singillatim tantummodo ad sc numerantur, ca<lb/>vero
+						parte qua vel aequatur minori major, vel cxcedit<lb/>non se metiuntur et
+						numerant. Non eniin potest in eis<lb/>dici, aut qnoties habeat minorem
+						major; aut illud quo<lb/>Excedit major minorem quoties habeat et major et
+						<lb/>minor. D. Accipio et ista vocabula, et quantum valco,<lb/>faciam ut
 						meminerim.</p>
 					</div>
 					</div>
@@ -818,37 +818,37 @@
 								rend="italic">et sesquali.</hi>
 						</title>
 						</ab>
-					<div type="textpart" subtype="dialog" n="17"><p>17. M. Age nunc videamus connumeratorum qu:c <lb/> possit esse partitio :
-						namque arbitror cam esse per. <lb/> spicuam. Unuin cnim genus est
-						connumeratorum, in <lb/> quo minor numerus metilur majorem; id est ali­
-						<lb/> quoties eum habet major sicut numeros duo et qua­ <lb/> tuor esse
-						diximus : vidcmus enim duo a quatuor bis <lb/> haberi; quae tcr haberemur,
-						si non quatuor, sed sex <lb/> ad duo poneremus ; quater autem, si octo;
-						quinquics, <lb/> si decem. Aliud genus est, in quo ea pars qua excedit <lb/>
-						major minorem, ambos metitur; id est aliquoties ha­ <lb/> bent eam et major
-						et minor, quod in illis numeris jam <lb/> perspeximus, sex et octo. Nam pars
-						illa qua exceditur <lb/> minor, duo sunt, quos vides esse in octonario
-						numero <lb/> quater, in senario ter : quare hos quoque motus de <lb/> quibns
-						agitur, et numeros pcr quos illustratur quod <lb/> in motibus discere
-						volumus, notemus atque signemus <lb/> vocabulis. Nam eorum distinctio
-						jamdudum, nisi <lb/> fillor, apparet. Quocirca, si tibi jam videtur, illi
-						ubi <lb/> multiplicato minore fit major, vocentur complicati; <lb/> illi
-						autem sesquali, veteri jam nomine. Nam sesque <lb/> appellatur !, ob! duo
-						numeri ad se ea ratione affecti <lb/> sunt, ut tot partes habeat ad minorem
-						major, quota <lb/> parte sui eum præcedit: nam si est tria ad duo, tertia
-						<lb/> parte sui præcedit major minorem; si quatuor ad <lb/> tria, quarta :
-						si quinque ad quatuor, quinta, atque ita <lb/> dcinceps : eadem ratio esi,
-						et in sex ad quatuor, octo <lb/> ad sex, doccm ad octo; et inde licet hanc
-						rationem <lb/> et 2in consequentibus et in majoribus numeris anim­ <lb/>
-						advertere alque explorare. Nominis autem hujus ori­ <lb/> ginem non facile
-						dixerim : nisi forte sesqne quasi se <lb/> ahsque dictum, id est absque se,
-						quia quinque ad qua­ <lb/> tuor absque quinta parte sua major hoc est quod
-						<lb/> minor. Quibus de rebus quaero quid tihi vidcalur. <lb/>
+					<div type="textpart" subtype="dialog" n="17"><p>17. M. Age nunc videamus connumeratorum qu:c<lb/>possit esse partitio :
+						namque arbitror cam esse per.<lb/>spicuam. Unuin cnim genus est
+						connumeratorum, in<lb/>quo minor numerus metilur majorem; id est ali­
+						<lb/>quoties eum habet major sicut numeros duo et qua­<lb/>tuor esse
+						diximus : vidcmus enim duo a quatuor bis<lb/>haberi; quae tcr haberemur,
+						si non quatuor, sed sex<lb/>ad duo poneremus ; quater autem, si octo;
+						quinquics,<lb/>si decem. Aliud genus est, in quo ea pars qua excedit<lb/>
+						major minorem, ambos metitur; id est aliquoties ha­<lb/>bent eam et major
+						et minor, quod in illis numeris jam<lb/>perspeximus, sex et octo. Nam pars
+						illa qua exceditur<lb/>minor, duo sunt, quos vides esse in octonario
+						numero<lb/>quater, in senario ter : quare hos quoque motus de<lb/>quibns
+						agitur, et numeros pcr quos illustratur quod<lb/>in motibus discere
+						volumus, notemus atque signemus<lb/>vocabulis. Nam eorum distinctio
+						jamdudum, nisi<lb/>fillor, apparet. Quocirca, si tibi jam videtur, illi
+						ubi<lb/>multiplicato minore fit major, vocentur complicati;<lb/>illi
+						autem sesquali, veteri jam nomine. Nam sesque<lb/>appellatur !, ob! duo
+						numeri ad se ea ratione affecti<lb/>sunt, ut tot partes habeat ad minorem
+						major, quota<lb/>parte sui eum praecedit: nam si est tria ad duo, tertia
+						<lb/>parte sui praecedit major minorem; si quatuor ad<lb/>tria, quarta :
+						si quinque ad quatuor, quinta, atque ita<lb/>dcinceps : eadem ratio esi,
+						et in sex ad quatuor, octo<lb/>ad sex, doccm ad octo; et inde licet hanc
+						rationem<lb/>et 2in consequentibus et in majoribus numeris anim­<lb/>
+						advertere alque explorare. Nominis autem hujus ori­<lb/>ginem non facile
+						dixerim : nisi forte sesqne quasi se<lb/>ahsque dictum, id est absque se,
+						quia quinque ad qua­<lb/>tuor absque quinta parte sua major hoc est quod
+						<lb/>minor. Quibus de rebus quaero quid tihi vidcalur.<lb/>
 						<hi rend="italic">D.</hi> Mihi vero et illa ratio dimensionum atque ,nume­
-						<lb/> rorum videtur verissima ; et vocabula quæ abs te inl­ <lb/> posita
-						sunt, congrua mihi videntur commemorandis <lb/> cia rebus quas intelleximus
-						: et hujus origo nomi­ <lb/> nis quam nunc explicasti, non est absurda,
-						etiamsi <lb/> forte non ea sit quam secutus est qui hoc nomen <lb/>
+						<lb/>rorum videtur verissima ; et vocabula quae abs te inl­<lb/>posita
+						sunt, congrua mihi videntur commemorandis<lb/>cia rebus quas intelleximus
+						: et hujus origo nomi­<lb/>nis quam nunc explicasti, non est absurda,
+						etiamsi<lb/>forte non ea sit quam secutus est qui hoc nomen<lb/>
 						instituit. 8 <note type="footnote">' <hi rend="italic">AttquOtte* habent
 								minorem</hi> major, juxta vatic. M. </note><note type="footnote">
 							-in B., <hi rend="italic">appellantur.</hi> vatic., <hi rend="italic"
@@ -866,63 +866,63 @@
 								coercetur.</hi>
 						</title>
 					</ab>
-					<div type="textpart" subtype="dialog" n="18"><p>18. 11. Probo et accipio sententiam tuam : sed vi­ <lb/> desne omnes istos
-						rationabiles motus, id est qui ad <lb/> sese habent aliquam numcrorum
-						dimensionem, in <lb/> infinitum posse per numeros pergere, nisi mrsus eos
-						<lb/> cer ta ratio coercuerit, et ad quemdam modum formam­ <lb/> que
-						revocaverit? Nam ut primo de ipsis æqualibus <lb/> dicain ; unum ad unum,
-						duo ad duo, tria ad tria, qua­ <lb/> tuor ad qnatuor, ac deinceps si
-						persequar, quis finis <lb/> erit, cum ipsius numeri finis nullus sit ?
-						Namque ista <lb/> vis numero inest, ut omnis dictus finitus sit, non di­
-						<lb/> ctus autem infinitus. Et quod æqualibus evenit, hoc <lb/> eliam
-						inæqualibus evenire potes animadvertere, sive <lb/> complicatis, sive
-						sesquatis, sive connumeratis, sive <lb/> dinumeratis. Si enim unum ad duo
-						constituas, et in <lb/> ea multiplicatione permancre velis, dicendo unum ad
-						<lb/> tria, unum ad quatuor, unum ad quinque, et deinceps; <lb/> non cril
-						finis : sive sola dupla, ut unum ad duo, duo <lb/> ad quatuor, quatuor ad
-						octo, octo ad sexdecim , et <lb/> deinde ; hic quoque nullus est finis : ita
-						et tripla sola <lb/> et quadrupla sola, et quidquid horum tentare volueris,
-						<lb/> in infinitum progrediuntur. Ita ctiam sesquali : nam <lb/> duo ad
-						tria, tria ad quatuor, guatuor ad quinque cum <lb/> dicimus; vides nihil
-						prohibere caetera persequi, nullo <lb/> resistente fine : sive isto modo
-						velis in eodem genere <lb/> perseverans, ut duo ad tria, quatuor ad sex, sex
-						ad <lb/> novem, octo ad duodecim , decem ad quindecim, et <lb/> deinceps ;
-						sive in hoc genere, sive in cæteris, nullus <lb/> finis occurrit. Quid opus
-						est de dinumcratis jam Ji­ <lb/> cere, cum ex iis quae jam dicta sunt quivis
-						intelligere <lb/> possit, in iis quoque gradatim surgentibus nullum esse
-						<lb/> finem ? An tibi non videtur?</p>
+					<div type="textpart" subtype="dialog" n="18"><p>18. 11. Probo et accipio sententiam tuam : sed vi­<lb/>desne omnes istos
+						rationabiles motus, id est qui ad<lb/>sese habent aliquam numcrorum
+						dimensionem, in<lb/>infinitum posse per numeros pergere, nisi mrsus eos
+						<lb/>cer ta ratio coercuerit, et ad quemdam modum formam­<lb/>que
+						revocaverit? Nam ut primo de ipsis aequalibus<lb/>dicain ; unum ad unum,
+						duo ad duo, tria ad tria, qua­<lb/>tuor ad qnatuor, ac deinceps si
+						persequar, quis finis<lb/>erit, cum ipsius numeri finis nullus sit ?
+						Namque ista<lb/>vis numero inest, ut omnis dictus finitus sit, non di­
+						<lb/>ctus autem infinitus. Et quod aequalibus evenit, hoc<lb/>eliam
+						inaequalibus evenire potes animadvertere, sive<lb/>complicatis, sive
+						sesquatis, sive connumeratis, sive<lb/>dinumeratis. Si enim unum ad duo
+						constituas, et in<lb/>ea multiplicatione permancre velis, dicendo unum ad
+						<lb/>tria, unum ad quatuor, unum ad quinque, et deinceps;<lb/>non cril
+						finis : sive sola dupla, ut unum ad duo, duo<lb/>ad quatuor, quatuor ad
+						octo, octo ad sexdecim , et<lb/>deinde ; hic quoque nullus est finis : ita
+						et tripla sola<lb/>et quadrupla sola, et quidquid horum tentare volueris,
+						<lb/>in infinitum progrediuntur. Ita ctiam sesquali : nam<lb/>duo ad
+						tria, tria ad quatuor, guatuor ad quinque cum<lb/>dicimus; vides nihil
+						prohibere caetera persequi, nullo<lb/>resistente fine : sive isto modo
+						velis in eodem genere<lb/>perseverans, ut duo ad tria, quatuor ad sex, sex
+						ad<lb/>novem, octo ad duodecim , decem ad quindecim, et<lb/>deinceps ;
+						sive in hoc genere, sive in caeteris, nullus<lb/>finis occurrit. Quid opus
+						est de dinumcratis jam Ji­<lb/>cere, cum ex iis quae jam dicta sunt quivis
+						intelligere<lb/>possit, in iis quoque gradatim surgentibus nullum esse
+						<lb/>finem ? An tibi non videtur?</p>
 					</div>
 					<div type="textpart" subtype="dialog" n="19">
-						<p>19. <hi rend="italic">D.</hi> Quid hoc vcro verius dici potest? Sed jam <lb/>
-						illam rationem quæ istam infinitatem revocat ad cer­ <lb/> lum modum formam
-						que præscribit quam excedere non <lb/> oporteat, avidissime cognoscere
-						exspecto. M. Hanc <lb/> quoque, ut alia, temetipsum nosse cognosces, cum
-						<lb/> me interrogante vera responderis. Nam primo abs te <lb/> qu:ero,
-						quoniam de numerosis motibus agimus, utrum <lb/> ipsos debeamus consulere
-						numeros, ut quas nobis le­ <lb/> gcs certas fixasque monstraverint, eas in
-						illis mo­ <lb/> tibus animadvertendas observandasque judicemus. <lb/>
+						<p>19. <hi rend="italic">D.</hi> Quid hoc vcro verius dici potest? Sed jam<lb/>
+						illam rationem quae istam infinitatem revocat ad cer­<lb/>lum modum formam
+						que praescribit quam excedere non<lb/>oporteat, avidissime cognoscere
+						exspecto. M. Hanc<lb/>quoque, ut alia, temetipsum nosse cognosces, cum
+						<lb/>me interrogante vera responderis. Nam primo abs te<lb/>qu:ero,
+						quoniam de numerosis motibus agimus, utrum<lb/>ipsos debeamus consulere
+						numeros, ut quas nobis le­<lb/>gcs certas fixasque monstraverint, eas in
+						illis mo­<lb/>tibus animadvertendas observandasque judicemus.<lb/>
 						<hi rend="italic">D.</hi> Placet vcro : non enim quidquam ordinatius fieri
-						<lb/> I osse arbitror. <hi rend="italic">II.</hi> Ergo 2b ipso, si videtur,
-						principio <lb/> numerorum capiamus considerationis hujus exordium <lb/> et
-						videamus, quantum pro viribus mentis nostræ talia <lb/> valemus intueri,
-						qurrnam sit ratio, ut quamvis per in- f <lb/> linitum, ut dictum est,
-						numeris progrediatur, arti­ <lb/> culos quosdam homines in numerando
-						fecerint; a <lb/> quibus ad unum rursus redeant, quod est principium <lb/>
-						numcromm. In numerando enim progreditnur ab uno <lb/> usque ad decem, atque
-						inde ad unum -revertimur : <lb/> ac I si denariam complicationem persequi
-						velis, tit <lb/> hoc modo progrediaris, decem. viginti, triginta,qua­ <lb/>
-						draginta ; usque ad centum est progressio : si cente­ <lb/> nan iam, centum,
+						<lb/>I osse arbitror. <hi rend="italic">II.</hi> Ergo 2b ipso, si videtur,
+						principio<lb/>numerorum capiamus considerationis hujus exordium<lb/>et
+						videamus, quantum pro viribus mentis nostrae talia<lb/>valemus intueri,
+						qurrnam sit ratio, ut quamvis per in- f<lb/>linitum, ut dictum est,
+						numeris progrediatur, arti­<lb/>culos quosdam homines in numerando
+						fecerint; a<lb/>quibus ad unum rursus redeant, quod est principium<lb/>
+						numcromm. In numerando enim progreditnur ab uno<lb/>usque ad decem, atque
+						inde ad unum -revertimur :<lb/>ac I si denariam complicationem persequi
+						velis, tit<lb/>hoc modo progrediaris, decem. viginti, triginta,qua­<lb/>
+						draginta ; usque ad centum est progressio : si cente­<lb/>nan iam, centum,
 						ducenta, trecenta, quadringenta ; n <note type="footnote"> I in a., <hi
 								rend="italic">at.</hi> h's. A, <hi rend="italic">ac,</hi> ct mclius.
 							M. </note>
 						<lb/>
-						<pb n="1095"/> mille est articulus a quo redeatur. Quid jam opus est <lb/>
-						ultra quaerere? Vides certe quos articulos dicam, quo­ <lb/> rum prima
-						regula denario numero praescribitur. Nam <lb/> ut decem, decies habent unum;
-						ita centum, decies <lb/> habent eosdem decem ; et mille, decies habent cen­
-						<lb/> tum ; ct ita deinceps quousque libitum est progredi , <lb/> ibit 1 in
-						hujuscemodi quasi articulis, quod in denario <lb/> numero præfinitum cst. An
-						aliquid horum non intel­ <lb/> ligis ? <hi rend="italic">D.</hi>
+						<pb n="1095"/> mille est articulus a quo redeatur. Quid jam opus est<lb/>
+						ultra quaerere? Vides certe quos articulos dicam, quo­<lb/>rum prima
+						regula denario numero praescribitur. Nam<lb/>ut decem, decies habent unum;
+						ita centum, decies<lb/>habent eosdem decem ; et mille, decies habent cen­
+						<lb/>tum ; ct ita deinceps quousque libitum est progredi ,<lb/>ibit 1 in
+						hujuscemodi quasi articulis, quod in denario<lb/>numero praefinitum cst. An
+						aliquid horum non intel­<lb/>ligis ? <hi rend="italic">D.</hi>
 						Manifestissima sunt omnia, ct verissima.</p>
 					</div>
 					</div>
@@ -934,107 +934,107 @@
 						</title>
 					</ab>
 						<div type="textpart" subtype="dialog" n="20">
-							<p>20. <hi rend="italic">M.</hi> Hoe ergo quantum diligenter possumus per­ <lb/>
-						scrulcmur, quænam sit ratio ut ab uno usque ad de.. <lb/> cem progressus, et
-						inde rursus ad unum reditus fiat. <lb/> Unde abs te quæro, utmm quod vocamus
-						principium, <lb/> possit omnino nisi alicujus esse principium. <hi
-							rend="italic">D.</hi> Nullo <lb/> modo potest. <hi rend="italic">M.</hi>
-						Item quod dicimus finem, potestne <lb/> nisi alicujus rei finis esse? <hi
-							rend="italic">D.</hi> Etiam id non potest. <lb/>
+							<p>20. <hi rend="italic">M.</hi> Hoe ergo quantum diligenter possumus per­<lb/>
+						scrulcmur, quaenam sit ratio ut ab uno usque ad de..<lb/>cem progressus, et
+						inde rursus ad unum reditus fiat.<lb/>Unde abs te quaero, utmm quod vocamus
+						principium,<lb/>possit omnino nisi alicujus esse principium. <hi
+							rend="italic">D.</hi> Nullo<lb/>modo potest. <hi rend="italic">M.</hi>
+						Item quod dicimus finem, potestne<lb/>nisi alicujus rei finis esse? <hi
+							rend="italic">D.</hi> Etiam id non potest.<lb/>
 						<hi rend="italic">M.</hi> Quid? a principio ad finem num putas perveniri
-						<lb/> posse, nisi per aliquod medium? <hi rend="italic">D.</hi> Non puto.
-							<hi rend="italic">M.</hi> Ergo <lb/> ut totum aliquid sit, principio et
-						medio ct fine constat. <lb/>
+						<lb/>posse, nisi per aliquod medium? <hi rend="italic">D.</hi> Non puto.
+							<hi rend="italic">M.</hi> Ergo<lb/>ut totum aliquid sit, principio et
+						medio ct fine constat.<lb/>
 						<hi rend="italic">D.</hi> Ita videtur. <hi rend="italic">M.</hi> Dic itaque
-						nunc, principium, me­ <lb/> dium et finis, quo numero libi contineri
-						videantur. <lb/>
+						nunc, principium, me­<lb/>dium et finis, quo numero libi contineri
+						videantur.<lb/>
 						<hi rend="italic">D.</hi> Arbitror ternarium numerum te velle ut respon­
-						<lb/> duam : tria enim quædam sunt, de quibus quaeris. <lb/>
+						<lb/>duam : tria enim quaedam sunt, de quibus quaeris.<lb/>
 						<hi rend="italic">M.</hi> Recta arbitraris. Quare in ternario numero quam­
-						<lb/> darn esse perfectionem vides, quia totus est: habet <lb/> cnim
-						principium, medium et finem. <hi rend="italic">D.</hi> Video plane. <lb/>
+						<lb/>darn esse perfectionem vides, quia totus est: habet<lb/>cnim
+						principium, medium et finem. <hi rend="italic">D.</hi> Video plane.<lb/>
 						<hi rend="italic">M.</hi> Quid? illud nonne ab incunte puerilia didicimus,
-						<lb/> omnem numcrum aut parem esse, aut imparem? <lb/>
+						<lb/>omnem numcrum aut parem esse, aut imparem?<lb/>
 						<hi rend="italic">D.</hi> Verum dicis. <hi rend="italic">M.</hi> Recordare
-						ergo et dic mihi, quem <lb/> soleamus dicere parem , quem imparem numerum. <lb/>
-						<hi rend="italic">D.</hi> Ille qui potest in duas partes æquales dividi,
-						par; <lb/> qui autem non potest, impar vocatur.</p>
+						ergo et dic mihi, quem<lb/>soleamus dicere parem , quem imparem numerum.<lb/>
+						<hi rend="italic">D.</hi> Ille qui potest in duas partes aequales dividi,
+						par;<lb/>qui autem non potest, impar vocatur.</p>
 						</div>
 						<div type="textpart" subtype="dialog" n="21"><p>21. <hi rend="italic">M.</hi> Rem tenes. Cum igitur ternarius primus sit
-						<lb/> totus impar; cl principio conio, et medio, et fine con­ <lb/> stat, ut
-						dictum est; nonne oportet etiam parcm esse <lb/> lotum atque perfectum , ut
-						in eo etiam principium, <lb/> medium, finisque inveniatur? <hi rend="italic"
-							>D.</hi> Oportet sane. M. At <lb/> iste quisquis est, non potest habere
-						individuum me­ <lb/> dium sicut impar: si enim habcret, non posset in duas
-						<lb/> æquales partes dividi, quod esse proprium paris nu­ <lb/> ncri
-						diximus. Individuum autem medium est unum, <lb/> dividuum duo. Medium autcm
-						est in numeris, a quo <lb/> ambo latera sibimet sunt æqualia. An aliquid
-						obscure <lb/> dictum est, minusquc assequeris? <hi rend="italic">D.</hi> Imo
-						mihi et hæc <lb/> manifesta sunt, cl dum quæro totum numerum parem, <lb/>
-						quaternarius primus occurrit. Nam in duobus quomodo <lb/> possunt tria illa
-						inveniri, per quæ totus est numerus, <lb/> id est principium, medium et
-						finis? M. Idipsum <lb/> omnino abs te responsum est quod volcbain, et quod
-						<lb/> ipsa ratio cogit fateri. Repete itaque ab ipso uno tra­ <lb/>
-						cta;ionem, atque considera; videbis profecto ideo <lb/> unum non habere
-						medium ct finem, quia tantum prin­ <lb/> cipium est; vel ideo esse
-						principium , qnia medio et <lb/> fine caret. <hi rend="italic">D.</hi>
+						<lb/>totus impar; cl principio conio, et medio, et fine con­<lb/>stat, ut
+						dictum est; nonne oportet etiam parcm esse<lb/>lotum atque perfectum , ut
+						in eo etiam principium,<lb/>medium, finisque inveniatur? <hi rend="italic"
+							>D.</hi> Oportet sane. M. At<lb/>iste quisquis est, non potest habere
+						individuum me­<lb/>dium sicut impar: si enim habcret, non posset in duas
+						<lb/>aequales partes dividi, quod esse proprium paris nu­<lb/>ncri
+						diximus. Individuum autem medium est unum,<lb/>dividuum duo. Medium autcm
+						est in numeris, a quo<lb/>ambo latera sibimet sunt aequalia. An aliquid
+						obscure<lb/>dictum est, minusquc assequeris? <hi rend="italic">D.</hi> Imo
+						mihi et haec<lb/>manifesta sunt, cl dum quaero totum numerum parem,<lb/>
+						quaternarius primus occurrit. Nam in duobus quomodo<lb/>possunt tria illa
+						inveniri, per quae totus est numerus,<lb/>id est principium, medium et
+						finis? M. Idipsum<lb/>omnino abs te responsum est quod volcbain, et quod
+						<lb/>ipsa ratio cogit fateri. Repete itaque ab ipso uno tra­<lb/>
+						cta;ionem, atque considera; videbis profecto ideo<lb/>unum non habere
+						medium ct finem, quia tantum prin­<lb/>cipium est; vel ideo esse
+						principium , qnia medio et<lb/>fine caret. <hi rend="italic">D.</hi>
 						Manifestum est. <hi rend="italic">M.</hi> Quid ergo dicemus <note
 							type="footnote"> * LOT., <hi rend="italic">progrediuntur in hujuscemodi
-								quasi articulis.</hi> ARN. <lb/> ft Er., <hi rend="italic">progredi,
+								quasi articulis.</hi> ARN.<lb/>ft Er., <hi rend="italic">progredi,
 								ririt</hi> in <hi rend="italic">hujuscemodi</hi> etc.; at Ibs.
-							meliores <lb/> habent, <hi rend="italic">progredi ibit,</hi> eu. </note>
-						<lb/> de duobus? Num possumus in eis intelligere <unclear>prin­</unclear>
-						<lb/> cipium et medium, cum medium esse non possit, ,.ibi <lb/> ubi finis
-						est; aut principium et finem, cum ad finem <lb/> nisi per medium non queat
-						perveniri ? <hi rend="italic">D.</hi> Urget ratio <lb/> confileri; et quid
-						de hoc numero respondcam, prorsus <lb/> incertus sum. M. Vide ne iste quoque
-						numerus possit <lb/> principium esse numerorum. Nam si medio care: <lb/> et
-						fine, quod, ut dixisti, cogit ratio confiteri; quid re­ <lb/> slat, nisi ut
-						sit hoc quoque principium? An dubitas <lb/> duo principia constituere? D.
-						Vehementer dubito. <lb/>
+							meliores<lb/>habent, <hi rend="italic">progredi ibit,</hi> eu. </note>
+						<lb/>de duobus? Num possumus in eis intelligere <unclear>prin­</unclear>
+						<lb/>cipium et medium, cum medium esse non possit, ,.ibi<lb/>ubi finis
+						est; aut principium et finem, cum ad finem<lb/>nisi per medium non queat
+						perveniri ? <hi rend="italic">D.</hi> Urget ratio<lb/>confileri; et quid
+						de hoc numero respondcam, prorsus<lb/>incertus sum. M. Vide ne iste quoque
+						numerus possit<lb/>principium esse numerorum. Nam si medio care:<lb/>et
+						fine, quod, ut dixisti, cogit ratio confiteri; quid re­<lb/>slat, nisi ut
+						sit hoc quoque principium? An dubitas<lb/>duo principia constituere? D.
+						Vehementer dubito.<lb/>
 						<hi rend="italic">M.</hi> Bene faceres, si ex adverso sibi constituerentur
-						<lb/> duo principia : nunc autem hoc alterum principium <lb/> de illo primo
-						est, ut illud a nullo sit, boc vero ab illo : <lb/> unum enim et unum duo
-						sunt, et principia ita sunt <lb/> ambo, ut omnes numeri quidem ab uno sint;
-						sed quia <lb/> per complicationem atque adjunctionem quamdam <lb/> fiunt,
-						origo autem complicalionis et adjunctionis duali <lb/> numero recte
-						tribuitur: fit ut illud primum principium <lb/> a quo numeri omnes; hoc
-						autem alterum per quod <lb/> numeri omnes, esse inveniantur. Nisi quid habes
-						ad­ <lb/> versum ista quod disseras. <hi rend="italic">D.</hi> Ego vero
-						nihil, et sine <lb/> admiratione ista non cogito; quamvis ea, icterrogatas
-						<lb/> abs te, ipse respondeam.</p>
+						<lb/>duo principia : nunc autem hoc alterum principium<lb/>de illo primo
+						est, ut illud a nullo sit, boc vero ab illo :<lb/>unum enim et unum duo
+						sunt, et principia ita sunt<lb/>ambo, ut omnes numeri quidem ab uno sint;
+						sed quia<lb/>per complicationem atque adjunctionem quamdam<lb/>fiunt,
+						origo autem complicalionis et adjunctionis duali<lb/>numero recte
+						tribuitur: fit ut illud primum principium<lb/>a quo numeri omnes; hoc
+						autem alterum per quod<lb/>numeri omnes, esse inveniantur. Nisi quid habes
+						ad­<lb/>versum ista quod disseras. <hi rend="italic">D.</hi> Ego vero
+						nihil, et sine<lb/>admiratione ista non cogito; quamvis ea, icterrogatas
+						<lb/>abs te, ipse respondeam.</p>
 						</div>
 						<div type="textpart" subtype="dialog" n="22">
-					<p>22. M. Subtilius ista quæruntur atque abstrusius in <lb/> ea disciplina qux
-						est de numeris : hie autem nos ad <lb/> institutum opus quanto citius
-						possumus, redeamus. <lb/> Quocirca quæro, uni duo juncta quid faciunt? <hi
-							rend="italic">D.</hi> Tria. <lb/>
+					<p>22. M. Subtilius ista quaeruntur atque abstrusius in<lb/>ea disciplina qux
+						est de numeris : hie autem nos ad<lb/>institutum opus quanto citius
+						possumus, redeamus.<lb/>Quocirca quaero, uni duo juncta quid faciunt? <hi
+							rend="italic">D.</hi> Tria.<lb/>
 						<hi rend="italic">M.</hi> Ergo haec duo principia numerorum sibimet co*
-						<lb/> pulata, totum numerum faciunt atque perfectum. <lb/>
+						<lb/>pulata, totum numerum faciunt atque perfectum.<lb/>
 						<hi rend="italic">D.</hi> Ita est. <hi rend="italic">M.</hi> Quid ? in
-						numerando post unum etduo <lb/> quem numerum ponimus? <hi rend="italic"
-							>II.</hi> Eadem tria. <hi rend="italic">M.</hi> Idem <lb/> igitur
-						numerus, qui fit ex uno et duobus, post utrum­ <lb/> que in ordine
-						collocatur, ita ut nullus alius interponi <lb/> queat. <hi rend="italic"
+						numerando post unum etduo<lb/>quem numerum ponimus? <hi rend="italic"
+							>II.</hi> Eadem tria. <hi rend="italic">M.</hi> Idem<lb/>igitur
+						numerus, qui fit ex uno et duobus, post utrum­<lb/>que in ordine
+						collocatur, ita ut nullus alius interponi<lb/>queat. <hi rend="italic"
 							>D.</hi> Ita video. <hi rend="italic">M.</hi> Atqui et illud videas
-						oportet, <lb/> in nullis reliquis numcris id posse contingere, ut cum <lb/>
-						duos quoslibet sibimet in numerandi ordine copulatos <lb/> notaveris,
-						consequatur cos ille qui ex ambobus con­ <lb/> ficitur, nullo interposito.
-							<hi rend="italic">D.</hi> Id quoque vidco : nam <lb/> duo et tria, qui
-						sibi numeri copulati sunt, in summa <lb/> quinque faciunt: non autem quinque
-						continuatim se­ <lb/> quuntur, sed quatuor. Rursus tria et quatuor septem
-						<lb/> couficiunt: inter quatuor autem ac septem , quinque <lb/> atque sex
-						ordinati sunt. Et quanto progredi volucro, <lb/> tanto plurcs interponuntur.
-						II. Magna hu c ergo con­ <lb/> cordia est in prioribus tribus numeris : unum
-						euim et <lb/> duo ct tria dicimus, quibus nihil interponi potest: <lb/> unum
-						autem ct duo, ipsa sunt tria. <hi rend="italic">D.</hi> Magna prorsus. <lb/>
+						oportet,<lb/>in nullis reliquis numcris id posse contingere, ut cum<lb/>
+						duos quoslibet sibimet in numerandi ordine copulatos<lb/>notaveris,
+						consequatur cos ille qui ex ambobus con­<lb/>ficitur, nullo interposito.
+							<hi rend="italic">D.</hi> Id quoque vidco : nam<lb/>duo et tria, qui
+						sibi numeri copulati sunt, in summa<lb/>quinque faciunt: non autem quinque
+						continuatim se­<lb/>quuntur, sed quatuor. Rursus tria et quatuor septem
+						<lb/>couficiunt: inter quatuor autem ac septem , quinque<lb/>atque sex
+						ordinati sunt. Et quanto progredi volucro,<lb/>tanto plurcs interponuntur.
+						II. Magna hu c ergo con­<lb/>cordia est in prioribus tribus numeris : unum
+						euim et<lb/>duo ct tria dicimus, quibus nihil interponi potest:<lb/>unum
+						autem ct duo, ipsa sunt tria. <hi rend="italic">D.</hi> Magna prorsus.<lb/>
 						<hi rend="italic">Al.</hi> Quid? illud nullane consideratione dignum putas,
-						<lb/> quod ista concordia quanto est arctior atque conjun­ <lb/> ctior,
-						tanto magis in unitatem quamdam tendit, et <lb/> unum quiddam de pluribus
-						efficit? <hi rend="italic">D.</hi> laO maxima, <lb/> et nescio quomodo, et
-						miror, et amo istam quain <lb/> commendas unitatem. Af. Multum. probo; sed
-						certe <lb/> quælibet rerum copulatio atque couucxio tunc maxi­ <lb/> me unum
-						quiddam eflicit, cum et media extremis, et <lb/> mediis extrema consentiunt.
+						<lb/>quod ista concordia quanto est arctior atque conjun­<lb/>ctior,
+						tanto magis in unitatem quamdam tendit, et<lb/>unum quiddam de pluribus
+						efficit? <hi rend="italic">D.</hi> laO maxima,<lb/>et nescio quomodo, et
+						miror, et amo istam quain<lb/>commendas unitatem. Af. Multum. probo; sed
+						certe<lb/>quaelibet rerum copulatio atque couucxio tunc maxi­<lb/>me unum
+						quiddam eflicit, cum et media extremis, et<lb/>mediis extrema consentiunt.
 							<hi rend="italic">D.</hi> Ita certe oportet.</p>
 						</div>
 						<div type="textpart" subtype="dialog" n="23"> 
@@ -1047,114 +1047,114 @@
 							<note type="footnote">t <hi rend="italic">ride an iste,</hi> juxta Ms.
 							A. Y.</note>
 						<lb/>
-						<pb n="1097"/> Jeamus. Nam cum unum , duo, tria dicimus, nonne <lb/> quanto
-						unum a duobus, tanto duo a tribus superantur? <lb/>
+						<pb n="1097"/> Jeamus. Nam cum unum , duo, tria dicimus, nonne<lb/>quanto
+						unum a duobus, tanto duo a tribus superantur?<lb/>
 						<hi rend="italic">D.</hi> Verissimum est. <hi rend="italic">M.</hi> Dic jam
-						nunc mihi, in ista <lb/> collatione quoties unum nominaverim. <hi
-							rend="italic">D.</hi> Semet. <lb/>
+						nunc mihi, in ista<lb/>collatione quoties unum nominaverim. <hi
+							rend="italic">D.</hi> Semet.<lb/>
 						<hi rend="italic">M.</hi> Tria quoties ? <hi rend="italic">D.</hi> Semel.
-							<hi rend="italic">II.</hi> Quid, duo? <hi rend="italic">D.</hi> Bis. <lb/>
+							<hi rend="italic">II.</hi> Quid, duo? <hi rend="italic">D.</hi> Bis.<lb/>
 						<hi rend="italic">M.</hi> Remcl ergo,. et bis, ei semel, quoties fit in
-						summa? <lb/>
+						summa?<lb/>
 						<hi rend="italic">D.</hi> Quater. <hi rend="italic">M.</hi> Recte igitur
-						istos tres quaternarius na­ <lb/> merus sequitur; ci quippe tribuitur ista
-						proportione <lb/> collatio. Quæ quantum valeat, eo jam assuesce cogno- <lb/>
-						Iceret quod illa irritas quam te amare dixisti, in rebus <lb/> ordinatis hac
-						una effici potest, cujus græcum nomen <lb/>
+						istos tres quaternarius na­<lb/>merus sequitur; ci quippe tribuitur ista
+						proportione<lb/>collatio. Quae quantum valeat, eo jam assuesce cogno<lb/>
+						Iceret quod illa irritas quam te amare dixisti, in rebus<lb/>ordinatis hac
+						una effici potest, cujus graecum nomen<lb/>
 						<foreign xml:lang="grc">άναλογία</foreign> est, nostri quidam proportionem
-						vocaverunt, <lb/> quo nomine utamur, si placct : non enim libenter, <lb/> .
-						nisi nccessitate, græca vocabula in latino sermone <lb/> usurpaverim. D.
-						Mihi vero placet; sed perge quo in­ <lb/> tenderas. M. Faciam. Nam quid sit
-						proportio, quan­ <lb/> tumque in rebus juris babeat, ct suo loco in hac
-						disci­ <lb/> plina diligentius requiremus; et quanto in eruditione <lb/>
-						promotior cris, tanto ejus vim melius naturamque <lb/> cognosces. Sed vides
-						certe, quod in præsentia satis <lb/> est, tres illos numeros, quor um
-						mirabare concordiam, <lb/> sibimet in cadem connexione nisi per quaternarium
-						<lb/> numerum non potuisse conferri. Quamobrem post <lb/> illos se ordinari,
-						sic ut illa concordia cum his arctiore <lb/> copuletur, quantum intelligis
-						jure impetravit1; ut jam <lb/> non unum, duo, tria tantum ; sed unum, duo,
-						tria, <lb/> quatuor, sit amicissime copulata progressio numcro­ <lb/> rum.
+						vocaverunt,<lb/>quo nomine utamur, si placct : non enim libenter,<lb/>.
+						nisi nccessitate, graeca vocabula in latino sermone<lb/>usurpaverim. D.
+						Mihi vero placet; sed perge quo in­<lb/>tenderas. M. Faciam. Nam quid sit
+						proportio, quan­<lb/>tumque in rebus juris babeat, ct suo loco in hac
+						disci­<lb/>plina diligentius requiremus; et quanto in eruditione<lb/>
+						promotior cris, tanto ejus vim melius naturamque<lb/>cognosces. Sed vides
+						certe, quod in praesentia satis<lb/>est, tres illos numeros, quor um
+						mirabare concordiam,<lb/>sibimet in cadem connexione nisi per quaternarium
+						<lb/>numerum non potuisse conferri. Quamobrem post<lb/>illos se ordinari,
+						sic ut illa concordia cum his arctiore<lb/>copuletur, quantum intelligis
+						jure impetravit1; ut jam<lb/>non unum, duo, tria tantum ; sed unum, duo,
+						tria,<lb/>quatuor, sit amicissime copulata progressio numcro­<lb/>rum.
 							<hi rend="italic">D.</hi> Omnino assentior.</p>
-					<p>i. II. At cætera intuere, ne arbitreris nihil habere <lb/> proprium
-						quaternarium numerum, quo reliqui omnes <lb/> numeri careant, quod valeat ad
-						istam connexionem <lb/> de qua loquor, ut ab uno usque ad quatuor certus sit
-						<lb/> numerus, et pulcherrimus progrediendi modus. Cen­ <lb/> venerat quippe
-						inter nos superius, tunc ex pluribus <lb/> unum aliquid maxime fieri, cum
-						extremis media, et <lb/> mediis extrema consentiunt. <hi rend="italic"
-							>D.</hi> Ita est. <hi rend="italic">II.</hi> Cum ergo <lb/> collocamus
-						unum et duo ct tria , dic quæ sint extre­ <lb/> ma,quod medium. <hi
-							rend="italic">D.</hi> Unum ct tria extrema video, <lb/> duo mediam. II.
-						Responde nunc, ex uno et tribus <lb/> quid conficiatur. <hi rend="italic"
-							>D.</hi> Quatuor. M. Quid? duo qui unus <lb/> in medio numerus est, num
-						potest nisi sibi con­ <lb/> ferri? Quamobrem dic etiam duo bis quid
-						conficiant. <lb/>
+					<p>i. II. At caetera intuere, ne arbitreris nihil habere<lb/>proprium
+						quaternarium numerum, quo reliqui omnes<lb/>numeri careant, quod valeat ad
+						istam connexionem<lb/>de qua loquor, ut ab uno usque ad quatuor certus sit
+						<lb/>numerus, et pulcherrimus progrediendi modus. Cen­<lb/>venerat quippe
+						inter nos superius, tunc ex pluribus<lb/>unum aliquid maxime fieri, cum
+						extremis media, et<lb/>mediis extrema consentiunt. <hi rend="italic"
+							>D.</hi> Ita est. <hi rend="italic">II.</hi> Cum ergo<lb/>collocamus
+						unum et duo ct tria , dic quae sint extre­<lb/>ma,quod medium. <hi
+							rend="italic">D.</hi> Unum ct tria extrema video,<lb/>duo mediam. II.
+						Responde nunc, ex uno et tribus<lb/>quid conficiatur. <hi rend="italic"
+							>D.</hi> Quatuor. M. Quid? duo qui unus<lb/>in medio numerus est, num
+						potest nisi sibi con­<lb/>ferri? Quamobrem dic etiam duo bis quid
+						conficiant.<lb/>
 						<hi rend="italic">D.</hi> Quatuor. <hi rend="italic">M.</hi> Ila ergo medium
-						extremis, et medio <lb/> extrema consentiunt. Quamobrem sicut excellit in
-						<lb/> tribus, quod post unum et dno collocantur, cum ex <lb/> uno et duobus
-						constent; sie excellit in quatuor, quod <lb/> post unum et duo et tria
-						numerantur, cum constent <lb/> ex uno et tribus, vel bis duobus : quæ
-						extremorum <lb/> cum medio, et medii cum extremis, in illa quæ græce <lb/>
+						extremis, et medio<lb/>extrema consentiunt. Quamobrem sicut excellit in
+						<lb/>tribus, quod post unum et dno collocantur, cum ex<lb/>uno et duobus
+						constent; sie excellit in quatuor, quod<lb/>post unum et duo et tria
+						numerantur, cum constent<lb/>ex uno et tribus, vel bis duobus : quae
+						extremorum<lb/>cum medio, et medii cum extremis, in illa quae graece<lb/>
 						<foreign xml:lang="grc">άναλογία</foreign> dicitur, proportione consensio
-						est. Quod <lb/> utrum intellexeris pande. <hi rend="italic">D.</hi> Satis
+						est. Quod<lb/>utrum intellexeris pande. <hi rend="italic">D.</hi> Satis
 						intelligo.</p>
-					<p>i. <hi rend="italic">M.</hi> Tenta ergo in reliquis numeris, utrumne <lb/>
-						inveniatur quod quaternarii numcri proprium ease <lb/> dixamus. <hi
-							rend="italic">D.</hi> Faciam. Nam si constituamus duo, tria, <lb/>
-						quatuor , extrema collata fiunt sex ; hoc facit et me­ <lb/> dium sibi
-						collatum : lace tamen SCI, scd quinque con­ <lb/> sequunlur. Rursus tria,
-						quatuor ct quinque constituo; <lb/> extrema octo faciunt, medium quoque bis
+					<p>i. <hi rend="italic">M.</hi> Tenta ergo in reliquis numeris, utrumne<lb/>
+						inveniatur quod quaternarii numcri proprium ease<lb/>dixamus. <hi
+							rend="italic">D.</hi> Faciam. Nam si constituamus duo, tria,<lb/>
+						quatuor , extrema collata fiunt sex ; hoc facit et me­<lb/>dium sibi
+						collatum : lace tamen SCI, scd quinque con­<lb/>sequunlur. Rursus tria,
+						quatuor ct quinque constituo;<lb/>extrema octo faciunt, medium quoque bis
 						ductum : at <note type="footnote"><hi rend="italic">1 imperavit,</hi> juxta
 							Mss. A et B. at </note>
-						<lb/> inter quinque ct octo, non jam unum, sed duos, se­ <lb/> narium
-						scilicet et septenarium numeros interpositos <lb/> video. Atque illa ratione
-						quantum progredior, tanto <lb/> hæc fiunt intervalla majora1. <hi
-							rend="italic">M.</hi> Video tc intellexisse, <lb/> et omnino scire quod
-						dictum est: sed jam ne immo­ <lb/> remur, animadvertis certe ab uno usque ad
-						quatuor <lb/> justissimam ficti progressionem ; sive propter impa­ <lb/> rem
-						ac parem numcrum , quoniam primus impar <lb/> totus tria, et primus par
-						totus quatuor, de qua re <lb/> paulo ante tractatum est; sive quia Unum et
-						duo prin­ <lb/> cipia sunt, et quasi semina numcrorum, e quibus tcr­ <lb/>
-						narius conficitur, ut sint jam tres numcri; qui sibi <lb/> dum proportione
-						conferuntur, quaternarius clucesCit <lb/> et gignitur, et propterea cis jure
-						conjungitur, ut usque <lb/> ad illum fiat ea, quam quærimus moderata
-						progressio. <lb/> D. Intelligo.</p>
-					<p>36. M. Bene sane. Sed meministine tandem quid <lb/> . institueramus
-						inquirere? Nam, ut opinor, proposi­ <lb/> tum erat, si quomodo invenire
-						possemus, cum in Illa <lb/> infinitate numerorum certi articuli cssent
-						numeranti­ <lb/> bus constituti, quid esset causæcur ipse primus arti­ <lb/>
-						culus in denario numero esset, qui per omnes cæteros I <lb/> valet plurimum;
-						id est, cur ab uno usque ad decem <lb/> progressi numerantes rursum ad uaum
-						remearent? <lb/>
-						<hi rend="italic">D.</hi> Recordor plane quæstionis hujus causa nos tantum
-						<lb/> circumisse : sed quid effecerimus quod ad cam sol­ <lb/> vendam
-						pertineat, non invenio. Siquidem illa omnis <lb/> nostra ratiocinatio ad id
-						conclusa est, ut non usque <lb/> ad denarium, sed usque ad quaternarium
-						nume­ <lb/> rum sit justa et moderata progressio. M. Tune <lb/> igitur non
-						vides, ex uno et duobus, et tribus <lb/> et quatuor quæ summa conficiatur!
-							<hi rend="italic">D.</hi> Video jam, <lb/> video, et miror omnia, et
-						ortam quætionem so- <lb/> Intam esse confiteor : unum enim ct duo et tria et
-						<lb/> quatuor simul decem sunt. <hi rend="italic">M.</hi> Ergo istos quatuor
-						<lb/> primos numeros, seriemque et connexionem corum <lb/> honorabilius
-						haberi, quam cætera, in numeris con­ <lb/> venit.</p>
+						<lb/>inter quinque ct octo, non jam unum, sed duos, se­<lb/>narium
+						scilicet et septenarium numeros interpositos<lb/>video. Atque illa ratione
+						quantum progredior, tanto<lb/>haec fiunt intervalla majora1. <hi
+							rend="italic">M.</hi> Video tc intellexisse,<lb/>et omnino scire quod
+						dictum est: sed jam ne immo­<lb/>remur, animadvertis certe ab uno usque ad
+						quatuor<lb/>justissimam ficti progressionem ; sive propter impa­<lb/>rem
+						ac parem numcrum , quoniam primus impar<lb/>totus tria, et primus par
+						totus quatuor, de qua re<lb/>paulo ante tractatum est; sive quia Unum et
+						duo prin­<lb/>cipia sunt, et quasi semina numcrorum, e quibus tcr­<lb/>
+						narius conficitur, ut sint jam tres numcri; qui sibi<lb/>dum proportione
+						conferuntur, quaternarius clucesCit<lb/>et gignitur, et propterea cis jure
+						conjungitur, ut usque<lb/>ad illum fiat ea, quam quaerimus moderata
+						progressio.<lb/>D. Intelligo.</p>
+					<p>36. M. Bene sane. Sed meministine tandem quid<lb/>. institueramus
+						inquirere? Nam, ut opinor, proposi­<lb/>tum erat, si quomodo invenire
+						possemus, cum in Illa<lb/>infinitate numerorum certi articuli cssent
+						numeranti­<lb/>bus constituti, quid esset causaecur ipse primus arti­<lb/>
+						culus in denario numero esset, qui per omnes caeteros I<lb/>valet plurimum;
+						id est, cur ab uno usque ad decem<lb/>progressi numerantes rursum ad uaum
+						remearent?<lb/>
+						<hi rend="italic">D.</hi> Recordor plane quaestionis hujus causa nos tantum
+						<lb/>circumisse : sed quid effecerimus quod ad cam sol­<lb/>vendam
+						pertineat, non invenio. Siquidem illa omnis<lb/>nostra ratiocinatio ad id
+						conclusa est, ut non usque<lb/>ad denarium, sed usque ad quaternarium
+						nume­<lb/>rum sit justa et moderata progressio. M. Tune<lb/>igitur non
+						vides, ex uno et duobus, et tribus<lb/>et quatuor quae summa conficiatur!
+							<hi rend="italic">D.</hi> Video jam,<lb/>video, et miror omnia, et
+						ortam quaetionem so<lb/>Intam esse confiteor : unum enim ct duo et tria et
+						<lb/>quatuor simul decem sunt. <hi rend="italic">M.</hi> Ergo istos quatuor
+						<lb/>primos numeros, seriemque et connexionem corum<lb/>honorabilius
+						haberi, quam caetera, in numeris con­<lb/>venit.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT XIII. — <hi rend="italic">De proportionatorum moluum
 								decore quatenus sensibus judicatur.</hi>
 						</title>
 					</ab>
-					<p>27. Tempus est autem ad illos motus rcdirc tra­ <lb/> ctandos et
-						discutiendos, qui huic disciplinæ proprie <lb/> tribuuntur, et propter quos
-						ista de numeris f de alia <lb/> scilicct disciplina , quantum pro negotio
-						satis visum <lb/> est, considcravimus. Itaque nunc abs te quæo, quo­ <lb/>
-						niam intelligendi gratia in horarum spatio motus <lb/> constituebamus , quos
-						ad se invicem habere aliquam <lb/> numerosam dimensionem ratio demonstrabat;
-						utrum <lb/> si quisquam mora unius horæ currat, et alius dc:n­ <lb/> ceps
-						duarum , possis non inspecto horologio vel cic. <lb/> psydra , vcl aliqna
-						hujuscemodi temporum notatione <lb/> sentire illos duos motus, quod unus
-						simplus, alius <lb/> duplus sit : vel etiamsi id non possis dicere, illa ta­
-						<lb/> mch congruentia delectari, atque aliqua voluptate af­ <lb/> fici. <hi
+					<p>27. Tempus est autem ad illos motus rcdirc tra­<lb/>ctandos et
+						discutiendos, qui huic disciplinae proprie<lb/>tribuuntur, et propter quos
+						ista de numeris f de alia<lb/>scilicct disciplina , quantum pro negotio
+						satis visum<lb/>est, considcravimus. Itaque nunc abs te quaeo, quo­<lb/>
+						niam intelligendi gratia in horarum spatio motus<lb/>constituebamus , quos
+						ad se invicem habere aliquam<lb/>numerosam dimensionem ratio demonstrabat;
+						utrum<lb/>si quisquam mora unius horae currat, et alius dc:n­<lb/>ceps
+						duarum , possis non inspecto horologio vel cic.<lb/>psydra , vcl aliqna
+						hujuscemodi temporum notatione<lb/>sentire illos duos motus, quod unus
+						simplus, alius<lb/>duplus sit : vel etiamsi id non possis dicere, illa ta­
+						<lb/>mch congruentia delectari, atque aliqua voluptate af­<lb/>fici. <hi
 							rend="italic">D.</hi> Nullo modo possum. <hi rend="italic">M.</hi> Quid,
-						si quispiam nu­ <lb/> mcrosc plaudat, iti ut unus sonitus simplum , alter
-						<lb/> duplum temporis teneat, quos iambos pedes vocant, <lb/> eosque
+						si quispiam nu­<lb/>mcrosc plaudat, iti ut unus sonitus simplum , alter
+						<lb/>duplum temporis teneat, quos iambos pedes vocant,<lb/>eosque
 						continuct atque contexat; alius antem ad <note type="footnote">1 In. a., <hi
 								rend="italic">(tfcitmt interrella majora.</hi> Ms. A, <hi
 								rend="italic">fiunt.</hi> II. </note><note type="footnote">PATROL.
@@ -1162,41 +1162,41 @@
 						<note type="footnote"><hi rend="italic">(Trentc-cinq.) .</hi>
 						</note>
 						<lb/>
-						<pb n="1099"/> eumdem sonum saltet, secundum ca scilicet tempora <lb/>
-						movens membra ? nonne 1 aut etiam dicas ipsum <lb/> modulum temporum, id est
-						quod simplum ad duplum <lb/> spatia in motibus alternent, sive in illo
-						plausu qui au­ <lb/> ditur, sive in illa saltatione quæ cernitur; aut saltem
-						<lb/> delecteris numerositate quam sentias, tametsi non <lb/> possis numeros
-						ejus dimensionis edicere? <hi rend="italic">D.</hi> Ita vero <lb/> cst, ut
-						dicis : nam et illi qui hos numeros noverunt, <lb/> sentiunt cos in plausu
-						atque saltatione , quique sint <lb/> facile dicunt; et qui cos non noverunt
-						nee possunt <lb/> uiccre, non negant tamen ex his se voluptate aliqua <lb/>
+						<pb n="1099"/> eumdem sonum saltet, secundum ca scilicet tempora<lb/>
+						movens membra ? nonne 1 aut etiam dicas ipsum<lb/>modulum temporum, id est
+						quod simplum ad duplum<lb/>spatia in motibus alternent, sive in illo
+						plausu qui au­<lb/>ditur, sive in illa saltatione quae cernitur; aut saltem
+						<lb/>delecteris numerositate quam sentias, tametsi non<lb/>possis numeros
+						ejus dimensionis edicere? <hi rend="italic">D.</hi> Ita vero<lb/>cst, ut
+						dicis : nam et illi qui hos numeros noverunt,<lb/>sentiunt cos in plausu
+						atque saltatione , quique sint<lb/>facile dicunt; et qui cos non noverunt
+						nee possunt<lb/>uiccre, non negant tamen ex his se voluptate aliqua<lb/>
 						perfrui.</p>
-					<p>is. M. Cum igitur ad ipsam rationem disciplinæ <lb/> hujus, siquidem scientia
-						est bene modulandi, non <lb/> possit negari omnes pertinere motus qui bene
-						modu­ <lb/> lati sunt, et cos potissimum qui non referuntur ad <lb/> aliud
-						aliquid, sed in seipsis finem dccoris delectatio­ <lb/> nisve conservant; hi
-						tamen motus, ut nunc a me ro­ <lb/> gatus recte vereque dixisti, si longo
+					<p>is. M. Cum igitur ad ipsam rationem disciplinae<lb/>hujus, siquidem scientia
+						est bene modulandi, non<lb/>possit negari omnes pertinere motus qui bene
+						modu­<lb/>lati sunt, et cos potissimum qui non referuntur ad<lb/>aliud
+						aliquid, sed in seipsis finem dccoris delectatio­<lb/>nisve conservant; hi
+						tamen motus, ut nunc a me ro­<lb/>gatus recte vereque dixisti, si longo
 						spatio temporis <note type="footnote">1 Ms. A addit, adverku. IL </note>
-						<lb/> fiant, inque ipsa dimensione quae decora est, horam <lb/> vel etiam
-						majus tempus obtineant, non possunt con­ <lb/> grucre nostris sensibus i.
-						Quamobrem cum procedens <lb/> quodammodo de secretissimis penetralibus
-						musica, iu <lb/> nostris etiam sensibus, vel his rebus quae a nobii <lb/>
-						sentiuntur, vestigia quaedam posuerit; nonne oportet <lb/> eadem vestigia
-						prius persequi, ut commodius ad ipsa <lb/> si potuerimus, quae dixi
-						penetralia, sine ullo errore <lb/> ducamur? <hi rend="italic">D.</hi>
-						Oportet vero, et hoc jamjamque ut fa­ <lb/> ciamus, efflagito. II. Omittamus
-						ergo illas ultra 2 ca­ <lb/> pacitatem sensus nostri porrectas temporum
-						metas, <lb/> et de his brevibus intervallorum spatiis, qun in can­ <lb/>
-						lando saltandoque nos mulcent, quantum ratio nos <lb/> duxerit, disseramus.
-						Nisi tu forte aliter putas illa <lb/> vestigia indagari posse, quæ in
-						nostris sensibus, his­ <lb/> que rebus quas valemus sentire, hanc
-						disciplinam <lb/> posuisse prædictum est. <hi rend="italic">D.</hi> Nullo
+						<lb/>fiant, inque ipsa dimensione quae decora est, horam<lb/>vel etiam
+						majus tempus obtineant, non possunt con­<lb/>grucre nostris sensibus i.
+						Quamobrem cum procedens<lb/>quodammodo de secretissimis penetralibus
+						musica, iu<lb/>nostris etiam sensibus, vel his rebus quae a nobii<lb/>
+						sentiuntur, vestigia quaedam posuerit; nonne oportet<lb/>eadem vestigia
+						prius persequi, ut commodius ad ipsa<lb/>si potuerimus, quae dixi
+						penetralia, sine ullo errore<lb/>ducamur? <hi rend="italic">D.</hi>
+						Oportet vero, et hoc jamjamque ut fa­<lb/>ciamus, efflagito. II. Omittamus
+						ergo illas ultra 2 ca­<lb/>pacitatem sensus nostri porrectas temporum
+						metas,<lb/>et de his brevibus intervallorum spatiis, qun in can­<lb/>
+						lando saltandoque nos mulcent, quantum ratio nos<lb/>duxerit, disseramus.
+						Nisi tu forte aliter putas illa<lb/>vestigia indagari posse, quae in
+						nostris sensibus, his­<lb/>que rebus quas valemus sentire, hanc
+						disciplinam<lb/>posuisse praedictum est. <hi rend="italic">D.</hi> Nullo
 						moda aliter puto. <note type="footnote"> 1 Addit vatic.: <hi rend="italic"
 								>licel aUcjuanto idern</hi> pes in <hi rend="italic">canendo, seT-
-								<lb/> VIlla collationis ratione, alias longforihi, alias
+								<lb/>VIlla collationis ratione, alias longforihi, alias
 								brerilniblu</hi>
-							<lb/> pmit fieri sonis. M. </note><note type="footnote">* vatic., <hi
+							<lb/>pmit fieri sonis. M. </note><note type="footnote">* vatic., <hi
 								rend="italic">extra. II.</hi>
 						</note></p>
 				</div>
@@ -1209,399 +1209,399 @@
 						<title type="sub">CAPUT PRIMUM.—Syllabarum <hi rend="italic">spatia aliunde
 								gram­ maticus, aliunde</hi> musicus attendit.</title>
 					</ab>
-					<p>1. M. Attende igitur diligenter, et nunc demum <lb/> accipe quasi alterum
-						nostra disputationis exordium. <lb/> Ac primum responde, utrum bene
-						didiceris eam <lb/> quam grammatici docent, syllabarum brevium longa­ <lb/>
-						rumque distantiam; an vero sive ista Doris sive ignores, <lb/> tnalis ut ita
-						quæramus, quasi omnino rudes harum re­ <lb/> rum simus, ut ad omnia nos
-						ratio potius perducat, quam <lb/> inveterata consuetudo, aut praejudicata
-						cogat auctori­ <lb/> tas. <hi rend="italic">D.</hi> Ita plane malle me, non
-						modo ipsa ratio, sed <lb/> istarum etiam syllabarum imperitia (quid enim
-						fateri <lb/> dubitem?) impellit. M. Age jam, saltem illud elo­ <lb/> quere,
-						utrum tu ipse per te nunquam animadverteris <lb/> in locutione nostra alias
-						syllabas raptim et minime <lb/> .litt, alias autem productius ct diutius
-						enuntiari. D. <lb/> Ncgare non possum non me ad ista etiam surdum <lb/>
+					<p>1. M. Attende igitur diligenter, et nunc demum<lb/>accipe quasi alterum
+						nostra disputationis exordium.<lb/>Ac primum responde, utrum bene
+						didiceris eam<lb/>quam grammatici docent, syllabarum brevium longa­<lb/>
+						rumque distantiam; an vero sive ista Doris sive ignores,<lb/>tnalis ut ita
+						quaeramus, quasi omnino rudes harum re­<lb/>rum simus, ut ad omnia nos
+						ratio potius perducat, quam<lb/>inveterata consuetudo, aut praejudicata
+						cogat auctori­<lb/>tas. <hi rend="italic">D.</hi> Ita plane malle me, non
+						modo ipsa ratio, sed<lb/>istarum etiam syllabarum imperitia (quid enim
+						fateri<lb/>dubitem?) impellit. M. Age jam, saltem illud elo­<lb/>quere,
+						utrum tu ipse per te nunquam animadverteris<lb/>in locutione nostra alias
+						syllabas raptim et minime<lb/>.litt, alias autem productius ct diutius
+						enuntiari. D.<lb/>Ncgare non possum non me ad ista etiam surdum<lb/>
 						fuissc. <hi rend="italic">M.</hi> Atqui scias velim totam illam scientiam,
-						<lb/> quæ grammatica græce , latine antem litteratura no­ <lb/> minatur,
-						historie custodiam profiteri, vel solam , ut <lb/> subtilior ducet ratio;
-						vel maxime, ut etiam pinguia <lb/> corda concedunt. itaque verbigratia
+						<lb/>quae grammatica graece , latine antem litteratura no­<lb/>minatur,
+						historie custodiam profiteri, vel solam , ut<lb/>subtilior ducet ratio;
+						vel maxime, ut etiam pinguia<lb/>corda concedunt. itaque verbigratia
 						cumdixeris, <hi rend="italic">cano,</hi>
-						<lb/> vel in versu forte posueris, ita ut vel tu pronuntians <lb/> producas
-						hujus verbi syllabam primam, vel in versu <lb/> ♦o loco ponas , ubi esse
-						productam oportebat; repre­ <lb/> hendet grammaticus , custos ille videlicet
-						historiæ, <lb/> nihil aliud asserens cur hunc'corripi oporteat, nisi <lb/>
-						quod hi qui ante nos fuerunt, et quorum libri exstant <lb/> tractanturque a
-						grammaticis, ea correpta 1 non pro­ <lb/> ducta usi fuerint. Quare hic
-						quidquid valet, auctoritas <lb/> valet. At vero musicæ ratio, ad quam
-						dimensio ipsa <lb/> vocum rationabilis et numerositas pertinet, non curat
+						<lb/>vel in versu forte posueris, ita ut vel tu pronuntians<lb/>producas
+						hujus verbi syllabam primam, vel in versu<lb/>♦o loco ponas , ubi esse
+						productam oportebat; repre­<lb/>hendet grammaticus , custos ille videlicet
+						historiae,<lb/>nihil aliud asserens cur hunc'corripi oporteat, nisi<lb/>
+						quod hi qui ante nos fuerunt, et quorum libri exstant<lb/>tractanturque a
+						grammaticis, ea correpta 1 non pro­<lb/>ducta usi fuerint. Quare hic
+						quidquid valet, auctoritas<lb/>valet. At vero musicae ratio, ad quam
+						dimensio ipsa<lb/>vocum rationabilis et numerositas pertinet, non curat
 							<note type="footnote"> I vatic., <hi rend="italic">pro correpta.</hi> M. </note>
-						<lb/> nisi ut corripiatur vel producatur syllaba, quæ illo vel <lb/> illo
-						loco est secundum rationem mensurarum suarum. <lb/> Nam si eo loco ubi duas
-						longas syllabas poni decet, <lb/> hoc verbum posueris, et primam quae brevis
-						est, pro­ <lb/> nuntiatione longain feceris, nibil musica omnino suc­ <lb/>
-						censet 1 : tempora enim vocum ea pervenerc ad au­ <lb/> res, quæ illi numero
-						debita fuerunt. Grammaticus <lb/> autem jubet emeudari, et illud te verbum
-						ponere <lb/> cujus prima .syllaba producenda sit, secundum majo­ <lb/> rum,
-						ut dictum est, auctoritatem, quorum scripta <lb/> custodit2.</p>
+						<lb/>nisi ut corripiatur vel producatur syllaba, quae illo vel<lb/>illo
+						loco est secundum rationem mensurarum suarum.<lb/>Nam si eo loco ubi duas
+						longas syllabas poni decet,<lb/>hoc verbum posueris, et primam quae brevis
+						est, pro­<lb/>nuntiatione longain feceris, nibil musica omnino suc­<lb/>
+						censet 1 : tempora enim vocum ea pervenerc ad au­<lb/>res, quae illi numero
+						debita fuerunt. Grammaticus<lb/>autem jubet emeudari, et illud te verbum
+						ponere<lb/>cujus prima .syllaba producenda sit, secundum majo­<lb/>rum,
+						ut dictum est, auctoritatem, quorum scripta<lb/>custodit2.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT II. — <hi rend="italic">De versu judicat</hi>
 							grammaticas <hi rend="italic">ex aucto­</hi> ritate, musicus ex <hi
 								rend="italic">ratione et</hi> sensu.</title>
 					</ab>
-					<p>i. Quamobrem nos, cum rationes musicae perse­ <lb/> qoendas susceperimus,
-						etiam si nescis quæ syllaba <lb/> corripienda, quæ producenda sit; possumus
-						tamen <lb/> non impediri hac ignorantia tua, satisque habere, <lb/> quod te
-						animadvertisse dixisti alias syitabas corre­ <lb/> ptiores, alias
-						productiores. Quare illud nunc quæro, <lb/> utrum sonos versuum aliquando te
-						aliqua per aures <lb/> voluptate commoverit. <hi rend="italic">D.</hi>
-						Prorsus sæpissime, ita ut <lb/> nunquam fere sine delectatione versum
-						audierim. M. <lb/> Si quis ergo in versu , quo audito delectaris, eo loco
-						<lb/> quo ratio ejusdem versus non postulat , vel producat <lb/> syllabas,
-						Tel corripiat, uum eodem modo delectari <lb/> potes? D. Imo audire hoc
-						sineoffensione non possum. <lb/> M. Nullo modo igitur dubium est, quin te in
-						sotio quo <lb/> te delectari dicis, dimensio quædam numerorum de­ <lb/>
+					<p>i. Quamobrem nos, cum rationes musicae perse­<lb/>qoendas susceperimus,
+						etiam si nescis quae syllaba<lb/>corripienda, quae producenda sit; possumus
+						tamen<lb/>non impediri hac ignorantia tua, satisque habere,<lb/>quod te
+						animadvertisse dixisti alias syitabas corre­<lb/>ptiores, alias
+						productiores. Quare illud nunc quaero,<lb/>utrum sonos versuum aliquando te
+						aliqua per aures<lb/>voluptate commoverit. <hi rend="italic">D.</hi>
+						Prorsus saepissime, ita ut<lb/>nunquam fere sine delectatione versum
+						audierim. M.<lb/>Si quis ergo in versu , quo audito delectaris, eo loco
+						<lb/>quo ratio ejusdem versus non postulat , vel producat<lb/>syllabas,
+						Tel corripiat, uum eodem modo delectari<lb/>potes? D. Imo audire hoc
+						sineoffensione non possum.<lb/>M. Nullo modo igitur dubium est, quin te in
+						sotio quo<lb/>te delectari dicis, dimensio quaedam numerorum de­<lb/>
 						lectet, qua perturbata delectatio illa exhiberi acribus <note
 							type="footnote"> I <hi rend="italic">offendutur,</hi> juxta vatic. M.
 							</note><note type="footnote"> I in B., <hi rend="italic"
 								>ciiftorfiuntur.</hi> F.r. l.ugd. vcn., <hi rend="italic"
-								>custodtuni;</hi> sic <lb/> etiam bIS. B.; at lls. A , <hi
-								rend="italic">custodit,</hi> ut sigaiflceiur coatodire <lb/>
-							gram?naiicus quem t au!o ante Augustinus hisLoriæ custodem <lb/> nunl4;
+								>custodtuni;</hi> sic<lb/>etiam bIS. B.; at lls. A , <hi
+								rend="italic">custodit,</hi> ut sigaiflceiur coatodire<lb/>
+							gram?naiicus quem t au!o ante Augustinus hisLoriae custodem<lb/>nunl4;
 							at. M. </note>
 						<lb/>
-						<pb n="1101"/> non potest. D. Manifestum est, M. Dic mihi deiuceps <lb/>
-						quod ad sonum versus attinel, quid inlersil, utrum <lb/> dicam, <hi
+						<pb n="1101"/> non potest. D. Manifestum est, M. Dic mihi deiuceps<lb/>
+						quod ad sonum versus attinel, quid inlersil, utrum<lb/>dicam, <hi
 							rend="italic">Anna virumque cano, Trojw qui primus ub oris:</hi>
-						<lb/> an <hi rend="italic">qui primis ab oris.</hi> D. Mihi vero utrumque,
-						quan­ <lb/> tum ad illam dimensionem pertinet, idem sonat. M. <lb/> At I hoc
-						mea pronuntiatione factum cst, cum eo scili­ <lb/> cet vitio quod
-						barbarismum grammatici vocant : nam <lb/>
+						<lb/>an <hi rend="italic">qui primis ab oris.</hi> D. Mihi vero utrumque,
+						quan­<lb/>tum ad illam dimensionem pertinet, idem sonat. M.<lb/>At I hoc
+						mea pronuntiatione factum cst, cum eo scili­<lb/>cet vitio quod
+						barbarismum grammatici vocant : nam<lb/>
 						<hi rend="italic">primus,</hi> longa cst et brevis syllaba; <hi
-							rend="italic">primis</hi> autem , <lb/> ambæ producendæsunt : sed cgo
-						ultimam earum cor­ <lb/> ripui; ita nihil fraudis passæ sunt aures tuæ.
-						Quam­ <lb/> obrem illud ctiam atque etiam tentandum est, utrum <lb/> me
-						pronuntiante sentias, quid sit I in syllabis diu et <lb/> non din , m
-						nostradisputatio, me interrogante ac te <lb/> respondente, sicut
-						instituimus, possit procedece. Ita­ <lb/> que jnm cumdem versum iu quo
-						barbarismum fece­ <lb/>
-						<lb/> ram, repetam, et illam syllabam quam, ne tua: aures <lb/>
-						offenderentur, corripui, producam, ut grammotici ja­ <lb/> bent: tu mihi
-						remuntiato, utrum illa versus dimensio <lb/> sensum taum cadcm afficiat
-						voluptato : sic enim pro­ <lb/> nuntiem, <hi rend="italic">Arma virumque
-							cano,</hi> Trojæ qui priMus <hi rend="italic">ab<lb/> oria. D.</hi> Nunc
-						vero negare non possum, nescio qua <lb/> son! deformitate me offensum. <hi
-							rend="italic">II.</hi> Non injuria : quan- . <lb/> quam enim barbarismus
-						factus non sit, id tamen <lb/> vitium factum est, quod et grammatica
-						reprehendat <lb/> et mu-ica : grammatica, quia id verbum, cujus no­ <lb/>
-						vissima syllaba producenda cst, eo loco positum est <lb/> ubi corripienda
-						poni debuit; musica vero tantum­ <lb/> modo quia producta quælibet vox est
-						eo loco, quo <lb/> corripi oportebat, et tempus debitum quod numc­ <lb/>
-						rosa dimensio postulabat, redditum non est. Quo­ <lb/> circa si jam salis
-						discernis quid sensus; quid au­ <lb/> ctoritas postulcL, sequitur ut
-						vidcamus, ille ipse <lb/> sensus cur alias delecietur in sonis vcl productis
-						vel <lb/> correptis , alias offendatur : id est enim quod ad diu, <lb/> ct
-						non diu pertinet. Qnam partem nos explicaudam <lb/> suscepissc credo quod
-						memineris. <hi rend="italic">D.</hi> Ego vero et <lb/> illud discrevi , ei
-						hoc memini, ct ca q'tae sequuntur <lb/> intentissime exspecto.</p>
+							rend="italic">primis</hi> autem ,<lb/>ambae producendaesunt : sed cgo
+						ultimam earum cor­<lb/>ripui; ita nihil fraudis passae sunt aures tuae.
+						Quam­<lb/>obrem illud ctiam atque etiam tentandum est, utrum<lb/>me
+						pronuntiante sentias, quid sit I in syllabis diu et<lb/>non din , m
+						nostradisputatio, me interrogante ac te<lb/>respondente, sicut
+						instituimus, possit procedece. Ita­<lb/>que jnm cumdem versum iu quo
+						barbarismum fece­<lb/>
+						<lb/>ram, repetam, et illam syllabam quam, ne tua: aures<lb/>
+						offenderentur, corripui, producam, ut grammotici ja­<lb/>bent: tu mihi
+						remuntiato, utrum illa versus dimensio<lb/>sensum taum cadcm afficiat
+						voluptato : sic enim pro­<lb/>nuntiem, <hi rend="italic">Arma virumque
+							cano,</hi> Trojae qui priMus <hi rend="italic">ab<lb/>oria. D.</hi> Nunc
+						vero negare non possum, nescio qua<lb/>son! deformitate me offensum. <hi
+							rend="italic">II.</hi> Non injuria : quan- .<lb/>quam enim barbarismus
+						factus non sit, id tamen<lb/>vitium factum est, quod et grammatica
+						reprehendat<lb/>et mu-ica : grammatica, quia id verbum, cujus no­<lb/>
+						vissima syllaba producenda cst, eo loco positum est<lb/>ubi corripienda
+						poni debuit; musica vero tantum­<lb/>modo quia producta quaelibet vox est
+						eo loco, quo<lb/>corripi oportebat, et tempus debitum quod numc­<lb/>
+						rosa dimensio postulabat, redditum non est. Quo­<lb/>circa si jam salis
+						discernis quid sensus; quid au­<lb/>ctoritas postulcL, sequitur ut
+						vidcamus, ille ipse<lb/>sensus cur alias delecietur in sonis vcl productis
+						vel<lb/>correptis , alias offendatur : id est enim quod ad diu,<lb/>ct
+						non diu pertinet. Qnam partem nos explicaudam<lb/>suscepissc credo quod
+						memineris. <hi rend="italic">D.</hi> Ego vero et<lb/>illud discrevi , ei
+						hoc memini, ct ca q'tae sequuntur<lb/>intentissime exspecto.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT III, — <hi rend="italic">Syllabarum tempora.</hi>
 						</title>
 					</ab>
-					<p>3. X. Quæ putas, nisi ut incipiamus sibimet sylla­ <lb/> bas compararc, ct
-						videre quos numeros ad scse ha­ <lb/> beant; sicut de motibus jam inter nos
-						tam longa supe­ <lb/> rius ratione tractatum est? In motu cst eniin etiam
-						<lb/> omne quod sonat; et syllabæ utique sonant: an quid­ <lb/> quam horum
-						negari potest? D. Nullo modo. <hi rend="italic">M.</hi> Cum <lb/> ergo inter
-						se syllabæ conferuntur, motus quidain inter <lb/> se conferuntur, in quibus
-						possint numeri quidam tem­ <lb/> poris 9 mensura diuturnitatis inquiri. <hi
+					<p>3. X. Quae putas, nisi ut incipiamus sibimet sylla­<lb/>bas compararc, ct
+						videre quos numeros ad scse ha­<lb/>beant; sicut de motibus jam inter nos
+						tam longa supe­<lb/>rius ratione tractatum est? In motu cst eniin etiam
+						<lb/>omne quod sonat; et syllabae utique sonant: an quid­<lb/>quam horum
+						negari potest? D. Nullo modo. <hi rend="italic">M.</hi> Cum<lb/>ergo inter
+						se syllabae conferuntur, motus quidain inter<lb/>se conferuntur, in quibus
+						possint numeri quidam tem­<lb/>poris 9 mensura diuturnitatis inquiri. <hi
 							rend="italic">D.</hi> Ita est. <hi rend="italic">M.</hi>
-						<lb/> Num igitur potest tibi una syllaba comparari? Nam <lb/> omnem
-						comparationem, nisi tu aliud putes, singula­ <lb/> ritas fugit. <hi
+						<lb/>Num igitur potest tibi una syllaba comparari? Nam<lb/>omnem
+						comparationem, nisi tu aliud putes, singula­<lb/>ritas fugit. <hi
 							rend="italic">D.</hi> Nihil puto aliud. <hi rend="italic">11.</hi> Quid?
-						uno uni, aut <lb/> una vel duae duabus vcl tribus, ct deinceps in pUtri­
-						<lb/> bus, quin possint sibimet conferri, num negas? <hi rend="italic"
+						uno uni, aut<lb/>una vel duae duabus vcl tribus, ct deinceps in pUtri­
+						<lb/>bus, quin possint sibimet conferri, num negas? <hi rend="italic"
 							>D.</hi>
-						<lb/> Quis boc negaverit? <hi rend="italic">II.</hi> Rursus boc vide,
-						quamlibet <lb/> sy llabam brevem minimeque diu pronuntiatam, et mox <lb/> ut
+						<lb/>Quis boc negaverit? <hi rend="italic">II.</hi> Rursus boc vide,
+						quamlibet<lb/>sy llabam brevem minimeque diu pronuntiatam, et mox<lb/>ut
 						cruperit desinentem, occupare tameu in tempore <note type="footnote"> 1 In
 							A., <hi rend="italic">et;</hi> Mss. A ct A, <hi rend="italic">at.</hi>
 							M. </note><note type="footnote"> 1 sic Mss. A et n. in B., <hi
 								rend="italic">quod fit,</hi> n1inus latine. K. </note><note
 							type="footnote"> ' <hi rend="italic">Temporis, et,</hi> jutta Ms. A. М. </note>
-						<lb/> aliquid spatii, cl habere quamdam morulam suam. i . <lb/> Video
-						necesse esse quod dicis. M. Dic nunc, unde nu­ <lb/> merum exordiamur. D. Ab
-						uno scilicet. <hi rend="italic">M.</hi> Non ab­ <lb/> surde igitur hoc in
-						tempore quasi minimum spatii, <lb/> quod brevis obtinet syllaba, unum tempus
-						veteres vo­ <lb/> caverunt : a brevi cnim ad longam progredimur. D. <lb/>
+						<lb/>aliquid spatii, cl habere quamdam morulam suam. i .<lb/>Video
+						necesse esse quod dicis. M. Dic nunc, unde nu­<lb/>merum exordiamur. D. Ab
+						uno scilicet. <hi rend="italic">M.</hi> Non ab­<lb/>surde igitur hoc in
+						tempore quasi minimum spatii,<lb/>quod brevis obtinet syllaba, unum tempus
+						veteres vo­<lb/>caverunt : a brevi cnim ad longam progredimur. D.<lb/>
 						Verum est. <hi rend="italic">M.</hi> Sequitur jam, ut illud quoque animad­
-						<lb/> vertas, quoniam ut in Humeris ab uno ad duo est <lb/> prima
-						progressio; ita in syllabis, qua I scilicet a brevi <lb/> ad longam
-						progredimur, longam duplum temporis ha­ <lb/> bere debere : ac per hoc si
-						spatium quod brevis oc­ <lb/> cupat, recte unum tempus vocatur; spatium item
-						quod <lb/> longa occupat, recte duo tempora nominari. <hi rend="italic"
-							>D.</hi> Recte <lb/> prorsus : nam id rationem postulare consentio.</p>
+						<lb/>vertas, quoniam ut in Humeris ab uno ad duo est<lb/>prima
+						progressio; ita in syllabis, qua I scilicet a brevi<lb/>ad longam
+						progredimur, longam duplum temporis ha­<lb/>bere debere : ac per hoc si
+						spatium quod brevis oc­<lb/>cupat, recte unum tempus vocatur; spatium item
+						quod<lb/>longa occupat, recte duo tempora nominari. <hi rend="italic"
+							>D.</hi> Recte<lb/>prorsus : nam id rationem postulare consentio.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT IV. — <hi rend="italic">Pedes</hi>
 							dissyllabi.</title>
 					</ab>
 					<p><hi rend="italic">A. M.</hi> Agc, nunc collationes ips:is vidcamus : nam
-						<lb/> una brevis syllaba ad unam brevem syllabam quæro <lb/> quam rationem
-						tibi habere videatur, vel hi motus in­ <lb/> ter se quid vocentur. Meministi
-						cnim, nisi fallor, in <lb/> superiore sermone nos omnibus motibus, qui inter
-						se <lb/> aliqua numerositate conveniunt, imposuisse vocabula. <lb/>
-						<hi rend="italic">D.</hi> Æquales eos memini nominatos : tantumdem enim
-						<lb/> ad sese habent temporis. <hi rend="italic">it.</hi> Sed istam
-						collationem <lb/> syllabarum qua sihi jam conferuntur ut habeant ad se <lb/>
-						aliquos numcros, num censes sine vocabulo csso re­ <lb/> linquendam? <hi
-							rend="italic">D.</hi> Non puto. M Atqui scias, voteres <lb/> pedem
-						nuncupasse talem collationem sonorum. Sed <lb/> quousque pedem progredi
-						ratio sinat, diligenter ad­ <lb/> vertendum est. Quamobrem jam dic etiam,
-						brevis et <lb/> longa syllaba qua sibi ratione conferuntur? D. Opinor, <lb/>
-						ex illo gencre numerorum, quos complicatos vocavi­ <lb/> mus, istam
-						collationem manare : siquidcm in ea sim­ <lb/> plum ad duplum collatum esso
-						video, id £ stunum <lb/> tempus brevis syllabæ ad dno tempora longæ syllabæ. <lb/>
+						<lb/>una brevis syllaba ad unam brevem syllabam quaero<lb/>quam rationem
+						tibi habere videatur, vel hi motus in­<lb/>ter se quid vocentur. Meministi
+						cnim, nisi fallor, in<lb/>superiore sermone nos omnibus motibus, qui inter
+						se<lb/>aliqua numerositate conveniunt, imposuisse vocabula.<lb/>
+						<hi rend="italic">D.</hi> aequales eos memini nominatos : tantumdem enim
+						<lb/>ad sese habent temporis. <hi rend="italic">it.</hi> Sed istam
+						collationem<lb/>syllabarum qua sihi jam conferuntur ut habeant ad se<lb/>
+						aliquos numcros, num censes sine vocabulo csso re­<lb/>linquendam? <hi
+							rend="italic">D.</hi> Non puto. M Atqui scias, voteres<lb/>pedem
+						nuncupasse talem collationem sonorum. Sed<lb/>quousque pedem progredi
+						ratio sinat, diligenter ad­<lb/>vertendum est. Quamobrem jam dic etiam,
+						brevis et<lb/>longa syllaba qua sibi ratione conferuntur? D. Opinor,<lb/>
+						ex illo gencre numerorum, quos complicatos vocavi­<lb/>mus, istam
+						collationem manare : siquidcm in ea sim­<lb/>plum ad duplum collatum esso
+						video, id £ stunum<lb/>tempus brevis syllabae ad dno tempora longae syllabae.<lb/>
 						<hi rend="italic">Al.</hi> Quid si ita ordinentur, ut prius longa, deinde
-						bre­ <lb/> v is syllaba pronuntietur ? num quia ordo mutatus est, <lb/> idco
-						complicatorum numerorum ratio non manet? <lb/> Nam ut in illo pede simplum
-						ad duplum, iia in isto <lb/> duplum ad simplum invenitur. <hi rend="italic"
-							>D.</hi> Ita est. M. Quid ? <lb/> in pede duarum longarum, nonnc duo
-						temp ora duo­ <lb/> bus temporibus conferuntur? <hi rend="italic">D.</hi>
-						Manifestum est. M. <lb/> Ex qua crgo ratione ducitur ista collatio?<hi
-							rend="italic">D.</hi> Ex eo­ <lb/> rum scilicet qui æquales appellati
+						bre­<lb/>v is syllaba pronuntietur ? num quia ordo mutatus est,<lb/>idco
+						complicatorum numerorum ratio non manet?<lb/>Nam ut in illo pede simplum
+						ad duplum, iia in isto<lb/>duplum ad simplum invenitur. <hi rend="italic"
+							>D.</hi> Ita est. M. Quid ?<lb/>in pede duarum longarum, nonnc duo
+						temp ora duo­<lb/>bus temporibus conferuntur? <hi rend="italic">D.</hi>
+						Manifestum est. M.<lb/>Ex qua crgo ratione ducitur ista collatio?<hi
+							rend="italic">D.</hi> Ex eo­<lb/>rum scilicet qui aequales appellati
 						sunt.</p>
-					<p>5. M. Age, nunc dic milii, ex quo a duabus brevi­ <lb/> bus orsi ad duas
-						syllabas longas pervenimus, quot <lb/> pedum collationes tractaverimus. <hi
-							rend="italic">D.</hi> Quatuor: nam <lb/> primo do duabus brevibus dictum
-						est, secundo d; <lb/> brevi et longa, tertio de longa ci brevi, quarto d *
-						<lb/> duabus longis. M. Num possunt esse plures quam qua­ <lb/> tuor, cum
-						dux syllabae sibimet conferuntur? D. Nul­ <lb/> lo modo : nam cum syllabae
-						hunc modum accepcrint, <lb/> ut brevis unum tempus, longa duo habeat, cumque
-						<lb/> sy llaba omnis aui brevis aut longa sit; quo pacto sibi <lb/> possunt
-						dux syllabae comparari atque copulari utpo­ <lb/> dem faciant, nisi aut
-						brevis et brevis sit, .ut brevis et <lb/> longa, aut longa ct brevis, aut
-						lon ga et longa? M. Dir <lb/> etiam quot habeat tempora binanlm syllabarum
+					<p>5. M. Age, nunc dic milii, ex quo a duabus brevi­<lb/>bus orsi ad duas
+						syllabas longas pervenimus, quot<lb/>pedum collationes tractaverimus. <hi
+							rend="italic">D.</hi> Quatuor: nam<lb/>primo do duabus brevibus dictum
+						est, secundo d;<lb/>brevi et longa, tertio de longa ci brevi, quarto d *
+						<lb/>duabus longis. M. Num possunt esse plures quam qua­<lb/>tuor, cum
+						dux syllabae sibimet conferuntur? D. Nul­<lb/>lo modo : nam cum syllabae
+						hunc modum accepcrint,<lb/>ut brevis unum tempus, longa duo habeat, cumque
+						<lb/>sy llaba omnis aui brevis aut longa sit; quo pacto sibi<lb/>possunt
+						dux syllabae comparari atque copulari utpo­<lb/>dem faciant, nisi aut
+						brevis et brevis sit, .ut brevis et<lb/>longa, aut longa ct brevis, aut
+						lon ga et longa? M. Dir<lb/>etiam quot habeat tempora binanlm syllabarum
 							mioi-<note type="footnote"> I Qvut, juxta alS. A. AL </note>
 						<lb/>
-						<pb n="1103"/> mus pes, quot item maximus. D. Duo ille, iste quatuor. <lb/>
-						M. Videsne ut progressio nisi usque ad quaternarium <lb/> numerum fieri non
-						potuerit, sive in pedibus , sive in <lb/> temporibus? <hi rend="italic"
-							>D.</hi> Video plane, et recordor rationem <lb/> progressionis in
-						numeris, atque illam vim hic etiam <lb/> inesse sentio cum magna animi
-						voluptate. <hi rend="italic">M.</hi> Nonne <lb/> ergo censes, cum pedes
-						syllabis constent, id est dis­ <lb/> tinctis et quasi articulatis motibus
-						qui sant in sonis, <lb/> syllabæ autem tendantur temporibus, oportere fieri
-						<lb/> etiam usque ad quatuor syllabas progressionem pedis, <lb/> Sicut jam
-						factam usque ad quaternarium numerum, et <lb/> ipsorum pedum et temporum
-						cernis? <hi rend="italic">D.</hi> Ita plane ut <lb/> dicis sentio, et hoc
-						videri perfectæ rationi cognosco <lb/> et debitum flagito.</p>
+						<pb n="1103"/> mus pes, quot item maximus. D. Duo ille, iste quatuor.<lb/>
+						M. Videsne ut progressio nisi usque ad quaternarium<lb/>numerum fieri non
+						potuerit, sive in pedibus , sive in<lb/>temporibus? <hi rend="italic"
+							>D.</hi> Video plane, et recordor rationem<lb/>progressionis in
+						numeris, atque illam vim hic etiam<lb/>inesse sentio cum magna animi
+						voluptate. <hi rend="italic">M.</hi> Nonne<lb/>ergo censes, cum pedes
+						syllabis constent, id est dis­<lb/>tinctis et quasi articulatis motibus
+						qui sant in sonis,<lb/>syllabae autem tendantur temporibus, oportere fieri
+						<lb/>etiam usque ad quatuor syllabas progressionem pedis,<lb/>Sicut jam
+						factam usque ad quaternarium numerum, et<lb/>ipsorum pedum et temporum
+						cernis? <hi rend="italic">D.</hi> Ita plane ut<lb/>dicis sentio, et hoc
+						videri perfectae rationi cognosco<lb/>et debitum flagito.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT V. — <hi rend="italic">Pedes trisyllubi.</hi>
 						</title>
 					</ab>
 					<p>6. <hi rend="italic">M.</hi> Age nunc ergo prius, ut ordo ipse postulat,
-						<lb/> ternarum syllabarum pedes quot esse possint, videa­ <lb/> mas, sicut
-						binarum quatuor esse comperimus. <hi rend="italic">D.</hi> Ita <lb/> fiat.
-						M. Meministi ab una brevi syllaba, id est unius <lb/> temporis istam nos
-						inchoasse rationem, et cur ita <lb/> oporteret satis intellexisse. D. Memini
-						ab illa lege <lb/> numerandi, qua I ab uno incipimus, quod principium <lb/>
-						numerorum est, placuisse nobis non oportere disce­ <lb/> dere. II. Cum
-						igitur in pedibus binarum syllaba'ram <lb/> ille sit primus qui duabns
-						brevibus constat (cogebat <lb/> enim ratio uni tempori prius unum tempus
-						jungi quam <lb/> duo); quem tandem arbitraris ill pedibus ternarum <lb/>
-						syllabarum primum esse debere? D. Quem, nisi ci1m <lb/> qui a tribus
-						brevibus confit? <hi rend="italic">M.</hi> Et iste quot tempo­ <lb/> rum
-						est? D. Trium scilicet. <hi rend="italic">M.</hi> Qnomodo ergo bu­ <lb/> jus
-						partes sibi conferuntur? Nam omnem pedem pro­ <lb/> pter illam numerorum
-						collationem duas habere par­ <lb/> tes, quae sibimet aliqua ratione
-						conferantur, nccesse <lb/> est, idque superius egisse nos memini : sed
-						numquid <lb/> ,,oBsumus hunc trium brevium syllabarum pedem in <lb/> duas
-						æquales pafles dividere? <hi rend="italic">D.</hi> Nullo modo. II. <lb/>
+						<lb/>ternarum syllabarum pedes quot esse possint, videa­<lb/>mas, sicut
+						binarum quatuor esse comperimus. <hi rend="italic">D.</hi> Ita<lb/>fiat.
+						M. Meministi ab una brevi syllaba, id est unius<lb/>temporis istam nos
+						inchoasse rationem, et cur ita<lb/>oporteret satis intellexisse. D. Memini
+						ab illa lege<lb/>numerandi, qua I ab uno incipimus, quod principium<lb/>
+						numerorum est, placuisse nobis non oportere disce­<lb/>dere. II. Cum
+						igitur in pedibus binarum syllaba'ram<lb/>ille sit primus qui duabns
+						brevibus constat (cogebat<lb/>enim ratio uni tempori prius unum tempus
+						jungi quam<lb/>duo); quem tandem arbitraris ill pedibus ternarum<lb/>
+						syllabarum primum esse debere? D. Quem, nisi ci1m<lb/>qui a tribus
+						brevibus confit? <hi rend="italic">M.</hi> Et iste quot tempo­<lb/>rum
+						est? D. Trium scilicet. <hi rend="italic">M.</hi> Qnomodo ergo bu­<lb/>jus
+						partes sibi conferuntur? Nam omnem pedem pro­<lb/>pter illam numerorum
+						collationem duas habere par­<lb/>tes, quae sibimet aliqua ratione
+						conferantur, nccesse<lb/>est, idque superius egisse nos memini : sed
+						numquid<lb/>,,oBsumus hunc trium brevium syllabarum pedem in<lb/>duas
+						aequales pafles dividere? <hi rend="italic">D.</hi> Nullo modo. II.<lb/>
 						Quomodo ergo dividitur ? <hi rend="italic">D.</hi> Nihil aliud video, nisi
-						ut <lb/> prima pars habeat unam syllabam, secunda duas; aut <lb/> prima
-						duas, secunda unam. <hi rend="italic">II.</hi> Dic etiam hoc a de qua <lb/>
+						ut<lb/>prima pars habeat unam syllabam, secunda duas; aut<lb/>prima
+						duas, secunda unam. <hi rend="italic">II.</hi> Dic etiam hoc a de qua<lb/>
 						regula numerorum sit? <hi rend="italic">D.</hi> De complicatorum genere
-						<lb/> esse cognosco.</p>
-					<p>i. <hi rend="italic">II.</hi> Age, nonc illud attende, tres sylLabæ in qui­
-						<lb/> bus est una longa, cæterae breves, quoties variari <lb/> possint, id
-						cst quot pedes facere ; et responde, si in­ <lb/> veneris. <hi rend="italic"
-							>D.</hi> Unum pedem video esse, qui longa et dua­ <lb/> bus brevibus
-						constet; aliud non intelligo. <hi rend="italic">M.</hi> Idemne <lb/> solus
-						tibi vidctur habere unam in tribus longam, qui <lb/> eam primo habet loco?
-							<hi rend="italic">D.</hi> Nullo pacto istud putave­ <lb/> rim, cum
-						possint dux brevos priores esse, longa ul­ <lb/> tima. M. Considera utrum
-						sit aliquid tertium. <hi rend="italic">D.</hi> Est <lb/> plane : nam hæc
-						longa etiam in medio duarum bre­ <lb/> vium collocari potest. <hi
-							rend="italic">M.</hi> Vide etiamne sit aliquid <lb/> quartum, <hi
+						<lb/>esse cognosco.</p>
+					<p>i. <hi rend="italic">II.</hi> Age, nonc illud attende, tres sylLabae in qui­
+						<lb/>bus est una longa, caeterae breves, quoties variari<lb/>possint, id
+						cst quot pedes facere ; et responde, si in­<lb/>veneris. <hi rend="italic"
+							>D.</hi> Unum pedem video esse, qui longa et dua­<lb/>bus brevibus
+						constet; aliud non intelligo. <hi rend="italic">M.</hi> Idemne<lb/>solus
+						tibi vidctur habere unam in tribus longam, qui<lb/>eam primo habet loco?
+							<hi rend="italic">D.</hi> Nullo pacto istud putave­<lb/>rim, cum
+						possint dux brevos priores esse, longa ul­<lb/>tima. M. Considera utrum
+						sit aliquid tertium. <hi rend="italic">D.</hi> Est<lb/>plane : nam haec
+						longa etiam in medio duarum bre­<lb/>vium collocari potest. <hi
+							rend="italic">M.</hi> Vide etiamne sit aliquid<lb/>quartum, <hi
 							rend="italic">D.</hi> Omnino non potest. <hi rend="italic">II.</hi>
-						Potesne jam re­ <lb/> spondere, tres syllabæ habentes in se unam longam
-						<lb/> et duas breves, <unclear>quotica</unclear> variani possint, id osi
+						Potesne jam re­<lb/>spondere, tres syllabae habentes in se unam longam
+						<lb/>et duas breves, <unclear>quotica</unclear> variani possint, id osi
 						quot pe- <note type="footnote"> I ngfWOSfO, juxta MSS. A et B. M.
 							</note><note type="footnote"> * in B., <hi rend="italic">quod.</hi> Ex
 							Ms. A, <hi rend="italic">qua,</hi> rectius. M. </note><note
 							type="footnote">ffl 3 In B. eiBSt <hi rend="italic">hoc.</hi> quod i
 							1Yl'uitur al.ud editos omnes et </note>
-						<lb/> des facere ? <hi rend="italic">D.</hi> Possum sane : nam ler sont
-						variatne, <lb/> et tres fecerunt pedes. <hi rend="italic">II.</hi> Quid?
-						isti tres pedes quo­ <lb/> modo sint ordinandi jamnc ipse colligis, an ad
-						hoc <lb/> eliam minutatim es perducendus ? D. Displicet enim <lb/> tibi ordo
-						ille quo ipsam varietatem comperi ? nam <lb/> primo adverti unam longam et
-						duas breves, deinde <lb/> duas breves et unam longam, postremo brevem et
-						<lb/> longam et brevem. <hi rend="italic">M.</hi> Itane vero tibi non
-						displiceat <lb/> qui sic ordinat, ut a primo ad tertium vcniat, a tertio
-						<lb/> ad sccundum ; ac non potius a primo ad secundum, et <lb/> deinde ad
-						tertium? <hi rend="italic">D.</hi> Displicet prorsus : sed quid hic <lb/>
+						<lb/>des facere ? <hi rend="italic">D.</hi> Possum sane : nam ler sont
+						variatne,<lb/>et tres fecerunt pedes. <hi rend="italic">II.</hi> Quid?
+						isti tres pedes quo­<lb/>modo sint ordinandi jamnc ipse colligis, an ad
+						hoc<lb/>eliam minutatim es perducendus ? D. Displicet enim<lb/>tibi ordo
+						ille quo ipsam varietatem comperi ? nam<lb/>primo adverti unam longam et
+						duas breves, deinde<lb/>duas breves et unam longam, postremo brevem et
+						<lb/>longam et brevem. <hi rend="italic">M.</hi> Itane vero tibi non
+						displiceat<lb/>qui sic ordinat, ut a primo ad tertium vcniat, a tertio
+						<lb/>ad sccundum ; ac non potius a primo ad secundum, et<lb/>deinde ad
+						tertium? <hi rend="italic">D.</hi> Displicet prorsus : sed quid hic<lb/>
 						tandem tale advertisti, rogo? <hi rend="italic">M.</hi> Cum ideo in hac tri
-						<lb/> partita differentia illum pedem primum posueris, qui <lb/> primo loco
-						habet lOngam, quia sensisti unitatem ipsam <lb/> longæ syllabae principatum
-						tenere ( siquidem ipsa <lb/> ibi una est). et propterea eam debere ordinem
-						gignere, <lb/> ut ille sit primas pes ubi prima ipsa est: simul etiam <lb/>
-						videre debuisti eum esse secundum ubi ipsa secunda <lb/> est, eum tertium
-						ubi eadem tertia est. An adhuc in <lb/> illa sententia manendum putas? <hi
-							rend="italic">D.</hi> Imo eam sine du­ <lb/> bitatione condemno : hunc
-						enim esse meliorem ord:­ <lb/> nem, vel potius hunc esse ordinem, quis non
-						assen­ <lb/> tiatur? M. Nunc ergo dic qua numerorum regula isti <lb/> quoque
-						dividantur pedes, eorumque sibi partes con­ <lb/> ferantur. <hi
-							rend="italic">D.</hi> Primum et postremum æquali regula di­ <lb/> vidi
-						video, quia et ille in longam et duas breves ct <lb/> iste in duas breves et
-						longam dividi potest, ut singula: <lb/> partes habeant bina tempora, et ob
-						hoc sint æquales. <lb/> In secundo autem quoniam mediam habet longnin syl­
-						<lb/> labam, sive priori sive posteriori parti tribuatur, aut <lb/> in tria
-						ei unum, aut in unum et tria tempora dividi­ <lb/> tur : ac per hoc in ejus
-						divisione complicatorum nu­ <lb/> merorum ratio valet.</p>
-					<p>8. M. Volo mihi jam dicas per te ipse si potes, <lb/> post istos qui a nobis
-						tractati sunt, quos pedes ordi­ <lb/> nandos putes. Tractati enim sunt primo
-						binarum syl­ <lb/> labarum quatuor, quorum ordo ductus est a nnmero­ <lb/>
-						rum ordine, ut a brevibus syllabis ordirmnur. Deinde <lb/> jam productiores
-						ternarum syllabarum pedes tractan­ <lb/> dos suscepimus, et quod facilc erat
-						cx superiore ra­ <lb/> tione, a tribus brevibus orsi sumus. Quid deinde se­
-						<lb/> quebatur, nisi ut una longa cum duabus brevibus quot <lb/> fonnas
-						ederct videremus? Visum est; et tres pedes <lb/> post illum primum, iia ut
-						oportebat, ordinati sunt. <lb/> Qui deinceps consequantur nonne per i ipsuiu
-						videre <lb/> jam debes, ne omnia <unclear>minutissimis</unclear>
-						interrogatiunculis <lb/> .eruamus ? D. Recte dicis : nam quis non videat eos
-						<lb/> jam sequi, in quibus una brevis sit, cæteræ lougn;: <lb/> cui brevi,
-						quia una est, cum superiore ratione prin­ <lb/> cipatus tribuatur, primus
-						erit profecto in his ubi <lb/> prima est, secundus ubi secunda, tertius ubi
-						trtia, <lb/> quae etiam ultima est. M. Cernis, ut opinor, quibus <lb/> etiam
-						rationibus dividantur, ut sibi eoram partes con­ <lb/> ferri queant. <hi
-							rend="italic">D.</hi> Ceroo prorsus : nam ijle qui ex una <lb/> brevi et
-						duabus longis constat, dividi uon potest, nisi <lb/> ita ut prior pars
-						habeat tria tempora, quae continet <lb/> brevem et longam; posterior duo,
-						quæ uni longæ in­ <lb/> sunt. IIic autem tertius in eo quidem priori par
-						est, <lb/> quod unam patitur divibionem ; ill eh autem dissimi­ <lb/>
-						<pb n="1105"/> lis, quod cum ille in tria et duo, iste in duo ct tria <lb/>
-						tempora secatur. Nam longa syllaba, quae primam te­ <lb/> uel partem, duobus
-						temporibus tenditur : restat longa <lb/> cl brevis, quod est trium temporum
-						spatium. At vero <lb/> medius qui habet brevem syllabam mediam, gemi­ <lb/>
-						nam potest partitionem pati, quia cadem brevis et <lb/> priori et posteriori
-						parti tribui potest : idcirco aut in <lb/> duo et tria, aut in tria et duo
-						dividitur tempora : <lb/> quamobrem sesquatorum numerorum ratio tres istos
-						<lb/> possidet pedes. M. Omnesne jam trium syllabarum <lb/> pedes
-						consideravimus, an aliquid restat? <hi rend="italic">D.</hi> Unni <lb/>
+						<lb/>partita differentia illum pedem primum posueris, qui<lb/>primo loco
+						habet lOngam, quia sensisti unitatem ipsam<lb/>longae syllabae principatum
+						tenere ( siquidem ipsa<lb/>ibi una est). et propterea eam debere ordinem
+						gignere,<lb/>ut ille sit primas pes ubi prima ipsa est: simul etiam<lb/>
+						videre debuisti eum esse secundum ubi ipsa secunda<lb/>est, eum tertium
+						ubi eadem tertia est. An adhuc in<lb/>illa sententia manendum putas? <hi
+							rend="italic">D.</hi> Imo eam sine du­<lb/>bitatione condemno : hunc
+						enim esse meliorem ord:­<lb/>nem, vel potius hunc esse ordinem, quis non
+						assen­<lb/>tiatur? M. Nunc ergo dic qua numerorum regula isti<lb/>quoque
+						dividantur pedes, eorumque sibi partes con­<lb/>ferantur. <hi
+							rend="italic">D.</hi> Primum et postremum aequali regula di­<lb/>vidi
+						video, quia et ille in longam et duas breves ct<lb/>iste in duas breves et
+						longam dividi potest, ut singula:<lb/>partes habeant bina tempora, et ob
+						hoc sint aequales.<lb/>In secundo autem quoniam mediam habet longnin syl­
+						<lb/>labam, sive priori sive posteriori parti tribuatur, aut<lb/>in tria
+						ei unum, aut in unum et tria tempora dividi­<lb/>tur : ac per hoc in ejus
+						divisione complicatorum nu­<lb/>merorum ratio valet.</p>
+					<p>8. M. Volo mihi jam dicas per te ipse si potes,<lb/>post istos qui a nobis
+						tractati sunt, quos pedes ordi­<lb/>nandos putes. Tractati enim sunt primo
+						binarum syl­<lb/>labarum quatuor, quorum ordo ductus est a nnmero­<lb/>
+						rum ordine, ut a brevibus syllabis ordirmnur. Deinde<lb/>jam productiores
+						ternarum syllabarum pedes tractan­<lb/>dos suscepimus, et quod facilc erat
+						cx superiore ra­<lb/>tione, a tribus brevibus orsi sumus. Quid deinde se­
+						<lb/>quebatur, nisi ut una longa cum duabus brevibus quot<lb/>fonnas
+						ederct videremus? Visum est; et tres pedes<lb/>post illum primum, iia ut
+						oportebat, ordinati sunt.<lb/>Qui deinceps consequantur nonne per i ipsuiu
+						videre<lb/>jam debes, ne omnia <unclear>minutissimis</unclear>
+						interrogatiunculis<lb/>.eruamus ? D. Recte dicis : nam quis non videat eos
+						<lb/>jam sequi, in quibus una brevis sit, caeterae lougn;:<lb/>cui brevi,
+						quia una est, cum superiore ratione prin­<lb/>cipatus tribuatur, primus
+						erit profecto in his ubi<lb/>prima est, secundus ubi secunda, tertius ubi
+						trtia,<lb/>quae etiam ultima est. M. Cernis, ut opinor, quibus<lb/>etiam
+						rationibus dividantur, ut sibi eoram partes con­<lb/>ferri queant. <hi
+							rend="italic">D.</hi> Ceroo prorsus : nam ijle qui ex una<lb/>brevi et
+						duabus longis constat, dividi uon potest, nisi<lb/>ita ut prior pars
+						habeat tria tempora, quae continet<lb/>brevem et longam; posterior duo,
+						quae uni longae in­<lb/>sunt. IIic autem tertius in eo quidem priori par
+						est,<lb/>quod unam patitur divibionem ; ill eh autem dissimi­<lb/>
+						<pb n="1105"/> lis, quod cum ille in tria et duo, iste in duo ct tria<lb/>
+						tempora secatur. Nam longa syllaba, quae primam te­<lb/>uel partem, duobus
+						temporibus tenditur : restat longa<lb/>cl brevis, quod est trium temporum
+						spatium. At vero<lb/>medius qui habet brevem syllabam mediam, gemi­<lb/>
+						nam potest partitionem pati, quia cadem brevis et<lb/>priori et posteriori
+						parti tribui potest : idcirco aut in<lb/>duo et tria, aut in tria et duo
+						dividitur tempora :<lb/>quamobrem sesquatorum numerorum ratio tres istos
+						<lb/>possidet pedes. M. Omnesne jam trium syllabarum<lb/>pedes
+						consideravimus, an aliquid restat? <hi rend="italic">D.</hi> Unni<lb/>
 						reliquum video, qui ex tribus longis constat. <hi rend="italic">It.</hi>
-						Tra­ <lb/> cta ergo etiam hujus divisionem. D. Una syllaba et <lb/> duæ, aut
-						duae atque una hujus divisio est ; tempora <lb/> scilicet duo et quatuor,
-						aut quatuor et duo : quare <lb/> con plicatorum numerorum ratione istius
-						pedis sibi <lb/> partes conferuntur.</p>
+						Tra­<lb/>cta ergo etiam hujus divisionem. D. Una syllaba et<lb/>duae, aut
+						duae atque una hujus divisio est ; tempora<lb/>scilicet duo et quatuor,
+						aut quatuor et duo : quare<lb/>con plicatorum numerorum ratione istius
+						pedis sibi<lb/>partes conferuntur.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT VI.— <hi rend="italic">Pedes tetrasyllabi.</hi>
 						</title>
 					</ab>
-					<p>9. M. Nunc quaternarum syllabarum pedes con­ <lb/> sequenter atque ordine
-						videamus, ct ipse jam dic <lb/> quem horum primum esse oporteat, addita
-						etiam ra­ <lb/> tione divisionis ejus. <hi rend="italic">D.</hi> Scilicet
-						quatuor brevium, <lb/> qui dividitur in duas binarum syllabarum partes,
-						<lb/> æqualium ratione numerorum duo et duo tempora <lb/> possidentes. M.
-						Tenes 1; jam itaque prge ipso, et <lb/> persequere cætera. Nihil enim opus
-						esse jam puto te <lb/> per singula interrogari, cum sit una ratio dcmendi
-						<lb/> deinceps breves syllabas, ct pro his longas subji­ <lb/> tiendi, donec
-						ad omnes longas veniatur; et cum de­ <lb/> muntur breves, longæque
-						subduntur, quas varietates <lb/> faciant, cl quot pedes gignant,
-						considcrandi; ea sci­ <lb/> licet syllaba principatum ordinis retinente, quæ
-						una <lb/> fuerit inter cæteras vel longa vel brevis: in his euim <lb/>
-						omnibus jam superius es exercitatus. Ubi antem duæ <lb/> breves sunt et duæ
-						longæ, quod in præcedentibus non <lb/> crat, quas censes principatum habere
-						debere? <hi rend="italic">D.</hi> Jani <lb/> hoc qnoque manifestum est de
-						superioribus. Siqui­ <lb/> dem magis tenet unitatem brevis syllaba quæ unum
-						<lb/> habet tempus, quam longa quæ duo. Et propterea in <lb/> omni capite
-						atquc principio eum pedem constituimus <lb/> qui cx brevibus constat.</p>
+					<p>9. M. Nunc quaternarum syllabarum pedes con­<lb/>sequenter atque ordine
+						videamus, ct ipse jam dic<lb/>quem horum primum esse oporteat, addita
+						etiam ra­<lb/>tione divisionis ejus. <hi rend="italic">D.</hi> Scilicet
+						quatuor brevium,<lb/>qui dividitur in duas binarum syllabarum partes,
+						<lb/>aequalium ratione numerorum duo et duo tempora<lb/>possidentes. M.
+						Tenes 1; jam itaque prge ipso, et<lb/>persequere caetera. Nihil enim opus
+						esse jam puto te<lb/>per singula interrogari, cum sit una ratio dcmendi
+						<lb/>deinceps breves syllabas, ct pro his longas subji­<lb/>tiendi, donec
+						ad omnes longas veniatur; et cum de­<lb/>muntur breves, longaeque
+						subduntur, quas varietates<lb/>faciant, cl quot pedes gignant,
+						considcrandi; ea sci­<lb/>licet syllaba principatum ordinis retinente, quae
+						una<lb/>fuerit inter caeteras vel longa vel brevis: in his euim<lb/>
+						omnibus jam superius es exercitatus. Ubi antem duae<lb/>breves sunt et duae
+						longae, quod in praecedentibus non<lb/>crat, quas censes principatum habere
+						debere? <hi rend="italic">D.</hi> Jani<lb/>hoc qnoque manifestum est de
+						superioribus. Siqui­<lb/>dem magis tenet unitatem brevis syllaba quae unum
+						<lb/>habet tempus, quam longa quae duo. Et propterea in<lb/>omni capite
+						atquc principio eum pedem constituimus<lb/>qui cx brevibus constat.</p>
 					</div>
-				<div type="textpart" subtype="dialog"><p>10. <hi rend="italic">M.</hi> Nihil igitur te impedit, quin omnes istos <lb/>
-						perscquaris pedes audiente ac judicante me, non in­ <lb/> terrogante. <hi
-							rend="italic">D.</hi> Faciam si potero : nam primo de qua­ <lb/> tuor
-						brevibus primi pedis, brevis una detrahenda est, <lb/> et pro ca longa
-						ponenda in primo loco propter uuila-, <lb/> tis dignitatem. IIic autem pes
-						dividilur bis : aut in <lb/> longam et tres breves; aut in longam et brevem,
-						et <lb/> duas breves; id est aut in duo et tria; aut in tria, ct <lb/> duo
-						tempora. Secundo autcm loco posita longa facit <lb/> alium pedem, qui uno
-						modo recte dividitur, in tria <lb/> scilicct et duo tempora, ut prior pars
-						teneat brevem <lb/> et longam, posterior duas breves. Porro lcriio loco­
-						<lb/> consLilula longa facil cum pedem, qui rursus uno <lb/> modo rite
-						dividitur; sed ita ut prior pars habeat duo <lb/> tempora in duabus brevibus
-						syllabis, posterior tria in <lb/> longa ct brevi. Quartum pedem facit longa
+				<div type="textpart" subtype="dialog"><p>10. <hi rend="italic">M.</hi> Nihil igitur te impedit, quin omnes istos<lb/>
+						perscquaris pedes audiente ac judicante me, non in­<lb/>terrogante. <hi
+							rend="italic">D.</hi> Faciam si potero : nam primo de qua­<lb/>tuor
+						brevibus primi pedis, brevis una detrahenda est,<lb/>et pro ca longa
+						ponenda in primo loco propter uuila-,<lb/>tis dignitatem. IIic autem pes
+						dividilur bis : aut in<lb/>longam et tres breves; aut in longam et brevem,
+						et<lb/>duas breves; id est aut in duo et tria; aut in tria, ct<lb/>duo
+						tempora. Secundo autcm loco posita longa facit<lb/>alium pedem, qui uno
+						modo recte dividitur, in tria<lb/>scilicct et duo tempora, ut prior pars
+						teneat brevem<lb/>et longam, posterior duas breves. Porro lcriio loco­
+						<lb/>consLilula longa facil cum pedem, qui rursus uno<lb/>modo rite
+						dividitur; sed ita ut prior pars habeat duo<lb/>tempora in duabus brevibus
+						syllabis, posterior tria in<lb/>longa ct brevi. Quartum pedem facit longa
 						ultima, qui <note type="footnote">1 lerucr, jutt2 Er, luflg. ven. et Mss. \
 							n H. M. </note>
-						<lb/> duobus modis dividitur, ut illc ubi prima est : nau, <lb/> vel in duas
-						breves, et brevem ac longam; vel in tres <lb/> breves, etlongam partiri cum
-						licet; in duo scilicet, et <lb/> tria; aut in tria, et duo tempora.
-						Omnesautem iiti <lb/> quatuor pedes, ubi cum tribus brevibus varie longa
-						<lb/> collocatur, sesquatorum numerorum ratione partes <lb/> suas ad se
+						<lb/>duobus modis dividitur, ut illc ubi prima est : nau,<lb/>vel in duas
+						breves, et brevem ac longam; vel in tres<lb/>breves, etlongam partiri cum
+						licet; in duo scilicet, et<lb/>tria; aut in tria, et duo tempora.
+						Omnesautem iiti<lb/>quatuor pedes, ubi cum tribus brevibus varie longa
+						<lb/>collocatur, sesquatorum numerorum ratione partes<lb/>suas ad se
 						collatas' habent.</p>
-					<p>ii. Sequitur ut de quatuor brevibus duabus de­ <lb/> tractis, pro his duas
-						longas subjiciamus, videamus­ <lb/> que quot formas ac pedes cum breves ac
-						longa. binæ <lb/> sint, possint edere. Primo igitur video duas broves <lb/>
-						et duas longas csse ponendas, quod a brevibus rectius <lb/> exordium sit.
-						Hic autem pes habet a duplicem divisio­ <lb/> nem : aut enim in duo at quatn
-						or, ant in quatuor et <lb/> duo dividitur lempora; ut aut duæ breves priorem
-						par­ <lb/> tem lencant, et posteriorem duæ longæ; aut ut prio-. <lb/> rem
-						duæ breves et longa, posteriorem autem longa <lb/> quæ reliqua est. Fit
-						alius pes, cum duæ istæ breves <lb/> quas in capite posueramus, ita ut ordo
-						ipse postulat, <lb/> in medio fuerint collocatæ, et est hujus pedis divisio
-						<lb/> in tria et tria tempora : nam priorem partem occu­ <lb/> pant longa et
-						brevis, posteriorem brevis et longa. <lb/> Cum autem ponuntur in ultimo, nam
-						hoc sequitur, <lb/> faciunt pedcm geminæ divisionis, cnjus aut prior pars
-						<lb/> habeat duo tempora in una longa, posterior quatuor in <lb/> longa et
-						duabus brevibus; aut prior quatuor in dua­ <lb/> bus longis, posterior in
-						duabus brevibus duo. Horum <lb/> autem trium pedum partes, quod ad primum et
-						tertium <lb/> attinet, complicatorum numerorum ratione sibi com­ <lb/>
-						parantur; medius æquales eas babet.</p>
+					<p>ii. Sequitur ut de quatuor brevibus duabus de­<lb/>tractis, pro his duas
+						longas subjiciamus, videamus­<lb/>que quot formas ac pedes cum breves ac
+						longa. binae<lb/>sint, possint edere. Primo igitur video duas broves<lb/>
+						et duas longas csse ponendas, quod a brevibus rectius<lb/>exordium sit.
+						Hic autem pes habet a duplicem divisio­<lb/>nem : aut enim in duo at quatn
+						or, ant in quatuor et<lb/>duo dividitur lempora; ut aut duae breves priorem
+						par­<lb/>tem lencant, et posteriorem duae longae; aut ut prio-.<lb/>rem
+						duae breves et longa, posteriorem autem longa<lb/>quae reliqua est. Fit
+						alius pes, cum duae istae breves<lb/>quas in capite posueramus, ita ut ordo
+						ipse postulat,<lb/>in medio fuerint collocatae, et est hujus pedis divisio
+						<lb/>in tria et tria tempora : nam priorem partem occu­<lb/>pant longa et
+						brevis, posteriorem brevis et longa.<lb/>Cum autem ponuntur in ultimo, nam
+						hoc sequitur,<lb/>faciunt pedcm geminae divisionis, cnjus aut prior pars
+						<lb/>habeat duo tempora in una longa, posterior quatuor in<lb/>longa et
+						duabus brevibus; aut prior quatuor in dua­<lb/>bus longis, posterior in
+						duabus brevibus duo. Horum<lb/>autem trium pedum partes, quod ad primum et
+						tertium<lb/>attinet, complicatorum numerorum ratione sibi com­<lb/>
+						parantur; medius aequales eas babet.</p>
 					</div>
-				<div type="textpart" subtype="dialog"><p>12. Jam deinceps istac duæ breves quae conjunctae <lb/> p onebantur,
-						disjunctæ ponendæ sunt : quarnm minima <lb/> disjunctio cst, a qua eliam
-						incipiendum, nt unam syl­ <lb/> labam longam inter se habeant; maxima, ut
-						duas. <lb/> Sed cum una est inter cas, duobus modis fit, et duo <lb/> pedes
-						gignuntur. Priof antem est horum modorum, ut <lb/> in capite brevis sit,
-						-deinde longa ; inde brevis, et longa <lb/> quæ rcliquaest. Alter modus est,
-						ut in secundo et in ulti­ <lb/> mo sint breves , in primo ct tertio loco
-						longae : ita ent <lb/> longa et brevis, cllonga ct brevis. MaXima vero illa
-						dis­ <lb/> junctio est, cum duae longre in medio sunt, brevium <lb/> autem
-						una in primo, altera in extremo loco. Et divi­ <lb/> duntur ii tres pedes,
-						in quibus breves disjunctæ po­ <lb/> nuntur, in tria ct tria tempora, id cst
-						primus horum in <lb/> brevem et longam, et brevem ac longam : secundus in
-						<lb/> longam ac brevem, ct longam ac brevem : tertius in <lb/> brevcm ac
-						longam, ct longam ac brevem. Ita fiunt sex <lb/> pedes duabus brevibus et
-						duabus longis syllabis varie <lb/> inter se, quoad possunt, locatis.</p>
+				<div type="textpart" subtype="dialog"><p>12. Jam deinceps istac duae breves quae conjunctae<lb/>p onebantur,
+						disjunctae ponendae sunt : quarnm minima<lb/>disjunctio cst, a qua eliam
+						incipiendum, nt unam syl­<lb/>labam longam inter se habeant; maxima, ut
+						duas.<lb/>Sed cum una est inter cas, duobus modis fit, et duo<lb/>pedes
+						gignuntur. Priof antem est horum modorum, ut<lb/>in capite brevis sit,
+						-deinde longa ; inde brevis, et longa<lb/>quae rcliquaest. Alter modus est,
+						ut in secundo et in ulti­<lb/>mo sint breves , in primo ct tertio loco
+						longae : ita ent<lb/>longa et brevis, cllonga ct brevis. MaXima vero illa
+						dis­<lb/>junctio est, cum duae longre in medio sunt, brevium<lb/>autem
+						una in primo, altera in extremo loco. Et divi­<lb/>duntur ii tres pedes,
+						in quibus breves disjunctae po­<lb/>nuntur, in tria ct tria tempora, id cst
+						primus horum in<lb/>brevem et longam, et brevem ac longam : secundus in
+						<lb/>longam ac brevem, ct longam ac brevem : tertius in<lb/>brevcm ac
+						longam, ct longam ac brevem. Ita fiunt sex<lb/>pedes duabus brevibus et
+						duabus longis syllabis varie<lb/>inter se, quoad possunt, locatis.</p>
 					</div>
-				<div type="textpart" subtype="dialog"><p>13. Restat ut de quatuor brevibus detrahantur tres, <lb/> et pro his tres
-						longæ constituantur : crit una brevis; <lb/> et quia una brevis in capitc,
-						quam tres longæ conse­ <lb/> quentur, facit alium pedem, secundo loco posita
-						secun­ <lb/> dum, tertium tertio, quartum quarto. Quorum qua­ <lb/> tuor,
-						duo primi in tria et quatuor tempora dividuntur, <lb/> duo autem posteriores
-						in quatuor et tria, ct omnes <lb/> sesquatorum ralionc numcrorum partes sibi
+				<div type="textpart" subtype="dialog"><p>13. Restat ut de quatuor brevibus detrahantur tres,<lb/>et pro his tres
+						longae constituantur : crit una brevis;<lb/>et quia una brevis in capitc,
+						quam tres longae conse­<lb/>quentur, facit alium pedem, secundo loco posita
+						secun­<lb/>dum, tertium tertio, quartum quarto. Quorum qua­<lb/>tuor,
+						duo primi in tria et quatuor tempora dividuntur,<lb/>duo autem posteriores
+						in quatuor et tria, ct omnes<lb/>sesquatorum ralionc numcrorum partes sibi
 						collatas <note type="footnote">" I collocatos, juxta MS. v ac Edd. omnes AL </note>
 						<lb/>
 						<pb n="1007"/> habent : nam prior pars primi est brevis et longa,
-							<unclear>te</unclear>- <lb/> Nem tria tempora; posterior duæ longæ in
-						quatuor <lb/> temporibus. Secundi prior pars est longa ei brevis, ergo <lb/>
-						tria lempora; posterior duae longæ, quatuor tempora. <lb/> Tertius priorem
-						pariem habet in duabus longis, qua­ <lb/> tuor temporibus; posteriorem cjus
-						partem brevis et <lb/> longa obtinet, id est tria tempora. Quarti priorem
-						<lb/> partem similiter facium dux longæ, quatuor tempo­ <lb/> rum; et
-						posteriorem longa et brevis, tribus tempori­ <lb/> bus. Reliquus pes est
-						quatuor syllabarum, ubi omnes <lb/> auferuntur breves, ut quatuor longis pes
-						constet. Hic <lb/> in duas et duas longas secundum æquales numeros, <lb/> kl
-						est in quatuor et quatuor videlicet dividitur tempora. <lb/> Habes quod per
-						meipsum explicari voluisti: perge <lb/> jam rogando persequi caetera.</p>
+							<unclear>te</unclear><lb/>Nem tria tempora; posterior duae longae in
+						quatuor<lb/>temporibus. Secundi prior pars est longa ei brevis, ergo<lb/>
+						tria lempora; posterior duae longae, quatuor tempora.<lb/>Tertius priorem
+						pariem habet in duabus longis, qua­<lb/>tuor temporibus; posteriorem cjus
+						partem brevis et<lb/>longa obtinet, id est tria tempora. Quarti priorem
+						<lb/>partem similiter facium dux longae, quatuor tempo­<lb/>rum; et
+						posteriorem longa et brevis, tribus tempori­<lb/>bus. Reliquus pes est
+						quatuor syllabarum, ubi omnes<lb/>auferuntur breves, ut quatuor longis pes
+						constet. Hic<lb/>in duas et duas longas secundum aequales numeros,<lb/>kl
+						est in quatuor et quatuor videlicet dividitur tempora.<lb/>Habes quod per
+						meipsum explicari voluisti: perge<lb/>jam rogando persequi caetera.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT VII. — Versus <hi rend="italic">certo pedum,</hi> ut
 								<hi rend="italic">pes syllabarum</hi> numero <hi rend="italic"
@@ -1609,161 +1609,161 @@
 						</title>
 					</ab>
 					</div>
-				<div type="textpart" subtype="dialog"><p>14. M Faciam : sed satisne considerasti progres­ <lb/> sionem istam usque ad
-						quaternarium numerum, quæ <lb/> ia ipsis numeria demonstrata est, quantum in
-						his etiam <lb/> pedibus valet! <hi rend="italic">D.</hi> Ita saue in bis ut
-						in illis hanc pro­ <lb/> grediendi rationem probo. M. Quid illud! nonne ut
-						<lb/> contextis syllabis pedes facti sunt, ita etiam contextis <lb/> pcdibus
+				<div type="textpart" subtype="dialog"><p>14. M Faciam : sed satisne considerasti progres­<lb/>sionem istam usque ad
+						quaternarium numerum, quae<lb/>ia ipsis numeria demonstrata est, quantum in
+						his etiam<lb/>pedibus valet! <hi rend="italic">D.</hi> Ita saue in bis ut
+						in illis hanc pro­<lb/>grediendi rationem probo. M. Quid illud! nonne ut
+						<lb/>contextis syllabis pedes facti sunt, ita etiam contextis<lb/>pcdibus
 						aliquid fieri posse existimandum est, quod <unclear/>
-						<lb/> jam neque syllabae neque pedis nomine censeatur ? <lb/>
+						<lb/>jam neque syllabae neque pedis nomine censeatur ?<lb/>
 						<hi rend="italic">J)</hi> Omnino existimo. <hi rend="italic">M.</hi> Quid
-						tandem id putas esse! <lb/> D. Versum arbitror. 3/. Quid si perpetuo
-						contexere <lb/> quispiam pedes aliquos velit, ita ut eis modum ac fi­ <lb/>
-						nem non imponat, nisi aut delectus vocis, aut aliquis <lb/> alius casus
-						interpellans, aut temporis ratio ad aliud <lb/> aliquid transeundi ? ctiamne
-						versus a te nominabitur, <lb/> habens vel viginti vel triginta vel centum
-						etiam sive <lb/> amplius pedes, ut voluerit ac potuerit ille qui cos <lb/>
+						tandem id putas esse!<lb/>D. Versum arbitror. 3/. Quid si perpetuo
+						contexere<lb/>quispiam pedes aliquos velit, ita ut eis modum ac fi­<lb/>
+						nem non imponat, nisi aut delectus vocis, aut aliquis<lb/>alius casus
+						interpellans, aut temporis ratio ad aliud<lb/>aliquid transeundi ? ctiamne
+						versus a te nominabitur,<lb/>habens vel viginti vel triginta vel centum
+						etiam sive<lb/>amplius pedes, ut voluerit ac potuerit ille qui cos<lb/>
 						quamlibet longa perpetuitate contexit? <hi rend="italic">D.</hi> Non ita
-						<lb/> est: neque enim aut ubi pedes quoslibet quibuslibet <lb/> permixtos
-						animadvertero, aut per infinitam longitudi­ <lb/> nem multos connexos,
-						versum appellabo; sed et se­ <lb/> nus et numerum pedum, id cst qui ct quot
-						pedes vcr­ <lb/> sum conficiant aliqua disciplina consequi, et'ex ea <lb/>
-						judicare potero, utrum versus aurcs meas pepulerit. <lb/>
-						<hi rend="italic">M.</hi> At hæc quæcumque est disciplina, versibus regu­
-						<lb/> lam et modum non utique ut libitum cst, sed aliqua ra­ <lb/> tione
-						constituit. <hi rend="italic">D.</hi> Non enim aliter, siquidem disci­ <lb/>
-						plina cst, aut oportebat, aut poterat. M. Hanc ergo <lb/> rationem
-						investigemus, et assequamur, si placet: <lb/> nam si auctoritatem solam
-						intueamur, is erit versus, <lb/> quem versum diei voluit Asclepiades nescio
-						qui, aut <lb/> Archilochus, pactæ scilicet veteres, aut Sappho poe­ <lb/>
-						tria, et cæteri, quorum etiam nominibus versuum ge­ <lb/> nera vocantur,
-						qu.c primi animadvertentes cecine­ <lb/> runt. Nam et Asclepiadæus versus
-						dicitur, ct Archilu­ <lb/> cuius et Sapphicus, et alia sexcenta auctorum
-						vocabula <lb/> Graeci versibus diversi generis indiderunt. Ex quo non <lb/>
-						absurde cuipiam videri potest, quod si quis ut volet, <lb/> pedes quot
-						volet, et quos volcl ordinaverit, quia nemo <lb/> ante ipsum hunc ordinem ac
-						mensuram pedibus con­ <lb/> stituerit, recte ac jure conditor novi generis
-						versuum <lb/> propagatorque dicctur. Aut si hæc licentia intercludi­ <lb/>
-						tur homini, cum conquestione quærend;un cst quid <lb/> tandem ilii
-						meruerunt, si nullam rationem seculi, <lb/> connexionem pedum quos illis
-						connectere placmt, <lb/>
-						<lb/> versam appellari haberique fecerant. An tibi aliter vi­ <lb/> detur?
+						<lb/>est: neque enim aut ubi pedes quoslibet quibuslibet<lb/>permixtos
+						animadvertero, aut per infinitam longitudi­<lb/>nem multos connexos,
+						versum appellabo; sed et se­<lb/>nus et numerum pedum, id cst qui ct quot
+						pedes vcr­<lb/>sum conficiant aliqua disciplina consequi, et'ex ea<lb/>
+						judicare potero, utrum versus aurcs meas pepulerit.<lb/>
+						<hi rend="italic">M.</hi> At haec quaecumque est disciplina, versibus regu­
+						<lb/>lam et modum non utique ut libitum cst, sed aliqua ra­<lb/>tione
+						constituit. <hi rend="italic">D.</hi> Non enim aliter, siquidem disci­<lb/>
+						plina cst, aut oportebat, aut poterat. M. Hanc ergo<lb/>rationem
+						investigemus, et assequamur, si placet:<lb/>nam si auctoritatem solam
+						intueamur, is erit versus,<lb/>quem versum diei voluit Asclepiades nescio
+						qui, aut<lb/>Archilochus, pactae scilicet veteres, aut Sappho poe­<lb/>
+						tria, et caeteri, quorum etiam nominibus versuum ge­<lb/>nera vocantur,
+						qu.c primi animadvertentes cecine­<lb/>runt. Nam et Asclepiadaeus versus
+						dicitur, ct Archilu­<lb/>cuius et Sapphicus, et alia sexcenta auctorum
+						vocabula<lb/>Graeci versibus diversi generis indiderunt. Ex quo non<lb/>
+						absurde cuipiam videri potest, quod si quis ut volet,<lb/>pedes quot
+						volet, et quos volcl ordinaverit, quia nemo<lb/>ante ipsum hunc ordinem ac
+						mensuram pedibus con­<lb/>stituerit, recte ac jure conditor novi generis
+						versuum<lb/>propagatorque dicctur. Aut si haec licentia intercludi­<lb/>
+						tur homini, cum conquestione quaerend;un cst quid<lb/>tandem ilii
+						meruerunt, si nullam rationem seculi,<lb/>connexionem pedum quos illis
+						connectere placmt,<lb/>
+						<lb/>versam appellari haberique fecerant. An tibi aliter vi­<lb/>detur?
 							<hi rend="italic">D.</hi> Ita vero est ut dicis, et prorsus assentior,
-						<lb/> ratione potius quam auctoritate versum esse genera­ <lb/> tum, quam
+						<lb/>ratione potius quam auctoritate versum esse genera­<lb/>tum, quam
 						peto jamjamque videamus.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT VIII.— <hi rend="italic">Varia pedum nomina.</hi>
 						</title>
 					</ab>
 					</div>
-				<div type="textpart" subtype="dialog"><p>15. <hi rend="italic">M.</hi> Videamus ergo qui pedes sibimet copulan­ <lb/>
-						di sint, deinde quid his copulatis liat (non enim ver­ <lb/> sus fit solus);
-						postremo de versus tota ratione tracta­ <lb/> bimus. Sed num censes commode
-						ista nos posse per­ <lb/> sequi, nisi pedum nomina teneamus! Quanquam hac
-						<lb/> ordine a nobis digesti sunt, ut possint ipsius sui or­ <lb/> dinis
-						nominibus nuncupari : dici enim potest, primus, <lb/> secundus, tertius,
-						atque hoc modo cæteri. Sed qnia <lb/> non sunt contemnenda vetusta vocabula,
-						nec facile a <lb/> consuetudine recedendum, nisi quae rationi adversa­ <lb/>
-						tur; utendum est his nominibus pedum quæ Greci in­ <lb/> stituerunt, et
-						nostri jam utuntur pro latinis : quæ <lb/> plane ita usurpemus, ut nou
-						qureramus origines no­ <lb/> minum. Mullum enim habet ista res loquacitatis,
-						nti­ <lb/> litatis parum. Neque euim eo minus utiliter in io­ <lb/> quendo
-						appellas panem, lignum, lapidem, quod nescis <lb/> cur haec ita sint
-						appellata. <hi rend="italic">D.</hi> Ita prorsus, ut dicis , <lb/>
+				<div type="textpart" subtype="dialog"><p>15. <hi rend="italic">M.</hi> Videamus ergo qui pedes sibimet copulan­<lb/>
+						di sint, deinde quid his copulatis liat (non enim ver­<lb/>sus fit solus);
+						postremo de versus tota ratione tracta­<lb/>bimus. Sed num censes commode
+						ista nos posse per­<lb/>sequi, nisi pedum nomina teneamus! Quanquam hac
+						<lb/>ordine a nobis digesti sunt, ut possint ipsius sui or­<lb/>dinis
+						nominibus nuncupari : dici enim potest, primus,<lb/>secundus, tertius,
+						atque hoc modo caeteri. Sed qnia<lb/>non sunt contemnenda vetusta vocabula,
+						nec facile a<lb/>consuetudine recedendum, nisi quae rationi adversa­<lb/>
+						tur; utendum est his nominibus pedum quae Greci in­<lb/>stituerunt, et
+						nostri jam utuntur pro latinis : quae<lb/>plane ita usurpemus, ut nou
+						qureramus origines no­<lb/>minum. Mullum enim habet ista res loquacitatis,
+						nti­<lb/>litatis parum. Neque euim eo minus utiliter in io­<lb/>quendo
+						appellas panem, lignum, lapidem, quod nescis<lb/>cur haec ita sint
+						appellata. <hi rend="italic">D.</hi> Ita prorsus, ut dicis ,<lb/>
 						sontio.</p>
-					<p>M. Primus pes vocatur Pyrrhichius, ex duabus brevi­ <lb/> bus, temporum duum,
+					<p>M. Primus pes vocatur Pyrrhichius, ex duabus brevi­<lb/>bus, temporum duum,
 						ut <hi rend="italic">fuga.</hi>
 					</p>
 					<p>Secundus, lanibus, ex brevi eL longa, ut <hi rend="italic">parens,</hi> tem­
-						<lb/> porum trium.</p>
-					<p>Tertius, Trochxus, vtl Chorius, ex longa ct brevi, ut <lb/>
+						<lb/>porum trium.</p>
+					<p>Tertius, Trochxus, vtl Chorius, ex longa ct brevi, ut<lb/>
 						<hi rend="italic">meta,</hi> temporum trium.</p>
-					<p>Quartus, Spondeus, ex duabus longis, ut <hi rend="italic">æstas,</hi> tem:
-						<lb/> porum quatuor.</p>
-					<p>Quintus, Tribracbus, ex tribus brevibus, ut macula, <lb/> temporum trium.</p>
-					<p>Sextus, Dactylus, ex longa at duabus brevibus, ut <lb/>
-						<hi rend="italic">Mænalus,</hi> temporum quatuor.</p>
-					<p>Septimus, Amphibrachus, ex brevi et longa ct brevi, <lb/> ut <hi
+					<p>Quartus, Spondeus, ex duabus longis, ut <hi rend="italic">aestas,</hi> tem:
+						<lb/>porum quatuor.</p>
+					<p>Quintus, Tribracbus, ex tribus brevibus, ut macula,<lb/>temporum trium.</p>
+					<p>Sextus, Dactylus, ex longa at duabus brevibus, ut<lb/>
+						<hi rend="italic">Maenalus,</hi> temporum quatuor.</p>
+					<p>Septimus, Amphibrachus, ex brevi et longa ct brevi,<lb/>ut <hi
 							rend="italic">carina,</hi> temporum quatuor.</p>
-					<p>Octavus, Anapaestus, ex duabus brevibus et longa, ut <lb/>
+					<p>Octavus, Anapaestus, ex duabus brevibus et longa, ut<lb/>
 						<hi rend="italic">Erato,</hi> temporum quatuor.</p>
-					<p>Nonus, Bacchius, ex brevi et duabus longis, ut Acha­ <lb/> tes, temporum
+					<p>Nonus, Bacchius, ex brevi et duabus longis, ut Acha­<lb/>tes, temporum
 						quinque.</p>
-					<p>Decimus, Creticus vel Amphimacrus, ex longa ei bre­ <lb/> vi et longa, ut <hi
-							rend="italic">insulæ,</hi> temporum quinque.</p>
-					<p>Undecimus, Palimbacchius, ex duabus longis et brevi, <lb/>
+					<p>Decimus, Creticus vel Amphimacrus, ex longa ei bre­<lb/>vi et longa, ut <hi
+							rend="italic">insulae,</hi> temporum quinque.</p>
+					<p>Undecimus, Palimbacchius, ex duabus longis et brevi,<lb/>
 						<hi rend="italic">utnatura9</hi> temporum quinque.</p>
-					<p>Duodecimus, Molossus, ex tribus longis, ut <hi rend="italic">Æneas,</hi>
-						<lb/> temporum sex.</p>
-					<p>Decimus tertius, Proceleumaticus, ox quatuor brevi­ <lb/> bus, <hi
+					<p>Duodecimus, Molossus, ex tribus longis, ut <hi rend="italic">aeneas,</hi>
+						<lb/>temporum sex.</p>
+					<p>Decimus tertius, Proceleumaticus, ox quatuor brevi­<lb/>bus, <hi
 							rend="italic">utavicula,</hi> temporum quatuor.</p>
-					<p>Decimus quartus, Pæon primus, ex prima longa et <lb/> tribus brevibus, ut
+					<p>Decimus quartus, Paeon primus, ex prima longa et<lb/>tribus brevibus, ut
 						legitimus, temporum quinque.</p>
-					<p>Decimus quintus, Pæon secundus, ex secunda longa <lb/> et tribus brevibus, m
+					<p>Decimus quintus, Paeon secundus, ex secunda longa<lb/>et tribus brevibus, m
 							<hi rend="italic">colonia,</hi> temporum quinque.</p>
-					<p>Decimus sextus, Pæon tertius, ex tertia longa et tribus <lb/> brevibus. ut
+					<p>Decimus sextus, Paeon tertius, ex tertia longa et tribus<lb/>brevibus. ut
 							<hi rend="italic">Menedemus,</hi> temporum quinque.</p>
-					<p>Decimus septimus, Pxon quartus, ex quarta longa <lb/>
+					<p>Decimus septimus, Pxon quartus, ex quarta longa<lb/>
 						<pb n="1009"/> et tribus brevibus, ut <hi rend="italic">celeritas,</hi>
-						temporum quln­ <lb/> que.</p>
-					<p>Decimus octavus, Ionicus a minore, ex duabus bre­ <lb/> vtbus et duabus
-						longis, ut <hi rend="italic">Diomedea,</hi> temporum <lb/> sex.</p>
-					<p>Decimus nomus, Choriambus, ex longa ct duabus <lb/> brevibus ct longa, ut <hi
+						temporum quln­<lb/>que.</p>
+					<p>Decimus octavus, Ionicus a minore, ex duabus bre­<lb/>vtbus et duabus
+						longis, ut <hi rend="italic">Diomedea,</hi> temporum<lb/>sex.</p>
+					<p>Decimus nomus, Choriambus, ex longa ct duabus<lb/>brevibus ct longa, ut <hi
 							rend="italic">armipotens,</hi> temporum sex.</p>
-					<p>Vigesimos, lonicus a majore, ex duabus longis et dua­ <lb/> bus brevibus, ut
+					<p>Vigesimos, lonicus a majore, ex duabus longis et dua­<lb/>bus brevibus, ut
 							<hi rend="italic">Junonius,</hi> temporum sex.</p>
-					<p>Vigesimus primus, Diiambus, ex brevi ct longa, et <lb/> brevi et longa, ut
+					<p>Vigesimus primus, Diiambus, ex brevi ct longa, et<lb/>brevi et longa, ut
 							<hi rend="italic">propinquitas,</hi> temporum sex.</p>
-					<p>Vigesimus sccundus, Dichorius vel Ditrochæus, ex <lb/> longa et brevi, et
-						longa et brevi, ut <hi rend="italic">caniilena</hi> tcm­ <lb/> porum
+					<p>Vigesimus sccundus, Dichorius vel Ditrochaeus, ex<lb/>longa et brevi, et
+						longa et brevi, ut <hi rend="italic">caniilena</hi> tcm­<lb/>porum
 						sex.</p>
-					<p>Vigesimus tertius, Antispastus, ex brevi ct duabus <lb/> longis it brevi, ut
+					<p>Vigesimus tertius, Antispastus, ex brevi ct duabus<lb/>longis it brevi, ut
 							<hi rend="italic">Saloninus,</hi> temporum sex.</p>
-					<p>Vigesimus quartus, Epitritus primus, ex prima brevi <lb/> et tribus longis,
+					<p>Vigesimus quartus, Epitritus primus, ex prima brevi<lb/>et tribus longis,
 						ut sacerdotes, temporum septem.</p>
-					<p>Vigesimus quintus, Epitritus sccundus, ex secunda <lb/> brevi et tribus
-						longis, ut <hi rend="italic">conditores,</hi> temporum sc­ <lb/> ptem.</p>
-					<p>Yigesimus sextus, Epitritus tertius, ex tertia brevi et <lb/> tribus longis,
+					<p>Vigesimus quintus, Epitritus sccundus, ex secunda<lb/>brevi et tribus
+						longis, ut <hi rend="italic">conditores,</hi> temporum sc­<lb/>ptem.</p>
+					<p>Yigesimus sextus, Epitritus tertius, ex tertia brevi et<lb/>tribus longis,
 						ut <hi rend="italic">Demosthenes,</hi> temporum septem.</p>
-					<p>Vigesimus septimus, Epitritus quartus, cx quarta <lb/> brevi cl tribus
-						longis, ut Fescenninus, temporum se­ <lb/> ptem.</p>
-					<p>Vigesimus octavus, Dispondeus, ex quatuor longis, <lb/> ut <hi rend="italic"
+					<p>Vigesimus septimus, Epitritus quartus, cx quarta<lb/>brevi cl tribus
+						longis, ut Fescenninus, temporum se­<lb/>ptem.</p>
+					<p>Vigesimus octavus, Dispondeus, ex quatuor longis,<lb/>ut <hi rend="italic"
 							>oratores,</hi> temporum octo I.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT IX.— <hi rend="italic">De pedum structura.</hi>
 						</title>
 					</ab>
 					</div>
-				<div type="textpart" subtype="dialog"><p><lb/> 16. <hi rend="italic">D.</hi> Habeo ista. Nunc dissere , qui sibi pedes
-						<lb/> copulentur. <hi rend="italic">M.</hi> Judicabis boc facile, si
-						æqualitatem <lb/> ac similitudinem inæqualitati ac dissimilitudini præ­
-						<lb/> stantiorem esse judicas. D. Ncminem esse arbitror, <lb/> qui non ita
-						judicet. <hi rend="italic">M.</hi> Ilanc ergo prius maxime in <lb/>
-						contexendis pedibus sequi oportet, nec ab ea omnino <lb/> deviandum, nisi
+				<div type="textpart" subtype="dialog"><p><lb/>16. <hi rend="italic">D.</hi> Habeo ista. Nunc dissere , qui sibi pedes
+						<lb/>copulentur. <hi rend="italic">M.</hi> Judicabis boc facile, si
+						aequalitatem<lb/>ac similitudinem inaequalitati ac dissimilitudini prae­
+						<lb/>stantiorem esse judicas. D. Ncminem esse arbitror,<lb/>qui non ita
+						judicet. <hi rend="italic">M.</hi> Ilanc ergo prius maxime in<lb/>
+						contexendis pedibus sequi oportet, nec ab ea omnino<lb/>deviandum, nisi
 						cum aliqua causa justissima est. <hi rend="italic">D.</hi>
-						<lb/> Assentior. <hi rend="italic">M.</hi> Non igitur dubitabis pyrrhichios
-						sibimet <lb/> pedes contexere, nec iambos, nec trochaeos qui etiam <lb/>
-						chorii nominantur, nec spondeos; atque ita caeteros <lb/> sui gcneris
-						profecto sibimet sine ulla dubitatione co­ <lb/> pulabis : est enim summa
-						aequalitas cum ejusdem ge­ <lb/> neris et nominis pedes sese consequuntur.
-						An tibi non <lb/> videtur? <hi rend="italic">D.</hi> Nullo modo niihi aliter
+						<lb/>Assentior. <hi rend="italic">M.</hi> Non igitur dubitabis pyrrhichios
+						sibimet<lb/>pedes contexere, nec iambos, nec trochaeos qui etiam<lb/>
+						chorii nominantur, nec spondeos; atque ita caeteros<lb/>sui gcneris
+						profecto sibimet sine ulla dubitatione co­<lb/>pulabis : est enim summa
+						aequalitas cum ejusdem ge­<lb/>neris et nominis pedes sese consequuntur.
+						An tibi non<lb/>videtur? <hi rend="italic">D.</hi> Nullo modo niihi aliter
 						videri potest. <hi rend="italic">M.</hi>
-						<lb/> Quid ? illud nonne approbas, alios aliis pedes æquali­ <lb/> tate
-						servata esse miscendos ? Quid enim auribus po­ <lb/> test jucundius esse,
-						quam cum et varietate mulcentur, <lb/> nec æqualitate fraudantur? <hi
-							rend="italic">D.</hi> Satis probo. M. Num <lb/> censes alios æquales
-						habendos pedes, nisi qui ejusdem <lb/> mensurx sunt? <hi rend="italic"
-							>D.</hi> Ita existimo. M. Quid? ejusdem <lb/> mensuræ putandine sunt,
-						nisi qui temporis tantum­ <lb/> dcm occupant? <hi rend="italic">D.</hi>
-						Verum est. II. Quos crgo invene­ <lb/> ris pedes lolidcm temporum, sine
-						aurium offensione <lb/> contexes. <hi rend="italic">D.</hi> Video esse
+						<lb/>Quid ? illud nonne approbas, alios aliis pedes aequali­<lb/>tate
+						servata esse miscendos ? Quid enim auribus po­<lb/>test jucundius esse,
+						quam cum et varietate mulcentur,<lb/>nec aequalitate fraudantur? <hi
+							rend="italic">D.</hi> Satis probo. M. Num<lb/>censes alios aequales
+						habendos pedes, nisi qui ejusdem<lb/>mensurx sunt? <hi rend="italic"
+							>D.</hi> Ita existimo. M. Quid? ejusdem<lb/>mensurae putandine sunt,
+						nisi qui temporis tantum­<lb/>dcm occupant? <hi rend="italic">D.</hi>
+						Verum est. II. Quos crgo invene­<lb/>ris pedes lolidcm temporum, sine
+						aurium offensione<lb/>contexes. <hi rend="italic">D.</hi> Video esse
 						consequens. <note type="footnote"> I Libri veteres aLsque explicatione et
-							exemplo uno sic <lb/> Ipedes recensent: trtinus <hi rend="italic">pes
-								vocatur Pyrrhichus, seam­<lb/> dns Iambus, Tertius,</hi> etc.,
-							scriptumque constanter praefe­ <lb/> runt <hi rend="italic">spondtus,
+							exemplo uno sic<lb/>Ipedes recensent: trtinus <hi rend="italic">pes
+								vocatur Pyrrhichus, seam­<lb/>dns Iambus, Tertius,</hi> etc.,
+							scriptumque constanter praefe­<lb/>runt <hi rend="italic">spondtus,
 								dispondiusy paan,</hi> pro <hi rend="italic">spondeus, dLpotideiis,
-								<lb/> væon.</hi> Itein i ro <hi rend="italic">tribracltus</hi> ct
-								<hi rend="italic">amphibrachus,</hi> habent aliquo­ <lb/> li05 <hi
+								<lb/>vaeon.</hi> Itein i ro <hi rend="italic">tribracltus</hi> ct
+								<hi rend="italic">amphibrachus,</hi> habent aliquo­<lb/>li05 <hi
 								rend="italic">tribrachijs</hi> et <hi rend="italic"
 								>amphibrachys.</hi>
 						</note>
@@ -1775,301 +1775,301 @@
 						</title>
 					</ab>
 					</div>
-				<div type="textpart" subtype="dialog"><p>17. M. Recte quidem : sed adhuc nonnihil quæ­ <lb/> stiools rcs habet.Namcum
-						Amphibrachus pes quatuor <lb/> sit temporum, negant eum quidam posse
-						misceri, vel <lb/> dactylis vel anapæstis vcl spondeis vel proceleumati
-						<lb/> cis : nam hi sunt onUs quaternorum temporum pc­ <lb/> des : et non
-						solum istis cum negant posse misceri, <lb/> sed nec ex ipso solo rcpelito et
-						sibimet connexo, rectc <lb/> ct quasi legitime procedcre numerum putant.
-						Quo­ <lb/> rum opinionem considerarc nos oportet, ne quid ha­ <lb/> beat
+				<div type="textpart" subtype="dialog"><p>17. M. Recte quidem : sed adhuc nonnihil quae­<lb/>stiools rcs habet.Namcum
+						Amphibrachus pes quatuor<lb/>sit temporum, negant eum quidam posse
+						misceri, vel<lb/>dactylis vel anapaestis vcl spondeis vel proceleumati
+						<lb/>cis : nam hi sunt onUs quaternorum temporum pc­<lb/>des : et non
+						solum istis cum negant posse misceri,<lb/>sed nec ex ipso solo rcpelito et
+						sibimet connexo, rectc<lb/>ct quasi legitime procedcre numerum putant.
+						Quo­<lb/>rum opinionem considerarc nos oportet, ne quid ha­<lb/>beat
 						rationis, quod scqui ct approbare conveniat. <hi rend="italic">D.</hi>
-						<lb/> Cupio atque aveo prorsus audire quid an'erant. Non <lb/> cnim parum me
-						movet, cum duodetriginta pedes sint, <lb/> quos ratio persecuta cst, hunc
-						solum excludi a conti­ <lb/> nualione nunicrorum, cum tantum spatii teneat
-						in <lb/> tempore quantum dactylus et alii quos parcs enume­ <lb/> fasti,
-						quos connectere ncmo prohibetur. M. Atqui <lb/> epus est, ut hoc dispicere
-						valeas, consideraTe cæteros. <lb/> pedes, quemadmodum sihimcl eorum partes
-						conferan­ <lb/> tur : ita enim videbis huic uni quiddam accidere no­ <lb/>
-						vum ac singulare, ut non frustra minime adhibendus <lb/> ad numerus
+						<lb/>Cupio atque aveo prorsus audire quid an'erant. Non<lb/>cnim parum me
+						movet, cum duodetriginta pedes sint,<lb/>quos ratio persecuta cst, hunc
+						solum excludi a conti­<lb/>nualione nunicrorum, cum tantum spatii teneat
+						in<lb/>tempore quantum dactylus et alii quos parcs enume­<lb/>fasti,
+						quos connectere ncmo prohibetur. M. Atqui<lb/>epus est, ut hoc dispicere
+						valeas, consideraTe caeteros.<lb/>pedes, quemadmodum sihimcl eorum partes
+						conferan­<lb/>tur : ita enim videbis huic uni quiddam accidere no­<lb/>
+						vum ac singulare, ut non frustra minime adhibendus<lb/>ad numerus
 						judicatus sit.</p>
 				</div>
-				<div type="textpart" subtype="dialog"><p>18. Sed hoc nobis considerantibus, opus est h:rc <lb/> duo nomina mandare
-						memoriæ, levationem et posi­ <lb/> tionem. In plaudendo enim quia levatur et
-						ponitur <lb/> manus, partem pedis sibi levatio vindicat, partem po­ <lb/>
-						sitio. Partes autem pedum dico illas, de quibus supc­ <lb/> rius, cum eos
-						ordine persequeremur, satis dictum est. <lb/> Quocirca si hoc probas, incipe
-						recensere breviter <lb/> mensuras partium in omnibus pedibus, ut quid huic
-						<lb/> uni de quo agitur proprium acciderit, novcris. <hi rend="italic"
-							>D.</hi> Vi­ <lb/> deo primum pyrrhichium tantum habere in levatione
-						<lb/> quantum in positione. Spoudeus quoque, dactylus, <lb/> anapaestus,
-						proceleumaticus, choriambus, diiambus, <lb/> dichorius, antispastus,
-						dispondeus, eadem ratione <lb/> dividuntur : nam tantumdem temporis in his
-						ponit <lb/> plausus, quantum levat. Video secundum, iambum <lb/> simpli
-						etdupli habere rationem; quam rationem cerno <lb/> et inchorio et in
-						tribracho et in molosso, et in utro­ <lb/> que ionico. Jam hujus amphibrachi
-						lcvatio ut positio <lb/> (nam ipsa mihi ex ordine occurrit, cui pares
-						cæteros <lb/> quxram), simpli ct tripli ratione constat. Sed nou in <lb/>
-						venio prorsus alium deinceps, cujus sibi partes tanto <lb/> intervallo
-						conferantur. Nam cum cos considero in qui­ <lb/> bus nna brevis est et dux
-						long;c, id cst bacchium, <lb/> creticum et palimbacchium, sesquialteri
-						numeri ra­ <lb/> tionc levationem ac positionem in his fieri vidco. <lb/>
-						Eadem ratio est et in iis quatuor, in quibus nna longa <lb/> est ct tres
-						breves, qui quatuor pxoncs ex ordine no­ <lb/> minantur. Reliqui sunt
-						quatuor epitriti similiter ex <lb/> ordine nuncupati, quorum levationem ac
-						positionem <lb/> sesquitertius numerus continet.</p>
+				<div type="textpart" subtype="dialog"><p>18. Sed hoc nobis considerantibus, opus est h:rc<lb/>duo nomina mandare
+						memoriae, levationem et posi­<lb/>tionem. In plaudendo enim quia levatur et
+						ponitur<lb/>manus, partem pedis sibi levatio vindicat, partem po­<lb/>
+						sitio. Partes autem pedum dico illas, de quibus supc­<lb/>rius, cum eos
+						ordine persequeremur, satis dictum est.<lb/>Quocirca si hoc probas, incipe
+						recensere breviter<lb/>mensuras partium in omnibus pedibus, ut quid huic
+						<lb/>uni de quo agitur proprium acciderit, novcris. <hi rend="italic"
+							>D.</hi> Vi­<lb/>deo primum pyrrhichium tantum habere in levatione
+						<lb/>quantum in positione. Spoudeus quoque, dactylus,<lb/>anapaestus,
+						proceleumaticus, choriambus, diiambus,<lb/>dichorius, antispastus,
+						dispondeus, eadem ratione<lb/>dividuntur : nam tantumdem temporis in his
+						ponit<lb/>plausus, quantum levat. Video secundum, iambum<lb/>simpli
+						etdupli habere rationem; quam rationem cerno<lb/>et inchorio et in
+						tribracho et in molosso, et in utro­<lb/>que ionico. Jam hujus amphibrachi
+						lcvatio ut positio<lb/>(nam ipsa mihi ex ordine occurrit, cui pares
+						caeteros<lb/>quxram), simpli ct tripli ratione constat. Sed nou in<lb/>
+						venio prorsus alium deinceps, cujus sibi partes tanto<lb/>intervallo
+						conferantur. Nam cum cos considero in qui­<lb/>bus nna brevis est et dux
+						long;c, id cst bacchium,<lb/>creticum et palimbacchium, sesquialteri
+						numeri ra­<lb/>tionc levationem ac positionem in his fieri vidco.<lb/>
+						Eadem ratio est et in iis quatuor, in quibus nna longa<lb/>est ct tres
+						breves, qui quatuor pxoncs ex ordine no­<lb/>minantur. Reliqui sunt
+						quatuor epitriti similiter ex<lb/>ordine nuncupati, quorum levationem ac
+						positionem<lb/>sesquitertius numerus continet.</p>
 					<p>19. <hi rend="italic">II.</hi> Num igitur parum libi justa causa videtur
-						<lb/> esse, cur iste pes (a) ad sericIn numerosam vocum <lb/> non
-						admittatur, quod solius partes tam longe a sc dif­ <lb/> fcrant, ut una
+						<lb/>esse, cur iste pes (a) ad sericIn numerosam vocum<lb/>non
+						admittatur, quod solius partes tam longe a sc dif­<lb/>fcrant, ut una
 						simpla sii, alia tripla? Vicinitas cuim <note type="footnote">(o) Ami
 							bibrachus. </note>
 						<lb/>
-						<pb n="1111"/> quædam partium tanto est approbatione dignior, <lb/> quanto
-						est proxima æqualitati. Itaque in illa regula 1 <lb/> numerorum CUDI ali uno
-						usque ad quatuor progredi­ <lb/> mur, nihil unicuique est scipso
-						propinquius. Quare <lb/> illud in pritnis approbandum est in pcdibus, cum
-						lan­ <lb/> tudem habent partes ad invicem; deinde copulatio <lb/> simpli et
-						dupli eminet in uno et duobus; sesquialtera <lb/> vcro copulatio in duobus
-						et tribus apparet; jam ses­ <lb/> quitertia, tribus et quatuor. Simplum vero
-						et triplum <lb/> quanquam complicatorum numerorum loge tcneatur, <lb/> non
-						tamen in ordine illo sibimet cohæret : non enim <lb/> post unum tria
-						numeramus, sed ab uno ad ternarium <lb/> numerum binario interposito
-						pervenitur. Haec ratio <lb/> est qua excludendus judicatur amphibrachus pes
-						ab <lb/> ea copulatione dc qua quaerimus 2, quæ si abs te pro­ <lb/> batur,
-						cætera videamus. <hi rend="italic">D.</hi> Probatur sane nam ma­ <lb/>
+						<pb n="1111"/> quaedam partium tanto est approbatione dignior,<lb/>quanto
+						est proxima aequalitati. Itaque in illa regula 1<lb/>numerorum CUDI ali uno
+						usque ad quatuor progredi­<lb/>mur, nihil unicuique est scipso
+						propinquius. Quare<lb/>illud in pritnis approbandum est in pcdibus, cum
+						lan­<lb/>tudem habent partes ad invicem; deinde copulatio<lb/>simpli et
+						dupli eminet in uno et duobus; sesquialtera<lb/>vcro copulatio in duobus
+						et tribus apparet; jam ses­<lb/>quitertia, tribus et quatuor. Simplum vero
+						et triplum<lb/>quanquam complicatorum numerorum loge tcneatur,<lb/>non
+						tamen in ordine illo sibimet cohaeret : non enim<lb/>post unum tria
+						numeramus, sed ab uno ad ternarium<lb/>numerum binario interposito
+						pervenitur. Haec ratio<lb/>est qua excludendus judicatur amphibrachus pes
+						ab<lb/>ea copulatione dc qua quaerimus 2, quae si abs te pro­<lb/>batur,
+						caetera videamus. <hi rend="italic">D.</hi> Probatur sane nam ma­<lb/>
 						nifestissima atque certissima est.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT XI. — <hi rend="italic">Pedum rationalibis</hi>
 							mixlura.</title>
 					</ab>
-					<p>20. <hi rend="italic">Al.</hi> Cum ergo placcat, quoquo modo se in <lb/>
-						syllabis habeant, tamen si ejusdem spatii sint in tem­ <lb/> pore, recte
-						sibi ct sine detrimento æqualitatis pedes <lb/> posse misceri, cxcepto
-						duntaxat amphibracho; quaeri <lb/> non immerito potest, utrum recte
-						misceantur, qui <lb/> quanquam sint aequales tempore, non eadem tamen <lb/>
-						percussione concordant, quæ levatione ac positionc <lb/> paries pcdis
-						sihimct confert. Nam dactylus et ana­ <lb/> pæstus et spondens non solum
-						æqualium temporum <lb/> sunt, sed etiam percutiuntur aequaliter : in omnibus
-						<lb/> caim tantum Icvatio, quantum positio sibi vindicat. <lb/> Itaque hi
-						sibi miscentur justius qunm quilibet ionicus <lb/> cæteris sex temporum
-						pedibus. Uterque quippe ioni­ <lb/> cus ad simplum et duplum percutitur, duo
-						scilicet <lb/> tempora quatuor temporibus conferens. Ilis molossus <lb/>
-						etiam in hac re congruit. Cæteri vero (a) ad tantum­ <lb/> dem ; nam in his
-						levationi ac positioni terna tempora <lb/> tribuuntur. Ergo tametsi omnes
-						legitime feriantur; <lb/> nam et illi Ires simpli et dupli ratione, et alii
-						quatuor <lb/> æquis partibus feriuntur; tamen quia plausum inaequa­ <lb/>
-						lem facit ista permixtio, haud scio an jure repudietur: <lb/> nisi quid
-						habes ad hæc. D. Proclivior sum in isfam <lb/> sententiam. Nam inæqualis
-						plausus quomodo sensum <lb/> non offendat ignoro : si autem offendit, non
-						utique id <lb/> potest sine vitio hujus permixtionis accidere.</p>
+					<p>20. <hi rend="italic">Al.</hi> Cum ergo placcat, quoquo modo se in<lb/>
+						syllabis habeant, tamen si ejusdem spatii sint in tem­<lb/>pore, recte
+						sibi ct sine detrimento aequalitatis pedes<lb/>posse misceri, cxcepto
+						duntaxat amphibracho; quaeri<lb/>non immerito potest, utrum recte
+						misceantur, qui<lb/>quanquam sint aequales tempore, non eadem tamen<lb/>
+						percussione concordant, quae levatione ac positionc<lb/>paries pcdis
+						sihimct confert. Nam dactylus et ana­<lb/>paestus et spondens non solum
+						aequalium temporum<lb/>sunt, sed etiam percutiuntur aequaliter : in omnibus
+						<lb/>caim tantum Icvatio, quantum positio sibi vindicat.<lb/>Itaque hi
+						sibi miscentur justius qunm quilibet ionicus<lb/>caeteris sex temporum
+						pedibus. Uterque quippe ioni­<lb/>cus ad simplum et duplum percutitur, duo
+						scilicet<lb/>tempora quatuor temporibus conferens. Ilis molossus<lb/>
+						etiam in hac re congruit. Caeteri vero (a) ad tantum­<lb/>dem ; nam in his
+						levationi ac positioni terna tempora<lb/>tribuuntur. Ergo tametsi omnes
+						legitime feriantur;<lb/>nam et illi Ires simpli et dupli ratione, et alii
+						quatuor<lb/>aequis partibus feriuntur; tamen quia plausum inaequa­<lb/>
+						lem facit ista permixtio, haud scio an jure repudietur:<lb/>nisi quid
+						habes ad haec. D. Proclivior sum in isfam<lb/>sententiam. Nam inaequalis
+						plausus quomodo sensum<lb/>non offendat ignoro : si autem offendit, non
+						utique id<lb/>potest sine vitio hujus permixtionis accidere.</p>
 					<p>it. <hi rend="italic">M.</hi> Atqui scias veteres miscendos judicasse istos
-						<lb/> pedes, et horum mixtione versus compositos condi­ <lb/> disse. Sed ne
-						te auctoritate premere videar, accipe <lb/> aliquid horum versuum, et vide
-						utrum offendat audi­ <lb/> tum. Si cnim non modo non offenderit, sed etiam
-						de­ <lb/> lectaverit, nulla erit ratio hujus mixtionis improbandæ. <lb/>
-						Versus autem ii sunt quos advertas volo : <lb/> At consona quae sunt, nisi
-						voca'ibus aptes, <lb/> Pars diinidium vocis ot us proeret ex se : <lb/> Pars
-						muta soni comprimet ora molientum : <lb/> llUs sonus obscurior
-						impeditiorque, <lb/> Utrumque tamen promitur ore semicluso. <lb/>
+						<lb/>pedes, et horum mixtione versus compositos condi­<lb/>disse. Sed ne
+						te auctoritate premere videar, accipe<lb/>aliquid horum versuum, et vide
+						utrum offendat audi­<lb/>tum. Si cnim non modo non offenderit, sed etiam
+						de­<lb/>lectaverit, nulla erit ratio hujus mixtionis improbandae.<lb/>
+						Versus autem ii sunt quos advertas volo :<lb/>At consona quae sunt, nisi
+						voca'ibus aptes,<lb/>Pars diinidium vocis ot us proeret ex se :<lb/>Pars
+						muta soni comprimet ora molientum :<lb/>llUs sonus obscurior
+						impeditiorque,<lb/>Utrumque tamen promitur ore semicluso.<lb/>
 						<hi rend="italic">(Terentianus.)</hi>
 						<note type="footnote"> I In B. deest vocula in, quam restituimus ex Er.
-							Lugd. <lb/> ven. l.ov. et iks. A et B. Nolaadum loco <hi rend="italic"
-								>illa,</hi> quoi habent <lb/> Benedictmi, esse in editis, <hi
+							Lugd.<lb/>ven. l.ov. et iks. A et B. Nolaadum loco <hi rend="italic"
+								>illa,</hi> quoi habent<lb/>Benedictmi, esse in editis, <hi
 								rend="italic">ista.</hi> M. </note><note type="footnote">' in B.,
-								<hi rend="italic">quæsivimus.</hi> F.r, Lugd. ven. Lov. nec non Ms.
-							** <lb/> A, <hi rend="italic">quwrinm.</hi> M. </note><note
+								<hi rend="italic">quaesivimus.</hi> F.r, Lugd. ven. Lov. nec non Ms.
+							**<lb/>A, <hi rend="italic">quwrinm.</hi> M. </note><note
 							type="footnote"> (11) cboriamhus, diiaJnhus. dichorius, antispastus. </note>
-						<lb/> S atis esse arbitror ad judicandum id quod volo.Quare <lb/> dic quæso,
-						utrum nihil tuas aurcs numerus iste <lb/> permul-erit. <hi rend="italic"
-							>D.</hi> Imo nihil mihi videtur currere ac <lb/> sonare festivius. <hi
-							rend="italic">M.</hi> Considera igitur pedes, inve­ <lb/> nies profecto
-						cum sint quinque versus , duos primos <lb/> solis ionicis currere, tres
-						posteriores habere ad­ <lb/> mixtum dichorium, cum omnes omnino sensum no­
-						<lb/> strum communi æqualitate delectent. <hi rend="italic">D.</hi> Jam hoc
-						<lb/> animadverti, et facilius te pronuntiante. <hi rend="italic">M.</hi>
-						Quid ergo <lb/> dubitamus consentire veteribus non eorum auctoritate, <lb/>
-						sed ipsa jam ratione victi, qui censent eos pedes qui <lb/> ejusdem temporis
-						sunt rationabiliter posse misceri, <lb/> si habeant legitimam, quamvis
-						diversam percussio­ <lb/> nem? D. Cedo jam prorsus : nam me ille sonus quid­
-						<lb/> quam Contradicere non sinit.</p>
+						<lb/>S atis esse arbitror ad judicandum id quod volo.Quare<lb/>dic quaeso,
+						utrum nihil tuas aurcs numerus iste<lb/>permul-erit. <hi rend="italic"
+							>D.</hi> Imo nihil mihi videtur currere ac<lb/>sonare festivius. <hi
+							rend="italic">M.</hi> Considera igitur pedes, inve­<lb/>nies profecto
+						cum sint quinque versus , duos primos<lb/>solis ionicis currere, tres
+						posteriores habere ad­<lb/>mixtum dichorium, cum omnes omnino sensum no­
+						<lb/>strum communi aequalitate delectent. <hi rend="italic">D.</hi> Jam hoc
+						<lb/>animadverti, et facilius te pronuntiante. <hi rend="italic">M.</hi>
+						Quid ergo<lb/>dubitamus consentire veteribus non eorum auctoritate,<lb/>
+						sed ipsa jam ratione victi, qui censent eos pedes qui<lb/>ejusdem temporis
+						sunt rationabiliter posse misceri,<lb/>si habeant legitimam, quamvis
+						diversam percussio­<lb/>nem? D. Cedo jam prorsus : nam me ille sonus quid­
+						<lb/>quam Contradicere non sinit.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT XII. — <hi rend="italic">Pedes sex</hi>
 							temporuM.</title>
 					</ab>
-					<p>22. M. Intende item in istos versus : <lb/> Volo tandem tibi parcas, labor
-						est in chartis, <lb/> Et apertum ire per auras animum permittas. <lb/>
-						Placet hoc nam sapienter, remiuere interdum <lb/> Aciem rebus agendis
-						decenter intentam. <lb/>
+					<p>22. M. Intende item in istos versus :<lb/>Volo tandem tibi parcas, labor
+						est in chartis,<lb/>Et apertum ire per auras animum permittas.<lb/>
+						Placet hoc nam sapienter, remiuere interdum<lb/>Aciem rebus agendis
+						decenter intentam.<lb/>
 						<hi rend="italic">D.</hi> Etiam hoc satis est. <hi rend="italic">M.</hi>
-						Præsertim cum isti versus <lb/> sint inconditi, quos necessitate ad tempu
-						fabricatus <lb/> sum. Verumtamen et in iis quatuor requiro judicium <lb/>
+						Praesertim cum isti versus<lb/>sint inconditi, quos necessitate ad tempu
+						fabricatus<lb/>sum. Verumtamen et in iis quatuor requiro judicium<lb/>
 						sensus tui. <hi rend="italic">D.</hi> Quid aliud et hic possum dicere, quam
-						<lb/> pulchre illos congruenterque sonuisse? M. S tisme <lb/> etiam duos
-						superiores altero ionico constare qui dici­ <lb/> tar a minore, duos autem
-						posteriores diiambum ha­ <lb/> bere permixtum? <hi rend="italic">D.</hi> Et
-						hoc te pronuntiando insi­ <lb/> nuante persensi. <hi rend="italic">II.</hi>
-						Quid? illud nonne te movet quod <lb/> in illis Terentiani versibus ionico ei
-						qui a majore d:­ <lb/> cilur, dichorius; in iis autcm nostris alteri ionico
-						qui <lb/> a minore nominatur, diiambus mixtus est? an nihil <lb/> interesse
-						arbitraris ? <hi rend="italic">D.</hi> Imo interest, ct videor m.hi <lb/>
-						rationem ipsam videre : nam quoniam ionicus a m i- <lb/> jore a duabus
-						incipit longis, eum sibi potius copulan­ <lb/> dum poscit, ubi longa prima
-						est, id cst dichorium. <lb/> Diiambus vcro quod incipit a brevi,
-						congruentius al­ <lb/> teri miscetur ionico a duabus brevibus
+						<lb/>pulchre illos congruenterque sonuisse? M. S tisme<lb/>etiam duos
+						superiores altero ionico constare qui dici­<lb/>tar a minore, duos autem
+						posteriores diiambum ha­<lb/>bere permixtum? <hi rend="italic">D.</hi> Et
+						hoc te pronuntiando insi­<lb/>nuante persensi. <hi rend="italic">II.</hi>
+						Quid? illud nonne te movet quod<lb/>in illis Terentiani versibus ionico ei
+						qui a majore d:­<lb/>cilur, dichorius; in iis autcm nostris alteri ionico
+						qui<lb/>a minore nominatur, diiambus mixtus est? an nihil<lb/>interesse
+						arbitraris ? <hi rend="italic">D.</hi> Imo interest, ct videor m.hi<lb/>
+						rationem ipsam videre : nam quoniam ionicus a m i<lb/>jore a duabus
+						incipit longis, eum sibi potius copulan­<lb/>dum poscit, ubi longa prima
+						est, id cst dichorium.<lb/>Diiambus vcro quod incipit a brevi,
+						congruentius al­<lb/>teri miscetur ionico a duabus brevibus
 						incipienti.</p>
-					<p>43. M. Bene intelligis: quare hoc quoque tenendum <lb/> est, istam etiam
-						congruentiam, excepta æqualitate <lb/> temporum, in pedibus miscendis
-						aliquantum valere <lb/> oportere : nou enim plurimum, sed tamen nonnihil
-						<lb/> valet. Nam pro omni pede sex temporum, omnem <lb/> pedem sex temporum
-						poni posse, ita sensu in­ <lb/> terrogato judices licet: primum molossi
-						exemplum <lb/> sit nobis, <hi rend="italic">virtutes</hi> : ionici a minore,
-						moderatas ; <lb/> cboriambi, <hi rend="italic">percipies</hi> : ionici a
+					<p>43. M. Bene intelligis: quare hoc quoque tenendum<lb/>est, istam etiam
+						congruentiam, excepta aequalitate<lb/>temporum, in pedibus miscendis
+						aliquantum valere<lb/>oportere : nou enim plurimum, sed tamen nonnihil
+						<lb/>valet. Nam pro omni pede sex temporum, omnem<lb/>pedem sex temporum
+						poni posse, ita sensu in­<lb/>terrogato judices licet: primum molossi
+						exemplum<lb/>sit nobis, <hi rend="italic">virtutes</hi> : ionici a minore,
+						moderatas ;<lb/>cboriambi, <hi rend="italic">percipies</hi> : ionici a
 						majore, <hi rend="italic">concedere :</hi>
-						<lb/> diiambi, benignitas : dichorii, civitasque : antispasti, <lb/>
+						<lb/>diiambi, benignitas : dichorii, civitasque : antispasti,<lb/>
 						<hi rend="italic">volet justa. D.</hi> Habeo ista. M. Contexe igitur isti
-						<lb/> omnia atque pronuntia, vel me potius pronuntian e <lb/> accipc, quo ad
-						judicandum liberior sensusvacel. Nam <lb/> ut continuati numeri æqualitatem
-						sine ulla offensi one <lb/> aurium tibi insinuem, hoc totum contextum ter
-						pro <lb/> nuntiabo, quod satis esse non dubitaverim. Virtutes <lb/>
+						<lb/>omnia atque pronuntia, vel me potius pronuntian e<lb/>accipc, quo ad
+						judicandum liberior sensusvacel. Nam<lb/>ut continuati numeri aequalitatem
+						sine ulla offensi one<lb/>aurium tibi insinuem, hoc totum contextum ter
+						pro<lb/>nuntiabo, quod satis esse non dubitaverim. Virtutes<lb/>
 						moderatas <hi rend="italic">percipies, concedere benignitas civitasque
-							vo­<lb/> let justa. Virtutes moderatas percipies, concedere beni­ <lb/>
-							gnitas civitasque volet justa. Virtutes moderatas perci - <lb/> pies,
-							concedere benignitas civitasque volet juata.</hi> Num <lb/> fortc
-						aliquid in hoc pedum cursu aures tuas æqualitate <lb/>
+							vo­<lb/>let justa. Virtutes moderatas percipies, concedere beni­<lb/>
+							gnitas civitasque volet justa. Virtutes moderatas perci<lb/>pies,
+							concedere benignitas civitasque volet juata.</hi> Num<lb/>fortc
+						aliquid in hoc pedum cursu aures tuas aequalitate<lb/>
 						<pb n="1113"/> aut suavitate fraudavit? <hi rend="italic">D.</hi> Nul o
-						modo. <hi rend="italic">M.</hi> Delecta­ <lb/> vine aliquid? quanquam hoc
-						quidem consequens est <lb/> in hoc genere, ut delectet omne quod non
-						offenderit. <lb/>
+						modo. <hi rend="italic">M.</hi> Delecta­<lb/>vine aliquid? quanquam hoc
+						quidem consequens est<lb/>in hoc genere, ut delectet omne quod non
+						offenderit.<lb/>
 						<hi rend="italic">D.</hi> Non possum aliter me dicere affectum, quam vi­
-						<lb/> dftur tibi. <hi rend="italic">I,.</hi> Probas ergo omnes istos pedes
-						senum <lb/> temporum recte sibi posse copulari atque 1 misceri. <lb/>
+						<lb/>dftur tibi. <hi rend="italic">I,.</hi> Probas ergo omnes istos pedes
+						senum<lb/>temporum recte sibi posse copulari atque 1 misceri.<lb/>
 						<hi rend="italic">D.</hi> Probo.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT XIII. — <hi rend="italic">Ordo pedum</hi> quomodo
 							mutetur <hi rend="italic">concinne.</hi>
 						</title>
 					</ab>
-					<p>24. <hi rend="italic">M.</hi> Nihilne formidas, ne qni, arbitretur tam <lb/>
-						æqualiter istos pedes hoc ordine collatos sonare <lb/> potuisse ; si autem
-						ordinem permutes, non idem pos­ <lb/> se? <hi rend="italic">D.</hi> Nonnihil
-						quidcm affert, sed experiri non est <lb/> difficile. <hi rend="italic"
-							>II.</hi> Istud ergo facito cum vacabit : non aliter <lb/> invenies quam
-						sensum luum multiformi varietate et <lb/> una æqualilate mulceri. <hi
-							rend="italic">D.</hi> Faciam : quanquam hoc <lb/> exmplo nemo est, qui
-						non praevideat necessario id <lb/> eventurum. M. Recte existimas : sed quod
-						ad propo­ <lb/> situm pertinet, ad.noto plausu ista percurram, ut de <lb/>
-						hoc quoque dijudicare possis utrum aliquid, an nihil <lb/> claudicet : atque
-						ut simul aliquid experiaris de com­ <lb/> mutatione illius ordinis, quam
-						nihil claudicationis il­ <lb/> laturam esse prædiximus; jam nunc ipsum
-						ordinem <lb/> muta, et ut libitum est, eosdem pedes collocatos ali­ <lb/>
-						tar atque ame coll əcati sunt, personandos mihi plau­ <lb/> dendosque
-						permitte. <hi rend="italic">D.</hi> Primum volo esse ionicum a <lb/> minore,
-						secundum ionicum a majore, tertium cho­ <lb/> riambum, quartum diiambum,
-						quintum antispastum, <lb/> sextum dichorium, septimum molossum. <hi
-							rend="italic">M.</hi> Intende <lb/> ergo ct aurem in sonum, et in
-						plausum oculos : non <lb/> euim audiri, sed videri opus est plaudentem
-						manum, <lb/> (i animadverti acriter quanta temporis mora in leva­ <lb/>
+					<p>24. <hi rend="italic">M.</hi> Nihilne formidas, ne qni, arbitretur tam<lb/>
+						aequaliter istos pedes hoc ordine collatos sonare<lb/>potuisse ; si autem
+						ordinem permutes, non idem pos­<lb/>se? <hi rend="italic">D.</hi> Nonnihil
+						quidcm affert, sed experiri non est<lb/>difficile. <hi rend="italic"
+							>II.</hi> Istud ergo facito cum vacabit : non aliter<lb/>invenies quam
+						sensum luum multiformi varietate et<lb/>una aequalilate mulceri. <hi
+							rend="italic">D.</hi> Faciam : quanquam hoc<lb/>exmplo nemo est, qui
+						non praevideat necessario id<lb/>eventurum. M. Recte existimas : sed quod
+						ad propo­<lb/>situm pertinet, ad.noto plausu ista percurram, ut de<lb/>
+						hoc quoque dijudicare possis utrum aliquid, an nihil<lb/>claudicet : atque
+						ut simul aliquid experiaris de com­<lb/>mutatione illius ordinis, quam
+						nihil claudicationis il­<lb/>laturam esse praediximus; jam nunc ipsum
+						ordinem<lb/>muta, et ut libitum est, eosdem pedes collocatos ali­<lb/>
+						tar atque ame coll əcati sunt, personandos mihi plau­<lb/>dendosque
+						permitte. <hi rend="italic">D.</hi> Primum volo esse ionicum a<lb/>minore,
+						secundum ionicum a majore, tertium cho­<lb/>riambum, quartum diiambum,
+						quintum antispastum,<lb/>sextum dichorium, septimum molossum. <hi
+							rend="italic">M.</hi> Intende<lb/>ergo ct aurem in sonum, et in
+						plausum oculos : non<lb/>euim audiri, sed videri opus est plaudentem
+						manum,<lb/>(i animadverti acriter quanta temporis mora in leva­<lb/>
 						tione, quanta in posiLionc sit. <hi rend="italic">D.</hi> Totus istic sum,
-						<lb/> quantum valeo. <hi rend="italic">M.</hi> Accipe igitur collocationem
-						illam <lb/> cum plausu tuam : <hi rend="italic">Moderatas, concedere, per
-							cipies, be­ <lb/> nignitas, volet justa,</hi> civitasque, <hi
-							rend="italic">virtutes. D.</hi> Sentio qui­ <lb/> dem nequəquam plausum
-						istum claudicare, et tantum <lb/> . Icvare quantum ponere; sed vehementer
-						admiror <lb/> quomodo eo percuti potucrint illi pedes, quorum di­ <lb/>
-						visio simpli et dupli ratione constat, sicuti sunt ambo <lb/> . ionici et
-						molossus. <hi rend="italic">M.</hi> Quid hic fieri tamen arbitraris, <lb/>
-						cum in his tria leventur tempora, totidemque ponan­ <lb/> tur? <hi
-							rend="italic">D.</hi> Nibil aliud hic prorsus video quam eam lon­ <lb/>
-						gam syllabam, quæ in ionico a majore et in molosso <lb/> secunda, in ionico
-						autem a minore tertia est, plausu <lb/> ipso dividi; ut quoniam duo habet
-						tempora, unum <lb/> inde supcriori parti, alterum posteriori tribuat, atque
-						<lb/> ita terna tempora levatio positioque sortiantur.</p>
+						<lb/>quantum valeo. <hi rend="italic">M.</hi> Accipe igitur collocationem
+						illam<lb/>cum plausu tuam : <hi rend="italic">Moderatas, concedere, per
+							cipies, be­<lb/>nignitas, volet justa,</hi> civitasque, <hi
+							rend="italic">virtutes. D.</hi> Sentio qui­<lb/>dem nequəquam plausum
+						istum claudicare, et tantum<lb/>. Icvare quantum ponere; sed vehementer
+						admiror<lb/>quomodo eo percuti potucrint illi pedes, quorum di­<lb/>
+						visio simpli et dupli ratione constat, sicuti sunt ambo<lb/>. ionici et
+						molossus. <hi rend="italic">M.</hi> Quid hic fieri tamen arbitraris,<lb/>
+						cum in his tria leventur tempora, totidemque ponan­<lb/>tur? <hi
+							rend="italic">D.</hi> Nibil aliud hic prorsus video quam eam lon­<lb/>
+						gam syllabam, quae in ionico a majore et in molosso<lb/>secunda, in ionico
+						autem a minore tertia est, plausu<lb/>ipso dividi; ut quoniam duo habet
+						tempora, unum<lb/>inde supcriori parti, alterum posteriori tribuat, atque
+						<lb/>ita terna tempora levatio positioque sortiantur.</p>
 					<p>25. <hi rend="italic">M.</hi> Nihil hie omnino aliud dici aut intelligi po­
-						<lb/> test. Sed cur non etiam ille amphibrachus, quem ab <lb/> ista
-						numerositate penitus ejiciebamus, hac conditione <lb/> misceatur spondeo,
-						dactylo, et anapaesto, vel per se <lb/> ipse numerosum I aliquid in musica
-						continuatus ef­ <lb/> ficiat? Potest enim simili ratinoe media quoqne pedis
-						<lb/> ejus syllaba, quæ longa est, plausu dividi; ut cum <note
+						<lb/>test. Sed cur non etiam ille amphibrachus, quem ab<lb/>ista
+						numerositate penitus ejiciebamus, hac conditione<lb/>misceatur spondeo,
+						dactylo, et anapaesto, vel per se<lb/>ipse numerosum I aliquid in musica
+						continuatus ef­<lb/>ficiat? Potest enim simili ratinoe media quoqne pedis
+						<lb/>ejus syllaba, quae longa est, plausu dividi; ut cum <note
 							type="footnote"> I in B. , <hi rend="italic">aut;</hi> rectiuscum
-							Er.l.u.rd. ven. Lov. et Mss. A., <lb/> aume.M. </note><note
+							Er.l.u.rd. ven. Lov. et Mss. A.,<lb/>aume.M. </note><note
 							type="footnote"> • , Sic Mas.; at Lov. ali3Dciue cditionos hal ent, <hi
 								rend="italic">mmiero­</hi>
-							<lb/> iui </note>
-						<lb/> s ngula tempora singulis lateribus dederit, nan j:un <lb/> unnm et
-						tria, sed bina tempora levatio positioque <lb/> sibi vindicent : nisi habes
-						aliquid quod resistat. <lb/>
+							<lb/>iui </note>
+						<lb/>s ngula tempora singulis lateribus dederit, nan j:un<lb/>unnm et
+						tria, sed bina tempora levatio positioque<lb/>sibi vindicent : nisi habes
+						aliquid quod resistat.<lb/>
 						<hi rend="italic">D.</hi> Nihil sane lubeo qnod dicam, nisi hunc etiam esse
-						<lb/> admittendum. <hi rend="italic">M.</hi> Aliquid ergo plaudamus
-						quaterno­ <lb/> rum temporum pedibus ordinatum atque contextum, <lb/> quibus
-						iste commixtus sit, et eodem modo sensu <lb/> exploremus utnim nibil
-						hnparile offendat. £t ideo at­ <lb/> tende in hunc numerum propter judicandi
-						facilitatem <lb/> cum plausu tertio repetitum. Sumas <hi rend="italic"
-							>optima, facias <lb/> honesta. Sumas</hi> optima, <hi rend="italic"
-							>facias honesta, Sumas optima, <lb/> facias honesta. D.</hi> Jamjam,
-						obsecro, parce auribus <lb/> micis : nam etiam plausu non admoto, ipse per
-						sc ho­ <lb/> rum pcdum cursus in illo amphibracho vehementissime <lb/>
-						claudicat. <hi rend="italic">M.</hi> Quid igitur putandum est esse causæ,
-						<lb/> ut in Loc fieri non possit quod in molosso et ionicis <lb/> p otuit?
-						an quoniam in illis æqualia sunt medio latera? <lb/> in numero enim pari,
-						ubi sit medium suis æquale la­ <lb/> teribus, primus senarius occurrit. Ergo
-						illi senum <lb/> temporum pedes qnoniam duo temp ora in medio <lb/>
-						possident, et bina in lateribus; libenter quodammodo <lb/> illud medium
-						cccidil in latera , quibus amicissima <lb/> æqualitate conjungitur. Non
-						autum idem fiet in <lb/> amphibracho, ubi sunt imparia medio latera,
-						siquidem <lb/> in illis siogula, in illo duo tempora sunt. Huc accedit <lb/>
-						quod in ionicis ct molosso medio in latera solnto, <lb/> terna fiunt
-						tempora, in quibus rursum medio pari I <lb/> paria Iatera inveniuntur; quod
-						item defit amphi­ <lb/> bracho. <hi rend="italic">D.</hi> Ita res est ut
-						dicis : nec immerito amphi­ <lb/> brachus in illa serie offendit auditum, hi
-						vero etiam <lb/> delectant.</p>
+						<lb/>admittendum. <hi rend="italic">M.</hi> Aliquid ergo plaudamus
+						quaterno­<lb/>rum temporum pedibus ordinatum atque contextum,<lb/>quibus
+						iste commixtus sit, et eodem modo sensu<lb/>exploremus utnim nibil
+						hnparile offendat. £t ideo at­<lb/>tende in hunc numerum propter judicandi
+						facilitatem<lb/>cum plausu tertio repetitum. Sumas <hi rend="italic"
+							>optima, facias<lb/>honesta. Sumas</hi> optima, <hi rend="italic"
+							>facias honesta, Sumas optima,<lb/>facias honesta. D.</hi> Jamjam,
+						obsecro, parce auribus<lb/>micis : nam etiam plausu non admoto, ipse per
+						sc ho­<lb/>rum pcdum cursus in illo amphibracho vehementissime<lb/>
+						claudicat. <hi rend="italic">M.</hi> Quid igitur putandum est esse causae,
+						<lb/>ut in Loc fieri non possit quod in molosso et ionicis<lb/>p otuit?
+						an quoniam in illis aequalia sunt medio latera?<lb/>in numero enim pari,
+						ubi sit medium suis aequale la­<lb/>teribus, primus senarius occurrit. Ergo
+						illi senum<lb/>temporum pedes qnoniam duo temp ora in medio<lb/>
+						possident, et bina in lateribus; libenter quodammodo<lb/>illud medium
+						cccidil in latera , quibus amicissima<lb/>aequalitate conjungitur. Non
+						autum idem fiet in<lb/>amphibracho, ubi sunt imparia medio latera,
+						siquidem<lb/>in illis siogula, in illo duo tempora sunt. Huc accedit<lb/>
+						quod in ionicis ct molosso medio in latera solnto,<lb/>terna fiunt
+						tempora, in quibus rursum medio pari I<lb/>paria Iatera inveniuntur; quod
+						item defit amphi­<lb/>bracho. <hi rend="italic">D.</hi> Ita res est ut
+						dicis : nec immerito amphi­<lb/>brachus in illa serie offendit auditum, hi
+						vero etiam<lb/>delectant.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT XIV.- <hi rend="italic">Qui pedes quibus
 								misceantur.</hi>
 						</title>
 					</ab>
-					<p>26. <hi rend="italic">M.</hi> Age, nunc tu per tc ab ipso eXOrdire pyr­ <lb/>
-						rhichio, et secundum supra dictas rationes, quos pedes <lb/> qUibus misceri
-						oporteat, quantum potes , breviter <lb/> explica. <hi rend="italic">D.</hi>
-						Nullus pyrrhichio : non enim alias inve­ <lb/> nitur totidem temportum.
-						Iambo posset chorius; sed <lb/> propter inaequalem plausum vitandum est,
-						quod alter <lb/> a simplo, a duplo alter incipit. Ergo tribrachus utri -
-						<lb/> que accommodari potest. Spondeum et dactylum et <lb/> anapæstum, et
-						proceleumaticum amicos inter scatque <lb/> copulabiles video : non enim
-						tantum temporibus, sed <lb/> plausu etiam sibi congruunt. Enimvero exclusus
-						<lb/> amphibrachus, nulla potuit ratione reduci, cui <lb/> parilitas
-						temporum auxiliari quid, divisionc plau­ <lb/> suque discordante, non
-						potuit. Bacchio creticum, <lb/> cl pæoces primum , secundum et qnartum.
-						Palim­ <lb/> bacchio autem eumdem creticum, (t pxones primum <lb/> ct
-						tertium et qnartum , et I temporibus ct plausu <lb/> concordare manifestum
-						est. Ergo cretico et pæoni­ <lb/> bus primo ct quarto , quoniam et a duobus
-						et a <lb/> tribus temporibus eorum incipere divisio potest, cæ­ <lb/> teri
-						omnes quinum temporum pcdes possunt sine <lb/> ulla claudicatione copulari.
-						Jam illorum qui sex tem­ <lb/> poribus constant, oninium inter se miram
+					<p>26. <hi rend="italic">M.</hi> Age, nunc tu per tc ab ipso eXOrdire pyr­<lb/>
+						rhichio, et secundum supra dictas rationes, quos pedes<lb/>qUibus misceri
+						oporteat, quantum potes , breviter<lb/>explica. <hi rend="italic">D.</hi>
+						Nullus pyrrhichio : non enim alias inve­<lb/>nitur totidem temportum.
+						Iambo posset chorius; sed<lb/>propter inaequalem plausum vitandum est,
+						quod alter<lb/>a simplo, a duplo alter incipit. Ergo tribrachus utri -
+						<lb/>que accommodari potest. Spondeum et dactylum et<lb/>anapaestum, et
+						proceleumaticum amicos inter scatque<lb/>copulabiles video : non enim
+						tantum temporibus, sed<lb/>plausu etiam sibi congruunt. Enimvero exclusus
+						<lb/>amphibrachus, nulla potuit ratione reduci, cui<lb/>parilitas
+						temporum auxiliari quid, divisionc plau­<lb/>suque discordante, non
+						potuit. Bacchio creticum,<lb/>cl paeoces primum , secundum et qnartum.
+						Palim­<lb/>bacchio autem eumdem creticum, (t pxones primum<lb/>ct
+						tertium et qnartum , et I temporibus ct plausu<lb/>concordare manifestum
+						est. Ergo cretico et paeoni­<lb/>bus primo ct quarto , quoniam et a duobus
+						et a<lb/>tribus temporibus eorum incipere divisio potest, cae­<lb/>teri
+						omnes quinum temporum pcdes possunt sine<lb/>ulla claudicatione copulari.
+						Jam illorum qui sex tem­<lb/>poribus constant, oninium inter se miram
 						quamdam <note type="footnote"> I In prius editis omittitur paii, quam vocem
-							restituimus <lb/> ex Mss., necnon ex iisdem paulo inira , In <hi
-								rend="italic">rero etutn de­ <lb/> lcetatit;</hi> ut! editi LaV.ent,
+							restituimus<lb/>ex Mss., necnon ex iisdem paulo inira , In <hi
+								rend="italic">rero etutn de­<lb/>lcetatit;</hi> ut! editi LaV.ent,
 								<hi rend="italic">hic verocti</hi> m <hi rend="italic"
 								>dt'lertJ.l.</hi>
 						</note><note type="footnote"> * In n., in tt m;)orilw ; reo tius cum
 							utroqiie Ms., <hi rend="italic">ct. 11.</hi>
 						</note>
 						<lb/>
-						<pb n="1115"/> esse concordiam, satis disputatum est. Quandoqnidcm <lb/>
-						Illi quoque ab aliis in plaudendo non dissonant, quos <lb/> aliter dividi
-						engil conditio syllabarum : tantam vim <lb/> habet cum medio laterum
-						aequalitas. Porro septenum <lb/> temporum pedes cum sint quatuor, qni
-						epitriti no­ <lb/> minantur, primum et secundum invenio sibi posse <lb/>
-						copulari : amborum enim divisio incipit a tribus tem­ <lb/> poribus, idcirco
-						nec spatio temporis nee plausu dis. <lb/> sident. Rursus libenter sibi
-						junguntur terlius et quar­ <lb/> tus, quia uterque in dividendo incipit a
-						quatuor tem­ <lb/> poribus, quare et metiuntur et plauduntur æqualiter.
-						<lb/> Restat octo temporum pes qui dispondeus vocamur , <lb/> cui sicut
-						pyrrhichio par nullus est. Habes a me quod <lb/> poposcisti et facere potui.
-						Perge ad reliqua. M. Fa <lb/> ciam : sed post tam longum sermonem respiremus
-						<lb/> aliquantulum; et illorum versuum meminerimus , <lb/> quos mibi
-						extemporalcs paulo aute ipsa lassitudo sug <lb/> gessit. ' <lb/> volo tandem
-						tilii parcas, labor est in cbartis, <lb/> Et apertum ire per auras animum
-						permittas. <lb/> Placet hoc nam sapienter, remittere interdum <lb/> Aciem
-						rehus agendis decenter intentam. <lb/>
+						<pb n="1115"/> esse concordiam, satis disputatum est. Quandoqnidcm<lb/>
+						Illi quoque ab aliis in plaudendo non dissonant, quos<lb/>aliter dividi
+						engil conditio syllabarum : tantam vim<lb/>habet cum medio laterum
+						aequalitas. Porro septenum<lb/>temporum pedes cum sint quatuor, qni
+						epitriti no­<lb/>minantur, primum et secundum invenio sibi posse<lb/>
+						copulari : amborum enim divisio incipit a tribus tem­<lb/>poribus, idcirco
+						nec spatio temporis nee plausu dis.<lb/>sident. Rursus libenter sibi
+						junguntur terlius et quar­<lb/>tus, quia uterque in dividendo incipit a
+						quatuor tem­<lb/>poribus, quare et metiuntur et plauduntur aequaliter.
+						<lb/>Restat octo temporum pes qui dispondeus vocamur ,<lb/>cui sicut
+						pyrrhichio par nullus est. Habes a me quod<lb/>poposcisti et facere potui.
+						Perge ad reliqua. M. Fa<lb/>ciam : sed post tam longum sermonem respiremus
+						<lb/>aliquantulum; et illorum versuum meminerimus ,<lb/>quos mibi
+						extemporalcs paulo aute ipsa lassitudo sug<lb/>gessit. '<lb/>volo tandem
+						tilii parcas, labor est in cbartis,<lb/>Et apertum ire per auras animum
+						permittas.<lb/>Placet hoc nam sapienter, remittere interdum<lb/>Aciem
+						rehus agendis decenter intentam.<lb/>
 						<hi rend="italic">D.</hi> Placet sane, ac libenetr obtempero.</p>
 				</div>
 				<div type="textpart" subtype="book">
@@ -2088,52 +2088,52 @@
 								quid.</hi>
 						</title>
 					</ab>
-					<p>i. M. Tertius hic sermo postulat, ut quoniam de <lb/> pedum amicitia quadam
-						concordiaque satis dictum <lb/> est , vidcamus quid ex bis contextis
-						continuatisque <lb/> gignatur. Quare primum cx te quæro, utrum possint <lb/>
-						copulati sibi pedes, quos copulari oportet, perpetuum <lb/> quemdam numerum
-						creare, ubi nullus finis certus <lb/> appareat: velut cum symphoniaci
-						scahella et cymbala <lb/> pedibus feriunt, certis quidcm numeris ct his qui
-						sibi <lb/> cum aurium voluptate junguntur; sed tamen tenore <lb/> perpetuo,
-						ita ut si tibias non audias, nullo modo ibi <lb/> notare possis quonsque
-						procurrat connexio pedum, et <lb/> nude rursus ad caput redeatur. Velut si
-						tu velis cen­ <lb/> ium vcl amplius, quousque libitum est, pyrrhichios vel
-						<lb/> alios qui inter se amici sunt pedes, continua con­ <lb/> ncxionc
-						decurrerc. <hi rend="italic">D.</hi> Jam intelligo, et fieri posse <lb/>
-						concedo quamdam pedum connexioncm, in qua cer­ <lb/> tum est usque ad quot
-						pedes progrediendum sil , <lb/> atquc inde redeundum. M. Num hujus generis
-						esse <lb/> dubitas 1, cum certam facicndorum versuum discipli­ <lb/> nam
-						esse non neges, et qui versus te semper cum <lb/> voluptate audisse
-						confessus sis? <hi rend="italic">D.</hi> Manifestum est ct <lb/> hoc esse,
+					<p>i. M. Tertius hic sermo postulat, ut quoniam de<lb/>pedum amicitia quadam
+						concordiaque satis dictum<lb/>est , vidcamus quid ex bis contextis
+						continuatisque<lb/>gignatur. Quare primum cx te quaero, utrum possint<lb/>
+						copulati sibi pedes, quos copulari oportet, perpetuum<lb/>quemdam numerum
+						creare, ubi nullus finis certus<lb/>appareat: velut cum symphoniaci
+						scahella et cymbala<lb/>pedibus feriunt, certis quidcm numeris ct his qui
+						sibi<lb/>cum aurium voluptate junguntur; sed tamen tenore<lb/>perpetuo,
+						ita ut si tibias non audias, nullo modo ibi<lb/>notare possis quonsque
+						procurrat connexio pedum, et<lb/>nude rursus ad caput redeatur. Velut si
+						tu velis cen­<lb/>ium vcl amplius, quousque libitum est, pyrrhichios vel
+						<lb/>alios qui inter se amici sunt pedes, continua con­<lb/>ncxionc
+						decurrerc. <hi rend="italic">D.</hi> Jam intelligo, et fieri posse<lb/>
+						concedo quamdam pedum connexioncm, in qua cer­<lb/>tum est usque ad quot
+						pedes progrediendum sil ,<lb/>atquc inde redeundum. M. Num hujus generis
+						esse<lb/>dubitas 1, cum certam facicndorum versuum discipli­<lb/>nam
+						esse non neges, et qui versus te semper cum<lb/>voluptate audisse
+						confessus sis? <hi rend="italic">D.</hi> Manifestum est ct<lb/>hoc esse,
 						ct ab illo superiore genere distare.</p>
-					<p>i. M. Ergo quoniam oportet distingui ctiam voca­ <lb/> bulis ea quæ re ab se
-						distincta sunt, scias illud su­ <lb/> perius gcnus copulationis, rhythmum a
-						Græcis; hoc <lb/> autem alterum, metrum vocali : latine autcm dici <lb/>
-						possent, illud numerus, hoc mensio vet mensura. <lb/> Scd qnonianl hæc apud
-						nos nomina late patent, et <lb/> cavendum est no ainbigue loquamur,
-						commodius <lb/> utimur græcis. Yidcs tamen, ut opinor, quam recte <lb/>
-						utrumque nomen sit his rebus impositum. Nam quo­ <lb/> niam illud pedibus
-						certis provolvitur, peccAturque in <lb/> co si pedes dissoni misceantur,
-						recte appelatus est <lb/> rhythmus, id est .numerus : seu quia ipsa
-						provolutio <lb/> mu habet modum, nec statutum est in quoto pedo <lb/> finis
-						aliquis emineat; propter nullam mensuram con­ <lb/> tinuationis non debuit
+					<p>i. M. Ergo quoniam oportet distingui ctiam voca­<lb/>bulis ea quae re ab se
+						distincta sunt, scias illud su­<lb/>perius gcnus copulationis, rhythmum a
+						Graecis; hoc<lb/>autem alterum, metrum vocali : latine autcm dici<lb/>
+						possent, illud numerus, hoc mensio vet mensura.<lb/>Scd qnonianl haec apud
+						nos nomina late patent, et<lb/>cavendum est no ainbigue loquamur,
+						commodius<lb/>utimur graecis. Yidcs tamen, ut opinor, quam recte<lb/>
+						utrumque nomen sit his rebus impositum. Nam quo­<lb/>niam illud pedibus
+						certis provolvitur, peccAturque in<lb/>co si pedes dissoni misceantur,
+						recte appelatus est<lb/>rhythmus, id est .numerus : seu quia ipsa
+						provolutio<lb/>mu habet modum, nec statutum est in quoto pedo<lb/>finis
+						aliquis emineat; propter nullam mensuram con­<lb/>tinuationis non debuit
 						metrum vocari. Hoc autem <note type="footnote"> 1 Lov.: Num certum <hi
 								rend="italic">esse cluiJitas;</hi> at <hi rend="italic">MSS., num
-								hujus generis <lb/> esae dubita*;</hi> Cluontooo clintn editiones
-							Ani. et. Er. qnæ <lb/> atWuni, <hi rend="italic">ct hoc tib illo
-								superiore</hi> iHsiare conocuis. — in Ms. A <lb/> tkest <hi
+								hujus generis<lb/>esae dubita*;</hi> Cluontooo clintn editiones
+							Ani. et. Er. qnae<lb/>atWuni, <hi rend="italic">ct hoc tib illo
+								superiore</hi> iHsiare conocuis. — in Ms. A<lb/>tkest <hi
 								rend="italic">IUljus grneris,</hi>
 							<unclear>fertque</unclear> simpliciicr, <hi rend="italic">nvm rSSe dic­
-								<lb/> pltas</hi> M. </note>
-						<lb/> utrumque habet ; nam ei certis pedibus currit 1, et <lb/> certo
-						terminatur modo. Itaquc non solum metrum <lb/> propter insignem finem, sed
-						ctiam rhythmus est, <lb/> propter pedum rationabilem connexionem. Quocirca
-						<lb/> omne metrum rhythmus, non omnis rhythmus etiam <lb/> metrum est.
-						Rhythmi enim nomen in musica usque <lb/> adeo late patet, lit hæc tota pars
-						ejus quæ ad diu et <lb/> non diu pertinet, rhythmus nominata sit. Sed de no­
-						<lb/> mine, cum res appareat, non esse satagendam, et <lb/> doctis et
-						sapientibus placuit. An aliquid contradicen­ <lb/> dum ant dubitandum putas
-						dc his quiB a me dicta <lb/> sunt? <hi rend="italic">D.</hi> Imo prorsus
+								<lb/>pltas</hi> M. </note>
+						<lb/>utrumque habet ; nam ei certis pedibus currit 1, et<lb/>certo
+						terminatur modo. Itaquc non solum metrum<lb/>propter insignem finem, sed
+						ctiam rhythmus est,<lb/>propter pedum rationabilem connexionem. Quocirca
+						<lb/>omne metrum rhythmus, non omnis rhythmus etiam<lb/>metrum est.
+						Rhythmi enim nomen in musica usque<lb/>adeo late patet, lit haec tota pars
+						ejus quae ad diu et<lb/>non diu pertinet, rhythmus nominata sit. Sed de no­
+						<lb/>mine, cum res appareat, non esse satagendam, et<lb/>doctis et
+						sapientibus placuit. An aliquid contradicen­<lb/>dum ant dubitandum putas
+						dc his quiB a me dicta<lb/>sunt? <hi rend="italic">D.</hi> Imo prorsus
 						assentior.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUТ II. - <hi rend="italic">Quid intersit infer versum
@@ -2141,385 +2141,385 @@
 						</title>
 					</ab>
 					<p>3. <hi rend="italic">II.</hi> Nunc ergo mecum illud considera, utrum sic­
-						<lb/> ut omnis versus mettum cst, iui omne metrum ctiani <lb/> versus sit.
-						D. Considero quidem, sed quid respondeam <lb/> non invenio. M. Uude id tibi
-						censes accidisse? an quia <lb/> de vocabulis quaestio est? Non enim ut de
-						rebus ad <lb/> disciplinam pertinentibus, ita de nominibus possumus <lb/>
-						respondere interrogati : propterea quia res omniuln <lb/> mentibus
-						communiter sunt insito; nominavero, ut <lb/> cuique placuit, imposita,
-						quorum vis auctoritate asque <lb/> consuctudine maxime nititur : unde etiam
-						esse lin­ <lb/> gnarum divcesitas potest, rerumautem in ipsa veritate <lb/>
-						constitutarum profecto non potest. A me igitur accipe <lb/> quod ipse nullo
-						pacto respondere posses : non versum <lb/> solum, metrum veteres vocavere.
-						Itaque quod ad te <lb/> attinet, ,-ide atque responde, non enim jam cic
-						nom!­ <lb/> nibusagitur, utrum inter hæc duo aliquid distet, <lb/> quod
-						quidam numerus pedum iia certo fine claudatur, <lb/> ut nihil ad rem
-						pertineat t, ubi fiat quidam articulus <lb/> autcquam veniatur ad finem;
-						alius autem non solum <lb/> certo fine claudatur, sed etiam ante finem I
-						certo quo­ <lb/> dam loco quædam ejus partitio emineat, ut quasi <lb/>
+						<lb/>ut omnis versus mettum cst, iui omne metrum ctiani<lb/>versus sit.
+						D. Considero quidem, sed quid respondeam<lb/>non invenio. M. Uude id tibi
+						censes accidisse? an quia<lb/>de vocabulis quaestio est? Non enim ut de
+						rebus ad<lb/>disciplinam pertinentibus, ita de nominibus possumus<lb/>
+						respondere interrogati : propterea quia res omniuln<lb/>mentibus
+						communiter sunt insito; nominavero, ut<lb/>cuique placuit, imposita,
+						quorum vis auctoritate asque<lb/>consuctudine maxime nititur : unde etiam
+						esse lin­<lb/>gnarum divcesitas potest, rerumautem in ipsa veritate<lb/>
+						constitutarum profecto non potest. A me igitur accipe<lb/>quod ipse nullo
+						pacto respondere posses : non versum<lb/>solum, metrum veteres vocavere.
+						Itaque quod ad te<lb/>attinet, ,-ide atque responde, non enim jam cic
+						nom!­<lb/>nibusagitur, utrum inter haec duo aliquid distet,<lb/>quod
+						quidam numerus pedum iia certo fine claudatur,<lb/>ut nihil ad rem
+						pertineat t, ubi fiat quidam articulus<lb/>autcquam veniatur ad finem;
+						alius autem non solum<lb/>certo fine claudatur, sed etiam ante finem I
+						certo quo­<lb/>dam loco quaedam ejus partitio emineat, ut quasi<lb/>
 						membris conficiatur duobus. D Non intelligo. <hi rend="italic">II.</hi> At­
-						<lb/> tende ergo in hæc exempla : <lb/> Ite igitur,
-							<unclear>Camænæ</unclear>
-						<lb/> Fonticolæ <unclear>puellæ</unclear>, <lb/> Quæ canitis sub antris
-						<lb/> Mellifluos s nores, <lb/> Quæ lavilis ca, illum <note type="footnote"
+						<lb/>tende ergo in haec exempla :<lb/>Ite igitur,
+							<unclear>Camaenae</unclear>
+						<lb/>Fonticolae <unclear>puellae</unclear>,<lb/>Quae canitis sub antris
+						<lb/>Mellifluos s nores,<lb/>Quae lavilis ca, illum <note type="footnote"
 							>1 In B., <unclear/><hi rend="italic">currtur.</hi> Ex t 1i. et vis.A,
 								<hi rend="italic">run it.</hi> vi. </note><note type="footnote"> I
 							Hiic rcvocavimus ex Vias. istli* c verba, <hi rend="italic">imie
-								finem,</hi> l'lna <lb/> in hactenus editis desunt. — Non desunt iu
+								finem,</hi> l'lna<lb/>in hactenus editis desunt. — Non desunt iu
 							':.:ic, 14. </note>
 						<lb/>
 						<pb n="1117"/> Purpureum <unclear>Hypocrene</unclear>
-						<lb/> Fonte, ubi fusus olim <lb/> Spumea lavit almus <lb/> Ora juhis aquosis
-						<lb/> Pegasus, in nitentem <lb/> Pervolaturus æthram. <lb/> Cernis profecto
-						quinque superiores versiculos eodem <lb/> loco partem orationis habere
-						terminatam, id est in <lb/> choriambo pede, cui subjungitur bacchius, ut
-						versi­ <lb/> culum compleat (namque hi undecim, choriambo et <lb/> bacchio
-						pcdibus constant); caeteros vero excepto uno, <lb/> scilicet <hi
-							rend="italic">Ora jubis</hi> aquosis, non eodem loco habere <lb/>
+						<lb/>Fonte, ubi fusus olim<lb/>Spumea lavit almus<lb/>Ora juhis aquosis
+						<lb/>Pegasus, in nitentem<lb/>Pervolaturus aethram.<lb/>Cernis profecto
+						quinque superiores versiculos eodem<lb/>loco partem orationis habere
+						terminatam, id est in<lb/>choriambo pede, cui subjungitur bacchius, ut
+						versi­<lb/>culum compleat (namque hi undecim, choriambo et<lb/>bacchio
+						pcdibus constant); caeteros vero excepto uno,<lb/>scilicet <hi
+							rend="italic">Ora jubis</hi> aquosis, non eodem loco habere<lb/>
 						terminatam partem orationis. <hi rend="italic">D.</hi> Cerno istud quidem,
-						<lb/> sed quo pertineat non video. M. Eo scilicet ut intel­ <lb/> ligas, hoc
-						nictrum non quasi legitimum locum habere, <lb/> ubi antc finem versus
-						finiatur pars orationis : nam si <lb/> ita esset, omnes eodem loco hunc
-						haberent articulum, <lb/> aut certe rarissime in his inveniretur qui non
-						habe­ <lb/> ret : nunc vcro cnm sint undecim, sex ita suut, quin­ <lb/> que
-						non ita. <hi rend="italic">D.</hi> Et hoc accipio, et adhuc quo ratio <lb/>
+						<lb/>sed quo pertineat non video. M. Eo scilicet ut intel­<lb/>ligas, hoc
+						nictrum non quasi legitimum locum habere,<lb/>ubi antc finem versus
+						finiatur pars orationis : nam si<lb/>ita esset, omnes eodem loco hunc
+						haberent articulum,<lb/>aut certe rarissime in his inveniretur qui non
+						habe­<lb/>ret : nunc vcro cnm sint undecim, sex ita suut, quin­<lb/>que
+						non ita. <hi rend="italic">D.</hi> Et hoc accipio, et adhuc quo ratio<lb/>
 						tendat exspecto. <hi rend="italic">M.</hi> Attende ergo etiam in ista per­
-						<lb/> vulgatissima : <hi rend="italic">Arma</hi> virumque <hi rend="italic"
-							>cano, Trojce</hi> qui <hi rend="italic">primus <lb/> nb</hi> oria. Et
-						ne longum faciamus, quia carmen notissi­ <lb/> mim est, ab hoc versu usque
-						ad quem volueris ex­ <lb/> plora singulos ; invenieS finilain partem
-						orationis in <lb/> quinto semipede, id est, in duobus pcdibus et semis­
-						<lb/> se : nam hi versus constant pedibus quaternorum <lb/> temporum : quare
-						iste finis de quo agitur partis ora­ <lb/> tionis, quasi legitimus in decimo
-						tcinporc est. <hi rend="italic">D.</hi> Ma­ <lb/> nifestum ct.</p>
+						<lb/>vulgatissima : <hi rend="italic">Arma</hi> virumque <hi rend="italic"
+							>cano, Trojce</hi> qui <hi rend="italic">primus<lb/>nb</hi> oria. Et
+						ne longum faciamus, quia carmen notissi­<lb/>mim est, ab hoc versu usque
+						ad quem volueris ex­<lb/>plora singulos ; invenieS finilain partem
+						orationis in<lb/>quinto semipede, id est, in duobus pcdibus et semis­
+						<lb/>se : nam hi versus constant pedibus quaternorum<lb/>temporum : quare
+						iste finis de quo agitur partis ora­<lb/>tionis, quasi legitimus in decimo
+						tcinporc est. <hi rend="italic">D.</hi> Ma­<lb/>nifestum ct.</p>
 					<p><hi rend="italic">A. M.</hi> Jain crgo intelligis inter illa duo genera quae
-						<lb/> ante ista exempla proposueram, nonnihil distare : <lb/> quod aliud
-						scilicct metrum antequam claadatur, non <lb/> habet certum et statutum
-						aliquem articulum, sicut in <lb/> illis undecim versiculis exploravimus :
-						aliud vero <lb/> habet, sicut in hcroico metro quintus semipes satis <lb/>
+						<lb/>ante ista exempla proposueram, nonnihil distare :<lb/>quod aliud
+						scilicct metrum antequam claadatur, non<lb/>habet certum et statutum
+						aliquem articulum, sicut in<lb/>illis undecim versiculis exploravimus :
+						aliud vero<lb/>habet, sicut in hcroico metro quintus semipes satis<lb/>
 						indicat. D. Jam liquet quod dicis. <hi rend="italic">M.</hi> Atqui scias
-						<lb/> opertet, a veteribus doctis, in quibus magna est au­ <lb/> ctoritas,
-						illud superius genus non esse versum appel­ <lb/> latum ; sed hunc definitum
-						et vocatum esse versum, <lb/> qui duobus quasi membris constaret, certa
-						mensura <lb/> ct ratione conjunctis. Sed tu non multum labores de <lb/>
-						nomine, quod nisi a me vel a quolibet alio tibi indi- <lb/> caretur, nullo
-						modo cle hoc interrogatus respondere <lb/> posses. Sed qnod rnlio docet, in
-						id præcipue et maxi­ <lb/> mc animum intende, velut hoc ipsum quod nunc agi­
-						<lb/> mus : ratio enin docct inter hæc duo genera distare <lb/> aliquid,
-						quibuslibet vocabulis nuncupentur : itaque <lb/> hoc bene interrogatus
-						posses dicere ipsa veritate <lb/> confisus; illud autem nisi auctoritatem
-						secutus, non <lb/> posses. <hi rend="italic">D.</hi> Apertissime jam ista
-						cognovi, et quanti <lb/> pendas hoc, de quo me tam crebro admones, jam <lb/>
-						existimo. <hi rend="italic">M.</hi> Hæc ergo tria nomina, quibus disse­
-						<lb/> rendi causa necessario usuri sumus, memoriae mandes <lb/> velint :
-						rhythmum, metrum, versum. Quæ sic distin­ <lb/> guuntur, ut omne metrum
-						etiam rhythmus sit, non <lb/> omnis rhythmus etiam metrum. Item omnis versus
-						<lb/> etiam metrum sit, non omne metrum etiam versus. <lb/> Ergo omnis
-						versus est rhythmus et metrum: nam hoc, <lb/> ut arbitror, esse consequens
-						vides. <hi rend="italic">D.</hi> Video sanc : <lb/> nam est luce
+						<lb/>opertet, a veteribus doctis, in quibus magna est au­<lb/>ctoritas,
+						illud superius genus non esse versum appel­<lb/>latum ; sed hunc definitum
+						et vocatum esse versum,<lb/>qui duobus quasi membris constaret, certa
+						mensura<lb/>ct ratione conjunctis. Sed tu non multum labores de<lb/>
+						nomine, quod nisi a me vel a quolibet alio tibi indi<lb/>caretur, nullo
+						modo cle hoc interrogatus respondere<lb/>posses. Sed qnod rnlio docet, in
+						id praecipue et maxi­<lb/>mc animum intende, velut hoc ipsum quod nunc agi­
+						<lb/>mus : ratio enin docct inter haec duo genera distare<lb/>aliquid,
+						quibuslibet vocabulis nuncupentur : itaque<lb/>hoc bene interrogatus
+						posses dicere ipsa veritate<lb/>confisus; illud autem nisi auctoritatem
+						secutus, non<lb/>posses. <hi rend="italic">D.</hi> Apertissime jam ista
+						cognovi, et quanti<lb/>pendas hoc, de quo me tam crebro admones, jam<lb/>
+						existimo. <hi rend="italic">M.</hi> Haec ergo tria nomina, quibus disse­
+						<lb/>rendi causa necessario usuri sumus, memoriae mandes<lb/>velint :
+						rhythmum, metrum, versum. Quae sic distin­<lb/>guuntur, ut omne metrum
+						etiam rhythmus sit, non<lb/>omnis rhythmus etiam metrum. Item omnis versus
+						<lb/>etiam metrum sit, non omne metrum etiam versus.<lb/>Ergo omnis
+						versus est rhythmus et metrum: nam hoc,<lb/>ut arbitror, esse consequens
+						vides. <hi rend="italic">D.</hi> Video sanc :<lb/>nam est luce
 						clarius.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT III. — <hi rend="italic">Rhythmi ex</hi>
 							pyrrhichiis.</title>
 					</ab>
-					<p>5. <hi rend="italic">M.</hi> Prius igitur, si placet, de rhythmo In quo <lb/>
-						nullum metrum est, deinde cic metro ubi versus non <lb/> est, postremo de
-						ipso versu, quantum possumus, dis­ <lb/> seramus. <hi rend="italic">D.</hi>
-						Placet vcro. <hi rend="italic">M.</hi> Sume ergo tibi ab ipso. <lb/> capite
-						pedes pyrrhichios, et de his rhythmum con­ <lb/> lcxe. <hi rend="italic"
-							>D.</hi> Etiam si id possim facere, qui modus erit? <lb/>
+					<p>5. <hi rend="italic">M.</hi> Prius igitur, si placet, de rhythmo In quo<lb/>
+						nullum metrum est, deinde cic metro ubi versus non<lb/>est, postremo de
+						ipso versu, quantum possumus, dis­<lb/>seramus. <hi rend="italic">D.</hi>
+						Placet vcro. <hi rend="italic">M.</hi> Sume ergo tibi ab ipso.<lb/>capite
+						pedes pyrrhichios, et de his rhythmum con­<lb/>lcxe. <hi rend="italic"
+							>D.</hi> Etiam si id possim facere, qui modus erit?<lb/>
 						<hi rend="italic">M.</hi> Satis est, ut cum tendas (exempli enim gratia id
-						<lb/> facilnus) usque ad decem pedes: nam usque ad hunc <lb/> pedum numerum
-						non progreditur versus, quod suo <lb/> loco diligenter tractabitur. <hi
-							rend="italic">D.</hi> Bene quidem tu non <lb/> multos pedcs milii
-						proposuisti copulandos ; sed vide­ <lb/> ris mihi non recordari, jam te
-						satis discrevisse, quid <lb/> .inter grammaticum et musicum intersit, cnm
-						cgo tibi <lb/> respondissem, syllabarum longarum et brevium cogni­ <lb/>
-						tionem me non habere, quæ a grammaticis traditur : <lb/> nist forte
-						permittis, ut non verbis, sed aliquo plausu <lb/> rhythmum istum exhibeam :
-						nam judicium aurium ad <lb/> temporum momenta moderanda me posse habere non
-						<lb/> nego; quoe vero syllaba producenda vel corripicnda <lb/> sit, quod in
+						<lb/>facilnus) usque ad decem pedes: nam usque ad hunc<lb/>pedum numerum
+						non progreditur versus, quod suo<lb/>loco diligenter tractabitur. <hi
+							rend="italic">D.</hi> Bene quidem tu non<lb/>multos pedcs milii
+						proposuisti copulandos ; sed vide­<lb/>ris mihi non recordari, jam te
+						satis discrevisse, quid<lb/>.inter grammaticum et musicum intersit, cnm
+						cgo tibi<lb/>respondissem, syllabarum longarum et brevium cogni­<lb/>
+						tionem me non habere, quae a grammaticis traditur :<lb/>nist forte
+						permittis, ut non verbis, sed aliquo plausu<lb/>rhythmum istum exhibeam :
+						nam judicium aurium ad<lb/>temporum momenta moderanda me posse habere non
+						<lb/>nego; quoe vero syllaba producenda vel corripicnda<lb/>sit, quod in
 						auctoritate situm cst, omnino nescio. <hi rend="italic">II.</hi>
-						<lb/> Fateor nos ita, ut dicis, grammaticum a musico dis­ <lb/> crevisse, et
-						in hoc te genere inscitiam luam esse con­ <lb/> fessum. Quare a me accipe
+						<lb/>Fateor nos ita, ut dicis, grammaticum a musico dis­<lb/>crevisse, et
+						in hoc te genere inscitiam luam esse con­<lb/>fessum. Quare a me accipe
 						hoc exempli gcnus : <hi rend="italic">Ago</hi>
-						<lb/> celeriter <hi rend="italic">agile quod ago libi quod anima velit.
-							D.</hi> Habeo <lb/> istuc.</p>
-					<p>6. M. Hoc ergo quoties libet rcpetendo, efficies. <lb/> rhythmi hujus
-						longitudinem quantam volcs, quan­ <lb/> quam hi decem pedes ad exemplum
-						sufficiant. Sed <lb/> illud quæro, si tibi quispiam dicai, non pyrrhichiis ,
-						<lb/> sed proceleumaticis pcdihus hunc rhythmum constare, <lb/> quid
-						respondebis? <hi rend="italic">D,</hi> Prorsus ignoro : nam ubi de­ <lb/>
-						cem pyrrhichii sunt, quin'lue proceleumaticos mctior; <lb/> et eo major
-						dubitatio est, quod de rhythmo consuli­ <lb/> mur, qai scilicet perpetuo
-						fluit. Undecim enim pyr­ <lb/> rhichii vel tredecim, et quolibet impari
-						numero, non <lb/> possunt habere integrum proceleumaticorum nuine­ <lb/>
-						rum. Si ergo esset certus finis in hoc de quo agiiur <lb/> rhythmo, ibi
-						saltem diccre possemus pyrrhichio po­ <lb/> tius quam proceleumatico cum
-						currere, ubi omnes <lb/> integri proceleumatici non invenirentur : nunc vero
-						<lb/> et ipsum infinitum nobis conturbat judicium, ct si <lb/> quando
-						numerati quidem pedes, sed pari numero no­ <lb/> bis proponuntur, sicut isti
-						sunt decem. M. Atqui nec <lb/> de ipso impari numero pyrrhichiorum, quod
-						tibi vi­ <lb/> sum est, liquido visum est. Quid enim si undecim pro­ <lb/>
-						positis pedibus pyrrhichiis dicatur rhythmus quinque <lb/> babere
-						proceleumaticos et semipcdem ? numquid re­ <lb/> sisti potest, cum multos
-						inveniamus versus claudi se­ <lb/> mipede? <hi rend="italic">D.</hi> Jam
-						dixi me nescire quid de hac re dici <lb/> possit. <hi rend="italic">II.</hi>
-						Num ctiam illud nescis, proceleumatico <lb/> priorem esse pyrrhichium ?
-						siquidem duobus pyrrbi­ <lb/> chiis proceleumaticus confit; sicut prius est
-						unum <lb/> qnam duo, et duo quam quatuor, ita proceleumatico <lb/> prior cst
-						pyrrhichius. D. Verissimum est. <hi rend="italic">II.</hi> Cum <lb/> ergO in
-						hanc ambiguitatem incidimus, ut possit in <lb/> rhythmo ct pyrrhichius
-						mctiri ct proceleumaticus , <lb/> cui principatum daturi sumus? priori, ex
-						quo iste <lb/> constat; an posteriori, t'X quo ille non constat? <hi
+						<lb/>celeriter <hi rend="italic">agile quod ago libi quod anima velit.
+							D.</hi> Habeo<lb/>istuc.</p>
+					<p>6. M. Hoc ergo quoties libet rcpetendo, efficies.<lb/>rhythmi hujus
+						longitudinem quantam volcs, quan­<lb/>quam hi decem pedes ad exemplum
+						sufficiant. Sed<lb/>illud quaero, si tibi quispiam dicai, non pyrrhichiis ,
+						<lb/>sed proceleumaticis pcdihus hunc rhythmum constare,<lb/>quid
+						respondebis? <hi rend="italic">D,</hi> Prorsus ignoro : nam ubi de­<lb/>
+						cem pyrrhichii sunt, quin'lue proceleumaticos mctior;<lb/>et eo major
+						dubitatio est, quod de rhythmo consuli­<lb/>mur, qai scilicet perpetuo
+						fluit. Undecim enim pyr­<lb/>rhichii vel tredecim, et quolibet impari
+						numero, non<lb/>possunt habere integrum proceleumaticorum nuine­<lb/>
+						rum. Si ergo esset certus finis in hoc de quo agiiur<lb/>rhythmo, ibi
+						saltem diccre possemus pyrrhichio po­<lb/>tius quam proceleumatico cum
+						currere, ubi omnes<lb/>integri proceleumatici non invenirentur : nunc vero
+						<lb/>et ipsum infinitum nobis conturbat judicium, ct si<lb/>quando
+						numerati quidem pedes, sed pari numero no­<lb/>bis proponuntur, sicut isti
+						sunt decem. M. Atqui nec<lb/>de ipso impari numero pyrrhichiorum, quod
+						tibi vi­<lb/>sum est, liquido visum est. Quid enim si undecim pro­<lb/>
+						positis pedibus pyrrhichiis dicatur rhythmus quinque<lb/>babere
+						proceleumaticos et semipcdem ? numquid re­<lb/>sisti potest, cum multos
+						inveniamus versus claudi se­<lb/>mipede? <hi rend="italic">D.</hi> Jam
+						dixi me nescire quid de hac re dici<lb/>possit. <hi rend="italic">II.</hi>
+						Num ctiam illud nescis, proceleumatico<lb/>priorem esse pyrrhichium ?
+						siquidem duobus pyrrbi­<lb/>chiis proceleumaticus confit; sicut prius est
+						unum<lb/>qnam duo, et duo quam quatuor, ita proceleumatico<lb/>prior cst
+						pyrrhichius. D. Verissimum est. <hi rend="italic">II.</hi> Cum<lb/>ergO in
+						hanc ambiguitatem incidimus, ut possit in<lb/>rhythmo ct pyrrhichius
+						mctiri ct proceleumaticus ,<lb/>cui principatum daturi sumus? priori, ex
+						quo iste<lb/>constat; an posteriori, t'X quo ille non constat? <hi
 							rend="italic">D :</hi>
 						<lb/>
 						<pb n="1119"/> Nemo dubitabit priori esse dandum. <hi rend="italic">M.</hi>
-						Quid ergo <lb/> dubitas de bac re consultis respondere, pyrrhichium <lb/>
-						potius quam proceleumaticum istum rhythmum csse <lb/> nuncupandum? <hi
-							rend="italic">D.</hi> Jam omnino non dubito ; pudel <lb/> tam manifestam
-						rationem non me cito animadver­ <lb/> tisse.</p>
+						Quid ergo<lb/>dubitas de bac re consultis respondere, pyrrhichium<lb/>
+						potius quam proceleumaticum istum rhythmum csse<lb/>nuncupandum? <hi
+							rend="italic">D.</hi> Jam omnino non dubito ; pudel<lb/>tam manifestam
+						rationem non me cito animadver­<lb/>tisse.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT IV. — <hi rend="italic">Rhythmus</hi>
 							continuus.</title>
 					</ab>
 					<p>7. <hi rend="italic">M.</hi> Videsne illud etiam ista ratione cogi, ut qui­
-						<lb/> dam pedes sint, qui rhythmum continuare non pos­ <lb/> sinl? Nam quod
-						de proceleumatico inventum est, cui <lb/> tollit pyrrhichius principatum,
-						hoc et do diiambo et <lb/> dc dichorio et de dispondeo inventum puto : nisi
-						tibi <lb/> aliud videtur. <hi rend="italic">D.</hi> Quid mihi aliud videri
-						potest, cum <lb/> probata illa rationc hoc quod sequitur improbare non <lb/>
-						possim ? M. Vide etiam ista, et compara ac judica. <lb/> Nam videtur, cum
-						tale incertum evenit, plausu potius <lb/> dcberc discerni 1 quo pede
-						curratur : ut si pyrrhichio <lb/> velrs currere, unum tibi tempus levandum,
-						uuum <lb/> ponendum sit; si proceleumatico, duo ct duo : ita et <lb/> pes
-						apparebit, et nullus pedum erit a rhythmi conti­ <lb/> nuatione seclusus.
-							<hi rend="italic">D.</hi> Huic magis favco sententiæ, <lb/> quæ nullum
-						pedem ab hac contextione esse immunem <lb/> sinit. <hi rend="italic">M.</hi>
-						Recte facis, et quo magis hoc approbcs , <lb/> considera de tribracho pede
-						quid respondere possimus, <lb/> si nihilominus quisque contendat non
-						pyrrhichio aut <lb/> proccleumalico istum rhythmum, sed tribracho cur­ <lb/>
+						<lb/>dam pedes sint, qui rhythmum continuare non pos­<lb/>sinl? Nam quod
+						de proceleumatico inventum est, cui<lb/>tollit pyrrhichius principatum,
+						hoc et do diiambo et<lb/>dc dichorio et de dispondeo inventum puto : nisi
+						tibi<lb/>aliud videtur. <hi rend="italic">D.</hi> Quid mihi aliud videri
+						potest, cum<lb/>probata illa rationc hoc quod sequitur improbare non<lb/>
+						possim ? M. Vide etiam ista, et compara ac judica.<lb/>Nam videtur, cum
+						tale incertum evenit, plausu potius<lb/>dcberc discerni 1 quo pede
+						curratur : ut si pyrrhichio<lb/>velrs currere, unum tibi tempus levandum,
+						uuum<lb/>ponendum sit; si proceleumatico, duo ct duo : ita et<lb/>pes
+						apparebit, et nullus pedum erit a rhythmi conti­<lb/>nuatione seclusus.
+							<hi rend="italic">D.</hi> Huic magis favco sententiae,<lb/>quae nullum
+						pedem ab hac contextione esse immunem<lb/>sinit. <hi rend="italic">M.</hi>
+						Recte facis, et quo magis hoc approbcs ,<lb/>considera de tribracho pede
+						quid respondere possimus,<lb/>si nihilominus quisque contendat non
+						pyrrhichio aut<lb/>proccleumalico istum rhythmum, sed tribracho cur­<lb/>
 						rcre. <hi rend="italic">D.</hi> Vico judicium ad plausum illum esse revo­
-						<lb/> c.tndum, ut si unum tempus cst ill levalione, duo in <lb/> positione,
-						id est, una ct duæ syllabæ ; aut contra duæ <lb/> in levatione, una in
-						posilione; tribrachus rhythmus <lb/> esse dicatur.</p>
-					<p>8. <hi rend="italic">M.</hi> Recte intelligis. Quamobrem jam dic mihi <lb/>
-						utrum spondeus pes pyrrhichio rhythmo possit ad­ <lb/> jungi. <hi
-							rend="italic">D.</hi> Nullo modo : non cnim continuabitur plau­ <lb/>
-						sus a qualis ; cum levatio ct positio in pyrrhichio sin­ <lb/> gula, in
-						Spondeo vero bina tempora lencanL. <hi rend="italic">M.</hi> Potest <lb/>
+						<lb/>c.tndum, ut si unum tempus cst ill levalione, duo in<lb/>positione,
+						id est, una ct duae syllabae ; aut contra duae<lb/>in levatione, una in
+						posilione; tribrachus rhythmus<lb/>esse dicatur.</p>
+					<p>8. <hi rend="italic">M.</hi> Recte intelligis. Quamobrem jam dic mihi<lb/>
+						utrum spondeus pes pyrrhichio rhythmo possit ad­<lb/>jungi. <hi
+							rend="italic">D.</hi> Nullo modo : non cnim continuabitur plau­<lb/>
+						sus a qualis ; cum levatio ct positio in pyrrhichio sin­<lb/>gula, in
+						Spondeo vero bina tempora lencanL. <hi rend="italic">M.</hi> Potest<lb/>
 						ergo proceleumatico adjungi. <hi rend="italic">D.</hi> Potest. <hi
-							rend="italic">M.</hi> Quid cum <lb/> ei ndjungitur? interrogati uirum
-						rhythmus prooe­ <lb/> leumaticus an spondiacus sit, quid respondebimus? <lb/>
+							rend="italic">M.</hi> Quid cum<lb/>ei ndjungitur? interrogati uirum
+						rhythmus prooe­<lb/>leumaticus an spondiacus sit, quid respondebimus?<lb/>
 						<hi rend="italic">D.</hi> Quid censes, nisi spondeo dandunt esse principa­
-						<lb/> lum? Cum enim plausu ista controversia noh dijudi­ <lb/> cetur, nam in
-						utroque bina levamus ac ponimus tem­ <lb/> pora ; quid aliud restat, nisi ut
-						i te regnet qui in ipso <lb/> pedum ordine prior est? <hi rend="italic"
-							>M.</hi> Rationem tc secutum esse <lb/> satis approbo; et vidcs, ut
-						arbitror, quid sequatur. <lb/> D Quid tandem? <hi rend="italic">M.</hi> Quid
-						putas, nisi proceleumatico <lb/> rhythmo 2 nullum alium pedem posse misceri?
-						quoniam <lb/> quisquis miscebitur totidem temporum , non cnim <lb/> aliter
-						potest misceri, in cum rhythmi nomen transfe­ <lb/> ratur necesse esl. Omnes
-						enim priores illo sunt, qui <lb/> totidem temporibus constant. Et. quoniam
-						iis qui prio­ <lb/> ics inventi fucrint, cogit nos ralio, quam vidisti <lb/>
-						principatum dare, id est, cx eo rhythmum nuncupare ; <lb/> non crit jam
+						<lb/>lum? Cum enim plausu ista controversia noh dijudi­<lb/>cetur, nam in
+						utroque bina levamus ac ponimus tem­<lb/>pora ; quid aliud restat, nisi ut
+						i te regnet qui in ipso<lb/>pedum ordine prior est? <hi rend="italic"
+							>M.</hi> Rationem tc secutum esse<lb/>satis approbo; et vidcs, ut
+						arbitror, quid sequatur.<lb/>D Quid tandem? <hi rend="italic">M.</hi> Quid
+						putas, nisi proceleumatico<lb/>rhythmo 2 nullum alium pedem posse misceri?
+						quoniam<lb/>quisquis miscebitur totidem temporum , non cnim<lb/>aliter
+						potest misceri, in cum rhythmi nomen transfe­<lb/>ratur necesse esl. Omnes
+						enim priores illo sunt, qui<lb/>totidem temporibus constant. Et. quoniam
+						iis qui prio­<lb/>ics inventi fucrint, cogit nos ralio, quam vidisti<lb/>
+						principatum dare, id est, cx eo rhythmum nuncupare ;<lb/>non crit jam
 						proceleumaticus rhythmus, aliquo alio <note type="footnote">
 							<hi rend="italic">I nccemu</hi> juxta Ms. A. M. </note><note
 							type="footnote"> ! tn B.: <hi rend="italic">Quid putas,</hi> ttM&lt; tam
-								<hi rend="italic">proceleumatico quarn pyrrhicllio<lb/> rhythmo</hi>
-							: corrupte pro'ecto; nam cum |yrrbicliius omnes <lb/> alios | ru cedat
-							JKXICS, ei male accommodaretur ratio ahAu­ <lb/> gustino subjecta, quur
-							ia p ro doumaiicu.ii convenientissime <unclear/><lb/> ineldit. M. </note>
-						<lb/> quatuor temporum mixto, sed spondiacus aut dacty­ <lb/> licus aut
-						anapæsticus. Amphibracbum enim ab isto­ <lb/> rum copulatione numerorum
-						recte remotum esse <lb/> convenit. <hi rend="italic">D.</hi> Fateor ita
+								<hi rend="italic">proceleumatico quarn pyrrhicllio<lb/>rhythmo</hi>
+							: corrupte pro'ecto; nam cum |yrrbicliius omnes<lb/>alios | ru cedat
+							JKXICS, ei male accommodaretur ratio ahAu­<lb/>gustino subjecta, quur
+							ia p ro doumaiicu.ii convenientissime <unclear/><lb/>ineldit. M. </note>
+						<lb/>quatuor temporum mixto, sed spondiacus aut dacty­<lb/>licus aut
+						anapaesticus. Amphibracbum enim ab isto­<lb/>rum copulatione numerorum
+						recte remotum esse<lb/>convenit. <hi rend="italic">D.</hi> Fateor ita
 						esse.</p>
-					<p>9. M. Nunc ergo ex ordine considera iambicum <lb/> rhythmum, quoniam
-						pyrrhichium et proceleumati­ <lb/> cum, qui duplicato pyrrbicbio gignitur,
-						satis discus­ <lb/> simus. Quare dicas velim huic quem censes admi­ <lb/>
-						scendum pedem, ut iambicus rhythmus suum nomen <lb/> obtineat. <hi
-							rend="italic">D.</hi> Quem, nisi tribrachum, qui et temporibus <lb/> et
-						plausu congruit; et quia posterior cst, regio pol <lb/> lcre non potest? Nam
-						chorius cst quidem posterior, <lb/> et totidem temporum, sed non eodem modo
-						plaudi­ <lb/> tur. M. Age, jam vide rhythmum trochaicum, et ad <lb/> eadem
-						de hoc quoque respoude. <hi rend="italic">D.</hi> Idem respoudco : <lb/> nam
-						potest et huic non solum spatio temporis, s d <lb/> plausu etiam concinere
-						tribrachus. Cavendum autem <lb/> iambum quis non videat? qui eliam si
-						æqualiter plau­ <lb/> docetur, principatum tamen mixtus auferret. <hi
-							rend="italic">M.</hi> Quid ? <lb/> spondiaco rhythmo quem taudem
-						copulabimus pe­ <lb/> dem? D. Sane in hoc largissima copia cst : nani et da­
-						<lb/> ctylum et anapæstum et proceleumaticum nulla im­ <lb/> parilitate
-						temporum, nulla claudicatione plausus, <lb/> nulla principatus ademptione
-						impediente, huic video <lb/> misceri posse.</p>
+					<p>9. M. Nunc ergo ex ordine considera iambicum<lb/>rhythmum, quoniam
+						pyrrhichium et proceleumati­<lb/>cum, qui duplicato pyrrbicbio gignitur,
+						satis discus­<lb/>simus. Quare dicas velim huic quem censes admi­<lb/>
+						scendum pedem, ut iambicus rhythmus suum nomen<lb/>obtineat. <hi
+							rend="italic">D.</hi> Quem, nisi tribrachum, qui et temporibus<lb/>et
+						plausu congruit; et quia posterior cst, regio pol<lb/>lcre non potest? Nam
+						chorius cst quidem posterior,<lb/>et totidem temporum, sed non eodem modo
+						plaudi­<lb/>tur. M. Age, jam vide rhythmum trochaicum, et ad<lb/>eadem
+						de hoc quoque respoude. <hi rend="italic">D.</hi> Idem respoudco :<lb/>nam
+						potest et huic non solum spatio temporis, s d<lb/>plausu etiam concinere
+						tribrachus. Cavendum autem<lb/>iambum quis non videat? qui eliam si
+						aequaliter plau­<lb/>docetur, principatum tamen mixtus auferret. <hi
+							rend="italic">M.</hi> Quid ?<lb/>spondiaco rhythmo quem taudem
+						copulabimus pe­<lb/>dem? D. Sane in hoc largissima copia cst : nani et da­
+						<lb/>ctylum et anapaestum et proceleumaticum nulla im­<lb/>parilitate
+						temporum, nulla claudicatione plausus,<lb/>nulla principatus ademptione
+						impediente, huic video<lb/>misceri posse.</p>
 					</div>
-				<div type="textpart" subtype="dialog"><p>10. M. Vidoo jam te facile posse cætera ordiuc <lb/> persequi : quocirca
-						remota interrogatione mea, vel <lb/> potius tanquam de omnibus interrogatus
-						responde <lb/> breviter, dilucidcque quantum |otcs, quomodo siu <lb/> guli
-						qui restant pedes, aliis legitime immixtis, obti­ <lb/> neant suum nomen in
-						rhythmo. <hi rend="italic">D.</hi> Faciam : neque <lb/> enim ullius negotii
-						est, tanta rationum luce præmissa. <lb/> Nam tribracho nullus miscebitur ;
-						omnes enim prio­ <lb/> res sunt, qui ei sunt u;mporibus pares. Dactylo ana­
-						<lb/> pæstus potest; nam ct cst posterior, et I tempore ac <lb/> plausu
-						currit aequaliter : ulriquc autem proceleuma­ <lb/> ticus eadem scilicet
-						ratione copulatur. Jam bacchio <lb/> creticus, et de paconibus primus,
-						sccundus ct qua.-. <lb/> tus misceri possunt. Porro ipsi cretico, omues qui
-						<lb/> post illum sunt quinque temporum pedes jure miscen <lb/> tur, sed non
-						omnes eadem divisione. Alii namque ad <lb/> duo et tria, alii ad tria et duo
-						tempora dividuntur. <lb/> Iste autem creticus ulroquc modo dividi pOtest,
-						quia <lb/> media brevis cuilibet parti tribuitur. Palimbacchius <lb/> autcm
-						, quia ejus divisio a duobus temporibus inci­ <lb/> piena, in tria desinit,
-						cougruos ct copulabiles habet <lb/> pæones omnes, præter secundum. Molossus
-						de tri­ <lb/> syllabis restat, a quo prino incipiunt sex temporum <lb/>
-						pedes, qui omnes eidem conjungi possunt, partim <lb/> propter simpli
-						duplique rationcm; partim propter <lb/> illam quam nobis plausus ostendit,
-						partitionem longæ <lb/> syllabæ, quæ singula tempora parti utrique concedit,
-						<lb/> quia in senario numero par lateribus medium est. <lb/> Ob quam causam
-						et molossus, et ambo ionici non so­ <lb/> lum in simplum et duplum, sed
-						ctiam in æquas par­ <lb/> tes per terna tempora feriuntur. Hinc efficitur ut
-						dcin­ <lb/> ceps omnibus sci temporum pedibus, omnes totidem <note
+				<div type="textpart" subtype="dialog"><p>10. M. Vidoo jam te facile posse caetera ordiuc<lb/>persequi : quocirca
+						remota interrogatione mea, vel<lb/>potius tanquam de omnibus interrogatus
+						responde<lb/>breviter, dilucidcque quantum |otcs, quomodo siu<lb/>guli
+						qui restant pedes, aliis legitime immixtis, obti­<lb/>neant suum nomen in
+						rhythmo. <hi rend="italic">D.</hi> Faciam : neque<lb/>enim ullius negotii
+						est, tanta rationum luce praemissa.<lb/>Nam tribracho nullus miscebitur ;
+						omnes enim prio­<lb/>res sunt, qui ei sunt u;mporibus pares. Dactylo ana­
+						<lb/>paestus potest; nam ct cst posterior, et I tempore ac<lb/>plausu
+						currit aequaliter : ulriquc autem proceleuma­<lb/>ticus eadem scilicet
+						ratione copulatur. Jam bacchio<lb/>creticus, et de paconibus primus,
+						sccundus ct qua.-.<lb/>tus misceri possunt. Porro ipsi cretico, omues qui
+						<lb/>post illum sunt quinque temporum pedes jure miscen<lb/>tur, sed non
+						omnes eadem divisione. Alii namque ad<lb/>duo et tria, alii ad tria et duo
+						tempora dividuntur.<lb/>Iste autem creticus ulroquc modo dividi pOtest,
+						quia<lb/>media brevis cuilibet parti tribuitur. Palimbacchius<lb/>autcm
+						, quia ejus divisio a duobus temporibus inci­<lb/>piena, in tria desinit,
+						cougruos ct copulabiles habet<lb/>paeones omnes, praeter secundum. Molossus
+						de tri­<lb/>syllabis restat, a quo prino incipiunt sex temporum<lb/>
+						pedes, qui omnes eidem conjungi possunt, partim<lb/>propter simpli
+						duplique rationcm; partim propter<lb/>illam quam nobis plausus ostendit,
+						partitionem longae<lb/>syllabae, quae singula tempora parti utrique concedit,
+						<lb/>quia in senario numero par lateribus medium est.<lb/>Ob quam causam
+						et molossus, et ambo ionici non so­<lb/>lum in simplum et duplum, sed
+						ctiam in aequas par­<lb/>tes per terna tempora feriuntur. Hinc efficitur ut
+						dcin­<lb/>ceps omnibus sci temporum pedibus, omnes totidem <note
 							type="footnote">1 In B. et omnibus editis, <hi rend="italic">posterior
-								tempore,</hi> omissa I ar­ <lb/> licula c(,quain fert Ms. A, et sine
+								tempore,</hi> omissa I ar­<lb/>licula c(,quain fert Ms. A, et sine
 							qua oratio claudicat. M. </note>
 						<lb/>
-						<pb n="1121"/> temporum posteriores copulari queant ; solusque an­ <lb/>
-						tispastus, qui nullum sibi velit misceri, remaneat. <lb/> Hos consequuntur
-						quatuor epitriti, quorum primus <lb/> admittit secundum, secundus nullum,
-						tertius quar­ <lb/> tum, quartus nullum. Restat dispondeus, rhythmum <lb/>
-						solus cnam ipse facturus, quia nec posteriorem quem­ <lb/> quam invenit, nec
-						æqualem. Itaque omnium pedum <lb/> octo sunt !, qui nullo alio mixto
-						rhythmum faciunt : <lb/> pyrrhichius, tribrachus,
-						proccleusmaticus,paeonquar­ <lb/> tus, aniispastus, epitritus secundus, et
-						quartus, et <lb/> dispondeus : rcliqui eos, qui se posteriores sunt, co­
-						<lb/> pulari sibi patiuntur, ita ut rhythmi nomen obti­ <lb/> neant, etiamsi
-						pauciores in ea serie numerentur. <lb/> Huc cst, ut opinor, satis a me quod
-						voluisti, expli­ <lb/> catum atque digestum : tuum cst jam videre quod <lb/>
+						<pb n="1121"/> temporum posteriores copulari queant ; solusque an­<lb/>
+						tispastus, qui nullum sibi velit misceri, remaneat.<lb/>Hos consequuntur
+						quatuor epitriti, quorum primus<lb/>admittit secundum, secundus nullum,
+						tertius quar­<lb/>tum, quartus nullum. Restat dispondeus, rhythmum<lb/>
+						solus cnam ipse facturus, quia nec posteriorem quem­<lb/>quam invenit, nec
+						aequalem. Itaque omnium pedum<lb/>octo sunt !, qui nullo alio mixto
+						rhythmum faciunt :<lb/>pyrrhichius, tribrachus,
+						proccleusmaticus,paeonquar­<lb/>tus, aniispastus, epitritus secundus, et
+						quartus, et<lb/>dispondeus : rcliqui eos, qui se posteriores sunt, co­
+						<lb/>pulari sibi patiuntur, ita ut rhythmi nomen obti­<lb/>neant, etiamsi
+						pauciores in ea serie numerentur.<lb/>Huc cst, ut opinor, satis a me quod
+						voluisti, expli­<lb/>catum atque digestum : tuum cst jam videre quod<lb/>
 						restat.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT V. — <hi rend="italic">An sint pedes supra syllabas
 								quatuor.</hi>
 						</title>
 					</ab>
-					<p>it. <hi rend="italic">M.</hi> Imo mecum etiam tuum * : ambo enin <lb/>
-						quarimus. Sed quid tandem restare arbitraris, quod <lb/> ad rhythmum
-						attinet? Nonne illud considerandum est <lb/> utrum aliqua dimensio pedis,
-						quamvis octo tempora <lb/> non excedat, quæ dispondeus obtinet, excedat
-						tamen <lb/> numerum quatuor syllabarum ? <hi rend="italic">D.</hi> Quare ,
-						quæso? <lb/>
-						<hi rend="italic">M.</hi> Imo In , quare mc potius quam teipsum rogas? <lb/>
-						An tibi non videtur sine ulla fraude vel offensione au­ <lb/> rium, sive
-						quod a ad plausum ac divisionem pedum, <lb/> sivc quod ad spatium temporis
-						pertinet, pro una <lb/> longa syllaba duas posse poni breves? <hi
-							rend="italic">D.</hi> Quis hoc <lb/> negaverit? M. Hinc ergo est, qnod
-						pro iambo velcho­ <lb/> ria tribrachum ponimus, ct pro spondeo dactylum vel
-						<lb/> anapæstum vcl proceleusmaticum, cum vel pro se­ <lb/> cunda ejus, vel
-						pro prima duas breves ponimus, vcl <lb/> quatuor pro utraque. <hi
+					<p>it. <hi rend="italic">M.</hi> Imo mecum etiam tuum * : ambo enin<lb/>
+						quarimus. Sed quid tandem restare arbitraris, quod<lb/>ad rhythmum
+						attinet? Nonne illud considerandum est<lb/>utrum aliqua dimensio pedis,
+						quamvis octo tempora<lb/>non excedat, quae dispondeus obtinet, excedat
+						tamen<lb/>numerum quatuor syllabarum ? <hi rend="italic">D.</hi> Quare ,
+						quaeso?<lb/>
+						<hi rend="italic">M.</hi> Imo In , quare mc potius quam teipsum rogas?<lb/>
+						An tibi non videtur sine ulla fraude vel offensione au­<lb/>rium, sive
+						quod a ad plausum ac divisionem pedum,<lb/>sivc quod ad spatium temporis
+						pertinet, pro una<lb/>longa syllaba duas posse poni breves? <hi
+							rend="italic">D.</hi> Quis hoc<lb/>negaverit? M. Hinc ergo est, qnod
+						pro iambo velcho­<lb/>ria tribrachum ponimus, ct pro spondeo dactylum vel
+						<lb/>anapaestum vcl proceleusmaticum, cum vel pro se­<lb/>cunda ejus, vel
+						pro prima duas breves ponimus, vcl<lb/>quatuor pro utraque. <hi
 							rend="italic">D.</hi> Assentior. <hi rend="italic">M.</hi> Fac igitur
-						boc <lb/> idcm in ionico quolibct, vel alio quopiam quadrisyl­ <lb/> labo
-						sex tem; orum pede, ct pro una cjus quacumque <lb/> longa duas breves
-						constitue 4. Num quidquam meu­ <lb/> suræ deperit, aut plausui resistit ?
-							<hi rend="italic">D.</hi> Nihil omnino. <lb/> M. Considera ergo quot
-						syllaba fiunt. <hi rend="italic">D.</hi> Quinque <lb/> fieri video. M. Vides
-						certe posse quatuor syllabarum <lb/> numerum excedi. <hi rend="italic"
-							>D.</hi> Video sane. <hi rend="italic">M.</hi> Quid, si pro <lb/>
-						duabus, quæ ibi sunt longæ, quatuor breves posuc­ <lb/> ris? nonne in uno
+						boc<lb/>idcm in ionico quolibct, vel alio quopiam quadrisyl­<lb/>labo
+						sex tem; orum pede, ct pro una cjus quacumque<lb/>longa duas breves
+						constitue 4. Num quidquam meu­<lb/>surae deperit, aut plausui resistit ?
+							<hi rend="italic">D.</hi> Nihil omnino.<lb/>M. Considera ergo quot
+						syllaba fiunt. <hi rend="italic">D.</hi> Quinque<lb/>fieri video. M. Vides
+						certe posse quatuor syllabarum<lb/>numerum excedi. <hi rend="italic"
+							>D.</hi> Video sane. <hi rend="italic">M.</hi> Quid, si pro<lb/>
+						duabus, quae ibi sunt longae, quatuor breves posuc­<lb/>ris? nonne in uno
 						pede sex syllabas neces e cst mc- <note type="footnote">1 in It. Am. Er.
-							ell.ov,: <hi rend="italic">omnium pedum nm'e?1' suni, <lb/> Qui nullo
+							ell.ov,: <hi rend="italic">omnium pedum nm'e?1' suni,<lb/>Qui nullo
 								clio muxU)</hi> rhylkuvm <hi rend="italic">fuciunl : pyrrhichius,
 								tri­</hi>
-							<lb/> brachus, <hi rend="italic">procclevwnalicus, pceon secundus,
-								paron</hi> quar­ <lb/>
+							<lb/>brachus, <hi rend="italic">procclevwnalicus, pceon secundus,
+								paron</hi> quar­<lb/>
 							<hi rend="italic">tus,</hi> etc. Ha?c addit nota edit. Bened.: <hi
-								rend="italic">Mss. otnnes quos per <lb/> nos inspicere licuit,
-								habent,</hi> octo sunt, <hi rend="italic">et mox in horum <lb/> ,
+								rend="italic">Mss. otnnes quos per<lb/>nos inspicere licuit,
+								habent,</hi> octo sunt, <hi rend="italic">et mox in horum<lb/>,
 								pedum recemione</hi> omittunt, prcon secundus; <hi rend="italic">qui
-								tamen pes<lb/> videtur haud posse ex lege hic præscripta rhythmum
-								alio<lb/> admixto pede facere</hi> : quippe <hi rend="italic">cum
-								posteriores totidem tem­ <lb/> porurn pedes misceri illi
-								prohibeat</hi> plausus <hi rend="italic">disparitas; prw--<lb/> res
+								tamen pes<lb/>videtur haud posse ex lege hic praescripta rhythmum
+								alio<lb/>admixto pede facere</hi> : quippe <hi rend="italic">cum
+								posteriores totidem tem­<lb/>porurn pedes misceri illi
+								prohibeat</hi> plausus <hi rend="italic">disparitas; prw<lb/>res
 								vero</hi> st <hi rend="italic">illi nmcetitur, rhythmum sibi
-								vindicent, suum­ <lb/> que ipsi nomen</hi> iMponant. <hi
-								rend="italic">Quapropter lectionem</hi> retinuimus <lb/>
+								vindicent, suum­<lb/>que ipsi nomen</hi> iMponant. <hi
+								rend="italic">Quapropter lectionem</hi> retinuimus<lb/>
 							<hi rend="italic">editionum :m. Er. et Lov.</hi> Falsa supj ositione
-							nititur illud ar­ <lb/> gumentum, scilicet paeonem
-							secundumcumnulloaliofede <lb/> posse misceri. nam paeon quartus, ut
-							testatur lihr. 2, n. 10, <lb/> dividi jiotest <hi rend="italic">aut</hi>
+							nititur illud ar­<lb/>gumentum, scilicet paeonem
+							secundumcumnulloaliofede<lb/>posse misceri. nam paeon quartus, ut
+							testatur lihr. 2, n. 10,<lb/>dividi jiotest <hi rend="italic">aut</hi>
 							in <hi rend="italic">auo et tiia, alll ill tria et duo tempora :</hi>
-							<lb/> quæ divisio eum jaconi secundo maritat sine plausus dIs- <lb/> I
+							<lb/>quae divisio eum jaconi secundo maritat sine plausus dIs<lb/>I
 							a: iiale. M. </note><note type="footnote"> 3 <hi rend="italic">,IlW meum
 								etiam Ill,</hi> juxta Er. I.ugd. ven. <hi rend="italic">imomeum,
-								<lb/> ne etiam tuum9</hi> juxta Ms. A. <hi rend="italic">II1W mew1t
+								<lb/>ne etiam tuum9</hi> juxta Ms. A. <hi rend="italic">II1W mew1t
 								est (jiuim luunt,</hi>
-							<lb/> juxta als. B. M. </note><note type="footnote"> 3 Hic et I aulo
+							<lb/>juxta als. B. M. </note><note type="footnote"> 3 Hic et I aulo
 							post, quod, juxta vatic. M. </note><note type="footnote"> 4 fr. Lugd.
 							Ven. ct Lov., <hi rend="italic">et pro</hi> rma <hi rend="italic"
 								>ejus... constituas.</hi>
-							<lb/> iLss. A et ti., <hi rend="italic">ut</hi> pro <hi rend="italic"
-								>ima ejus quacumque hnga duas</hi> b TM3 <lb/>
+							<lb/>iLss. A et ti., <hi rend="italic">ut</hi> pro <hi rend="italic"
+								>ima ejus quacumque hnga duas</hi> b TM3<lb/>
 							<hi rend="italic">comtilKus.</hi> M. </note>
-						<lb/> tiri? <hi rend="italic">D.</hi> Ita est. <hi rend="italic">M.</hi>
-						Quid, si cujuslibet epitriti omnes <lb/> longas solvas in breves? num eliam
-						de septem sylla­ <lb/> bisdubitandum est? D. Nullomodo. <hi rend="italic"
-							>M.</hi> Quid ipse dis­ <lb/> pondeus? nonne octo efficit, cum pro
-						omnibus lon­ <lb/> gis binas breves locamus? <hi rend="italic">D.</hi>
+						<lb/>tiri? <hi rend="italic">D.</hi> Ita est. <hi rend="italic">M.</hi>
+						Quid, si cujuslibet epitriti omnes<lb/>longas solvas in breves? num eliam
+						de septem sylla­<lb/>bisdubitandum est? D. Nullomodo. <hi rend="italic"
+							>M.</hi> Quid ipse dis­<lb/>pondeus? nonne octo efficit, cum pro
+						omnibus lon­<lb/>gis binas breves locamus? <hi rend="italic">D.</hi>
 						Verissimum est.</p>
 					</div>
-				<div type="textpart" subtype="dialog"><p>12. <hi rend="italic">M.</hi> Quæ igitur ratio est, qua cogimur et tam <lb/>
-						multarum syllabarum metiri pedes, et pedem qui <lb/> adhibetur ad numeros,
-						non excedere quatuor sylla­ <lb/> bas, ante tractatis rationibus confitemur?
-						nonne libi <lb/> videntur inter se ista pugnare? <hi rend="italic">D.</hi>
-						Imo maxime, et <lb/> quomodo istud pacari possit, ignoro. <hi rend="italic"
-							>M.</hi> Etiam hoc <lb/> facile est, si te ipsum rursum interroges,
-						utrum ra­ <lb/> tionabiliter inter nos paulo anle constiterit, ideo pyr­
-						<lb/> rhichium,et proceleusmaticum plausu debere dijudi­ <lb/> cari atque
-						discerni, ne sit ullus pes legitimæ divisio­ <lb/> nis, qni rhythmum non
-						faciat, id cst, ut ex eo <lb/> rhythmus nominetur. <hi rend="italic">D.</hi>
-						Hoc vero memini, et non <lb/> invenio cur mihi placuisse poeniteat : sed
-						quorsum <lb/> ista ? <hi rend="italic">M.</hi> Quia scilicet hi omnes pedes
-						quaternarum <lb/> syllabarum, excepto amphibracho, rhythmum faciunt, <lb/>
-						id est, principatum in rhythmo tenent, eumque usu <lb/> et nomine efficiunt
-						: illi vero qui plures quam qua­ <lb/> tuor syllabas habent, multi quidem
-						pro his poni pos­ <lb/> sunt t; sed ipsi per se rhythmum facere, ac rhythmi
-						<lb/> nomen obtinere non possunt : el ideo ne pedes qui­ <lb/> dem istos
-						appellandos putaverim Quamobrem repu­ <lb/> gnantia illa quæ nos movebat,
-						jam, ut opinor, conpo­ <lb/> sita est et sopita, quandoquidem licet ct
-						plures <lb/> syllabas quam quatuor pro aliquo pede ponere, et <lb/> pedem
-						tamen non appellare, nisi eum quo rhythmus <lb/> efficiatur. Oportebat cnim
-						jedi constitui aliquem nio­ <lb/> dum progressionis in syllabis. Is aulcm
-						modus con­ <lb/> stitui optime potuit, qui de ipsa numerorum ratione <lb/>
-						translatus in quaternario constitit. Itaque longarum <lb/> syllabarum
-						quatuor pes esse potuit. Cum autcm pro <lb/> eo breves octo constituimus,
-						quoniam tautum spatii <lb/> habent in tempore, pro altero poni possunt. Quia
-						<lb/> vero legitimam progressionem, id est quaternarium <lb/> numerum
-						cxcedunt, pro ac ipsi poui, ac rhythmum <lb/> gignere non sensu aurium, sea
-						disciplinae lege prohi­ <lb/> bentur. Nisi contradicere aliquid paras.</p>
+				<div type="textpart" subtype="dialog"><p>12. <hi rend="italic">M.</hi> Quae igitur ratio est, qua cogimur et tam<lb/>
+						multarum syllabarum metiri pedes, et pedem qui<lb/>adhibetur ad numeros,
+						non excedere quatuor sylla­<lb/>bas, ante tractatis rationibus confitemur?
+						nonne libi<lb/>videntur inter se ista pugnare? <hi rend="italic">D.</hi>
+						Imo maxime, et<lb/>quomodo istud pacari possit, ignoro. <hi rend="italic"
+							>M.</hi> Etiam hoc<lb/>facile est, si te ipsum rursum interroges,
+						utrum ra­<lb/>tionabiliter inter nos paulo anle constiterit, ideo pyr­
+						<lb/>rhichium,et proceleusmaticum plausu debere dijudi­<lb/>cari atque
+						discerni, ne sit ullus pes legitimae divisio­<lb/>nis, qni rhythmum non
+						faciat, id cst, ut ex eo<lb/>rhythmus nominetur. <hi rend="italic">D.</hi>
+						Hoc vero memini, et non<lb/>invenio cur mihi placuisse poeniteat : sed
+						quorsum<lb/>ista ? <hi rend="italic">M.</hi> Quia scilicet hi omnes pedes
+						quaternarum<lb/>syllabarum, excepto amphibracho, rhythmum faciunt,<lb/>
+						id est, principatum in rhythmo tenent, eumque usu<lb/>et nomine efficiunt
+						: illi vero qui plures quam qua­<lb/>tuor syllabas habent, multi quidem
+						pro his poni pos­<lb/>sunt t; sed ipsi per se rhythmum facere, ac rhythmi
+						<lb/>nomen obtinere non possunt : el ideo ne pedes qui­<lb/>dem istos
+						appellandos putaverim Quamobrem repu­<lb/>gnantia illa quae nos movebat,
+						jam, ut opinor, conpo­<lb/>sita est et sopita, quandoquidem licet ct
+						plures<lb/>syllabas quam quatuor pro aliquo pede ponere, et<lb/>pedem
+						tamen non appellare, nisi eum quo rhythmus<lb/>efficiatur. Oportebat cnim
+						jedi constitui aliquem nio­<lb/>dum progressionis in syllabis. Is aulcm
+						modus con­<lb/>stitui optime potuit, qui de ipsa numerorum ratione<lb/>
+						translatus in quaternario constitit. Itaque longarum<lb/>syllabarum
+						quatuor pes esse potuit. Cum autcm pro<lb/>eo breves octo constituimus,
+						quoniam tautum spatii<lb/>habent in tempore, pro altero poni possunt. Quia
+						<lb/>vero legitimam progressionem, id est quaternarium<lb/>numerum
+						cxcedunt, pro ac ipsi poui, ac rhythmum<lb/>gignere non sensu aurium, sea
+						disciplinae lege prohi­<lb/>bentur. Nisi contradicere aliquid paras.</p>
 					</div>
-				<div type="textpart" subtype="dialog"><p>13. <hi rend="italic">D.</hi> Paro sanc, et jam faciam. Nam quid impe­ <lb/>
-						diebat usque ad octonarium numerum syllabarum <lb/> progredi pedum, cum
-						cumdem numerum ad rhy­ <lb/> thmum admitti posse videamus? n'eque enim me
-						mo­ <lb/> vet, quod pro alio dicis admitti : imo hoc me magis <lb/> admonet
-						quærere. vel potius queri, quod non etiam <lb/> suo nomine admittitur qui
-						pro alio potest. <hi rend="italic">M.</hi> Non <lb/> mirum est, quod hic
-						falleris; sed facilis explicatio <lb/> veri est. Nam ut omittam tanta quæ
-						pro qnaternario <lb/> numero jam ante disputata sunt, cur usquc ad illum
-						<lb/> fieri debeat progressio sylhharmn; fac me jam ces­ <lb/> sisse libi et
-						consensisse usque in octo syllabas pedis <lb/> debere longitudinem porrigi :
-						num resistere poteris <lb/> esse jam posse octo longarum syllabarum pcdem ?
-						<lb/> Certe enim ad quem numerum syllabarum pervenit <lb/> pes, non solus ad
+				<div type="textpart" subtype="dialog"><p>13. <hi rend="italic">D.</hi> Paro sanc, et jam faciam. Nam quid impe­<lb/>
+						diebat usque ad octonarium numerum syllabarum<lb/>progredi pedum, cum
+						cumdem numerum ad rhy­<lb/>thmum admitti posse videamus? n'eque enim me
+						mo­<lb/>vet, quod pro alio dicis admitti : imo hoc me magis<lb/>admonet
+						quaerere. vel potius queri, quod non etiam<lb/>suo nomine admittitur qui
+						pro alio potest. <hi rend="italic">M.</hi> Non<lb/>mirum est, quod hic
+						falleris; sed facilis explicatio<lb/>veri est. Nam ut omittam tanta quae
+						pro qnaternario<lb/>numero jam ante disputata sunt, cur usquc ad illum
+						<lb/>fieri debeat progressio sylhharmn; fac me jam ces­<lb/>sisse libi et
+						consensisse usque in octo syllabas pedis<lb/>debere longitudinem porrigi :
+						num resistere poteris<lb/>esse jam posse octo longarum syllabarum pcdem ?
+						<lb/>Certe enim ad quem numerum syllabarum pervenit<lb/>pes, non solus ad
 						cum pervenit qui brevibus, sed <note type="footnote"> 1 vatie.: <hi
 								rend="italic">:'lli vero qvi</hi> pturc* <hi rend="italic">nuam
-								quatuor sijlLibns ha­ <lb/> bent, pro aliis poni possunt, zcd</hi>
+								quatuor sijlLibns ha­<lb/>bent, pro aliis poni possunt, zcd</hi>
 							ilnl. M. </note>
 						<lb/>
-						<pb n="1123"/> etiam qni longis syllabis constat. Quo fit ut adhibita <lb/>
-						rursus ea lege, quæ abrogari non potest, qua duas <lb/> breves pro una longa
-						poni licet, ad sexdecim sylla­ <lb/> bas pertendamus. Ubi si rursus pedis
-						incrementum <lb/> statuero volueris, in triginta duas breves proficisci­
-						<lb/> mur : huc qnoque ratio tua pedem te compellit addu­ <lb/> cere, at
-						rursus lex illa duplum numerum brevium <lb/> pro longis locare : atque ita
-						nullus constituetur mo­ <lb/> dus. <hi rend="italic">D.</hi> Jam cedo
-						rationi, qua usque ad quaterna- <lb/> Tium syllabarum numerum promovemus
-						pedem. Pro <lb/> bis autem legitimis pedibus poni oportere pedes plu­ <lb/>
-						rium syllabarum, dum breves duae unius longæ locum <lb/> occupant non
+						<pb n="1123"/> etiam qni longis syllabis constat. Quo fit ut adhibita<lb/>
+						rursus ea lege, quae abrogari non potest, qua duas<lb/>breves pro una longa
+						poni licet, ad sexdecim sylla­<lb/>bas pertendamus. Ubi si rursus pedis
+						incrementum<lb/>statuero volueris, in triginta duas breves proficisci­
+						<lb/>mur : huc qnoque ratio tua pedem te compellit addu­<lb/>cere, at
+						rursus lex illa duplum numerum brevium<lb/>pro longis locare : atque ita
+						nullus constituetur mo­<lb/>dus. <hi rend="italic">D.</hi> Jam cedo
+						rationi, qua usque ad quaterna<lb/>Tium syllabarum numerum promovemus
+						pedem. Pro<lb/>bis autem legitimis pedibus poni oportere pedes plu­<lb/>
+						rium syllabarum, dum breves duae unius longae locum<lb/>occupant non
 						recuso.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT VI. — <hi rend="italic">Pedes quatuor syllabis
@@ -2527,47 +2527,47 @@
 							nequeunt.</title>
 					</ab>
 					</div>
-				<div type="textpart" subtype="dialog"><p>14. M. Facile est ergo te etiam illud videre atque <lb/> concedere, alios
-						pedes esse pro his, penes quos rhy­ <lb/> thmi est principatns, alios qui
-						cum his collocantur. <lb/> Nam ubi pro longis singulis geminantur breves,
-						pro <lb/> eo qui rhythmum obtinet, alium locamus; velut pro <lb/> iambo vel
-						trochæo tribrachum, aut pro spondeo da­ <lb/> ctylum aut anapæstum aut
-						proceleusmaticum. Ubi <lb/> vero non idem fit, non pro co, sed cum eo
-						ponitur <lb/> quisquis miscetur inferiorum; ut cum dactylo anapae­ <lb/>
-						atus , cum ionico vero utrolibet diiambus vel dicho­ <lb/> rius: et reliqui
-						similiter san jure cum cæteris. An pa­ <lb/> rum tibi dilucidum, vel falsum
-						videtur <unclear>3</unclear> D. Jam intel­ <lb/> iigo. <hi rend="italic"
-							>M.</hi> Responde ergo utrum illi qui pro aliis <lb/> ponuntur, possint
-						eliam ipsi pcr se facere rhythmum. <lb/> D. Possunt. M. Omnesne? <hi
-							rend="italic">D.</hi> Omnes. <hi rend="italic">M.</hi> Ergo et <lb/>
-						quinque syllabarum pes potest suonomine rhythmum <lb/> facere, quia pro
-						bacchio vel cretico vel quolibet <lb/> pæone poni potest. <hi rend="italic"
-							>D.</hi> Non potest quidem; sed jam <lb/> istum non vocamus pedem, si
-						progressionis illius us­ <lb/> que ad quaternarium numerum satis memini t.
-						Ego <lb/> autem cum omnes posse respondi, pedes utiquc <lb/> posse respondi.
-						M. Laudo etiam in nomine reti­ <lb/> nendo diligentiam et vigilantiam tuam.
-						Sed scias <lb/> multis visum esse etiam senarum syllabarum pedes <lb/> nun
-						cupandos ; sed amplius, quod sciam, nemini pla­ <lb/> cuit. Et illi quibus
-						hoc placuit, negaverunt ad rhy­ <lb/> thmum, aut ad metrum per se gignendum
-						tam longos <lb/> pedes adhiberi oportere. Itaque ne nomina quidcm <lb/> his
-						indiderunt. Quocirca verissimus est ille progres­ <lb/> sionis modus, qui
-						usquead quatuor syllabas pervenit; <lb/> quandoquidem hi omnes pedes, quibus
-						divisis dno <lb/> 'Heri non possont, conjuncti pedem facere potuerunt: <lb/>
-						et ita qui in Mesiam syllabam usque progreesi sunt, <lb/> nomen tantum pedis
-						in eos, qui quaitam excesserunt, <lb/> transferre ausi sunt; ad principatum
-						vero , qui est <lb/> in rhythmis et metris, nuHo modo eos aspirare sive­
-						<lb/> runt. Sed cum pro longis breves duplicantur, etiam <lb/> ad septimam
-						atque octavam, ut jam ostendit ratio, <lb/> syllabam pervenitur : ad quem
-						numerum nemo te­ <lb/> tendit pedem. Sed quoniam video constare inter nos
-						<lb/> quemlibet plurium quam quatuor syllabarum, cum pro <note
+				<div type="textpart" subtype="dialog"><p>14. M. Facile est ergo te etiam illud videre atque<lb/>concedere, alios
+						pedes esse pro his, penes quos rhy­<lb/>thmi est principatns, alios qui
+						cum his collocantur.<lb/>Nam ubi pro longis singulis geminantur breves,
+						pro<lb/>eo qui rhythmum obtinet, alium locamus; velut pro<lb/>iambo vel
+						trochaeo tribrachum, aut pro spondeo da­<lb/>ctylum aut anapaestum aut
+						proceleusmaticum. Ubi<lb/>vero non idem fit, non pro co, sed cum eo
+						ponitur<lb/>quisquis miscetur inferiorum; ut cum dactylo anapae­<lb/>
+						atus , cum ionico vero utrolibet diiambus vel dicho­<lb/>rius: et reliqui
+						similiter san jure cum caeteris. An pa­<lb/>rum tibi dilucidum, vel falsum
+						videtur <unclear>3</unclear> D. Jam intel­<lb/>iigo. <hi rend="italic"
+							>M.</hi> Responde ergo utrum illi qui pro aliis<lb/>ponuntur, possint
+						eliam ipsi pcr se facere rhythmum.<lb/>D. Possunt. M. Omnesne? <hi
+							rend="italic">D.</hi> Omnes. <hi rend="italic">M.</hi> Ergo et<lb/>
+						quinque syllabarum pes potest suonomine rhythmum<lb/>facere, quia pro
+						bacchio vel cretico vel quolibet<lb/>paeone poni potest. <hi rend="italic"
+							>D.</hi> Non potest quidem; sed jam<lb/>istum non vocamus pedem, si
+						progressionis illius us­<lb/>que ad quaternarium numerum satis memini t.
+						Ego<lb/>autem cum omnes posse respondi, pedes utiquc<lb/>posse respondi.
+						M. Laudo etiam in nomine reti­<lb/>nendo diligentiam et vigilantiam tuam.
+						Sed scias<lb/>multis visum esse etiam senarum syllabarum pedes<lb/>nun
+						cupandos ; sed amplius, quod sciam, nemini pla­<lb/>cuit. Et illi quibus
+						hoc placuit, negaverunt ad rhy­<lb/>thmum, aut ad metrum per se gignendum
+						tam longos<lb/>pedes adhiberi oportere. Itaque ne nomina quidcm<lb/>his
+						indiderunt. Quocirca verissimus est ille progres­<lb/>sionis modus, qui
+						usquead quatuor syllabas pervenit;<lb/>quandoquidem hi omnes pedes, quibus
+						divisis dno<lb/>'Heri non possont, conjuncti pedem facere potuerunt:<lb/>
+						et ita qui in Mesiam syllabam usque progreesi sunt,<lb/>nomen tantum pedis
+						in eos, qui quaitam excesserunt,<lb/>transferre ausi sunt; ad principatum
+						vero , qui est<lb/>in rhythmis et metris, nuHo modo eos aspirare sive­
+						<lb/>runt. Sed cum pro longis breves duplicantur, etiam<lb/>ad septimam
+						atque octavam, ut jam ostendit ratio,<lb/>syllabam pervenitur : ad quem
+						numerum nemo te­<lb/>tendit pedem. Sed quoniam video constare inter nos
+						<lb/>quemlibet plurium quam quatuor syllabarum, cum pro <note
 							type="footnote"> * sic Mss. A et ai B; at in B. legitur <hi
-								rend="italic">sed jam istum non<lb/> vecart pedem, progressio tllius
-								ultra qttaternarium nu­ <lb/> merum transeat, satis memini.</hi> Er.
+								rend="italic">sed jam istum non<lb/>vecart pedem, progressio tllius
+								ultra qttaternarium nu­<lb/>merum transeat, satis memini.</hi> Er.
 							Lugd. Vea., si <hi rend="italic">progres</hi>sione etc.M. </note><lb/>
-						longa duas breves ponimus, non cum his legitimis <lb/> pedibus, sed pro hi,
-						posse poni, neque per seipsos <lb/> rhythmum creare, ne in infinitum eat
-						quod ratione <lb/> finiendum est, satisque jam inter nos de rhythmo exi.
-						<lb/> sumo disputatum ; transeamus ad mItra, si placet. <lb/>
+						longa duas breves ponimus, non cum his legitimis<lb/>pedibus, sed pro hi,
+						posse poni, neque per seipsos<lb/>rhythmum creare, ne in infinitum eat
+						quod ratione<lb/>finiendum est, satisque jam inter nos de rhythmo exi.
+						<lb/>sumo disputatum ; transeamus ad mItra, si placet.<lb/>
 						<hi rend="italic">D.</hi> Placet vero.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">-CAPUT VII. — <hi rend="italic">De</hi> metro <hi
@@ -2576,61 +2576,61 @@
 						</title>
 					</ab>
 					</div>
-				<div type="textpart" subtype="dialog"><p>15. M. Dic igitur, metrumne arbitreris pedibusfleri, <lb/> an pedes metro.
+				<div type="textpart" subtype="dialog"><p>15. M. Dic igitur, metrumne arbitreris pedibusfleri,<lb/>an pedes metro.
 							<hi rend="italic">D.</hi> Non intelligo. <hi rend="italic">M.</hi>
-						Pedesne con­ <lb/> juncti metrum creant, an metris conjunctis pedes cre­
-						<lb/> antur ? D. Scio jam quid dicas, et conjunctis pedibus <lb/> metrum
-						fieri pato. X. Cur tandem id putas! D. Quia <lb/> inter rhythmum et metrum
-						hoe interesse dixisti, quod <lb/> in rhythmo contextio pedum nullum certum
-						babet fi­ <lb/> Dem, in metro vero habet : ita ista pedum contextio <lb/> et
-						rhythmi et metri esse intelligitur ; sed ibi infinita, <lb/> hic autem
-						finita constat. <hi rend="italic">M.</hi> Ergo unus pes metrum <lb/> non
-						est. <hi rend="italic">D.</hi> Non utique. H. Quid unus pes et semipes? <lb/>
+						Pedesne con­<lb/>juncti metrum creant, an metris conjunctis pedes cre­
+						<lb/>antur ? D. Scio jam quid dicas, et conjunctis pedibus<lb/>metrum
+						fieri pato. X. Cur tandem id putas! D. Quia<lb/>inter rhythmum et metrum
+						hoe interesse dixisti, quod<lb/>in rhythmo contextio pedum nullum certum
+						babet fi­<lb/>Dem, in metro vero habet : ita ista pedum contextio<lb/>et
+						rhythmi et metri esse intelligitur ; sed ibi infinita,<lb/>hic autem
+						finita constat. <hi rend="italic">M.</hi> Ergo unus pes metrum<lb/>non
+						est. <hi rend="italic">D.</hi> Non utique. H. Quid unus pes et semipes?<lb/>
 						<hi rend="italic">D.</hi> Ne hoc quidem. <hi rend="italic">II.</hi> Quare?
-						an quia metrum pedi­ <lb/> bus confit, nec utique possunt dici pedes, ubi
-						minus <lb/> quam duo sunt ? <hi rend="italic">D.</hi> Ita est. <hi
-							rend="italic">M.</hi> Inspiciamus igitur me­ <lb/> tra illa quæ a me
-						paulo ante commemorata sunt, et <lb/> videamus quibus pcdibus constent: non
-						enim te in hoc <lb/> generc animadvertendo rudem esse adhuc decet. Ea <lb/>
-						sunt autem : <lb/> Ite igitur, Camœnæ <lb/> Fonticolx puellae, <lb/> Quae
-						canitis sub antris <lb/> Mellifluos sonores. <lb/> Satis hæc esse ad id quod
-						intendimus puto : tu jam <lb/> metire ista, et quos habeant pedes renuntia.
-						D.Omni­ <lb/> no non possum : eos enim metiendos puto, qui sibi le­ <lb/>
-						gitime copulari queunt; nec valeo me hinc expedire. <lb/> Si enim primum
-						chorium fecero, sequitur iambus, qui <lb/> temporibus par est, sed non
-						similiter plauditur: si da­ <lb/> ctylum, non sequitur alius qui ei saltem
-						temporibus <lb/> coæquetur : si choriambum, eadem difficultas est; <lb/>
-						quod enim restat, nec temporibus cum eo, nec plausu <lb/> convenit. Quare
-						aut hoc metrum non est, aut falsum <lb/> est quod inter nos de pedum
-						copulatione dissertum <lb/> est: nam quid aliud dicam non invenio.</p>
+						an quia metrum pedi­<lb/>bus confit, nec utique possunt dici pedes, ubi
+						minus<lb/>quam duo sunt ? <hi rend="italic">D.</hi> Ita est. <hi
+							rend="italic">M.</hi> Inspiciamus igitur me­<lb/>tra illa quae a me
+						paulo ante commemorata sunt, et<lb/>videamus quibus pcdibus constent: non
+						enim te in hoc<lb/>generc animadvertendo rudem esse adhuc decet. Ea<lb/>
+						sunt autem :<lb/>Ite igitur, Camœnae<lb/>Fonticolx puellae,<lb/>Quae
+						canitis sub antris<lb/>Mellifluos sonores.<lb/>Satis haec esse ad id quod
+						intendimus puto : tu jam<lb/>metire ista, et quos habeant pedes renuntia.
+						D.Omni­<lb/>no non possum : eos enim metiendos puto, qui sibi le­<lb/>
+						gitime copulari queunt; nec valeo me hinc expedire.<lb/>Si enim primum
+						chorium fecero, sequitur iambus, qui<lb/>temporibus par est, sed non
+						similiter plauditur: si da­<lb/>ctylum, non sequitur alius qui ei saltem
+						temporibus<lb/>coaequetur : si choriambum, eadem difficultas est;<lb/>
+						quod enim restat, nec temporibus cum eo, nec plausu<lb/>convenit. Quare
+						aut hoc metrum non est, aut falsum<lb/>est quod inter nos de pedum
+						copulatione dissertum<lb/>est: nam quid aliud dicam non invenio.</p>
 					</div>
-				<div type="textpart" subtype="dialog"><p>16. <hi rend="italic">M.</hi> Metrum quidem esse et eo quod plus es! <lb/>
-						quam pes, certumque finem habet, et ipsarum aurium <lb/> judicio convincitur
-						1 Non enim tam suavi sonaret <lb/> æqualitate, aut motu tam concinno
-						plaudcretur, si non <lb/> inesset in illo numerositas, quoe profecto esse
-						nisi iD <lb/> hac parte musicæ non potest. Falsa vero esse, quæ <lb/> ioter
-						nos constiterunt, miror quod existimes : non <lb/> enim aut numcris quidquam
-						est certius, aut illa pcdum <lb/> commemoratione et collocatione ordinatius.
-						Nain ex <lb/> ipsa numeroruin ratione, quæ nullo modo fallit, ei­ <lb/>
-						pressum est quidquid in cis et ad mulcendas aures, ct <lb/> ad obtinendum in
-						rhythmo principatum t valere pcr­ <lb/> speximus : sed vide potius cum sæpe
-						repeto, <hi rend="italic">Que</hi> ca­ <lb/>
+				<div type="textpart" subtype="dialog"><p>16. <hi rend="italic">M.</hi> Metrum quidem esse et eo quod plus es!<lb/>
+						quam pes, certumque finem habet, et ipsarum aurium<lb/>judicio convincitur
+						1 Non enim tam suavi sonaret<lb/>aequalitate, aut motu tam concinno
+						plaudcretur, si non<lb/>inesset in illo numerositas, quoe profecto esse
+						nisi iD<lb/>hac parte musicae non potest. Falsa vero esse, quae<lb/>ioter
+						nos constiterunt, miror quod existimes : non<lb/>enim aut numcris quidquam
+						est certius, aut illa pcdum<lb/>commemoratione et collocatione ordinatius.
+						Nain ex<lb/>ipsa numeroruin ratione, quae nullo modo fallit, ei­<lb/>
+						pressum est quidquid in cis et ad mulcendas aures, ct<lb/>ad obtinendum in
+						rhythmo principatum t valere pcr­<lb/>speximus : sed vide potius cum saepe
+						repeto, <hi rend="italic">Que</hi> ca­<lb/>
 						<hi rend="italic">nitis sub antris,</hi> dcmulccoque ista numerositate sen­
-						<lb/> sum tuum; quid distat inter hoc, et si adderem ad <lb/> finem hujus
-						brevem aliquam syllabam, et item istud <lb/> eodem modo repeterem, <hi
+						<lb/>sum tuum; quid distat inter hoc, et si adderem ad<lb/>finem hujus
+						brevem aliquam syllabam, et item istud<lb/>eodem modo repeterem, <hi
 							rend="italic">Qum canitis sub</hi> antrisve? <hi rend="italic">D.</hi>
 						<note type="footnote"> 1 CGiivetmwtr, jUXt: Er. et Mss. A ct B. M. </note>
 						<lb/>
-						<pb n="1125"/> Utrumque mihi jucunde illabitur auribus : hoc tamen <lb/>
-						posterius, cui syllab::m addidisti brevem, plus tenere <lb/> spatii ac
-						temporis, siquidem longius factum est, cogor <lb/> fateri. <hi rend="italic"
-							>M.</hi> Quid cum illud superius, <hi rend="italic">Qu</hi>æ <hi
-							rend="italic">canitis</hi> sub <hi rend="italic">an­<lb/> tris,</hi> ita
-						repeto, ut post Onem nihil sileam ? eademne <lb/> ad te jucunditas pervenit
-						? <hi rend="italic">D.</hi> Imo nescio quid clau­ <lb/> dum me offendit,
-						nisi torte illam uUimam plus quam <lb/> Cæteras longas produxeris. M. Ergo
-						sive idipsum am­ <lb/> plius quod producitur, sive quod siletur, censesne in
-						<lb/> tempore babere aliquid spatii ? <hi rend="italic">D.</hi> Qui aliter
+						<pb n="1125"/> Utrumque mihi jucunde illabitur auribus : hoc tamen<lb/>
+						posterius, cui syllab::m addidisti brevem, plus tenere<lb/>spatii ac
+						temporis, siquidem longius factum est, cogor<lb/>fateri. <hi rend="italic"
+							>M.</hi> Quid cum illud superius, <hi rend="italic">Qu</hi>ae <hi
+							rend="italic">canitis</hi> sub <hi rend="italic">an­<lb/>tris,</hi> ita
+						repeto, ut post Onem nihil sileam ? eademne<lb/>ad te jucunditas pervenit
+						? <hi rend="italic">D.</hi> Imo nescio quid clau­<lb/>dum me offendit,
+						nisi torte illam uUimam plus quam<lb/>Caeteras longas produxeris. M. Ergo
+						sive idipsum am­<lb/>plius quod producitur, sive quod siletur, censesne in
+						<lb/>tempore babere aliquid spatii ? <hi rend="italic">D.</hi> Qui aliter
 						potest?</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT VIII — Silentia in metris quanta <hi rend="italic"
@@ -2638,162 +2638,162 @@
 						</title>
 					</ab>
 					</div>
-				<div type="textpart" subtype="dialog"><p>17. M. Recte censes. Sed dic mibi etiam quantum <lb/> spatium putas esse? <hi
-							rend="italic">D.</hi> Metiri hoc omnino difficile est. <lb/> It. Vcrum
-						dicis : sed nonne tibi videtur brevis illa syl­ <lb/> laba id metiri, quam
-						cum addidimus, neque longæ <lb/> ultimae ultra solitum productionem, neque
-						ullam si­ <lb/> lentium in ejus metri repetitionc sensus desideravit? D.
-						<lb/> Omnino assentior : nam et te illud superius pronun­ <lb/> tiante atque
-						repetente, hoc posterius ego apud me ipse <lb/> repetebam pariter tecum :
-						ita sensi idem spatium tem­ <lb/> poris ambobus occurrere, cum silentio tuo
-						brevis mea <lb/> ultima conveniret. M. Teneas Igitur oportet hæc si­ <lb/>
-						lentiorum spatia certa in metris esse. Quare cum <lb/> in veneris aliquid
-						deesse pedi legitimo, considerare <lb/> te oportebit, utrum dimenso 1 atque
-						annumerato si­ <lb/> lentio compensetur. <hi rend="italic">D.</hi> Teneo jam
-						istud, persequcre <lb/> cætera.</p>
+				<div type="textpart" subtype="dialog"><p>17. M. Recte censes. Sed dic mibi etiam quantum<lb/>spatium putas esse? <hi
+							rend="italic">D.</hi> Metiri hoc omnino difficile est.<lb/>It. Vcrum
+						dicis : sed nonne tibi videtur brevis illa syl­<lb/>laba id metiri, quam
+						cum addidimus, neque longae<lb/>ultimae ultra solitum productionem, neque
+						ullam si­<lb/>lentium in ejus metri repetitionc sensus desideravit? D.
+						<lb/>Omnino assentior : nam et te illud superius pronun­<lb/>tiante atque
+						repetente, hoc posterius ego apud me ipse<lb/>repetebam pariter tecum :
+						ita sensi idem spatium tem­<lb/>poris ambobus occurrere, cum silentio tuo
+						brevis mea<lb/>ultima conveniret. M. Teneas Igitur oportet haec si­<lb/>
+						lentiorum spatia certa in metris esse. Quare cum<lb/>in veneris aliquid
+						deesse pedi legitimo, considerare<lb/>te oportebit, utrum dimenso 1 atque
+						annumerato si­<lb/>lentio compensetur. <hi rend="italic">D.</hi> Teneo jam
+						istud, persequcre<lb/>caetera.</p>
 					</div>
-				<div type="textpart" subtype="dialog"><p>18. II. Video jam nos quærere debere ipsius si­ <lb/> lentii modum : namque
-						in hoc metro, ubi post cho­ <lb/> riambum bacchium comperimus , quia unum
-						tempus <lb/> dees! ut sex temporum esset sicut choriambus, fa­ <lb/> cillime
-						id aures senserunt, et in repetitione tanti <lb/> spatii silentium
-						interponere coegerunt, quantum syl­ <lb/> laba occuparet brevis : at si post
-						choriambum lo­ <lb/> cetur spondeus, duo nobis tempora cum 2 silentio <lb/>
-						peragenda sunt ad caput redeuntibus, veluti hoc est, <lb/>
+				<div type="textpart" subtype="dialog"><p>18. II. Video jam nos quaerere debere ipsius si­<lb/>lentii modum : namque
+						in hoc metro, ubi post cho­<lb/>riambum bacchium comperimus , quia unum
+						tempus<lb/>dees! ut sex temporum esset sicut choriambus, fa­<lb/>cillime
+						id aures senserunt, et in repetitione tanti<lb/>spatii silentium
+						interponere coegerunt, quantum syl­<lb/>laba occuparet brevis : at si post
+						choriambum lo­<lb/>cetur spondeus, duo nobis tempora cum 2 silentio<lb/>
+						peragenda sunt ad caput redeuntibus, veluti hoc est,<lb/>
 						<hi rend="italic">Quoe</hi> canitis <hi rend="italic">fontem.</hi> Nam te
-						sentire jam credo si­ <lb/> lendum esse. ut cum redimus ad caput, plausus
-						non <lb/> claudicet. Sed ut experiri queas quanta sihntii hujus <lb/>
+						sentire jam credo si­<lb/>lendum esse. ut cum redimus ad caput, plausus
+						non<lb/>claudicet. Sed ut experiri queas quanta sihntii hujus<lb/>
 						mensura sit, adde unam syllabam longam, ut Gat, <hi rend="italic">Quce<lb/>
-							canitis fontem</hi> vos ; atque hoc cam plausu repete : vi­ <lb/> bubis
-						tantum occupare temporis plausum, quantum in <lb/> dpperiore occupabat, cum
-						ibi duæ longæ post choriam 0 <lb/> sum, hic tres sint locatæ. Unde apparet
-						duum iLi <lb/> temporum interponi silentium. At si post choriambum <lb/>
+							canitis fontem</hi> vos ; atque hoc cam plausu repete : vi­<lb/>bubis
+						tantum occupare temporis plausum, quantum in<lb/>dpperiore occupabat, cum
+						ibi duae longae post choriam 0<lb/>sum, hic tres sint locatae. Unde apparet
+						duum iLi<lb/>temporum interponi silentium. At si post choriambum<lb/>
 						iambus locetur, sicut hoc est, <hi rend="italic">Quas canitis locos,</hi>
-						tria <lb/> tempora silere cogimur: quod ut exploretur, adduntur <lb/> sive
-						per alterunt iambum, sive per choriom, sive per <lb/> tribrachum ut sit ita
+						tria<lb/>tempora silere cogimur: quod ut exploretur, adduntur<lb/>sive
+						per alterunt iambum, sive per choriom, sive per<lb/>tribrachum ut sit ita
 						: <hi rend="italic">Qua</hi> canitis <hi rend="italic">locos bonos:</hi>
-						aut, <lb/>
-						<hi rend="italic">Qu</hi>æ <hi rend="italic">canitis locos monte</hi> : aut,
+						aut,<lb/>
+						<hi rend="italic">Qu</hi>ae <hi rend="italic">canitis locos monte</hi> : aut,
 							<hi rend="italic">Qum</hi> canis locos <hi rend="italic">nemore.</hi>
-						<lb/> II 5 caina additis, cum sine silentio jucunda et æquabi- <lb/> Ii...
-						repetitio movet, et plausu adhibito tantum spatii <lb/> hiic tria singula
-						tenere inveniuntur, quantum illud in <lb/> quo silebamus, manifestum fit
+						<lb/>II 5 caina additis, cum sine silentio jucunda et aequabi<lb/>Ii...
+						repetitio movet, et plausu adhibito tantum spatii<lb/>hiic tria singula
+						tenere inveniuntur, quantum illud in<lb/>quo silebamus, manifestum fit
 						trium temporum ibi esse <note type="footnote"> * juxta
 								<unclear>atie</unclear>., <hi rend="italic">in menso atque
-								annumerato silentio</hi> com­ <lb/>
+								annumerato silentio</hi> com­<lb/>
 							<hi rend="italic">pensetur. M.</hi>
 						</note><note type="footnote"> 17 <hi rend="italic">empora silentio,</hi>
-							juxta vatic.. omisa pnepoaitione, . <lb/> cum. M </note>
-						<lb/> silentium. Potest post cborianjbum una syllaba longa <lb/> constitui,
-						ut quatuor tempora sileantur. Nam etiam sic <lb/> choriambus dividi potest,
-						ut simplo ct duplo levatio <lb/> sibi positioque conveniant. Hujus metri
-						exemplum est, <lb/> Qum cantia <hi rend="italic">rea.</hi> Cui si addas vel
-						duas lungas, vel lon­ <lb/> gam et duas breves, vel brevem et longam et
-						brevem, <lb/> vel duas breves ct longam, vel quatuor breves, imple­ <lb/>
-						bis sex temporum pedem, ut nullo desiderato silentio <lb/> repetatur. Talia
-						sunt, <hi rend="italic">Qu</hi>æ <hi rend="italic">canitis rea
-							pulchras,</hi> Qum <lb/>
+							juxta vatic.. omisa pnepoaitione, .<lb/>cum. M </note>
+						<lb/>silentium. Potest post cborianjbum una syllaba longa<lb/>constitui,
+						ut quatuor tempora sileantur. Nam etiam sic<lb/>choriambus dividi potest,
+						ut simplo ct duplo levatio<lb/>sibi positioque conveniant. Hujus metri
+						exemplum est,<lb/>Qum cantia <hi rend="italic">rea.</hi> Cui si addas vel
+						duas lungas, vel lon­<lb/>gam et duas breves, vel brevem et longam et
+						brevem,<lb/>vel duas breves ct longam, vel quatuor breves, imple­<lb/>
+						bis sex temporum pedem, ut nullo desiderato silentio<lb/>repetatur. Talia
+						sunt, <hi rend="italic">Qu</hi>ae <hi rend="italic">canitis rea
+							pulchras,</hi> Qum<lb/>
 						<hi rend="italic">canitis rea in bona,</hi> Qum <hi rend="italic">canitis
-							res bonumve, Quas ca</hi> .niti, <lb/>
-						<hi rend="italic">nilis rea teneras , Qu</hi>æ <hi rend="italic">canitis rea
-							modo bene.</hi> Quibus <lb/> cognitis atque concessis, credo tibi jam
-						satis apparere, <lb/> nec minus uno tempore sileri posse, nec plus quatuor
-						<lb/> temporibus sileri oportere. Nam et ipsa est illa, de qua <lb/> jam
-						multa dicta sunt, moderata progressio; et in <lb/> omnibus pedibus nulla
-						levatio aut positio amplius quam <lb/> quatuor occupat tempora.</p>
-					<p>19. Itaque cnm aliquid canitur sive pronuntiatur <lb/> quod habeat certum
-						finem, et plus habeat quam ununt <lb/> pedem, et naturali motu ante
-						considerationem nume­ <lb/> rorum sensum quadam aequabilitate demulceat1,
-						jam <lb/> me:rum est. Quanquam enim minus habeat quam duos <lb/> pedes,
-						tamen quia excedit unum et silere cogit, non <lb/> sine mensura , sed I
-						quantum implendis temporibus <lb/> satis est quae alteri debentur pedi; pro
-						duobuspedibus <lb/> auditus accipit •, quod duorum pedum occupat tempera
-						<lb/> donec ad caput redeatur, dum annumeratur sono etinm <lb/> certum atque
-						dimensum intervalli silentium. Sed jain <lb/> mihi dicas velim , utrum his
-						quæ dicta sunt cognitis <lb/> assentiaris. <hi rend="italic">D.</hi> Cognovi
-						et assentior. <hi rend="italic">M.</hi> Mihine cre­ <lb/> dens, an per te
-						ipse vera esse perspiciens ? <hi rend="italic">D.</hi> Per me <lb/> ipse
+							res bonumve, Quas ca</hi> .niti,<lb/>
+						<hi rend="italic">nilis rea teneras , Qu</hi>ae <hi rend="italic">canitis rea
+							modo bene.</hi> Quibus<lb/>cognitis atque concessis, credo tibi jam
+						satis apparere,<lb/>nec minus uno tempore sileri posse, nec plus quatuor
+						<lb/>temporibus sileri oportere. Nam et ipsa est illa, de qua<lb/>jam
+						multa dicta sunt, moderata progressio; et in<lb/>omnibus pedibus nulla
+						levatio aut positio amplius quam<lb/>quatuor occupat tempora.</p>
+					<p>19. Itaque cnm aliquid canitur sive pronuntiatur<lb/>quod habeat certum
+						finem, et plus habeat quam ununt<lb/>pedem, et naturali motu ante
+						considerationem nume­<lb/>rorum sensum quadam aequabilitate demulceat1,
+						jam<lb/>me:rum est. Quanquam enim minus habeat quam duos<lb/>pedes,
+						tamen quia excedit unum et silere cogit, non<lb/>sine mensura , sed I
+						quantum implendis temporibus<lb/>satis est quae alteri debentur pedi; pro
+						duobuspedibus<lb/>auditus accipit •, quod duorum pedum occupat tempera
+						<lb/>donec ad caput redeatur, dum annumeratur sono etinm<lb/>certum atque
+						dimensum intervalli silentium. Sed jain<lb/>mihi dicas velim , utrum his
+						quae dicta sunt cognitis<lb/>assentiaris. <hi rend="italic">D.</hi> Cognovi
+						et assentior. <hi rend="italic">M.</hi> Mihine cre­<lb/>dens, an per te
+						ipse vera esse perspiciens ? <hi rend="italic">D.</hi> Per me<lb/>ipse
 						sanc, quamvis dicente te vera hac esse cognosco.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT IX — <hi rend="italic">Quot ad summum temporibus ac
 								pedibul metrum constare possit.</hi>
 						</title>
 					</ab>
-					<p>20. <hi rend="italic">II.</hi> Age ergo nunc quoniam invenimus unde <lb/>
-						metrum esse incipiat, inveniamus etiam quousque pro­ <lb/> cedat. Nam metrum
-						incipit a duobus pedibus, sive ipso <lb/> sono plenis, sive ad implendum
-						quod deest annume­ <lb/> rato silentio. Quare oportet te jam respiccre ad
-						illam <lb/> quaternariam progressionem, mihique renuntiare us­ <lb/> que ad
-						quot pedes metrum tendere debeamus. <hi rend="italic">D.</hi> Fa­ <lb/> cHe
-						istud quidcm est. Nam octo pedes esse ratio salis <lb/> ducet. <hi
-							rend="italic">3f.</hi> Quid? illud recordarisne, dixisse nos eum <lb/>
-						versum a doctis appellatum, qui duobus membris certa <lb/> ratione dimensis
-						copulatisque constaret? <hi rend="italic">D.</hi> Bene me­ <lb/> mini. M.
-						Cum ergo non sit dictum duobus pcdibus, <lb/> sed duobns membris constare
-						versum, cumque mani­ <lb/> festam sit versum non unum pedem habere, sed
-						plures; <lb/> nonne Ipsa res indicat longius membrum esse quam <lb/> pedem ?
+					<p>20. <hi rend="italic">II.</hi> Age ergo nunc quoniam invenimus unde<lb/>
+						metrum esse incipiat, inveniamus etiam quousque pro­<lb/>cedat. Nam metrum
+						incipit a duobus pedibus, sive ipso<lb/>sono plenis, sive ad implendum
+						quod deest annume­<lb/>rato silentio. Quare oportet te jam respiccre ad
+						illam<lb/>quaternariam progressionem, mihique renuntiare us­<lb/>que ad
+						quot pedes metrum tendere debeamus. <hi rend="italic">D.</hi> Fa­<lb/>cHe
+						istud quidcm est. Nam octo pedes esse ratio salis<lb/>ducet. <hi
+							rend="italic">3f.</hi> Quid? illud recordarisne, dixisse nos eum<lb/>
+						versum a doctis appellatum, qui duobus membris certa<lb/>ratione dimensis
+						copulatisque constaret? <hi rend="italic">D.</hi> Bene me­<lb/>mini. M.
+						Cum ergo non sit dictum duobus pcdibus,<lb/>sed duobns membris constare
+						versum, cumque mani­<lb/>festam sit versum non unum pedem habere, sed
+						plures;<lb/>nonne Ipsa res indicat longius membrum esse quam<lb/>pedem ?
 							<hi rend="italic">D.</hi> Ita vero. <hi rend="italic">M.</hi> At si
-						membra æqualia sint iti <lb/> versu, nonne præposterari poterit, ut prima
-						pars sine <lb/> discrimine ultima, et ultima prima fiat? D. Intelligo <lb/>
+						membra aequalia sint iti<lb/>versu, nonne praeposterari poterit, ut prima
+						pars sine<lb/>discrimine ultima, et ultima prima fiat? D. Intelligo<lb/>
 						<hi rend="italic">M. Ergo ut hoc</hi> non accidat 4, satisque appareat
-						discer­ <lb/> naturque in versu aliud esse membrum quo incipit, <lb/> aliud
-						quo desinit ; non possumus recusare inæqualia <note type="footnote">s <hi
+						discer­<lb/>naturque in versu aliud esse membrum quo incipit,<lb/>aliud
+						quo desinit ; non possumus recusare inaequalia <note type="footnote">s <hi
 								rend="italic">Aqualtiate,</hi> iuxta vatlc. ct blS. A. M.
 							</note><note type="footnote"> t <hi rend="italic">Et,</hi> jutta vatic.
 							at. </note><note type="footnote"> • <hi rend="italic">fccepit,</hi>
 							juxta eumdem. SI. </note><note type="footnote"> a Er., <hi rend="italic"
 								>ne accidat.</hi> ven. 1.0 v , Ms. A, <hi rend="italic">hoc n*
-								accidct,</hi> Sic <lb/> euani LUt;tJ., <unclear/> S4'1't.a laiijvu
+								accidct,</hi> Sic<lb/>euani LUt;tJ., <unclear/> S4'1't.a laiijvu
 							vocc, <hi rend="italic">hoc</hi> M. </note>
 						<lb/>
 						<pb n="1127"/> membra esse oportere. <hi rend="italic">D.</hi> Nullo modo.
-							<hi rend="italic">M.</hi> Id ergo <lb/> prius in pyrrhichio
-						consideremus, si placet, inquo jam <lb/> credo videri libi minus tribus
-						temporibus membrum <lb/> esse non posse, quoniam id primum est plus quam
-						pes. <lb/> D. Assentior. M. Ergo minimus versus quot tempora <lb/>
+							<hi rend="italic">M.</hi> Id ergo<lb/>prius in pyrrhichio
+						consideremus, si placet, inquo jam<lb/>credo videri libi minus tribus
+						temporibus membrum<lb/>esse non posse, quoniam id primum est plus quam
+						pes.<lb/>D. Assentior. M. Ergo minimus versus quot tempora<lb/>
 						possidebit? <hi rend="italic">D.</hi> Dicerem sex, nisi me illa
-						praeposteratio <lb/> revocaret. Septem ergo hahebit : quia minus quam tria
-						<lb/> membrum babere non potest; plus autem habere, non­ <lb/> dum
+						praeposteratio<lb/>revocaret. Septem ergo hahebit : quia minus quam tria
+						<lb/>membrum babere non potest; plus autem habere, non­<lb/>dum
 						prohibitum est. <hi rend="italic">M.</hi> Recte intelligis. Sed dic quot
-						<lb/> pedes pyrrhichios habeant septem tempora. <hi rend="italic">D.</hi>
-						Tres <lb/> et semis. <hi rend="italic">M.</hi> Debetur ergo unius temporis
-						silentium; <lb/> dum ad principium reditur, ut spatium pedis possit im­
-						<lb/> pleri. <hi rend="italic">D.</hi> Debetur sane. <hi rend="italic"
-							>M.</hi> Hoc annumeratoquot tem. <lb/> pora erunt? D. Octo. <hi
-							rend="italic">M.</hi> Ut ergo minimus, qui etiam <lb/> primus est pes ,
-						minus quam duo; ita minimus qui <lb/> primus est versus, minus habere quam
-						octo tempora <lb/> non potest. <hi rend="italic">D.</hi> Ita est. <hi
-							rend="italic">M.</hi> Quid maximus versus, quo <lb/> ampliorem esse non
-						oporteat? quot tandem temporum <lb/> esse debet ? Nonne statim videbis, si
-						ad illam progres­ <lb/> sionem retulerimus animum, de qua toties tam multa
-						<lb/> dicta sunt ? <hi rend="italic">D.</hi> Jam intelligo ampliorem quam
-						triginta <lb/> duum temporum versum osse non posse.</p>
-					<p>21. <hi rend="italic">M.</hi> Quid de metri longitudine? censesne am­ <lb/>
-						pliorem esse dcberc qnam versus1, cum metrum id <lb/> quod est minimum, tam
+						<lb/>pedes pyrrhichios habeant septem tempora. <hi rend="italic">D.</hi>
+						Tres<lb/>et semis. <hi rend="italic">M.</hi> Debetur ergo unius temporis
+						silentium;<lb/>dum ad principium reditur, ut spatium pedis possit im­
+						<lb/>pleri. <hi rend="italic">D.</hi> Debetur sane. <hi rend="italic"
+							>M.</hi> Hoc annumeratoquot tem.<lb/>pora erunt? D. Octo. <hi
+							rend="italic">M.</hi> Ut ergo minimus, qui etiam<lb/>primus est pes ,
+						minus quam duo; ita minimus qui<lb/>primus est versus, minus habere quam
+						octo tempora<lb/>non potest. <hi rend="italic">D.</hi> Ita est. <hi
+							rend="italic">M.</hi> Quid maximus versus, quo<lb/>ampliorem esse non
+						oporteat? quot tandem temporum<lb/>esse debet ? Nonne statim videbis, si
+						ad illam progres­<lb/>sionem retulerimus animum, de qua toties tam multa
+						<lb/>dicta sunt ? <hi rend="italic">D.</hi> Jam intelligo ampliorem quam
+						triginta<lb/>duum temporum versum osse non posse.</p>
+					<p>21. <hi rend="italic">M.</hi> Quid de metri longitudine? censesne am­<lb/>
+						pliorem esse dcberc qnam versus1, cum metrum id<lb/>quod est minimum, tam
 						minus sit quam minimus ver- <note type="footnote">1 In B., <hi rend="italic"
 								>versum.</hi> Melius cum Ms. A, <hi rend="italic">versus.</hi> M. </note>
-						<lb/> sus? <hi rend="italic">D.</hi> Non censeo. <hi rend="italic">M.</hi>
-						Cum ergo metrum incipiat <lb/> a duobus pcdihus, versus a quatuor; aut illud
-						ab spa­ <lb/> tio duorum pedum, hoc a quatuor annumerato silen­ <lb/> tio;
-						metrum autcm octo pedes non excedat: nonne <lb/> cnm et versus metrum sit,
-						necesse est eum pedes <lb/> totidem non excedere ? <hi rend="italic">D.</hi>
-						Ita est. M. Rursus cum <lb/> versus non sit longior quam triginta duum
-						temporum, <lb/> et metrum sit etiam longitudo versus, si conjunctio­ <lb/>
-						nem duorum membrorum talem non habeat qualis in <lb/> versu præcipitur, sed
-						tantum1 certo fine claudatur, <lb/> neque debeat longius esse quam versus :
-						nonne ma­ <lb/> nifestum est ut versum pedes octo, ita metrum tri­ <lb/>
-						ginta duo tempora excedere non oportere? D. Assen­ <lb/> tior. M. Erit ergo
-						idem spatium temporis, et idem <lb/> numcrus pedum et metro et versui,
-						communisque <lb/> quidam terminus, ultra quem progredi utrumque <lb/> non
-						debeat : quamvis metrum quadruplicatis pedi­ <lb/> bus, a quibus esse
-						incipit; versus autem quadrupli­ <lb/> catis temporibus, a quibus et ipse
-						esse incipit, finia­ <lb/> tur : ut crescendi scilicet modum quaternaria
-						illa <lb/> ratione servata metrum cum versu communicaverit <lb/> in pcdibus,
-						versus cum metro in temporibus. <hi rend="italic">D.</hi> In­ <lb/> telligo,
-						et probo; atque ita se habere istam concur­ <lb/> diam consensionemquc
+						<lb/>sus? <hi rend="italic">D.</hi> Non censeo. <hi rend="italic">M.</hi>
+						Cum ergo metrum incipiat<lb/>a duobus pcdihus, versus a quatuor; aut illud
+						ab spa­<lb/>tio duorum pedum, hoc a quatuor annumerato silen­<lb/>tio;
+						metrum autcm octo pedes non excedat: nonne<lb/>cnm et versus metrum sit,
+						necesse est eum pedes<lb/>totidem non excedere ? <hi rend="italic">D.</hi>
+						Ita est. M. Rursus cum<lb/>versus non sit longior quam triginta duum
+						temporum,<lb/>et metrum sit etiam longitudo versus, si conjunctio­<lb/>
+						nem duorum membrorum talem non habeat qualis in<lb/>versu praecipitur, sed
+						tantum1 certo fine claudatur,<lb/>neque debeat longius esse quam versus :
+						nonne ma­<lb/>nifestum est ut versum pedes octo, ita metrum tri­<lb/>
+						ginta duo tempora excedere non oportere? D. Assen­<lb/>tior. M. Erit ergo
+						idem spatium temporis, et idem<lb/>numcrus pedum et metro et versui,
+						communisque<lb/>quidam terminus, ultra quem progredi utrumque<lb/>non
+						debeat : quamvis metrum quadruplicatis pedi­<lb/>bus, a quibus esse
+						incipit; versus autem quadrupli­<lb/>catis temporibus, a quibus et ipse
+						esse incipit, finia­<lb/>tur : ut crescendi scilicet modum quaternaria
+						illa<lb/>ratione servata metrum cum versu communicaverit<lb/>in pcdibus,
+						versus cum metro in temporibus. <hi rend="italic">D.</hi> In­<lb/>telligo,
+						et probo; atque ita se habere istam concur­<lb/>diam consensionemquc
 						delector. <note type="footnote"> 4 <hi rend="italic">Tamen,</hi> juxta
 							vatic. M. </note><note type="footnote"> I Ita legit vatic. : <hi
 								rend="italic">it idem mmierus pedum;</hi> et <hi rend="italic"
-								>quidam <lb/> tcrimnus metro et versui communi, ultra quem.</hi> M.
+								>quidam<lb/>tcrimnus metro et versui communi, ultra quem.</hi> M.
 						</note>
 					</p>
 				</div>
@@ -2808,43 +2808,43 @@
 						</title>
 					</ab>
 					<p><hi rend="italic">1. M.</hi> Redeamus ergo ad metri considerationem, pro­
-						<lb/> pter cujus progressum ac longitudinem de versu te­ <lb/> cum aliquid
-						agere coactus sum, cujus tractandi postea <lb/> nobis est conslilulus locus.
-						Sed primo illud quærO, <lb/> utrum non repudies, quod ultimam syllabam, quæ
-						<lb/> metrum terminat, seu longa seu brevis sit, poeLc at­ <lb/> que horum
-						judices grammatici nihil ad rem pertinere <lb/> arbitrati sunt. <hi
-							rend="italic">D.</hi> Omnino repudio : non cnim mihi <lb/> vidctur esse
-						rationis. M. Dic mihi, obsecro, quod me­ <lb/> trum sit in pyrrhichio
+						<lb/>pter cujus progressum ac longitudinem de versu te­<lb/>cum aliquid
+						agere coactus sum, cujus tractandi postea<lb/>nobis est conslilulus locus.
+						Sed primo illud quaerO,<lb/>utrum non repudies, quod ultimam syllabam, quae
+						<lb/>metrum terminat, seu longa seu brevis sit, poeLc at­<lb/>que horum
+						judices grammatici nihil ad rem pertinere<lb/>arbitrati sunt. <hi
+							rend="italic">D.</hi> Omnino repudio : non cnim mihi<lb/>vidctur esse
+						rationis. M. Dic mihi, obsecro, quod me­<lb/>trum sit in pyrrhichio
 						minimum. <hi rend="italic">D.</hi> Tres breves. <hi rend="italic">II.</hi>
-						<lb/> Quantum ergo silendum est, dum repetitur? <hi rend="italic">D.</hi>
-						Unum <lb/> tempus, quod cst unius brevis syllabae spatium. <hi rend="italic"
+						<lb/>Quantum ergo silendum est, dum repetitur? <hi rend="italic">D.</hi>
+						Unum<lb/>tempus, quod cst unius brevis syllabae spatium. <hi rend="italic"
 							>M.</hi>
-						<lb/> Age, jam perente hoc metrum, non voce, sed plausu. <lb/>
+						<lb/>Age, jam perente hoc metrum, non voce, sed plausu.<lb/>
 						<hi rend="italic">D.</hi> Feci. <hi rend="italic">M.</hi> Percute etiam hoc
-						modo anapæstum. <hi rend="italic">D.</hi>
-						<lb/> Ei hoc feci. <hi rend="italic">M.</hi> Quid libi visum cst interesse?
+						modo anapaestum. <hi rend="italic">D.</hi>
+						<lb/>Ei hoc feci. <hi rend="italic">M.</hi> Quid libi visum cst interesse?
 							<hi rend="italic">D.</hi>
-						<lb/> Prorsus nihil. <hi rend="italic">M.</hi> Quid? causam, cur ita sit,
-						potesne <lb/> dicere? D. Videtur mihi satis apparere : nam quod in <lb/>
-						illo ad silentium, hoc in isto ad productionem ultimae <lb/> syllabae
-						refertur; nam codem modo ibi brevis ultima, <lb/> ut hic long:., percutitur;
-						et post tantumdem interval­ <lb/> lum rcditur ad caput. Sed ibi quiescitur
-						donec spa­ <lb/> tium pyrrhichii pedis, hic donec longæ syllabae im­ <lb/>
-						pleatur. Ita in utroque par mora cst, qua inlerposlLa <lb/> remeamns. <hi
-							rend="italic">M.</hi> Non igitur absurde illi ultimam sylla­ <lb/> bam
-						metri, seu longa scu brevis sii. nihil ad rem per­ <lb/> tinere voluerunt :
-						ubi enim finis cst, silentium sequi­ <lb/> tur, quantum ad ipsum metrum
-						attinet quod finitur. <lb/> An eos in bac causa repe itioncm ullam vel
-						reditum <lb/> ad caput considerare debuisse existimas, ac non tan­ <lb/>
-						tummodo quia finitur, quasi deinceps uihil dicendum <lb/> sit? <hi
+						<lb/>Prorsus nihil. <hi rend="italic">M.</hi> Quid? causam, cur ita sit,
+						potesne<lb/>dicere? D. Videtur mihi satis apparere : nam quod in<lb/>
+						illo ad silentium, hoc in isto ad productionem ultimae<lb/>syllabae
+						refertur; nam codem modo ibi brevis ultima,<lb/>ut hic long:., percutitur;
+						et post tantumdem interval­<lb/>lum rcditur ad caput. Sed ibi quiescitur
+						donec spa­<lb/>tium pyrrhichii pedis, hic donec longae syllabae im­<lb/>
+						pleatur. Ita in utroque par mora cst, qua inlerposlLa<lb/>remeamns. <hi
+							rend="italic">M.</hi> Non igitur absurde illi ultimam sylla­<lb/>bam
+						metri, seu longa scu brevis sii. nihil ad rem per­<lb/>tinere voluerunt :
+						ubi enim finis cst, silentium sequi­<lb/>tur, quantum ad ipsum metrum
+						attinet quod finitur.<lb/>An eos in bac causa repe itioncm ullam vel
+						reditum<lb/>ad caput considerare debuisse existimas, ac non tan­<lb/>
+						tummodo quia finitur, quasi deinceps uihil dicendum<lb/>sit? <hi
 							rend="italic">D.</hi> Jam assentior, ultimam syllabam indifferenter
-						<lb/> esse accipiendam. M. Recte. Sed si hoc propter silen­ <lb/> tium fit,
-						quoniam ita consideratus est finis, quasi <lb/> deinceps nihil soniturus1
-						sit qui fmicrit, et ob hoc <lb/> spatium temporis in ipsa quiete largissimum
-						niliil di­ <lb/> stat quoe ibi syllaba locetur; nonne illud est conse­ <lb/>
-						quens, ut ipsa ultimae syllabæ indifferentia, quae pro­ <lb/> pter largum
-						spatium conceditur, ad id proficiat, ut <lb/> sive ibi brevis syllaba sive
-						longa sit, cam sibi aures <lb/> pro longa vindicent ? <hi rend="italic"
+						<lb/>esse accipiendam. M. Recte. Sed si hoc propter silen­<lb/>tium fit,
+						quoniam ita consideratus est finis, quasi<lb/>deinceps nihil soniturus1
+						sit qui fmicrit, et ob hoc<lb/>spatium temporis in ipsa quiete largissimum
+						niliil di­<lb/>stat quoe ibi syllaba locetur; nonne illud est conse­<lb/>
+						quens, ut ipsa ultimae syllabae indifferentia, quae pro­<lb/>pter largum
+						spatium conceditur, ad id proficiat, ut<lb/>sive ibi brevis syllaba sive
+						longa sit, cam sibi aures<lb/>pro longa vindicent ? <hi rend="italic"
 							>D.</hi> Video plane esse consequens.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT II. — <hi rend="italic">Quoi syllabis minimum
@@ -2852,150 +2852,150 @@
 								quoqne silendum.</hi>
 						</title>
 					</ab>
-					<p>i. <hi rend="italic">M.</hi> Videsne etiam illud, cum dicimUs minimum <lb/>
-						metrum esse pyrrhichium tres breves syllabas, ut <lb/> unius brevis spatio
-						sileatur, dum ad initium reverti­ <lb/> mur; nihil interesse, utrum hoc
-						metrum, an pedes <lb/> anapæstos repetamus? <hi rend="italic">D.</hi> Jain
-						hoc quidem paulo ante <lb/> illa percussione percepi. M. Nonne irgo quidquid
-						hic <lb/> est conf..sum, distinguendum aliqua ratione arbitra­ <lb/> ris?
+					<p>i. <hi rend="italic">M.</hi> Videsne etiam illud, cum dicimUs minimum<lb/>
+						metrum esse pyrrhichium tres breves syllabas, ut<lb/>unius brevis spatio
+						sileatur, dum ad initium reverti­<lb/>mur; nihil interesse, utrum hoc
+						metrum, an pedes<lb/>anapaestos repetamus? <hi rend="italic">D.</hi> Jain
+						hoc quidem paulo ante<lb/>illa percussione percepi. M. Nonne irgo quidquid
+						hic<lb/>est conf..sum, distinguendum aliqua ratione arbitra­<lb/>ris?
 							<hi rend="italic">D.</hi> Omnino arbitror. <hi rend="italic">M.</hi> Dic
 						utrum aliam videas <note type="footnote"> I sonaturus, juxta vatic. et Ms.
 							A. v </note>
 						<lb/>
-						<pb n="1129"/> esse rationem, quae ista distinguat, nisi ut metrum <lb/>
-						pyrrhichium non illud sit minimum, quod tibi videba­ <lb/> tur in tribus
-						brevibus, sed in quinque. Post unum <lb/> enim pedem ac semipedem silere
-						mora semipedis <lb/> ejus qui debetur implendo pedi, atque ila rcdire ad
-						<lb/> initium, et hoc minimum metrum in pyrrhichio con­ <lb/> stituere non
-						nos sinit anapæsti parilitas, ut jam de­ <lb/> monstratum est: quare post
-						duos pedes et semipedem <lb/> silendum est illud unum tempus, si confusione
-						carere <lb/> volumus. <hi rend="italic">D.</hi> Cur enim non duo pyrrhichii
-						sunt mini­ <lb/> mum metrum in pyrrhichio, et quatuor syllabæ breves <lb/>
-						potius, post quas silere opus non sit, quam quinque <lb/> post quas opus
-						sit? <hi rend="italic">M.</hi> Vigilanter quidem, sed non <lb/> caves ne ab
-						hoc te ita proceleusmaticus, ut ab illo ana­ <lb/> pæstus excludat. <hi
+						<pb n="1129"/> esse rationem, quae ista distinguat, nisi ut metrum<lb/>
+						pyrrhichium non illud sit minimum, quod tibi videba­<lb/>tur in tribus
+						brevibus, sed in quinque. Post unum<lb/>enim pedem ac semipedem silere
+						mora semipedis<lb/>ejus qui debetur implendo pedi, atque ila rcdire ad
+						<lb/>initium, et hoc minimum metrum in pyrrhichio con­<lb/>stituere non
+						nos sinit anapaesti parilitas, ut jam de­<lb/>monstratum est: quare post
+						duos pedes et semipedem<lb/>silendum est illud unum tempus, si confusione
+						carere<lb/>volumus. <hi rend="italic">D.</hi> Cur enim non duo pyrrhichii
+						sunt mini­<lb/>mum metrum in pyrrhichio, et quatuor syllabae breves<lb/>
+						potius, post quas silere opus non sit, quam quinque<lb/>post quas opus
+						sit? <hi rend="italic">M.</hi> Vigilanter quidem, sed non<lb/>caves ne ab
+						hoc te ita proceleusmaticus, ut ab illo ana­<lb/>paestus excludat. <hi
 							rend="italic">D.</hi> V crum dicis. <hi rend="italic">II.</hi> Placet
-						ergo hic <lb/> modus in quinque brevibus, et silentio unius tempo­ <lb/> .
+						ergo hic<lb/>modus in quinque brevibus, et silentio unius tempo­<lb/>.
 						ris? <hi rend="italic">D.</hi> Placet vero. <hi rend="italic">II.</hi>
-						Videtur mihi oblitum esse te, <lb/> quomadmodum in rhythmo dixerimus posse
-						discerni <lb/> utruni pyrrhichio an proceleusmatico curreretur. <hi
+						Videtur mihi oblitum esse te,<lb/>quomadmodum in rhythmo dixerimus posse
+						discerni<lb/>utruni pyrrhichio an proceleusmatico curreretur. <hi
 							rend="italic">D.</hi>
-						<lb/> Bene admones : nam plausu istos numcros ab invicem <lb/> distinguendos
-						comperimus : quare jam neque hic <lb/> isium proceleusmaticum metuo, quem
-						plausu adhibito <lb/> a pyrrbichio discernere potero. <hi rend="italic"
-							>M.</hi> Cur igitur non <lb/> eumdem plausum adhibendum vidisti, ut ab
-						illis tri­ <lb/> bus brevibus, id est jyrrhichio et scmipcde, post <lb/>
-						quem oporteret unum tempus silere, discerneretur <lb/> anapcestus? <hi
-							rend="italic">D.</hi> Jam intelligo, et in viam redeo, me­ <lb/> trumque
-						in pyrrhichio minimum tres syllabas breves, <lb/> quae, annumerato silentio,
-						duorum pyrrhichiorum <lb/> tempus occupant, esse confirmo. <hi rend="italic"
-							>M.</hi> Probant ergo <lb/> aures tuæ hoc genus numeri: <hi
-							rend="italic">Si aliqua, Bene vis, Bene<lb/> dic, Bene fac, Animus,</hi>
+						<lb/>Bene admones : nam plausu istos numcros ab invicem<lb/>distinguendos
+						comperimus : quare jam neque hic<lb/>isium proceleusmaticum metuo, quem
+						plausu adhibito<lb/>a pyrrbichio discernere potero. <hi rend="italic"
+							>M.</hi> Cur igitur non<lb/>eumdem plausum adhibendum vidisti, ut ab
+						illis tri­<lb/>bus brevibus, id est jyrrhichio et scmipcde, post<lb/>
+						quem oporteret unum tempus silere, discerneretur<lb/>anapcestus? <hi
+							rend="italic">D.</hi> Jam intelligo, et in viam redeo, me­<lb/>trumque
+						in pyrrhichio minimum tres syllabas breves,<lb/>quae, annumerato silentio,
+						duorum pyrrhichiorum<lb/>tempus occupant, esse confirmo. <hi rend="italic"
+							>M.</hi> Probant ergo<lb/>aures tuae hoc genus numeri: <hi
+							rend="italic">Si aliqua, Bene vis, Bene<lb/>dic, Bene fac, Animus,</hi>
 						Si ali;uid, <hi rend="italic">Male</hi> vis, <hi rend="italic">Male dir,
-							<lb/> Maie fac, Animus, Medium est. D.</hi> Satis probant, <lb/>
-						præsertim cum jam rccordalus sim quemadmodum <lb/> eas plaudi oporteat, ne
-						cnm metro pyrrhicliio ana­ <lb/> paesti confundantur pedes.</p>
+							<lb/>Maie fac, Animus, Medium est. D.</hi> Satis probant,<lb/>
+						praesertim cum jam rccordalus sim quemadmodum<lb/>eas plaudi oporteat, ne
+						cnm metro pyrrhicliio ana­<lb/>paesti confundantur pedes.</p>
 					<p>3. <hi rend="italic">M.</hi> Vide et ista : Si <hi rend="italic">aliquid</hi>
-						es , <hi rend="italic">Age bene, Male <lb/> quiayit, Nihil agit,</hi> Et <hi
-							rend="italic">ideo, Miser erit. D.</hi> Suaviter <lb/> etiam ista se
-						insinuant, nisi uno loco, uhi finis tertii <lb/> cum initio quarti
-						copulatur. M. Idipsum omnino est, <lb/> quod a tuis auribus desideravi. Non
-						enim frustra sen­ <lb/> sus offenditur, cum omnium syllabarum nullo inter­
-						<lb/> posito silentio tempora singula exspectat : quam ex­ <lb/>
-						spectationem profecto fraudat concursus duarum <lb/> consonauLium, t el II,
-						quæ præcedentem vocalem <lb/> longam esse cogunt, et in duo tempora
-						extendunt; <lb/> quod genus grammatici positione longam syllabam <lb/>
-						vocant. Sed propter illam ultimae syllabæ indilferen­ <lb/> tiam , nemo
-						criminatur hoc metrum , cum id since­ <lb/> ras atque severæ aures ctiam
-						sine accusatore conde­ <lb/> mnent. Nam vide, quæso, quantum interest, si
-						pro <lb/> eo quod est, <lb/> Male qui agit, Nihil agit : <lb/> Male qui
-						agit, Homo perit. dicatur, <lb/>
-						<hi rend="italic">D.</hi> Hoc sane liquidum atque integrum est. M. noc <lb/>
-						ergo nos observemus propter musicaE sinceritatem , <lb/> quod poetæ non
-						observant propter facilitatem canen­ <lb/> di : ut quoties, exempli causa ,
-						nobis necesse est ali. <lb/> qua metra interponere, in qufbus nihil debetur
-						pedi <lb/> quod silentio compensetur, eas ponamus ultimas syl- <lb/> labas
-						quas lex ejusdem numeri flagital : ne eum ali­ <lb/> qua offensione aurium
-						et falsitate mensuræ, a fine <lb/> ad initium redeamus; concedentes tamen
-						illis ut ita <lb/> metra talia finiant, quasi deinceps nihil dicturi, et
-						<lb/> idco extremam syllabam seu longam seu brevem im­ <lb/> pune
-						constituant : nam in continuatione metrorum <lb/> apertissime convincuntur
-						aurium judicio, non se <lb/> debere poncre ultimam, nisi quae ipsius metri
-						jure <lb/> atque ratione ponenda est. Hæc autem continuatio <lb/> iit, cum
-						pedi nihil debetur propter quod silere co­ <lb/> gamur. D. Intelligo, et
-						gratum habeo quod talia pol­ <lb/> liceris exempta , quibus nullam patiatur
-						sensus in­ <lb/> jurialn.</p>
+						es , <hi rend="italic">Age bene, Male<lb/>quiayit, Nihil agit,</hi> Et <hi
+							rend="italic">ideo, Miser erit. D.</hi> Suaviter<lb/>etiam ista se
+						insinuant, nisi uno loco, uhi finis tertii<lb/>cum initio quarti
+						copulatur. M. Idipsum omnino est,<lb/>quod a tuis auribus desideravi. Non
+						enim frustra sen­<lb/>sus offenditur, cum omnium syllabarum nullo inter­
+						<lb/>posito silentio tempora singula exspectat : quam ex­<lb/>
+						spectationem profecto fraudat concursus duarum<lb/>consonauLium, t el II,
+						quae praecedentem vocalem<lb/>longam esse cogunt, et in duo tempora
+						extendunt;<lb/>quod genus grammatici positione longam syllabam<lb/>
+						vocant. Sed propter illam ultimae syllabae indilferen­<lb/>tiam , nemo
+						criminatur hoc metrum , cum id since­<lb/>ras atque severae aures ctiam
+						sine accusatore conde­<lb/>mnent. Nam vide, quaeso, quantum interest, si
+						pro<lb/>eo quod est,<lb/>Male qui agit, Nihil agit :<lb/>Male qui
+						agit, Homo perit. dicatur,<lb/>
+						<hi rend="italic">D.</hi> Hoc sane liquidum atque integrum est. M. noc<lb/>
+						ergo nos observemus propter musicaE sinceritatem ,<lb/>quod poetae non
+						observant propter facilitatem canen­<lb/>di : ut quoties, exempli causa ,
+						nobis necesse est ali.<lb/>qua metra interponere, in qufbus nihil debetur
+						pedi<lb/>quod silentio compensetur, eas ponamus ultimas syl<lb/>labas
+						quas lex ejusdem numeri flagital : ne eum ali­<lb/>qua offensione aurium
+						et falsitate mensurae, a fine<lb/>ad initium redeamus; concedentes tamen
+						illis ut ita<lb/>metra talia finiant, quasi deinceps nihil dicturi, et
+						<lb/>idco extremam syllabam seu longam seu brevem im­<lb/>pune
+						constituant : nam in continuatione metrorum<lb/>apertissime convincuntur
+						aurium judicio, non se<lb/>debere poncre ultimam, nisi quae ipsius metri
+						jure<lb/>atque ratione ponenda est. Haec autem continuatio<lb/>iit, cum
+						pedi nihil debetur propter quod silere co­<lb/>gamur. D. Intelligo, et
+						gratum habeo quod talia pol­<lb/>liceris exempta , quibus nullam patiatur
+						sensus in­<lb/>jurialn.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT III. — <hi rend="italic">Pyrrhichiorum</hi> metrorum
 								<hi rend="italic">ordo et</hi> numerus.</title>
 					</ab>
-					<p>d. M. Age, nunc ordine de his quoque renuntia <lb/> pyrrhichiis : <lb/> Quid
-						erit homo <lb/> Qui amat hominem, <lb/> si amet in eo <lb/> Fragile quod
-						est? <lb/> Amet igitur <lb/> Animum hominis, <lb/> £t erit homo <lb/>
-						Aliquid amans. <lb/> Quid haec videntur ? <hi rend="italic">D.</hi> Quid
-						nisi suavissime atque <lb/> integerrime currere ? M. Quid ista ? <lb/> x
-						Bonus erit amor, <lb/> Anima bona sit: <lb/> Amor inhabitat, <lb/> Et anima
-						domus. <lb/> lea bene habitat, <lb/> Ubi bona domus; <lb/> Ubi mala, male. <lb/>
-						<hi rend="italic">D.</hi> Eliam ista continuata suavissime aedpio. M. <lb/>
-						Nunc tres semis pedes, vide : <lb/> Animus bominis eat <lb/> Mala bonave
-						agitans. <lb/> Bona voluit, habet; <lb/> Mala voluit, habet. <lb/>
-						<hi rend="italic">D.</hi> Hæc quoqne interposito unius temporis silentio,
-						<lb/> jucunda sunt. <hi rend="italic">M.</hi> Sequuntur quatuor pleni
-						pyrrlii­ <lb/> chii; hos accipe, et judica: <lb/> - Animus hominis agit
-						<lb/> Ut habeat ea bona, <lb/> Quibus inhabitet homo, <lb/> Nihil ibi
-						metuitur. <lb/>
-						<hi rend="italic">D.</hi> In his quoque certa et jucunda mensura est. <lb/>
-						M. Auli jam nunc novem syllabas breves ; audi et <lb/> judica: <lb/> Homo
-						malus amat et eget; <lb/> Malus etenim ea bona amat, <lb/> Mihil ubi satiat
-						eum. <lb/>
+					<p>d. M. Age, nunc ordine de his quoque renuntia<lb/>pyrrhichiis :<lb/>Quid
+						erit homo<lb/>Qui amat hominem,<lb/>si amet in eo<lb/>Fragile quod
+						est?<lb/>Amet igitur<lb/>Animum hominis,<lb/>£t erit homo<lb/>
+						Aliquid amans.<lb/>Quid haec videntur ? <hi rend="italic">D.</hi> Quid
+						nisi suavissime atque<lb/>integerrime currere ? M. Quid ista ?<lb/>x
+						Bonus erit amor,<lb/>Anima bona sit:<lb/>Amor inhabitat,<lb/>Et anima
+						domus.<lb/>lea bene habitat,<lb/>Ubi bona domus;<lb/>Ubi mala, male.<lb/>
+						<hi rend="italic">D.</hi> Eliam ista continuata suavissime aedpio. M.<lb/>
+						Nunc tres semis pedes, vide :<lb/>Animus bominis eat<lb/>Mala bonave
+						agitans.<lb/>Bona voluit, habet;<lb/>Mala voluit, habet.<lb/>
+						<hi rend="italic">D.</hi> Haec quoqne interposito unius temporis silentio,
+						<lb/>jucunda sunt. <hi rend="italic">M.</hi> Sequuntur quatuor pleni
+						pyrrlii­<lb/>chii; hos accipe, et judica:<lb/>- Animus hominis agit
+						<lb/>Ut habeat ea bona,<lb/>Quibus inhabitet homo,<lb/>Nihil ibi
+						metuitur.<lb/>
+						<hi rend="italic">D.</hi> In his quoque certa et jucunda mensura est.<lb/>
+						M. Auli jam nunc novem syllabas breves ; audi et<lb/>judica:<lb/>Homo
+						malus amat et eget;<lb/>Malus etenim ea bona amat,<lb/>Mihil ubi satiat
+						eum.<lb/>
 						<hi rend="italic">D.</hi> Prome nunc qniAquc pyrrhichios. <hi rend="italic"
 							>M.</hi>
-						<lb/> Levicula fragilia bona, <lb/> Qui amat homo, similiterhabet. <lb/>
-						<hi rend="italic">D.</hi> Jam hoc sat est, et probo; nunc adde semi­ <lb/>
-						pedem. M. Faciam : <lb/> vaga levia fragilia bona, <lb/> Qui amat homo,
-						similis erit eis. <lb/>
-						<hi rend="italic">D.</hi> Bene prorsus ; ci sex jam exspecto pyrrhicmos. <lb/>
-						<hi rend="italic">M.</hi> Et bos audi : <lb/> Vaga levicula fragQia booa, .
-						<lb/> Qui adamat homo, similis erit eis. <lb/>
-						<hi rend="italic">D.</hi> Satis est; adde semipcdem. M. <lb/> Fluida
-						levicula fragilia bona <lb/> Quæ adamat anima, similis erit <unclear/>
+						<lb/>Levicula fragilia bona,<lb/>Qui amat homo, similiterhabet.<lb/>
+						<hi rend="italic">D.</hi> Jam hoc sat est, et probo; nunc adde semi­<lb/>
+						pedem. M. Faciam :<lb/>vaga levia fragilia bona,<lb/>Qui amat homo,
+						similis erit eis.<lb/>
+						<hi rend="italic">D.</hi> Bene prorsus ; ci sex jam exspecto pyrrhicmos.<lb/>
+						<hi rend="italic">M.</hi> Et bos audi :<lb/>Vaga levicula fragQia booa, .
+						<lb/>Qui adamat homo, similis erit eis.<lb/>
+						<hi rend="italic">D.</hi> Satis est; adde semipcdem. M.<lb/>Fluida
+						levicula fragilia bona<lb/>Quae adamat anima, similis erit <unclear/>
 						<note type="footnote">PATROL. XXXII.</note>
 						<note type="footnote"><hi rend="italic">(Trente-six.)</hi></note>
 						<lb/>
-						<pb n="1131"/> D Sat est, et bene est; da jam septem pyrrhi­ <lb/> chios. M.
-						<lb/> Levicula fragilia gracilia bona, <lb/> Quæ adamai animula, similis
-						erit eis. <lb/> D. Accedat his semipes; nam hoc eleganter se <lb/> habeL.
+						<pb n="1131"/> D Sat est, et bene est; da jam septem pyrrhi­<lb/>chios. M.
+						<lb/>Levicula fragilia gracilia bona,<lb/>Quae adamai animula, similis
+						erit eis.<lb/>D. Accedat his semipes; nam hoc eleganter se<lb/>habeL.
 							<hi rend="italic">Al.</hi>
-						<lb/> vaga fluida levicula fragilia bona, <lb/> Qux adamat animula, fit ea
-						similis cis. <lb/> D. Octo pedes jam restare video, ut jam istas mi­ <lb/>
-						nutias evadamus. Quanquam enim approbent aures <lb/> naturali quadam
-						dimensione quod sonas, nolim te <lb/> tamen tot breves syllabas quærere;
-						quas, ni fallor, <lb/> contoxtas invenire in conjunctione verborum diffici­
-						<lb/> lius est, quam si eis miscere longas liceret. <hi rend="italic"
-							>M.</hi> Ni­ <lb/> hil te fallit, et ul tibi probem gratulationem meam,
-						<lb/> quod hinc aliquando transire permittimur, metrum <lb/> quod restat
-						hujus generis sententia feliciore compo­ <lb/> uam I : <lb/> solida bona
-						bonus amat, et ea qui amat habet. <lb/> Itaque nec eget amor, et ea bona
-						Deus est. <lb/>
+						<lb/>vaga fluida levicula fragilia bona,<lb/>Qux adamat animula, fit ea
+						similis cis.<lb/>D. Octo pedes jam restare video, ut jam istas mi­<lb/>
+						nutias evadamus. Quanquam enim approbent aures<lb/>naturali quadam
+						dimensione quod sonas, nolim te<lb/>tamen tot breves syllabas quaerere;
+						quas, ni fallor,<lb/>contoxtas invenire in conjunctione verborum diffici­
+						<lb/>lius est, quam si eis miscere longas liceret. <hi rend="italic"
+							>M.</hi> Ni­<lb/>hil te fallit, et ul tibi probem gratulationem meam,
+						<lb/>quod hinc aliquando transire permittimur, metrum<lb/>quod restat
+						hujus generis sententia feliciore compo­<lb/>uam I :<lb/>solida bona
+						bonus amat, et ea qui amat habet.<lb/>Itaque nec eget amor, et ea bona
+						Deus est.<lb/>
 						<hi rend="italic">D.</hi> Habeo cumulatissime perlecta metra pyrrhichii.
-						<lb/> Sequuntur iambica, de quibus mihi singulis bina <lb/> exempla
-						sufficiunt, quæ nulla interpellatione audire <lb/> delectat.</p>
+						<lb/>Sequuntur iambica, de quibus mihi singulis bina<lb/>exempla
+						sufficiunt, quae nulla interpellatione audire<lb/>delectat.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT <hi rend="italic">IV. - De m</hi> tro <hi
 								rend="italic">iambico.</hi>
 						</title>
 					</ab>
-					<p>5. <hi rend="italic">M.</hi> Geram tibi morem. Sed ista quæ jam per­ <lb/>
+					<p>5. <hi rend="italic">M.</hi> Geram tibi morem. Sed ista quae jam per­<lb/>
 						egimus quot sunt? <hi rend="italic">D.</hi> Quatuordecim. <hi rend="italic"
-							>M.</hi> Quot etiam <lb/> iambica fore credis? <hi rend="italic">D.</hi>
-						Æque quatuordecim. <hi rend="italic">M.</hi>
-						<lb/> Quid, si in eis velim pro iambo tribrachum ponere , <lb/> nonne
-						multiformior varietas erit? D. Manifestum est <lb/> quidem : sed ego exempla
-						ista in solis iambis audire <lb/> cupio , ne longum faciamus : pro quavis
-						enim longa <lb/> syllaba duas breves posse poni , facilis disciplina est. <lb/>
+							>M.</hi> Quot etiam<lb/>iambica fore credis? <hi rend="italic">D.</hi>
+						aeque quatuordecim. <hi rend="italic">M.</hi>
+						<lb/>Quid, si in eis velim pro iambo tribrachum ponere ,<lb/>nonne
+						multiformior varietas erit? D. Manifestum est<lb/>quidem : sed ego exempla
+						ista in solis iambis audire<lb/>cupio , ne longum faciamus : pro quavis
+						enim longa<lb/>syllaba duas breves posse poni , facilis disciplina est.<lb/>
 						<hi rend="italic">II.</hi> Faciam quod vis, gratumque habeo quod intelli­
-						<lb/> gentia sequaci minuis laborem meum : sed aurcm ad <lb/> iambicum
-						præbe. D. Istic sum, incipe. <hi rend="italic">M.</hi>
+						<lb/>gentia sequaci minuis laborem meum : sed aurcm ad<lb/>iambicum
+						praebe. D. Istic sum, incipe. <hi rend="italic">M.</hi>
 						<figure type="illustration">
 							<graphic url="PL32_fig7.jpg"/>
 						</figure></p>
@@ -3003,8 +3003,8 @@
 						<title type="sub">CAPUT V. <hi rend="italic">- De metro trochaico.</hi>
 						</title>
 					</ab>
-					<p>6. <hi rend="italic">D</hi> 'trochæus sequitur, prome trochaica : nam <lb/>
-						ista se haben' optime. <hi rend="italic">M.</hi> Faciam, et codem modo <lb/>
+					<p>6. <hi rend="italic">D</hi> 'trochaeus sequitur, prome trochaica : nam<lb/>
+						ista se haben' optime. <hi rend="italic">M.</hi> Faciam, et codem modo<lb/>
 						QUO iambica : <figure type="illustration">
 							<graphic url="PL32_fig8.jpg"/>
 						</figure><note type="footnote"> ' III B., <hi rend="italic">jaciaore.</hi>
@@ -3016,8 +3016,8 @@
 						<title type="sub">CAPUT VI. <hi rend="italic">- De metro sponduico.</hi>
 						</title>
 					</ab>
-					<p>7. <hi rend="italic">D.</hi> Spondeum sequi video : nam et trochæus <lb/>
-						satis auribus fecit. <hi rend="italic">M.</hi> Hæc sunt metra spondei :
+					<p>7. <hi rend="italic">D.</hi> Spondeum sequi video : nam et trochaeus<lb/>
+						satis auribus fecit. <hi rend="italic">M.</hi> Haec sunt metra spondei :
 							<figure type="illustration">
 							<graphic url="PL32_fig10.jpg"/>
 						</figure></p>
@@ -3026,239 +3026,239 @@
 								sint.</hi>
 						</title>
 					</ab>
-					<p>8. <hi rend="italic">D.</hi> Nec de spondeo habeo quod requiram , ve <lb/>
+					<p>8. <hi rend="italic">D.</hi> Nec de spondeo habeo quod requiram , ve<lb/>
 						uiamus ad tribrachum. <hi rend="italic">M.</hi> Ita vero. Sed cum omnes
-						<lb/> quatuor superiores pedes, de quibus dictum est, qua- <lb/> tuordena
-						metra pepererint, quæ fiunt simul sex ci <lb/> quinquaginta, plura sunt
-						exspectanda de tribracho. <lb/> In illis enim cum spatium semipedis in
-						silentio est. <lb/> plus una syllaba non siletur: in hoc autem cum sile­
-						<lb/> mus, num censes unius brevis syllabæ spatio tantum­ <lb/> modo siler i
-						oportere , an et duarum brevium mora <lb/> silentio contineri potest?
-						quandoquidem nemo dubi­ <lb/> taverit duplicem hujus esse divisionem :
-						itamque aut <lb/> ab una incipit, et finitur ad duas, aut centra iuci­ <lb/>
-						piens a duabus, una terminatur. Quare Imnc ne­ <lb/> cessc est viginti et
-						unum metra procreare. <hi rend="italic">D.</hi> Veris.- <lb/> simum est. Nam
-						incipiunt a quatuor brevibus, ut duo <lb/> tempora sileamus: deinde quinque
-						sunt, ubi unum <lb/> silemus : tertio sex , ubi nihil silendum est: quarto
-						<lb/> septem, ubi rursus duo tempora silenda sunt : inde <lb/> octo, ubi
-						unum : sexto novem, ubi nullum. Atque <lb/> ita cum singuLe adduntur, donec
-						ad viginti quatuor <lb/> syllabas veniatur, qui octo suut tribrachi, viginti
-						<lb/> unum omnino metra complentur. <hi rend="italic">M.</hi> Expeditissime
-						<lb/> rationem secutus es : sed censesne ubique a nobis <lb/> exempla esse
-						promenda; an ea quæ illis quatuur <lb/> primis pedibus subjecimus, satis
-						putandum cst lumi­ <lb/> nis cæteiis esse præbitura? <hi rend="italic"
-							>D.</hi> Meo quidem judicio <lb/> satis. <hi rend="italic">M.</hi> Nec
-						ego nunc aliud requiro quam tuum. Ve­ <lb/> rumtamen quoniam jam optime scis
-						in pyrrhichiis <lb/> metris muLato plausu posse tribrachos percuti; quæro, <lb/>
-						<pb n="1133"/> utrum pyrrhichii primuin metrum possil etiam tribra­ <lb/>
+						<lb/>quatuor superiores pedes, de quibus dictum est, qua<lb/>tuordena
+						metra pepererint, quae fiunt simul sex ci<lb/>quinquaginta, plura sunt
+						exspectanda de tribracho.<lb/>In illis enim cum spatium semipedis in
+						silentio est.<lb/>plus una syllaba non siletur: in hoc autem cum sile­
+						<lb/>mus, num censes unius brevis syllabae spatio tantum­<lb/>modo siler i
+						oportere , an et duarum brevium mora<lb/>silentio contineri potest?
+						quandoquidem nemo dubi­<lb/>taverit duplicem hujus esse divisionem :
+						itamque aut<lb/>ab una incipit, et finitur ad duas, aut centra iuci­<lb/>
+						piens a duabus, una terminatur. Quare Imnc ne­<lb/>cessc est viginti et
+						unum metra procreare. <hi rend="italic">D.</hi> Veris.<lb/>simum est. Nam
+						incipiunt a quatuor brevibus, ut duo<lb/>tempora sileamus: deinde quinque
+						sunt, ubi unum<lb/>silemus : tertio sex , ubi nihil silendum est: quarto
+						<lb/>septem, ubi rursus duo tempora silenda sunt : inde<lb/>octo, ubi
+						unum : sexto novem, ubi nullum. Atque<lb/>ita cum singuLe adduntur, donec
+						ad viginti quatuor<lb/>syllabas veniatur, qui octo suut tribrachi, viginti
+						<lb/>unum omnino metra complentur. <hi rend="italic">M.</hi> Expeditissime
+						<lb/>rationem secutus es : sed censesne ubique a nobis<lb/>exempla esse
+						promenda; an ea quae illis quatuur<lb/>primis pedibus subjecimus, satis
+						putandum cst lumi­<lb/>nis caeteiis esse praebitura? <hi rend="italic"
+							>D.</hi> Meo quidem judicio<lb/>satis. <hi rend="italic">M.</hi> Nec
+						ego nunc aliud requiro quam tuum. Ve­<lb/>rumtamen quoniam jam optime scis
+						in pyrrhichiis<lb/>metris muLato plausu posse tribrachos percuti; quaero,<lb/>
+						<pb n="1133"/> utrum pyrrhichii primuin metrum possil etiam tribra­<lb/>
 						chi metrum habere. <hi rend="italic">D.</hi> Non potest : majus enim me­
-						<lb/> trum oportet esse quam pedem. M. Quid, secundum? <lb/>
+						<lb/>trum oportet esse quam pedem. M. Quid, secundum?<lb/>
 						<hi rend="italic">D.</hi> Potest: nam breves quatuor pyrrhichii duo sunt,
-						<lb/> tribrachus unus et semipes, ita ut ibi nullum , hic <lb/> duo tempora
-						sileamus. <hi rend="italic">I,.</hi> Mutato igitur plausu habcs <lb/> in
-						pyrrhichiis etiam trihrachi exempla usque ad sex­ <lb/> decim syllabas, id
-						est usque ad quinque tribrachos <lb/> et semipedem , quihus debes esse
-						contentus : cætera <lb/> enim potes vel voce vel aliquo plausu per tc ipso
-						<lb/> contexere. Si tamen adhuc aurit:m sensu explorandos <lb/> hujuscemodi
-						numeros arbitraris. <hi rend="italic">D.</hi> Faciam equidem <lb/> quod
-						videbitur : videamus quæ restant.</p>
+						<lb/>tribrachus unus et semipes, ita ut ibi nullum , hic<lb/>duo tempora
+						sileamus. <hi rend="italic">I,.</hi> Mutato igitur plausu habcs<lb/>in
+						pyrrhichiis etiam trihrachi exempla usque ad sex­<lb/>decim syllabas, id
+						est usque ad quinque tribrachos<lb/>et semipedem , quihus debes esse
+						contentus : caetera<lb/>enim potes vel voce vel aliquo plausu per tc ipso
+						<lb/>contexere. Si tamen adhuc aurit:m sensu explorandos<lb/>hujuscemodi
+						numeros arbitraris. <hi rend="italic">D.</hi> Faciam equidem<lb/>quod
+						videbitur : videamus quae restant.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT VIII. — <hi rend="italic">De dactylo.</hi>
 						</title>
 					</ab>
 					<p>9. <hi rend="italic">M.</hi> Dactylus sequitur, qui semel dividi potest.
-						<lb/> An aliter putes 7 D. Imo ita cst. 31. Quota ergo ejus <lb/> pars
+						<lb/>An aliter putes 7 D. Imo ita cst. 31. Quota ergo ejus<lb/>pars
 						potest esso in silentio ? <hi rend="italic">D.</hi> Dimidia scilicet. <hi
 							rend="italic">M.</hi>
-						<lb/> Quid, si post dactylum trochæo constituto, vclil <lb/> quispiam silere
-						uuum tempus, quod in brevi syllaha <lb/> dactylo debetur implendo? quid
-						respondebimus? Non <lb/> enim possumus dicer e minus quam spatium scmipc­
-						<lb/> dis sileri non oportere. natio enim superius tractata <lb/> non minus,
-						sed amplus quam semipedis tempus si­ <lb/> lendum nou esse persuaserat. Nam
-						utique minus quam <lb/> semipes siletur in choriambo, ubi pon ipsum chor­
-						<lb/> iambum bacchius collocilur, cujus exemplum est, <lb/>
-						<hi rend="italic">Fonticolæ</hi> puellæ. Unius cnim brevis syllabæ spatio
-						<lb/> hic nos silere cognoscis, quod sex temporibus debc­ <lb/> lur
+						<lb/>Quid, si post dactylum trochaeo constituto, vclil<lb/>quispiam silere
+						uuum tempus, quod in brevi syllaha<lb/>dactylo debetur implendo? quid
+						respondebimus? Non<lb/>enim possumus dicer e minus quam spatium scmipc­
+						<lb/>dis sileri non oportere. natio enim superius tractata<lb/>non minus,
+						sed amplus quam semipedis tempus si­<lb/>lendum nou esse persuaserat. Nam
+						utique minus quam<lb/>semipes siletur in choriambo, ubi pon ipsum chor­
+						<lb/>iambum bacchius collocilur, cujus exemplum est,<lb/>
+						<hi rend="italic">Fonticolae</hi> puellae. Unius cnim brevis syllabae spatio
+						<lb/>hic nos silere cognoscis, quod sex temporibus debc­<lb/>lur
 						implendis. <hi rend="italic">D.</hi> Verum dicis. <hi rend="italic">M.</hi>
-						Constituto ergo <lb/> trochæo post dactylum, licebitne eliam unum tempus
-						<lb/> silere ? <hi rend="italic">D.</hi> Ita cogor fater i. <hi
-							rend="italic">M.</hi> Quis te tandem coge­ <lb/> ret, si meminisses
-						superiorum ? Hoc cnim libi acci- - <lb/> dii, quod de indifferentia ullimx
-						syllabæ, et quomodo <lb/> sibi ultimam longam vindicent aurcs, ubi restat
-						spa­ <lb/> lium quo ponigatur, etiamsi brevis sit, quid demon­ <lb/> stratum
-						fuerit oblitus es. D. Jam intelligo : nam uti­ <lb/> que si ultimam syllabam
-						brevem, quando restat si­ <lb/> lentium, longam aurcs accipiunt, sicut
-						superiore <lb/> ratione exemplisque cognovimus; nihil intererit utrum <lb/>
-						post dactylum trochxus, an spondeus locetur. Quam­ <lb/> obrem cum repetitio
-						distinguenda silentio est, unam <lb/> longam syllabam oportet post dactylum
-						ponere , ut <lb/> duorum temporum spatio sileamus. <hi rend="italic">M.</hi>
-						Quid si pyr­ <lb/> rhichius ponatur post dactyluin , rectene fieri putas ? <lb/>
+						Constituto ergo<lb/>trochaeo post dactylum, licebitne eliam unum tempus
+						<lb/>silere ? <hi rend="italic">D.</hi> Ita cogor fater i. <hi
+							rend="italic">M.</hi> Quis te tandem coge­<lb/>ret, si meminisses
+						superiorum ? Hoc cnim libi acci-<lb/>dii, quod de indifferentia ullimx
+						syllabae, et quomodo<lb/>sibi ultimam longam vindicent aurcs, ubi restat
+						spa­<lb/>lium quo ponigatur, etiamsi brevis sit, quid demon­<lb/>stratum
+						fuerit oblitus es. D. Jam intelligo : nam uti­<lb/>que si ultimam syllabam
+						brevem, quando restat si­<lb/>lentium, longam aurcs accipiunt, sicut
+						superiore<lb/>ratione exemplisque cognovimus; nihil intererit utrum<lb/>
+						post dactylum trochxus, an spondeus locetur. Quam­<lb/>obrem cum repetitio
+						distinguenda silentio est, unam<lb/>longam syllabam oportet post dactylum
+						ponere , ut<lb/>duorum temporum spatio sileamus. <hi rend="italic">M.</hi>
+						Quid si pyr­<lb/>rhichius ponatur post dactyluin , rectene fieri putas ?<lb/>
 						<hi rend="italic">D.</hi> Non recte : nam utrum idem sit, an iambus, , ni­
-						<lb/> hil interest : siquidem pro iambo eum necesse est ac­ <lb/> cipi
-						propter ultimam, quam longum cxigunt aures, <lb/> quia restat silentium.
-						Iambum autem non oportere <lb/> poni post dactylum, propterdiversitatem
-						levationis et <lb/> positionis, quarum neutram oportet in dactylo habcre
-						<lb/> tria tempora, quis non intelligat?</p>
+						<lb/>hil interest : siquidem pro iambo eum necesse est ac­<lb/>cipi
+						propter ultimam, quam longum cxigunt aures,<lb/>quia restat silentium.
+						Iambum autem non oportere<lb/>poni post dactylum, propterdiversitatem
+						levationis et<lb/>positionis, quarum neutram oportet in dactylo habcre
+						<lb/>tria tempora, quis non intelligat?</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT IX. — <hi rend="italic">De bacchio.</hi>
 						</title>
 					</ab>
-						<div type="textpart" subtype="dialog"><p>10. M. Optime omnino atque sequacitcr. Sed quid <lb/> tibi tandem videtur de
-						anapæsto? an eadem ratio est? <lb/> . <hi rend="italic">D.</hi> Prorsus
-						eadem. <hi rend="italic">M.</hi> Jam ergo bacchium conside­ <lb/> remus, si
-						placet, et dic mihi quod primum ejus ine­ <lb/> trum est. <hi rend="italic"
-							>D.</hi> Quatuor syllabas puto esse, unam bre­ <lb/> vem, et tres
-						longas, quarum duæ ad bacchium per­ <lb/> tinent, una vero ultima ad
-						inchoationem ejus pedis <lb/> qui cum bacchio poni potest; ut id quod ei
-						debetur, <lb/> sit in silentio : in aliquo tamen exemplo vellem ! oc <lb/>
+						<div type="textpart" subtype="dialog"><p>10. M. Optime omnino atque sequacitcr. Sed quid<lb/>tibi tandem videtur de
+						anapaesto? an eadem ratio est?<lb/>. <hi rend="italic">D.</hi> Prorsus
+						eadem. <hi rend="italic">M.</hi> Jam ergo bacchium conside­<lb/>remus, si
+						placet, et dic mihi quod primum ejus ine­<lb/>trum est. <hi rend="italic"
+							>D.</hi> Quatuor syllabas puto esse, unam bre­<lb/>vem, et tres
+						longas, quarum duae ad bacchium per­<lb/>tinent, una vero ultima ad
+						inchoationem ejus pedis<lb/>qui cum bacchio poni potest; ut id quod ei
+						debetur,<lb/>sit in silentio : in aliquo tamen exemplo vellem ! oc<lb/>
 						auribus explorare. <hi rend="italic">II.</hi> Facile quidem tst exempla
-						<lb/> subjicere, quibus tamen non te arbitror ita ut supe­ <lb/> rioribus
-						posse delectari: nam isti quinum temporum <lb/> pedes, ut etiam septenum,
-						non tam suaviter currunt, <lb/> quam ii qui aut in æquas partes dividuntur,
-						aut in <lb/> simplam et duplant, vel in duplam el simplam; tan­ <lb/> tum
-						interest inter sesquatos motus ct æquales aut <lb/> complicatos, dequibus
-						satis in primo illo nostro ser­ <lb/> mone tractavimus. Itaque hos pedes,
-						quinque ac se­ <lb/> ptem scilicet temporum, uti aspernantins poetac, ita
-						<lb/> soluta libentius assumit oratio : qnod videri facilius <lb/> in
-						exemplis quæ postulasti, potest : nam ista sunt, <lb/>
+						<lb/>subjicere, quibus tamen non te arbitror ita ut supe­<lb/>rioribus
+						posse delectari: nam isti quinum temporum<lb/>pedes, ut etiam septenum,
+						non tam suaviter currunt,<lb/>quam ii qui aut in aequas partes dividuntur,
+						aut in<lb/>simplam et duplant, vel in duplam el simplam; tan­<lb/>tum
+						interest inter sesquatos motus ct aequales aut<lb/>complicatos, dequibus
+						satis in primo illo nostro ser­<lb/>mone tractavimus. Itaque hos pedes,
+						quinque ac se­<lb/>ptem scilicet temporum, uti aspernantins poetac, ita
+						<lb/>soluta libentius assumit oratio : qnod videri facilius<lb/>in
+						exemplis quae postulasti, potest : nam ista sunt,<lb/>
 						<hi rend="italic">Laborat magister docens</hi> tardos. Hoc revolve interpo­
-						<lb/> sito trium temporum silcmio , quod ut sentires faci­ <lb/> lius, ideo
-						post tres pedes longam syllabam posui, <lb/> quod est initium cretici , qui
-						cum bacchio poni po­ <lb/> test. Nee ad primum metrum exemplum dedi quod
-						<lb/> est quatuor syllabarum, ne unus pes non esset sa­ <lb/> tis ad
-						commonendum sensum tuum, quantum post <lb/> illum a1que unam longam silere
-						deberes. Quod ecce <lb/> nanc edam, atque ipse repetam , ut in meo silentio
-						<lb/> tria tempora sentias : <hi rend="italic">Labor nullus, Amor magnus.
+						<lb/>sito trium temporum silcmio , quod ut sentires faci­<lb/>lius, ideo
+						post tres pedes longam syllabam posui,<lb/>quod est initium cretici , qui
+						cum bacchio poni po­<lb/>test. Nee ad primum metrum exemplum dedi quod
+						<lb/>est quatuor syllabarum, ne unus pes non esset sa­<lb/>tis ad
+						commonendum sensum tuum, quantum post<lb/>illum a1que unam longam silere
+						deberes. Quod ecce<lb/>nanc edam, atque ipse repetam , ut in meo silentio
+						<lb/>tria tempora sentias : <hi rend="italic">Labor nullus, Amor magnus.
 							D.</hi>
-						<lb/> Satis apparet solutæ orationi hos esse congruentiores <lb/> pedes, et
-						nihil opus est exemplis cætera excurrere. <lb/>
+						<lb/>Satis apparet solutae orationi hos esse congruentiores<lb/>pedes, et
+						nihil opus est exemplis caetera excurrere.<lb/>
 						<hi rend="italic">II.</hi> Verum dicis : sed num libi cum silendum est,
-						<lb/> una tantum longa videtur pom posse post bacchium? <lb/> D. Non sane ;
-						sed etiam brevis ct longa, qui ejus­ <lb/> dem bacchii semipes primus est:
-						nam si nobis in­ <lb/> choare creticum licuit, quia cum eodem baccbio poni
-						<lb/> potest; quanto magis id de ipso bacchio facere lice­ <lb/> bit, cum
-						præscrtim non totum de cretico posueri­ <lb/> mus quod primæ parti bacchii
-						sit æquale temporibus'</p>
+						<lb/>una tantum longa videtur pom posse post bacchium?<lb/>D. Non sane ;
+						sed etiam brevis ct longa, qui ejus­<lb/>dem bacchii semipes primus est:
+						nam si nobis in­<lb/>choare creticum licuit, quia cum eodem baccbio poni
+						<lb/>potest; quanto magis id de ipso bacchio facere lice­<lb/>bit, cum
+						praescrtim non totum de cretico posueri­<lb/>mus quod primae parti bacchii
+						sit aequale temporibus'</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT X. — <hi rend="italic">Pleno pedi quid addatur ante
 								silentium.</hi>
 						</title>
 					</ab>
-					<p>ii. M. Jam ergo, si placet, mc audiente atque ju­ <lb/> dicante, tu ipse per
-						catcra excurre, et quid ponatur <lb/> post plenum pedcm, quando silentio
-						reliquum iut­ <lb/> pletur in omnibus pedibus qui restant, exsequcrc. <lb/>
+					<p>ii. M. Jam ergo, si placet, mc audiente atque ju­<lb/>dicante, tu ipse per
+						catcra excurre, et quid ponatur<lb/>post plenum pedcm, quando silentio
+						reliquum iut­<lb/>pletur in omnibus pedibus qui restant, exsequcrc.<lb/>
 						<hi rend="italic">D.</hi> Brevissimum jam, opinor , atque facillimum est
-						<lb/> quod rcquiris : nam quod de bacchio dictum est, id <lb/> etiam de
-						secundo pæone dici potest. Post creticum au­ <lb/> tcm cl unam longam
-						syllabam licet ponere, et iam­ <lb/> bum, ct spondeum ; iLa ut aut ti ia
-						tempora, aul duo, <lb/> aut unum silcalur. Quod autem de hoc dictum est,
-						<lb/> id et in primum et in ultimum pæonem cadit '. Jam <lb/> post
-						palimbacchium vel unam longam vcl spondcuna <lb/> collocari decet, quocirca
-						et in hoc metro aut tria <lb/> tempora, aut unum silebitur. Eadem conditio
-						est <lb/> pæonis tertii. Sanc ubicumque spondeus, ibi et ana­ <lb/> pæstus
-						jure ponatur. Post molossum vero, quod ad <lb/> ejus attinet divisionem, aut
-						unam longam ut quatuor, <lb/> aut duas ponimus ut duo tempora sileamus. Sed
-						quo­ <lb/> niam et censu et ratione exploratum est, ordinari <note
+						<lb/>quod rcquiris : nam quod de bacchio dictum est, id<lb/>etiam de
+						secundo paeone dici potest. Post creticum au­<lb/>tcm cl unam longam
+						syllabam licet ponere, et iam­<lb/>bum, ct spondeum ; iLa ut aut ti ia
+						tempora, aul duo,<lb/>aut unum silcalur. Quod autem de hoc dictum est,
+						<lb/>id et in primum et in ultimum paeonem cadit '. Jam<lb/>post
+						palimbacchium vel unam longam vcl spondcuna<lb/>collocari decet, quocirca
+						et in hoc metro aut tria<lb/>tempora, aut unum silebitur. Eadem conditio
+						est<lb/>paeonis tertii. Sanc ubicumque spondeus, ibi et ana­<lb/>paestus
+						jure ponatur. Post molossum vero, quod ad<lb/>ejus attinet divisionem, aut
+						unam longam ut quatuor,<lb/>aut duas ponimus ut duo tempora sileamus. Sed
+						quo­<lb/>niam et censu et ratione exploratum est, ordinari <note
 							type="footnote"> I Er. Lugd. habent: <hi rend="italic">Sec ad</hi>
 							prinii <hi rend="italic">metri</hi> exemplum <hi rend="italic"
 								>dedt;</hi>
-							<lb/> et in margine <hi rend="italic">adeo,</hi> j ro <hi rend="italic"
-								>ad;</hi> Lov., <hi rend="italic">nec adeo primi</hi> nwtri. <lb/>
+							<lb/>et in margine <hi rend="italic">adeo,</hi> j ro <hi rend="italic"
+								>ad;</hi> Lov., <hi rend="italic">nec adeo primi</hi> nwtri.<lb/>
 							MS. A, <hi rend="italic">nec</hi> pritni <hi rend="italic">melrt;</hi>
-							at Ms. B legit ui Benedictini. vcu. <lb/> textum Er. ct l ugd. sequitur.
+							at Ms. B legit ui Benedictini. vcu.<lb/>textum Er. ct l ugd. sequitur.
 							II. </note><note type="footnote">t Adjiciuntur a *:s. A tirc verba : <hi
 								rend="italic">Propter</hi> duas <hi rend="italic">divi­</hi>
-							<lb/> siones. ii. </note>
+							<lb/>siones. ii. </note>
 						<lb/>
-						<pb n="1135"/> cum eo posse omnes senum temporum pedes, erit <lb/> post cum
-						locus et iambo, et tria tempora silenda re­ <lb/> manebant; erit et cretico
-						, et unum tacebitur; hac <lb/> conditione erit et bacchio. At si in duas
-						breves pri­ <lb/> mam cretici, et secundam bacchii solverimus, ent et <lb/>
-						pæoni quarto. Quod autem de molosso, id etiam de <lb/> cjeleris sex temporum
-						pedibus dixerim. Jam procc­ <lb/> leusmaticum arbitror ad cæteros qui
-						quatuor tempo­ <lb/> ribus constant, esse referendum, nisi cum tres bre­
-						<lb/> res post cum locamus. Quod ita est ac si anapræstum <lb/> locemus,
-						propter ultiinam syllabam quæ cum silentio <lb/> longa accipi solet. Primo
-						vero cpitrito iambus recte <lb/> subjungitur, et bacchius ct creticus et
-						pxon quar­ <lb/> tus. Hoc dctum sil et de secundo, ut tempora si- <lb/>
-						Icantur aut quatuor, aul duo. Duos autem reliqnos <lb/> epitritos recte
-						possunt consequi spondcus ct molos­ <lb/> sus : ita ut primam s; ondei, et
-						primam vel sccun­ <lb/> dam molossi in duas breves solvere liceat. Ergo in
-						<lb/> his metris aut tria tempora, aut unum tacebitur. <lb/> Dispondeus
-						restat, post quem si posuerimus spon­ <lb/> deum, quatuor tempora silenda
-						erunt; si molossum , <lb/> duo, manente licentia solvendi longam in duas
-						bre­ <lb/> ves , vel in spondeo, vet in molosso, excepta ul­ <lb/> tima.
-						Habes quod me excurrere voluisti. Nisi aliquid <lb/> forte emendabis.</p>
+						<pb n="1135"/> cum eo posse omnes senum temporum pedes, erit<lb/>post cum
+						locus et iambo, et tria tempora silenda re­<lb/>manebant; erit et cretico
+						, et unum tacebitur; hac<lb/>conditione erit et bacchio. At si in duas
+						breves pri­<lb/>mam cretici, et secundam bacchii solverimus, ent et<lb/>
+						paeoni quarto. Quod autem de molosso, id etiam de<lb/>cjeleris sex temporum
+						pedibus dixerim. Jam procc­<lb/>leusmaticum arbitror ad caeteros qui
+						quatuor tempo­<lb/>ribus constant, esse referendum, nisi cum tres bre­
+						<lb/>res post cum locamus. Quod ita est ac si anapraestum<lb/>locemus,
+						propter ultiinam syllabam quae cum silentio<lb/>longa accipi solet. Primo
+						vero cpitrito iambus recte<lb/>subjungitur, et bacchius ct creticus et
+						pxon quar­<lb/>tus. Hoc dctum sil et de secundo, ut tempora si<lb/>
+						Icantur aut quatuor, aul duo. Duos autem reliqnos<lb/>epitritos recte
+						possunt consequi spondcus ct molos­<lb/>sus : ita ut primam s; ondei, et
+						primam vel sccun­<lb/>dam molossi in duas breves solvere liceat. Ergo in
+						<lb/>his metris aut tria tempora, aut unum tacebitur.<lb/>Dispondeus
+						restat, post quem si posuerimus spon­<lb/>deum, quatuor tempora silenda
+						erunt; si molossum ,<lb/>duo, manente licentia solvendi longam in duas
+						bre­<lb/>ves , vel in spondeo, vet in molosso, excepta ul­<lb/>tima.
+						Habes quod me excurrere voluisti. Nisi aliquid<lb/>forte emendabis.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">. CAPUT X I. — <hi rend="italic">Iambus post</hi>
 							dichorium <hi rend="italic">male ponitur.</hi>
 						</title>
 					</ab>
-					<p>ii. <hi rend="italic">M.</hi> lino non ego, sed tu, cum aurem ad judi­ <lb/>
-						candum adhibueris : nam quæro a te, utrum cum di­ <lb/> co et plaudo istud
-						metrum, <hi rend="italic">Verus optimus; et hoc,<lb/> Verus optimorum;</hi>
-						et boc, <hi rend="italic">Veritatis inops</hi> : tam jucun­ <lb/> de hoc
-						tertium quam illa superiora tuus sensus acci­ <lb/> piat; quod ea repetendo,
-						et cum debilis silentiis plau­ <lb/> dendo facile judicabit. <hi
-							rend="italic">D.</hi> Manifestum est quod jucun­ <lb/> de illa, hoc
-						injucunde accipiat1. <hi rend="italic">M.</hi> Non ergo recte <lb/> post
+					<p>ii. <hi rend="italic">M.</hi> lino non ego, sed tu, cum aurem ad judi­<lb/>
+						candum adhibueris : nam quaero a te, utrum cum di­<lb/>co et plaudo istud
+						metrum, <hi rend="italic">Verus optimus; et hoc,<lb/>Verus optimorum;</hi>
+						et boc, <hi rend="italic">Veritatis inops</hi> : tam jucun­<lb/>de hoc
+						tertium quam illa superiora tuus sensus acci­<lb/>piat; quod ea repetendo,
+						et cum debilis silentiis plau­<lb/>dendo facile judicabit. <hi
+							rend="italic">D.</hi> Manifestum est quod jucun­<lb/>de illa, hoc
+						injucunde accipiat1. <hi rend="italic">M.</hi> Non ergo recte<lb/>post
 						dichorium iambus ponitur. <hi rend="italic">D.</hi> Ita est. <hi
-							rend="italic">37.</hi> Recte <lb/> autcm poni posse post cæteros
-						assentitur quisquis <lb/> hæc metra cum disciplina interponendoram silentio­
-						<lb/> rum repetierit. <lb/> Fallacem cave. <lb/> Malo castum cave. <lb/>
-						Mutiloquum cave. <lb/> Fallaciam cave. <lb/> Et invidum cave. <lb/> Et
-						infirmum cave. <lb/> D. Sentio quod dicis, ct approbo. <hi rend="italic"
-							>M.</hi> Vide etiam <lb/> utrum te nihil offendat, cum interposito
-						duorum tem­ <lb/> porum silentio, hoc metrum npetitum inæquale per­ <lb/>
-						git I. Num enin, ita senet nt ista ? <lb/> Veraces regnant. <lb/> sapientes
-						regnant. <lb/> Veriloqui regnant. <lb/> Prudentia regnat. <lb/> Boni in
-						bonis regnant. <lb/> Pura eunc1a regnant. <lb/> D. Imo hæc æqualiter ct
-						suaviter, illud autem ab­ <lb/> surde. <hi rend="italic">M.</hi> Hoc ergo
-						tenebimus in metris scx tempo­ <lb/> rum pedum, dichorium iambo, antispastum
-						spondeo <lb/> male claudi. <hi rend="italic">D.</hi> Tenebimus sanc.</p>
+							rend="italic">37.</hi> Recte<lb/>autcm poni posse post caeteros
+						assentitur quisquis<lb/>haec metra cum disciplina interponendoram silentio­
+						<lb/>rum repetierit.<lb/>Fallacem cave.<lb/>Malo castum cave.<lb/>
+						Mutiloquum cave.<lb/>Fallaciam cave.<lb/>Et invidum cave.<lb/>Et
+						infirmum cave.<lb/>D. Sentio quod dicis, ct approbo. <hi rend="italic"
+							>M.</hi> Vide etiam<lb/>utrum te nihil offendat, cum interposito
+						duorum tem­<lb/>porum silentio, hoc metrum npetitum inaequale per­<lb/>
+						git I. Num enin, ita senet nt ista ?<lb/>Veraces regnant.<lb/>sapientes
+						regnant.<lb/>Veriloqui regnant.<lb/>Prudentia regnat.<lb/>Boni in
+						bonis regnant.<lb/>Pura eunc1a regnant.<lb/>D. Imo haec aequaliter ct
+						suaviter, illud autem ab­<lb/>surde. <hi rend="italic">M.</hi> Hoc ergo
+						tenebimus in metris scx tempo­<lb/>rum pedum, dichorium iambo, antispastum
+						spondeo<lb/>male claudi. <hi rend="italic">D.</hi> Tenebimus sanc.</p>
 					<p>43. M. Quid ? causam cur ita sit nonne approbabis, <note type="footnote"> I
 							Mss. A et B ferum : <hi rend="italic">Manifestum eat juetmde illa, hoc
-								<lb/> injucunde</hi> accipi. M. </note><note type="footnote"> I <hi
-								rend="italic">Inæqualiter,</hi> juxta Ms. A et omnes editos. Ks. B
-							legit <lb/> uti Benedictini, inæquale. M. </note>
-						<lb/> si animadverteris levatione ac positronc in duas partes <lb/> dividi
-						pedem, ita ut si qua in eo syllaba media est, <lb/> vel una vol duae, aut
-						uni parti attribuantur priori vel <lb/> posteriori, aut in utramque
-						partiantur? <hi rend="italic">D.</hi> Novi qni­ <lb/> dem istuc, et vcrum
-						est: sed quid ad rcm? M. Ho c <lb/> quoque attende quod dicam, tum videbis
-						facilius quod <lb/> requiris. Nam manifestum tibi esse arbitror, alios <lb/>
-						esse sine mediis syllabis pedes, tri pyrrhichius, et <lb/> cæteri binarum
-						syllabarum; alios in quibus medium <lb/> aut primae parti, aut extremæ, aut
-						utrique, aut neu­ <lb/> ti i, spatio conveniat; primæ, ut in anapæsto, vel
-						in <lb/> palimbacchio, vel in pæone primo : extremae, ut in <lb/> dactylo
-						vel in bacchio, vcl in pæone quarto: utrique, <lb/> ut in tribracho, sive in
-						molosso, sive in choriambo, <lb/> sive in quolibet ionico : neutri, ut in
-						cretico, sive in <lb/> paeonibus secundo et tertio, sive in diiambo, dicho­
-						<lb/> rio, antispasto. Nam qui pedes in tres acquales par­ <lb/> les dividi
-						possunt, media pars in his convenit cum <lb/> prima et extrema; qui autem.
-						non possunt, aut cum <lb/> prima tantum, aut cum extrema, aut cum neutra.
+								<lb/>injucunde</hi> accipi. M. </note><note type="footnote"> I <hi
+								rend="italic">Inaequaliter,</hi> juxta Ms. A et omnes editos. Ks. B
+							legit<lb/>uti Benedictini, inaequale. M. </note>
+						<lb/>si animadverteris levatione ac positronc in duas partes<lb/>dividi
+						pedem, ita ut si qua in eo syllaba media est,<lb/>vel una vol duae, aut
+						uni parti attribuantur priori vel<lb/>posteriori, aut in utramque
+						partiantur? <hi rend="italic">D.</hi> Novi qni­<lb/>dem istuc, et vcrum
+						est: sed quid ad rcm? M. Ho c<lb/>quoque attende quod dicam, tum videbis
+						facilius quod<lb/>requiris. Nam manifestum tibi esse arbitror, alios<lb/>
+						esse sine mediis syllabis pedes, tri pyrrhichius, et<lb/>caeteri binarum
+						syllabarum; alios in quibus medium<lb/>aut primae parti, aut extremae, aut
+						utrique, aut neu­<lb/>ti i, spatio conveniat; primae, ut in anapaesto, vel
+						in<lb/>palimbacchio, vel in paeone primo : extremae, ut in<lb/>dactylo
+						vel in bacchio, vcl in paeone quarto: utrique,<lb/>ut in tribracho, sive in
+						molosso, sive in choriambo,<lb/>sive in quolibet ionico : neutri, ut in
+						cretico, sive in<lb/>paeonibus secundo et tertio, sive in diiambo, dicho­
+						<lb/>rio, antispasto. Nam qui pedes in tres acquales par­<lb/>les dividi
+						possunt, media pars in his convenit cum<lb/>prima et extrema; qui autem.
+						non possunt, aut cum<lb/>prima tantum, aut cum extrema, aut cum neutra.
 							<hi rend="italic">D.</hi>
-						<lb/> Et hoc aeque scio, et quo tendat exspecto. M. Quo tan­ <lb/> dem
-						putas, nisi ut videas iambum post dichorium ideo <lb/> male poni cum
-						silentio, quia medium ejus est, nec <lb/> primae parti æquale nec extremae,
-						et idcirco a leva­ <lb/> tione ac positione discordat ? Hoc etiam de spondeo
-						<lb/> intelligitur, qui similiter post antispastumcum silen­ <lb/> tio nou
-						amat poni. An quidquam tibi adversum ista <lb/> dicendum est? D. Mihi vero
-						nihil ? nisi quod ista offen­ <lb/> sio quae fit auribus, cum ita hi pedes
-						collocantur, in <lb/> comparatione fit ejus suavitatis, quæ oblectat audi­
-						<lb/> tum, cum post caeteros senum temporum hi cum si­ <lb/> lentio ponuntur
-						pedes. Nam si aliis tacitis me consu­ <lb/> leres quemadmodum sonarent,
-						exemplis subjectis, <lb/> aut post dichorium iambus, aut post antispastum
-						spon­ <lb/> deus, cum silentio positi; dicam quod sentio, for­ <lb/> tasse
-						approbarem et laudarcm. <hi rend="italic">M.</hi> Non equidem <lb/> resisto
-						tibi. Satis est mihi tamen, quod hæc collocatio <lb/> in comparatione lIlium
-						numerorum, sed melius so­ <lb/> nantium, sicut dicis, offendit: co enim est
-						impro­ <lb/> banda, quod cum ejusdem generis etiam illi sint pe­ <lb/> des,
-						quos his semipedibus clausos labi jucundius con­ <lb/> fitemur, ab iis
-						discrepare non dcbuit. Sed nonne tibi <lb/> vidctur secundum istam rationem,
-						nec post epitritum <lb/> secundum iambum cum silentio poni oportere! Nam
-						<lb/> et in hoc pede iambus ita medium locum tenet, ut <lb/> nec prioris nec
-						posterioris partis temporibus sequetur <lb/>
+						<lb/>Et hoc aeque scio, et quo tendat exspecto. M. Quo tan­<lb/>dem
+						putas, nisi ut videas iambum post dichorium ideo<lb/>male poni cum
+						silentio, quia medium ejus est, nec<lb/>primae parti aequale nec extremae,
+						et idcirco a leva­<lb/>tione ac positione discordat ? Hoc etiam de spondeo
+						<lb/>intelligitur, qui similiter post antispastumcum silen­<lb/>tio nou
+						amat poni. An quidquam tibi adversum ista<lb/>dicendum est? D. Mihi vero
+						nihil ? nisi quod ista offen­<lb/>sio quae fit auribus, cum ita hi pedes
+						collocantur, in<lb/>comparatione fit ejus suavitatis, quae oblectat audi­
+						<lb/>tum, cum post caeteros senum temporum hi cum si­<lb/>lentio ponuntur
+						pedes. Nam si aliis tacitis me consu­<lb/>leres quemadmodum sonarent,
+						exemplis subjectis,<lb/>aut post dichorium iambus, aut post antispastum
+						spon­<lb/>deus, cum silentio positi; dicam quod sentio, for­<lb/>tasse
+						approbarem et laudarcm. <hi rend="italic">M.</hi> Non equidem<lb/>resisto
+						tibi. Satis est mihi tamen, quod haec collocatio<lb/>in comparatione lIlium
+						numerorum, sed melius so­<lb/>nantium, sicut dicis, offendit: co enim est
+						impro­<lb/>banda, quod cum ejusdem generis etiam illi sint pe­<lb/>des,
+						quos his semipedibus clausos labi jucundius con­<lb/>fitemur, ab iis
+						discrepare non dcbuit. Sed nonne tibi<lb/>vidctur secundum istam rationem,
+						nec post epitritum<lb/>secundum iambum cum silentio poni oportere! Nam
+						<lb/>et in hoc pede iambus ita medium locum tenet, ut<lb/>nec prioris nec
+						posterioris partis temporibus sequetur<lb/>
 						<hi rend="italic">D.</hi> Cogii me superior ratio concedere.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT XII. — <hi rend="italic">Summa</hi> omnium <hi
@@ -3266,568 +3266,568 @@
 						</title>
 					</ab>
 					</div>
-				<div type="textpart" subtype="dialog"><p>14. <hi rend="italic">M.</hi> . Age ,nunc, reddc mihi omnium metrorum <lb/>
-						numerum, si placet, quæ jam tractavimus; id est eo­ <lb/> rum quæ a suis
-						plenis pedibus incipiunt, clauduntur <lb/> antem aut suis pcdibus plenis.
-						ila ut silentium, cum <lb/> ad caput reditur, non interponamus ; aut non
-						plenis <lb/> pedibus cum silentio, quos tamen cis congruere ratio <lb/>
-						docuit; incipiente humero a duobus non plenis usque <lb/> ad octo plenos,
-						ita tamen ut triginta duo tempora non <lb/> excedantur. <hi rend="italic"
-							>D.</hi> Operosum quidem est quod imponis, <lb/> est tamen opcrae
-						pretium. Sed memini nos paulo an­ <lb/> te jam pervenisse ad septuaginta
-						septem metra a <lb/>
-						<pb n="1137"/> pyrrhichio usque ad tribrachum, cum illi binarum <lb/>
-						syllabarum pedes quatuordecim singuli crearent, qu:o <lb/> fiunt simul
-						quinquaginta ct sex. Tribrachus autem <lb/> viginti et unum, propter geminam
-						divisioncm. His <lb/> igitur septuaginta ct septem addimus quatuordecim
-						<lb/> dactyli, et anapaesti totidem : pleni enim si locentur <lb/> nullo
-						silentio, incipicnte metro a duobus usque ad <lb/> octo pedes, septena
-						pariunt; additis vero semipedi­ <lb/> bus cum silentio, incipiente metro ab
-						uno pede, et <lb/> semipede perveniente ad septem et sontis, alia sopte­
-						<lb/> na. Et fiunt jam omnia centum ct quinque, Bacchius <lb/> vcro non
-						potest metrum suum ad octo pedes perdu­ <lb/> ecre, ne triginta duo tompora
-						transeat, neqne quis­ <lb/> quam quinum temporum pes; scd possunt isti usque
-						<lb/> ad sex pervenire. Bacchius ergo et qui ei par est, nun <lb/> modo
-						temporibus, scil etiam divisione pæon secun­ <lb/> dus, a duobus pedibus
-						usque ad sex procedentes cum <lb/> integri ordinantur sine silentio, quina
-						metra pariunt ; <lb/> cum silentio autem incipientes ab uno semipcde, et
-						<lb/> ad quinque semipedes pervenientes, niia quina cum <lb/> una longa post
-						cos ponitur, ct item quina cum bre - <lb/> via et longa : quindena igitur
-						creant, quæ in summam <lb/> redacta triginta sunt. Et fiunt jam metra omnia
-						cen­ <lb/> tum et triginta quin'luc, Creticus vero, et qni pariter <lb/>
-						dividuntur, pxoncs primus et quartus, quoniam post <lb/> illos et unam
-						longam, ct iambum, et spondeum, ct <lb/> anapæstum licet ponere, ad
-						septuaginta quinque pcr­ <lb/> veniunt : cum enim tres sint pedes, qnina
-						crcant sine <lb/> silentio, cum silentio autem viginti, quæ simul, ut <lb/>
-						dictum est, fiunt quinque et septuaginta, quibus addi­ <lb/> tis superiori
-						summæ, decem et ducenta complentur. <lb/> Palimbacchius et qui ei divisione
-						concordat tertius <lb/> paeon, quina pariunt integri sine silentio : cum
-						silen­ <lb/> tio autem quina cum una longa, quina cum spondeo, <lb/> quina
-						cum anapæsto. Hæc addimus ad majorem sum­ <lb/> mam, ct habemus metra omnia
-						ducenta quinqua­ <lb/> ginta.</p>
-					<p>i5. Molossus et cæteri sex temporum pe.lcs, qui <lb/> cum illo simnl septem
-						fiunt, quaterna crcanl integri : <lb/> cum silentio autem quoniam et una
-						longa post unum­ <lb/> quemque eorum locari potest, et iambus, et spondeus,
-						<lb/> et anapæstus, et bacchius, et creticus, et pæon qunr­ <lb/> rus;
-						vicena et octona complent, quae simul fiunt cen­ <lb/> tum nonaginta sex,
-						quæ ducta cum illis quaternis du­ <lb/> centa viginti quatuor complentur :
-						sed hinc octo dc­ <lb/> ducendi sunt, quia post dichorium iambus, ct post
-						<lb/> antispastum spondcus male ordinantur. Reliqua sunt <lb/> ducenta
-						sexdecim, qune addita majori summae, fa­ <lb/> ciunt metra omuia
-						quadringenta sexaginta sex. Proce­ <lb/> leumatici ratio hab eri non potuit
-						cum his pedibus qui­ <lb/> hus congruit, propter semipedes qui post hunc
-						plures <lb/> ponuntur. Nam ct una syllaba longa post eum poni <lb/> potest
-						cum si'entio, sicut post dactylum et rjus con­ <lb/> sortes ut duo, cl tres
-						breves ut unum tempus silea­ <lb/> tur; quo efficitur ut ultima brevis pro
-						longa accipia­ <lb/> tur. Epitriti metra gignunt terna integri, incipiente
-						<lb/> metro a duobus pedibus, perveniente ad quatuor : si <lb/> cniin addas
-						quintum, triginta duo tempora, quod uon <lb/> oportet, excedes. Cum silentio
-						vero primus et secun­ <lb/> dus epitritus terna post locato i mbo, terna
-						bacchio, <lb/> terna cretico, terna pæone quarto; quae fiuut cum <lb/> illis
-						ternis quæ sunt sine silentio, triginta. Tet tius ve­ <lb/> ro et quartus
-						epitriti tres ante silentium gignunt, cum <lb/> spondeo terna, ct terna cum
-						anapæsto, lerna cum <lb/> molosso, terna cum ionico minore, terna cum chor­
-						<lb/> iambo; quæ fiunt simul cum illis ternis, quæ sine <lb/> silentio
-						genuerunt, triginta et sev. Ergo epitriti orn­ <lb/> lies sexaginta et sex
-						metra pariunt. : quæ cum viginti <lb/> ct uno proceleumatici, superiori
-						summæ addta, fa­ <lb/> ciunt quingenta quinquaginta tria. Dispondeus restat
-						<lb/> gignens et ipse liia integer; adhibito autem silemio <lb/> cum spondeo
-						tria, et tria cum anapæsto, tria cum mo­ <lb/> losso, tria cum ionico a
-						miaore, tria cum choriambo: <lb/> quæ in summam ducta cum illis tribus quæ
-						creat in­ <lb/> teger, fiunt decem et octo. Ita erum metra omma <lb/>
+				<div type="textpart" subtype="dialog"><p>14. <hi rend="italic">M.</hi> . Age ,nunc, reddc mihi omnium metrorum<lb/>
+						numerum, si placet, quae jam tractavimus; id est eo­<lb/>rum quae a suis
+						plenis pedibus incipiunt, clauduntur<lb/>antem aut suis pcdibus plenis.
+						ila ut silentium, cum<lb/>ad caput reditur, non interponamus ; aut non
+						plenis<lb/>pedibus cum silentio, quos tamen cis congruere ratio<lb/>
+						docuit; incipiente humero a duobus non plenis usque<lb/>ad octo plenos,
+						ita tamen ut triginta duo tempora non<lb/>excedantur. <hi rend="italic"
+							>D.</hi> Operosum quidem est quod imponis,<lb/>est tamen opcrae
+						pretium. Sed memini nos paulo an­<lb/>te jam pervenisse ad septuaginta
+						septem metra a<lb/>
+						<pb n="1137"/> pyrrhichio usque ad tribrachum, cum illi binarum<lb/>
+						syllabarum pedes quatuordecim singuli crearent, qu:o<lb/>fiunt simul
+						quinquaginta ct sex. Tribrachus autem<lb/>viginti et unum, propter geminam
+						divisioncm. His<lb/>igitur septuaginta ct septem addimus quatuordecim
+						<lb/>dactyli, et anapaesti totidem : pleni enim si locentur<lb/>nullo
+						silentio, incipicnte metro a duobus usque ad<lb/>octo pedes, septena
+						pariunt; additis vero semipedi­<lb/>bus cum silentio, incipiente metro ab
+						uno pede, et<lb/>semipede perveniente ad septem et sontis, alia sopte­
+						<lb/>na. Et fiunt jam omnia centum ct quinque, Bacchius<lb/>vcro non
+						potest metrum suum ad octo pedes perdu­<lb/>ecre, ne triginta duo tompora
+						transeat, neqne quis­<lb/>quam quinum temporum pes; scd possunt isti usque
+						<lb/>ad sex pervenire. Bacchius ergo et qui ei par est, nun<lb/>modo
+						temporibus, scil etiam divisione paeon secun­<lb/>dus, a duobus pedibus
+						usque ad sex procedentes cum<lb/>integri ordinantur sine silentio, quina
+						metra pariunt ;<lb/>cum silentio autem incipientes ab uno semipcde, et
+						<lb/>ad quinque semipedes pervenientes, niia quina cum<lb/>una longa post
+						cos ponitur, ct item quina cum bre<lb/>via et longa : quindena igitur
+						creant, quae in summam<lb/>redacta triginta sunt. Et fiunt jam metra omnia
+						cen­<lb/>tum et triginta quin'luc, Creticus vero, et qni pariter<lb/>
+						dividuntur, pxoncs primus et quartus, quoniam post<lb/>illos et unam
+						longam, ct iambum, et spondeum, ct<lb/>anapaestum licet ponere, ad
+						septuaginta quinque pcr­<lb/>veniunt : cum enim tres sint pedes, qnina
+						crcant sine<lb/>silentio, cum silentio autem viginti, quae simul, ut<lb/>
+						dictum est, fiunt quinque et septuaginta, quibus addi­<lb/>tis superiori
+						summae, decem et ducenta complentur.<lb/>Palimbacchius et qui ei divisione
+						concordat tertius<lb/>paeon, quina pariunt integri sine silentio : cum
+						silen­<lb/>tio autem quina cum una longa, quina cum spondeo,<lb/>quina
+						cum anapaesto. Haec addimus ad majorem sum­<lb/>mam, ct habemus metra omnia
+						ducenta quinqua­<lb/>ginta.</p>
+					<p>i5. Molossus et caeteri sex temporum pe.lcs, qui<lb/>cum illo simnl septem
+						fiunt, quaterna crcanl integri :<lb/>cum silentio autem quoniam et una
+						longa post unum­<lb/>quemque eorum locari potest, et iambus, et spondeus,
+						<lb/>et anapaestus, et bacchius, et creticus, et paeon qunr­<lb/>rus;
+						vicena et octona complent, quae simul fiunt cen­<lb/>tum nonaginta sex,
+						quae ducta cum illis quaternis du­<lb/>centa viginti quatuor complentur :
+						sed hinc octo dc­<lb/>ducendi sunt, quia post dichorium iambus, ct post
+						<lb/>antispastum spondcus male ordinantur. Reliqua sunt<lb/>ducenta
+						sexdecim, qune addita majori summae, fa­<lb/>ciunt metra omuia
+						quadringenta sexaginta sex. Proce­<lb/>leumatici ratio hab eri non potuit
+						cum his pedibus qui­<lb/>hus congruit, propter semipedes qui post hunc
+						plures<lb/>ponuntur. Nam ct una syllaba longa post eum poni<lb/>potest
+						cum si'entio, sicut post dactylum et rjus con­<lb/>sortes ut duo, cl tres
+						breves ut unum tempus silea­<lb/>tur; quo efficitur ut ultima brevis pro
+						longa accipia­<lb/>tur. Epitriti metra gignunt terna integri, incipiente
+						<lb/>metro a duobus pedibus, perveniente ad quatuor : si<lb/>cniin addas
+						quintum, triginta duo tempora, quod uon<lb/>oportet, excedes. Cum silentio
+						vero primus et secun­<lb/>dus epitritus terna post locato i mbo, terna
+						bacchio,<lb/>terna cretico, terna paeone quarto; quae fiuut cum<lb/>illis
+						ternis quae sunt sine silentio, triginta. Tet tius ve­<lb/>ro et quartus
+						epitriti tres ante silentium gignunt, cum<lb/>spondeo terna, ct terna cum
+						anapaesto, lerna cum<lb/>molosso, terna cum ionico minore, terna cum chor­
+						<lb/>iambo; quae fiunt simul cum illis ternis, quae sine<lb/>silentio
+						genuerunt, triginta et sev. Ergo epitriti orn­<lb/>lies sexaginta et sex
+						metra pariunt. : quae cum viginti<lb/>ct uno proceleumatici, superiori
+						summae addta, fa­<lb/>ciunt quingenta quinquaginta tria. Dispondeus restat
+						<lb/>gignens et ipse liia integer; adhibito autem silemio<lb/>cum spondeo
+						tria, et tria cum anapaesto, tria cum mo­<lb/>losso, tria cum ionico a
+						miaore, tria cum choriambo:<lb/>quae in summam ducta cum illis tribus quae
+						creat in­<lb/>teger, fiunt decem et octo. Ita erum metra omma<lb/>
 						quingenta septuaginta et unum.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT XIII. - <hi rend="italic">Ratio metietidi metra et
 								silentia interponendi.</hi>
 						</title>
 					</ab>
-					<p>46. M. Essent quidcm, nisi tria detrabenda essent, . <lb/> quia post secundum
-						epitritum dictum est iainbum ara­ <lb/> le poni. Sed hoc quidem bene se
-						habet: quare jant <lb/> dic mihi, quomodo libi aurem tangat metrum hoe, <lb/>
-						<hi rend="italic">Triplici vides, ut ortu Triviæ rotetur ignis. D.</hi>
-						Persua­ <lb/> viter. <hi rend="italic">M.</hi> Potesne dicere quibus pedibus
+					<p>46. M. Essent quidcm, nisi tria detrabenda essent, .<lb/>quia post secundum
+						epitritum dictum est iainbum ara­<lb/>le poni. Sed hoc quidem bene se
+						habet: quare jant<lb/>dic mihi, quomodo libi aurem tangat metrum hoe,<lb/>
+						<hi rend="italic">Triplici vides, ut ortu Triviae rotetur ignis. D.</hi>
+						Persua­<lb/>viter. <hi rend="italic">M.</hi> Potesne dicere quibus pedibus
 						constet? <hi rend="italic">D.</hi>
-						<lb/> Non possum : neque enim invenio quomodo sibi con­ <lb/> gruantquos
-						melior : sive cniui pyrrhichium a capite <lb/> constituam, sive anapæstum,
-						sive pæonem tertium, <lb/> non his conveniunt qui. sequuntur ct invenio bic
-						qui­ <lb/> dem creticum post tertium pæonem, ut reliqua sit <lb/> longa
-						syllaba, quam creticus post se non respuit col­ <lb/> locari; sed his
-						pedibus hoc metrum constare recte <lb/> non posset, nisi interposito
-						silentio trium temporum : <lb/> nunc vero nihil siletur, cum hoe repetendo
-						permulcet <lb/> auditum. M. Vide igitur, utrum hicipere debeat a pyr­ <lb/>
-						rhichio, deinde mctiamur dichorium, tum spondeum, <lb/> qui complet tempora,
-						quorum duo sunt in principio : <lb/> potest item caput tenere anapæstus,
-						deinde diiambus <lb/> metiri, ut extrema longa collocata cum' quatuor tem­
-						<lb/> poribus anapæsti perficiat sex timpora, quae cum di­ <lb/> iambo
-						conveniunt, ex quo intelligas licct, partes pe­ <lb/> dum non solum in fine
-						poni, sed etiam in capite me­ <lb/> trorum. <hi rend="italic">D.</hi> Jam
+						<lb/>Non possum : neque enim invenio quomodo sibi con­<lb/>gruantquos
+						melior : sive cniui pyrrhichium a capite<lb/>constituam, sive anapaestum,
+						sive paeonem tertium,<lb/>non his conveniunt qui. sequuntur ct invenio bic
+						qui­<lb/>dem creticum post tertium paeonem, ut reliqua sit<lb/>longa
+						syllaba, quam creticus post se non respuit col­<lb/>locari; sed his
+						pedibus hoc metrum constare recte<lb/>non posset, nisi interposito
+						silentio trium temporum :<lb/>nunc vero nihil siletur, cum hoe repetendo
+						permulcet<lb/>auditum. M. Vide igitur, utrum hicipere debeat a pyr­<lb/>
+						rhichio, deinde mctiamur dichorium, tum spondeum,<lb/>qui complet tempora,
+						quorum duo sunt in principio :<lb/>potest item caput tenere anapaestus,
+						deinde diiambus<lb/>metiri, ut extrema longa collocata cum' quatuor tem­
+						<lb/>poribus anapaesti perficiat sex timpora, quae cum di­<lb/>iambo
+						conveniunt, ex quo intelligas licct, partes pe­<lb/>dum non solum in fine
+						poni, sed etiam in capite me­<lb/>trorum. <hi rend="italic">D.</hi> Jam
 						intelligo.</p>
 					</div>
-				<div type="textpart" subtype="dialog"><p>17. <hi rend="italic">M</hi> Quid, si demam unam ultimam rongam, ut <lb/>
+				<div type="textpart" subtype="dialog"><p>17. <hi rend="italic">M</hi> Quid, si demam unam ultimam rongam, ut<lb/>
 						tale sil metrum, <hi rend="italic">Segetes</hi> meus <hi rend="italic">labor
-							:</hi> nonne aninlad­ <lb/> vertis cum silentio duorum temporum repeti i
-						Ex quo <lb/> manifestum est, et aliquam partem pedis posse in <lb/>
-						principio metri poni, et aliquam in fine, et aliquam <lb/> in silentio. <hi
+							:</hi> nonne aninlad­<lb/>vertis cum silentio duorum temporum repeti i
+						Ex quo<lb/>manifestum est, et aliquam partem pedis posse in<lb/>
+						principio metri poni, et aliquam in fine, et aliquam<lb/>in silentio. <hi
 							rend="italic">D.</hi> Et hoc manifestum est. <hi rend="italic">M.</hi>
-						Sed hoe <lb/> fieri si dichorium metiaris integrum in hoc metro; <lb/> nam
-						si diiambum, et a capite anapæstus ponatur, <lb/> cernis partem pedis in
-						principio positam, quai habet <lb/> jam quatuor tempora : duo autcm quæ
-						debentur, si­ <lb/> lentur in fine. Ex quo discimus, posse metrum inci­
-						<lb/> pere a parte pedis, et desinere ad plenum pedem, <lb/> sed nunquam
-						siue silentio. <hi rend="italic">D.</hi> Et hoc perspicuum <lb/> est. <note
+						Sed hoe<lb/>fieri si dichorium metiaris integrum in hoc metro;<lb/>nam
+						si diiambum, et a capite anapaestus ponatur,<lb/>cernis partem pedis in
+						principio positam, quai habet<lb/>jam quatuor tempora : duo autcm quae
+						debentur, si­<lb/>lentur in fine. Ex quo discimus, posse metrum inci­
+						<lb/>pere a parte pedis, et desinere ad plenum pedem,<lb/>sed nunquam
+						siue silentio. <hi rend="italic">D.</hi> Et hoc perspicuum<lb/>est. <note
 							type="footnote"> 1 In B, <hi rend="italic">coliocata quatllO",</hi>
-							ooussa præpositione <hi rend="italic">""PL,</hi>
-							<lb/> quam in Ms. A reperimus. </note>
+							ooussa praepositione <hi rend="italic">""PL,</hi>
+							<lb/>quam in Ms. A reperimus. </note>
 						<pb n="1139"/>
 					</p></div>
 				<div type="textpart" subtype="dialog">
 					<p>18. <hi rend="italic">M.</hi> Quid ? hoc metrum potesne metiri et dicere
-						<lb/> quibas pcdibus constet ? <lb/> jam satis terris nivis, atque dire
-						<lb/> Grandinis misit Pater, et rubente <lb/> Dextera sacras jaculatus
-						arces. <lb/>
+						<lb/>quibas pcdibus constet ?<lb/>jam satis terris nivis, atque dire
+						<lb/>Grandinis misit Pater, et rubente<lb/>Dextera sacras jaculatus
+						arces.<lb/>
 						<hi rend="italic">(Horat. lib.</hi> i <hi rend="italic">carminum, ode</hi>
-						2.; <lb/>
+						2.;<lb/>
 						<hi rend="italic">D.</hi> Possum constituere in capite creticum , et duos
-						<lb/> metiri reliquos senum temporum pedes, unum ioni­ <lb/> cum a majori,
-						alterum dichorium, et silcre unum <lb/> tempus quod adjungitur cretico ut
-						sex tempora com­ <lb/> pleantur. <hi rend="italic">M.</hi> Nonnihil dcfuit
-						considerationi tusc : <lb/> nam cum dichorius est in line, restante silentio
-						, ul­ <lb/> lima ejus quæ brevis est, pro longa accipitur. An hoc <lb/>
+						<lb/>metiri reliquos senum temporum pedes, unum ioni­<lb/>cum a majori,
+						alterum dichorium, et silcre unum<lb/>tempus quod adjungitur cretico ut
+						sex tempora com­<lb/>pleantur. <hi rend="italic">M.</hi> Nonnihil dcfuit
+						considerationi tusc :<lb/>nam cum dichorius est in line, restante silentio
+						, ul­<lb/>lima ejus quae brevis est, pro longa accipitur. An hoc<lb/>
 						negabis? <hi rend="italic">D.</hi> Imo fateor. <hi rend="italic">M.</hi> Non
-						ergo constitui dccet <lb/> in fine dichorium, nisi nullo in repetitione
-						consequente <lb/> silenlio , ne non jam dichorius, sed epitritus secun­
-						<lb/> dus semiatur. D. Manifestum est. Quomodo ergo me­ <lb/> tiemur hoc
+						ergo constitui dccet<lb/>in fine dichorium, nisi nullo in repetitione
+						consequente<lb/>silenlio , ne non jam dichorius, sed epitritus secun­
+						<lb/>dus semiatur. D. Manifestum est. Quomodo ergo me­<lb/>tiemur hoc
 						metruin ? <hi rend="italic">D.</hi> Nescio.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT XIV. — <hi rend="italic">Persequitur rationem
 								adhibendi</hi> silen­ <hi rend="italic">tia</hi> in metiendis
 							metris.</title>
 					</ab>
-					<p>M. Attende ergo utrum bene sonet, cnm ila pro­ <lb/> nuntio, ut post tres
-						primas syllabas unum tempus si­ <lb/> leam : ita enim in fine nihil
-						debebitur , ut decenter <lb/> ibi possit esse dichorius. <hi rend="italic"
+					<p>M. Attende ergo utrum bene sonet, cnm ila pro­<lb/>nuntio, ut post tres
+						primas syllabas unum tempus si­<lb/>leam : ita enim in fine nihil
+						debebitur , ut decenter<lb/>ibi possit esse dichorius. <hi rend="italic"
 							>D.</hi> Jucundissime sonat.</p>
-					<p>49. <hi rend="italic">M.</hi> Hoc qnoque igitur adjungamus arti, ut non <lb/>
-						solum in fine , sed et ante tinem cum oportet silea­ <lb/> mus. Tunc autem
-						oportet, cnm id quod debetur im­ <lb/> plendis temporibus pedum , ant
-						indecenter siletur in <lb/> line propter ultimam brevem, ut in hoc quod
-						dictum <lb/> est ; aut cum duo constitnuntur non pleni pedes, <lb/> unus in
-						capite, alter in fine, qualis iste est, <lb/> Gentiles nostros inter oberrat
-						equos. <lb/> Sensisti enim, ut opinor, me post quinque syllabas <lb/> longas
-						, moram duorum temporum siluisse , et tan - <lb/> tumdem in fine silendum
-						est, dum reditur ad caput. <lb/> Si enim hoc metrum ad legem sex temporum
-						metii­ <lb/> ris; erit tibi primus spondeus, secundus molossus, <lb/>
-						tertius choriambus, quartus anapaestus. Spondeo igi­ <lb/> tur debentur duo
-						tempora ut sex temporum pedcm <lb/> impleat, et anapæsto : itaque duo
-						silentur post mo­ <lb/> lossum ante finem, et duo post anapæstum in fine. Si
-						<lb/> amem ad legem temporum quatuor; una longa erit <lb/> in capite, deinde
-						duos metimur spondeos, dcinde <lb/> duos dactylos, et post una longa
-						concludet1. Sile­ <lb/> mus itaque duo tempora post geminum spondeum <lb/>
-						ante finem, et duo in fine, ut ambo pedes implean­ <lb/> tur, quorum
-						dimidias partes in capite atque in extre­ <lb/> mo posuimus.</p>
-					<p>20. Nonnunquam tamen qnod duobus non plenis <lb/> pedibus debetur in
-						principio ac fine collocatis, finali <lb/> tantum silentio redditur2; si
-						tantum sit ut dimidii <lb/> spatium pedis non excedat, qualia hæc duo sunt:
-						<lb/> silvæ laborantes, geluque <lb/> Flumina constiterint acuto. <lb/>
-						Horum enim prius incipit a palimbacchio, inde excur­ <lb/> rit in molossum,
-						et bacchio terminatur : silentur ergo <lb/> duo tempora ; quorum unum
-						bacchio, alterum pa­ <lb/> limbacchio cum reddideris, sena ubique tempora
-						in,.. <lb/>
+					<p>49. <hi rend="italic">M.</hi> Hoc qnoque igitur adjungamus arti, ut non<lb/>
+						solum in fine , sed et ante tinem cum oportet silea­<lb/>mus. Tunc autem
+						oportet, cnm id quod debetur im­<lb/>plendis temporibus pedum , ant
+						indecenter siletur in<lb/>line propter ultimam brevem, ut in hoc quod
+						dictum<lb/>est ; aut cum duo constitnuntur non pleni pedes,<lb/>unus in
+						capite, alter in fine, qualis iste est,<lb/>Gentiles nostros inter oberrat
+						equos.<lb/>Sensisti enim, ut opinor, me post quinque syllabas<lb/>longas
+						, moram duorum temporum siluisse , et tan<lb/>tumdem in fine silendum
+						est, dum reditur ad caput.<lb/>Si enim hoc metrum ad legem sex temporum
+						metii­<lb/>ris; erit tibi primus spondeus, secundus molossus,<lb/>
+						tertius choriambus, quartus anapaestus. Spondeo igi­<lb/>tur debentur duo
+						tempora ut sex temporum pedcm<lb/>impleat, et anapaesto : itaque duo
+						silentur post mo­<lb/>lossum ante finem, et duo post anapaestum in fine. Si
+						<lb/>amem ad legem temporum quatuor; una longa erit<lb/>in capite, deinde
+						duos metimur spondeos, dcinde<lb/>duos dactylos, et post una longa
+						concludet1. Sile­<lb/>mus itaque duo tempora post geminum spondeum<lb/>
+						ante finem, et duo in fine, ut ambo pedes implean­<lb/>tur, quorum
+						dimidias partes in capite atque in extre­<lb/>mo posuimus.</p>
+					<p>20. Nonnunquam tamen qnod duobus non plenis<lb/>pedibus debetur in
+						principio ac fine collocatis, finali<lb/>tantum silentio redditur2; si
+						tantum sit ut dimidii<lb/>spatium pedis non excedat, qualia haec duo sunt:
+						<lb/>silvae laborantes, geluque<lb/>Flumina constiterint acuto.<lb/>
+						Horum enim prius incipit a palimbacchio, inde excur­<lb/>rit in molossum,
+						et bacchio terminatur : silentur ergo<lb/>duo tempora ; quorum unum
+						bacchio, alterum pa­<lb/>limbacchio cum reddideris, sena ubique tempora
+						in,..<lb/>
 						<note type="footnote">1 III B., concludetur. concludet, juxta Mss. A et B.
 							M. </note><note type="footnote"> ' in prius excusis, <hi rend="italic"
-								>finaii tamcn silentio redditur.</hi> At iD <lb/> AUS , <hi
+								>finaii tamcn silentio redditur.</hi> At iD<lb/>AUS , <hi
 								rend="italic">nnali tantum.</hi>
 						</note>
-						<lb/> plebuntur. Mcc autem posterius dactylo inchoatur , <lb/> indc pergit
-						in choriambum, clauditur bacchio : tria <lb/> igitur tempora silere
-						oportebit; hinc unum bacchio , <lb/> dno dactylo redhibebimus, ut in omnibus
-						sint sena <lb/> tempora.,</p>
-					<p>24. Prins autem redditur quod debetur implendo <lb/> extremo pedi, quam in
-						principio constituto. Nec ali­ <lb/> tcr omnino fieri aures sinunt. Nec
-						mirum : id enim <lb/> cum repetimus, adjungitur capiti quod prorsus extre­
-						<lb/> mum est. Itaque in hoc metro quod dictum est, Flu­ <lb/>
+						<lb/>plebuntur. Mcc autem posterius dactylo inchoatur ,<lb/>indc pergit
+						in choriambum, clauditur bacchio : tria<lb/>igitur tempora silere
+						oportebit; hinc unum bacchio ,<lb/>dno dactylo redhibebimus, ut in omnibus
+						sint sena<lb/>tempora.,</p>
+					<p>24. Prins autem redditur quod debetur implendo<lb/>extremo pedi, quam in
+						principio constituto. Nec ali­<lb/>tcr omnino fieri aures sinunt. Nec
+						mirum : id enim<lb/>cum repetimus, adjungitur capiti quod prorsus extre­
+						<lb/>mum est. Itaque in hoc metro quod dictum est, Flu­<lb/>
 						<hi rend="italic">mina constiterint acuto :</hi> cum tria tempora scnis
-						utique <lb/> implendis dcbeantur, si ea non silentio velis, sed <lb/> voce
-						reddere, possintque reddi et per ianibum , et <lb/> per chorium , et per
-						tribrachum , quia omnes tern <lb/> tempora possident; nullo modo ca per
-						chorium reddi <lb/> sensus ipse permittit, in quo prior cst longa syllaba,
-						<lb/> brevis posterior : id enim prius sonare debet, quod <lb/> bacchio
-						debetur extremo, id est brevis syllaba; non <lb/> longa, quae dactylo primo.
-						Licet hoc explorare his <lb/> exemplis : <lb/> Flumina consUtcrint acuto
-						gelu. <lb/> Flumina constiterint acute gelida. <lb/> Flumina constiterint in
-						alta nocte. <lb/> Gui dubium cst, duo illa suaviter repeti, hoc autem <lb/>
+						utique<lb/>implendis dcbeantur, si ea non silentio velis, sed<lb/>voce
+						reddere, possintque reddi et per ianibum , et<lb/>per chorium , et per
+						tribrachum , quia omnes tern<lb/>tempora possident; nullo modo ca per
+						chorium reddi<lb/>sensus ipse permittit, in quo prior cst longa syllaba,
+						<lb/>brevis posterior : id enim prius sonare debet, quod<lb/>bacchio
+						debetur extremo, id est brevis syllaba; non<lb/>longa, quae dactylo primo.
+						Licet hoc explorare his<lb/>exemplis :<lb/>Flumina consUtcrint acuto
+						gelu.<lb/>Flumina constiterint acute gelida.<lb/>Flumina constiterint in
+						alta nocte.<lb/>Gui dubium cst, duo illa suaviter repeti, hoc autem<lb/>
 						tertium nullo modo ?</p>
-					<p>22. Item cum singula tempora singulis debentur <lb/> pedibus minus plenis, si
-						ea voce reddere velis, non <lb/> sinit sensus in unam syllabam coarctari;
-						mira omnino <lb/> justitia. Non enim convenit, quod separatim redden­ <lb/>
-						dum est, non etiam constitui separatim. Quocirca iD <lb/> illo metro, <hi
-							rend="italic">Silvce laborantes, geluquc,</hi> si unam longam <lb/> pro
-						silentio fini addas, sicuti est, <hi rend="italic">Silvæ laborantes <lb/>
-							gelu duro,</hi> non probant aures; sicut probant cum di­ <lb/> cimus ,
-							<hi rend="italic">Silvæ laborantes gelu et frigore.</hi> Quod satiatis­
-						<lb/> simc sentis, cum singula repetis.</p>
-					<p>25. Item non oportet cum duo minus pleni pedes <lb/> ponuntur, majorem in
-						principio quam in fine poni; <lb/> nam et hoc condemnat auditus, tanquam si
-						dicas, <lb/>
+					<p>22. Item cum singula tempora singulis debentur<lb/>pedibus minus plenis, si
+						ea voce reddere velis, non<lb/>sinit sensus in unam syllabam coarctari;
+						mira omnino<lb/>justitia. Non enim convenit, quod separatim redden­<lb/>
+						dum est, non etiam constitui separatim. Quocirca iD<lb/>illo metro, <hi
+							rend="italic">Silvce laborantes, geluquc,</hi> si unam longam<lb/>pro
+						silentio fini addas, sicuti est, <hi rend="italic">Silvae laborantes<lb/>
+							gelu duro,</hi> non probant aures; sicut probant cum di­<lb/>cimus ,
+							<hi rend="italic">Silvae laborantes gelu et frigore.</hi> Quod satiatis­
+						<lb/>simc sentis, cum singula repetis.</p>
+					<p>25. Item non oportet cum duo minus pleni pedes<lb/>ponuntur, majorem in
+						principio quam in fine poni;<lb/>nam et hoc condemnat auditus, tanquam si
+						dicas,<lb/>
 						<hi rend="italic">Optimum tempus adest tandem,</hi> ut primus pos sit cre-
-						<lb/> Licus, secundus choriambus, tertius spondeus; ut tria <lb/> tempora
-						sileamus, quorum duo debentur ultimo spon­ <lb/> deo ad sena implenda, et
-						unum primo cretico. At si <lb/> ita dicalur, <hi rend="italic">Tandem tempus
-							adest optimum,</hi> eadem <lb/> interposita trium temporum mora in
-						silentio, quis <lb/> non sentiat jucundissime repeti ? Quare aut tanti spa­
-						<lb/> tii decet esse in fine minus plenum pedem, quanti est <lb/> in
-						principio, ut illud, <hi rend="italic">Silvæ laborantes , geluque</hi> : aut
-						<lb/> minorem in principio, et in fine majorem, veluti est, <lb/> Flumina
-							<hi rend="italic">constiterint acuto.</hi> Ncque injuria, quia ubi <lb/>
-						est aequalitas, nulla discordia : uhi autem dispar est <lb/> numerus, si a
-						minore ad majorem veniamus, ul <lb/> in numerando solet , facit rursus ipse
-						ordo concor­ <lb/> diam.</p>
-					<p>24. Ex quo illud est etiam consequens, ut cum ii <lb/> de quibus agitur,
-						minus pleni ponuntur pedes, si duo­ <lb/> bus locis interponitur silentium,
-						id est ante finem et in <lb/> fine; tantum ante finem sileatur quantum
-						debcturex­ <lb/> tremo, tantum autem in fine quantum scilicet primo I :
-						<lb/> quia medium tendit ad finem; a fine vero ad princi­ <note
+						<lb/>Licus, secundus choriambus, tertius spondeus; ut tria<lb/>tempora
+						sileamus, quorum duo debentur ultimo spon­<lb/>deo ad sena implenda, et
+						unum primo cretico. At si<lb/>ita dicalur, <hi rend="italic">Tandem tempus
+							adest optimum,</hi> eadem<lb/>interposita trium temporum mora in
+						silentio, quis<lb/>non sentiat jucundissime repeti ? Quare aut tanti spa­
+						<lb/>tii decet esse in fine minus plenum pedem, quanti est<lb/>in
+						principio, ut illud, <hi rend="italic">Silvae laborantes , geluque</hi> : aut
+						<lb/>minorem in principio, et in fine majorem, veluti est,<lb/>Flumina
+							<hi rend="italic">constiterint acuto.</hi> Ncque injuria, quia ubi<lb/>
+						est aequalitas, nulla discordia : uhi autem dispar est<lb/>numerus, si a
+						minore ad majorem veniamus, ul<lb/>in numerando solet , facit rursus ipse
+						ordo concor­<lb/>diam.</p>
+					<p>24. Ex quo illud est etiam consequens, ut cum ii<lb/>de quibus agitur,
+						minus pleni ponuntur pedes, si duo­<lb/>bus locis interponitur silentium,
+						id est ante finem et in<lb/>fine; tantum ante finem sileatur quantum
+						debcturex­<lb/>tremo, tantum autem in fine quantum scilicet primo I :
+						<lb/>quia medium tendit ad finem; a fine vero ad princi­ <note
 							type="footnote">i Am. Er. l.ov. sic habent <hi rend="italic">Qtumtum
 								scilictl</hi> prvicipto;</note>
 						<lb/>
-						<pb n="1141"/> pium redeundum est. Si antem utrique tantumdem de­ <lb/>
-						betur, nulla controversia est quin tantum ante finem <lb/> quantum in fine
-						silendum sit. Sileri autem oportet non <lb/> nisi ubi terminatur pars
-						orationis. In iis antem numeris <lb/> qui non verbis fiunt1, sed aliquo
-						pulsu vel flatu, vel <lb/> ipsa etiam lingua, nullum in hac re discrimen
-						est, post <lb/> quam vocem percussionemve sileatur; modo ut legiti­ <lb/>
-						mum secundum supradictas rationes intercedat silen­ <lb/> tium. Quamobrem et
-						a duobus potest minus plenis <lb/> pedibus metrum incipere, si tamen
-						utriusque con­ <lb/> junctum spatium minus non -sil, quam posset esse <lb/>
-						unius cl dilnidii pedis; nam supra diximus, tum recte <lb/> poni duos minus
-						plenos pedes, cum id quod debetur <lb/> ambobus, non transit spatio pedem
-						dimidium : exem­ <lb/> plum est, <hi rend="italic">Montes acuti;</hi> ut aut
-						in fine tria tempora <lb/> sileamus, aut unum tempus post spondeum, et duo
-						in <lb/> fine. Aliter enim hoc metrum convenienter metiri <lb/> non
+						<pb n="1141"/> pium redeundum est. Si antem utrique tantumdem de­<lb/>
+						betur, nulla controversia est quin tantum ante finem<lb/>quantum in fine
+						silendum sit. Sileri autem oportet non<lb/>nisi ubi terminatur pars
+						orationis. In iis antem numeris<lb/>qui non verbis fiunt1, sed aliquo
+						pulsu vel flatu, vel<lb/>ipsa etiam lingua, nullum in hac re discrimen
+						est, post<lb/>quam vocem percussionemve sileatur; modo ut legiti­<lb/>
+						mum secundum supradictas rationes intercedat silen­<lb/>tium. Quamobrem et
+						a duobus potest minus plenis<lb/>pedibus metrum incipere, si tamen
+						utriusque con­<lb/>junctum spatium minus non -sil, quam posset esse<lb/>
+						unius cl dilnidii pedis; nam supra diximus, tum recte<lb/>poni duos minus
+						plenos pedes, cum id quod debetur<lb/>ambobus, non transit spatio pedem
+						dimidium : exem­<lb/>plum est, <hi rend="italic">Montes acuti;</hi> ut aut
+						in fine tria tempora<lb/>sileamus, aut unum tempus post spondeum, et duo
+						in<lb/>fine. Aliter enim hoc metrum convenienter metiri<lb/>non
 						potest.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT XV. — <hi rend="italic">Item de silentio in
 								metris</hi> interponendo.</title>
 					</ab>
-					<p>25. Sit hoc etiam in disciplina , ut cum ante finem <lb/> silemus, non ibi
-						pars orationis brevi syllaba termino­ <lb/> tur, ne secundum illam sæpe
-						commemoratam rcgu­ <lb/> lam, pro longa eam sensus accipiat, sequente
-						silentio. <lb/> Itaque in hoc metro , <hi rend="italic">Montibu,
-							acutis,</hi> non possumus <lb/> silere post dactylum tempus unum, quod
-						post spon­ <lb/> deum in superiore potcramus; ne non jam dactylus, <lb/> sed
-						creticus sentiatur : atque ita non duobus minus <lb/> plenis pedibus, quod
-						nunc demonstramus, sed pleno <lb/> dichorio et ultimo spondco metrum
-						constare videatur, <lb/> duum temporum silentio in fine reddendo.</p>
-					<p>2G. Sed illud notandum est, in principio posito mi­ <lb/> nus pleno pedi, aut
-						ibidem reddi debitum per silen­ <lb/> tiu:n, sicuti est, <hi rend="italic"
-							>Jam satis terris</hi> nivis <hi rend="italic">atque diræ :</hi> ant
-						<lb/> in fine, velut, <hi rend="italic">Segetes nieus labor.</hi> Minus
-						autem pleno <lb/> pedi qui in fine ponitur, aut ibidem restitui silentio,
-						<lb/> quod debetur, ut in illo, <hi rend="italic">Ite</hi> 'fitur Camænce :
-						aut in <lb/> aliquo de mediis loco, vcluii in hoc, <hi rend="italic">I'a
-							blandum vi­ <lb/> gel arvis, adest hospes hirundo.</hi> Unum enim tempus
-						<lb/> qnod debetur ultimo bacchio, vel post totum nume­ <lb/> nim sileri
-						potest, vel post primam ejus numeri pedem <lb/> molossum, vcl sccundum
-						ionicum a minore. Quod <lb/> vcro mediis forte ninus plenis pedibus dcbiti
-						est, non <lb/> nisi ibidem reddi potest : ut est, <lb/> Tuba terribilem
-						sonitum dedit acre curvo. <lb/> Si enim sic mutianum. hoc metrum , ut primum
-						fa­ <lb/> ciamus anapæstum, secundum ioniculn qucmlibct ill <lb/> syllabis
-						quinque, soluta scilicet longa vel prima vel <lb/> ultima in duas breves,
-						tertium choriambum, ultimum <lb/> bacchium : tria eruut tempora in debito,
-						unum ex­ <lb/> tremo bacchio reddendum, et duo anapæsto primo, ut <lb/> sena
-						compleantur. Sed hoc totum spatium trium tem­ <lb/> porum in fine sileri
-						potest. At si ab integro pede in­ <lb/> cipias, quiuque syllabas primas pro
+					<p>25. Sit hoc etiam in disciplina , ut cum ante finem<lb/>silemus, non ibi
+						pars orationis brevi syllaba termino­<lb/>tur, ne secundum illam saepe
+						commemoratam rcgu­<lb/>lam, pro longa eam sensus accipiat, sequente
+						silentio.<lb/>Itaque in hoc metro , <hi rend="italic">Montibu,
+							acutis,</hi> non possumus<lb/>silere post dactylum tempus unum, quod
+						post spon­<lb/>deum in superiore potcramus; ne non jam dactylus,<lb/>sed
+						creticus sentiatur : atque ita non duobus minus<lb/>plenis pedibus, quod
+						nunc demonstramus, sed pleno<lb/>dichorio et ultimo spondco metrum
+						constare videatur,<lb/>duum temporum silentio in fine reddendo.</p>
+					<p>2G. Sed illud notandum est, in principio posito mi­<lb/>nus pleno pedi, aut
+						ibidem reddi debitum per silen­<lb/>tiu:n, sicuti est, <hi rend="italic"
+							>Jam satis terris</hi> nivis <hi rend="italic">atque dirae :</hi> ant
+						<lb/>in fine, velut, <hi rend="italic">Segetes nieus labor.</hi> Minus
+						autem pleno<lb/>pedi qui in fine ponitur, aut ibidem restitui silentio,
+						<lb/>quod debetur, ut in illo, <hi rend="italic">Ite</hi> 'fitur Camaence :
+						aut in<lb/>aliquo de mediis loco, vcluii in hoc, <hi rend="italic">I'a
+							blandum vi­<lb/>gel arvis, adest hospes hirundo.</hi> Unum enim tempus
+						<lb/>qnod debetur ultimo bacchio, vel post totum nume­<lb/>nim sileri
+						potest, vel post primam ejus numeri pedem<lb/>molossum, vcl sccundum
+						ionicum a minore. Quod<lb/>vcro mediis forte ninus plenis pedibus dcbiti
+						est, non<lb/>nisi ibidem reddi potest : ut est,<lb/>Tuba terribilem
+						sonitum dedit acre curvo.<lb/>Si enim sic mutianum. hoc metrum , ut primum
+						fa­<lb/>ciamus anapaestum, secundum ioniculn qucmlibct ill<lb/>syllabis
+						quinque, soluta scilicet longa vel prima vel<lb/>ultima in duas breves,
+						tertium choriambum, ultimum<lb/>bacchium : tria eruut tempora in debito,
+						unum ex­<lb/>tremo bacchio reddendum, et duo anapaesto primo, ut<lb/>sena
+						compleantur. Sed hoc totum spatium trium tem­<lb/>porum in fine sileri
+						potest. At si ab integro pede in­<lb/>cipias, quiuque syllabas primas pro
 						quolibet ionico <note type="footnote">quia <hi rend="italic">medium tendU
 								ad</hi> finem, si xmam longam pro <hi rend="italic">silentio
-								fim<lb/> addas, sicuti</hi> Silvae lal)orantes gelu duro. <hi
-								rend="italic">A fine vero,</hi> etc. <lb/> Plerique autem MSS., <hi
-								rend="italic">quantumsciiicet</hi> pritno : supple, minus <lb/>
+								fim<lb/>addas, sicuti</hi> Silvae lal)orantes gelu duro. <hi
+								rend="italic">A fine vero,</hi> etc.<lb/>Plerique autem MSS., <hi
+								rend="italic">quantumsciiicet</hi> pritno : supple, minus<lb/>
 							pleno pedi debetur. Postea carent hisce verbis, si <hi rend="italic"
-								>unam<lb/> ongam;</hi> Quae exigente sensu removimus. </note><note
+								>unam<lb/>ongam;</hi> Quae exigente sensu removimus. </note><note
 							type="footnote"> I ita Mss. AL editi babent, finiimtur. </note>
-						<lb/> metitus, sequitur choriambus r inde jam pedem inte­ <lb/> grum non
-						invenies : quocirca unius longæ spatio silere <lb/> oportebit: qno
-						annumerato, choriambus alter impte­ <lb/> bitur; bacchio reliquo metrum
-						clausuro, cui tempus <lb/> unum debitum silebis in fine.</p>
-					<p>27. Unde janfesse opinor perspicuum, cum in me­ <lb/> diis siletur locis, aut
-						ea restitui tempora quoe in fine <lb/> debentur, aut ea quoo ibi debentur
-						ubi siletur. Sed ali­ <lb/> quando non est necesse ut sileatur in medii,.
-						cum <lb/> potest alitcr metrum mctiri, ut in eo quod paulo ante <lb/>
-						posuimus. Aliquando autcm necesse cst, ut in hoc, <lb/>
-						<hi rend="italic">Vernat temperies,</hi> auræ tepent, sunt <hi rend="italic"
-							>deliciæ</hi> : nam ma­ <lb/> nifeslum est istum numeruin, aut
-						quaternorum tem­ <lb/> porum, aut senorum pedibus currere. Si quaternorum;
-						<lb/> silenduln est unum tempus post syllabam octavum, et <lb/> in fine duo;
-						metiatur primo spondeus, secundo da. <lb/> ctylus, tertio spondeus, quarto
-						dactylus annumerato <lb/> post longam silentio, quia post brevem non
-						oportet, <lb/> quinto spondcus, sexto dactylus, ultima longa qua <lb/>
-						numerus clauditur, cui duo tempora debita silentur in <lb/> fine. Si autem
-						scnurum temporum hie metimur pe­ <lb/> des , primus erit molossus, secundos
-						ionicus a mi­ <lb/> nore, tertius creticus qui fit dichorius adjuncto silen­
-						<lb/> tio unius temporis, quartus ionicus a majore et longa <lb/> ultima,
-						post quam quatu r tempora silebuntur. Posset <lb/> alitcr, ut una longa in
-						principio locaretur, quam se- <lb/> queretur ionicus a majore, deinde
-						molossus, deinde <lb/> bacchius, qui fieret antispastus adjuncto silentio
-						unius <lb/> temporis; ultimus choriambus meti um clauderet, ita <lb/> ut
-						quatuor temporum in fine silentium redderetur uni <lb/> longae in principio
-						constitutæ. Sed aures istam di­ <lb/> mensionem repudiant; quia pars pedis
-						in principio <lb/> collocata, nisi major quam dimidia fuerit, non recte
-						<lb/> illi post plenum pedem finali silentio redditur ubi de-. <lb/> betur :
-						sed aliis interpositis pedibus, scimus quidem <lb/> quantum debeatur; sed
-						uon comprehenditur sensu, <lb/> ut tanto spatio sileatur, nisi minus
-						debentur in silen­ <lb/> tio quam positum est in sono : quia cum mojorem
-						<lb/> partem pedis vox peregerit, minor quae reliqua est, <lb/> ubicumque
+						<lb/>metitus, sequitur choriambus r inde jam pedem inte­<lb/>grum non
+						invenies : quocirca unius longae spatio silere<lb/>oportebit: qno
+						annumerato, choriambus alter impte­<lb/>bitur; bacchio reliquo metrum
+						clausuro, cui tempus<lb/>unum debitum silebis in fine.</p>
+					<p>27. Unde janfesse opinor perspicuum, cum in me­<lb/>diis siletur locis, aut
+						ea restitui tempora quoe in fine<lb/>debentur, aut ea quoo ibi debentur
+						ubi siletur. Sed ali­<lb/>quando non est necesse ut sileatur in medii,.
+						cum<lb/>potest alitcr metrum mctiri, ut in eo quod paulo ante<lb/>
+						posuimus. Aliquando autcm necesse cst, ut in hoc,<lb/>
+						<hi rend="italic">Vernat temperies,</hi> aurae tepent, sunt <hi rend="italic"
+							>deliciae</hi> : nam ma­<lb/>nifeslum est istum numeruin, aut
+						quaternorum tem­<lb/>porum, aut senorum pedibus currere. Si quaternorum;
+						<lb/>silenduln est unum tempus post syllabam octavum, et<lb/>in fine duo;
+						metiatur primo spondeus, secundo da.<lb/>ctylus, tertio spondeus, quarto
+						dactylus annumerato<lb/>post longam silentio, quia post brevem non
+						oportet,<lb/>quinto spondcus, sexto dactylus, ultima longa qua<lb/>
+						numerus clauditur, cui duo tempora debita silentur in<lb/>fine. Si autem
+						scnurum temporum hie metimur pe­<lb/>des , primus erit molossus, secundos
+						ionicus a mi­<lb/>nore, tertius creticus qui fit dichorius adjuncto silen­
+						<lb/>tio unius temporis, quartus ionicus a majore et longa<lb/>ultima,
+						post quam quatu r tempora silebuntur. Posset<lb/>alitcr, ut una longa in
+						principio locaretur, quam se<lb/>queretur ionicus a majore, deinde
+						molossus, deinde<lb/>bacchius, qui fieret antispastus adjuncto silentio
+						unius<lb/>temporis; ultimus choriambus meti um clauderet, ita<lb/>ut
+						quatuor temporum in fine silentium redderetur uni<lb/>longae in principio
+						constitutae. Sed aures istam di­<lb/>mensionem repudiant; quia pars pedis
+						in principio<lb/>collocata, nisi major quam dimidia fuerit, non recte
+						<lb/>illi post plenum pedem finali silentio redditur ubi de-.<lb/>betur :
+						sed aliis interpositis pedibus, scimus quidem<lb/>quantum debeatur; sed
+						uon comprehenditur sensu,<lb/>ut tanto spatio sileatur, nisi minus
+						debentur in silen­<lb/>tio quam positum est in sono : quia cum mojorem
+						<lb/>partem pedis vox peregerit, minor quae reliqua est,<lb/>ubicumque
 						facile occurrit.</p>
-					<p>28. Quamobrem metri quod sub hoc exemplo po­ <lb/> suimus, <hi rend="italic"
+					<p>28. Quamobrem metri quod sub hoc exemplo po­<lb/>suimus, <hi rend="italic"
 							>Vernat temperies, aura lepenl,</hi> sunt <hi rend="italic"
-							>deliciæ:</hi>
-						<lb/> cum sit una necessaria, quam diximus, dimensio, si <lb/> post decimam
-						ejus syllabam tempus unum silentur, eI <lb/> quatuor in fine; est alia
-						voluntaria, si quis post <lb/> sextam syllabam velit silere duo tempora, et
-						unum <lb/> post undecimam , et duo in fine: ut sii in principio <lb/>
-						spondeas, sequatur hunc choriambus, tertio spondeo <lb/> silentium duum
-						temporum annumeretur, ut vd mo­ <lb/> loSSUs vel a minore ionicus fiat,
-						quartus bacchius <lb/> adjuncto itidem silentio unius temporis fiat antispa­
-						<lb/> stus, quinto choriambo numcrus torminetur in voce, <lb/> duobus
-						temporibus in fine per silentium redditis in <lb/> principio locato spondeo.
-						Est item alia. Si enim velis, <lb/> post sextam syllabam unum tempus
-						silcbis, ct post <lb/> decimam unum, post undecimam tantumdem, et doc <lb/>
-						in fine : ut sil primus spondeus, secundus cboriam­ <lb/> bus, tertius
-						palimbacchius fiat antispastas uno silentii <lb/> tempore annumerato,
-						quartus spondeus fiat dit borius <lb/>
-						<pb n="1143"/> unius temporis interjecto, et unius temporis conse­ <lb/>
-						queote silentio, choriambos ultimus numerum clau­ <lb/> dat, ita ut sileamus
-						duo tempora in fine, quæ primo <lb/> debentur spondeo. Est et tertia
-						dimensio, si post pri­ <lb/> mum spondeum tempus unum sileatur, et reliqua
-						quæ <lb/> In proximo superiore serventur; nisi quod in hujus <lb/> fine unum
-						tempus silebitur, quia spondeus ille qui so­ <lb/> let in principio locari,
-						consequente unius temporis <lb/> silentio factus est palimbacchius, ut plus
-						uno tempore <lb/> nihil ei debeatur, quod in fine silendum est, Unde jam
-						<lb/> perspicis metris interponi silentia, quædam necessa­ <lb/> ria ,
-						quaedam voluntaria : et necessaria qnidem , cum <lb/> aliquid pedibus
-						dcbetur implendis; voluntaria vero, <lb/> cum pleni sunt pedes atque
+							>deliciae:</hi>
+						<lb/>cum sit una necessaria, quam diximus, dimensio, si<lb/>post decimam
+						ejus syllabam tempus unum silentur, eI<lb/>quatuor in fine; est alia
+						voluntaria, si quis post<lb/>sextam syllabam velit silere duo tempora, et
+						unum<lb/>post undecimam , et duo in fine: ut sii in principio<lb/>
+						spondeas, sequatur hunc choriambus, tertio spondeo<lb/>silentium duum
+						temporum annumeretur, ut vd mo­<lb/>loSSUs vel a minore ionicus fiat,
+						quartus bacchius<lb/>adjuncto itidem silentio unius temporis fiat antispa­
+						<lb/>stus, quinto choriambo numcrus torminetur in voce,<lb/>duobus
+						temporibus in fine per silentium redditis in<lb/>principio locato spondeo.
+						Est item alia. Si enim velis,<lb/>post sextam syllabam unum tempus
+						silcbis, ct post<lb/>decimam unum, post undecimam tantumdem, et doc<lb/>
+						in fine : ut sil primus spondeus, secundus cboriam­<lb/>bus, tertius
+						palimbacchius fiat antispastas uno silentii<lb/>tempore annumerato,
+						quartus spondeus fiat dit borius<lb/>
+						<pb n="1143"/> unius temporis interjecto, et unius temporis conse­<lb/>
+						queote silentio, choriambos ultimus numerum clau­<lb/>dat, ita ut sileamus
+						duo tempora in fine, quae primo<lb/>debentur spondeo. Est et tertia
+						dimensio, si post pri­<lb/>mum spondeum tempus unum sileatur, et reliqua
+						quae<lb/>In proximo superiore serventur; nisi quod in hujus<lb/>fine unum
+						tempus silebitur, quia spondeus ille qui so­<lb/>let in principio locari,
+						consequente unius temporis<lb/>silentio factus est palimbacchius, ut plus
+						uno tempore<lb/>nihil ei debeatur, quod in fine silendum est, Unde jam
+						<lb/>perspicis metris interponi silentia, quaedam necessa­<lb/>ria ,
+						quaedam voluntaria : et necessaria qnidem , cum<lb/>aliquid pedibus
+						dcbetur implendis; voluntaria vero,<lb/>cum pleni sunt pedes atque
 						integri.</p>
-					<p>29.'Quod autem superius dictam est, amplius qua­ <lb/> tuor temporibus
-						silendum non esse, de necessariis <lb/> silentiis dictum est, ubi debita
-						tempora explentur. <lb/> Nam in iis qu:c voluntaria silentia nominavimus,
-						licet <lb/> etiam pedem sonare, et pedem silere : quod si pari­ <lb/> bus
-						intervallis fecerimus, non erit metrum, sed rhy­ <lb/> thmus, nullo certo
-						fine apparente unde redeatur ad <lb/> caput. Quamobrem si exempli gratia
-						silentiis velis <lb/> distinguere, ut post primum pedem alterius pedis <lb/>
-						tempora sileas, non hoc perpetuo servandum est. Li­ <lb/> cet autem
-						varietate qualibet connumeratis silentiis <lb/> usque ad legitima tempora
-						metrum producere, velut <lb/> in boe, <hi rend="italic">Nobis</hi> verum <hi
+					<p>29.'Quod autem superius dictam est, amplius qua­<lb/>tuor temporibus
+						silendum non esse, de necessariis<lb/>silentiis dictum est, ubi debita
+						tempora explentur.<lb/>Nam in iis qu:c voluntaria silentia nominavimus,
+						licet<lb/>etiam pedem sonare, et pedem silere : quod si pari­<lb/>bus
+						intervallis fecerimus, non erit metrum, sed rhy­<lb/>thmus, nullo certo
+						fine apparente unde redeatur ad<lb/>caput. Quamobrem si exempli gratia
+						silentiis velis<lb/>distinguere, ut post primum pedem alterius pedis<lb/>
+						tempora sileas, non hoc perpetuo servandum est. Li­<lb/>cet autem
+						varietate qualibet connumeratis silentiis<lb/>usque ad legitima tempora
+						metrum producere, velut<lb/>in boe, <hi rend="italic">Nobis</hi> verum <hi
 							rend="italic">in promptu est , tu</hi> si verum <hi rend="italic"
 							>dicis.</hi>
-						<lb/> Licet hic post primum spondeum quatuor tempora si- <lb/> Jere, et alia
-						quatuor post sequentes duos : post tres <lb/> autem finales nihil silebitur;
-						jam cnim triginta duo <lb/> tempora terminata sunt. Sed multo est aptius, et
-						quo­ <lb/> dammodo justius, ut vel in fine tantum , vel etiam <lb/> in medio
-						et One sileatur t, quod subtracto uno pede <lb/> leri potest, ut ita sit :
+						<lb/>Licet hic post primum spondeum quatuor tempora si<lb/>Jere, et alia
+						quatuor post sequentes duos : post tres<lb/>autem finales nihil silebitur;
+						jam cnim triginta duo<lb/>tempora terminata sunt. Sed multo est aptius, et
+						quo­<lb/>dammodo justius, ut vel in fine tantum , vel etiam<lb/>in medio
+						et One sileatur t, quod subtracto uno pede<lb/>leri potest, ut ita sit :
 							<hi rend="italic">Nobis verum in promptu est,</hi>
-						<lb/> tu <hi rend="italic">dic</hi> verum. Hoc et in metris caeterorum pedum
-						<lb/> tenendum est, scilicet necessariis silentiis, sive <lb/> finalibus
-						sive mediis reddi debita, ut pedes implean­ <lb/> tur : non autem sileri2
-						oportere amplius qnam pedis <lb/> partem, quam levatio positiove occupant.
-						Voluntariis <lb/> antem silentiis et partes pedum et integros pedes si­
-						<lb/> fere conceditur, sicut exemplis supra editis1 monstra­ <lb/> vimus.
-						Sed hactenus interponendorum silentiorum <lb/> ratio tractata sit.</p>
+						<lb/>tu <hi rend="italic">dic</hi> verum. Hoc et in metris caeterorum pedum
+						<lb/>tenendum est, scilicet necessariis silentiis, sive<lb/>finalibus
+						sive mediis reddi debita, ut pedes implean­<lb/>tur : non autem sileri2
+						oportere amplius qnam pedis<lb/>partem, quam levatio positiove occupant.
+						Voluntariis<lb/>antem silentiis et partes pedum et integros pedes si­
+						<lb/>fere conceditur, sicut exemplis supra editis1 monstra­<lb/>vimus.
+						Sed hactenus interponendorum silentiorum<lb/>ratio tractata sit.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT X VI. — <hi rend="italic">De pedum commixtione, et
 								de</hi> me­ trorum <hi rend="italic">copulatione.</hi>
 						</title>
 					</ab>
-					<p>30. Nunc de pedum commixtione, et de ipsorum <lb/> metrorum copulatione pauca
-						dicamus : quoniam jam <lb/> multa dicta sunt cum quaereremus, quos sibimet
-						opor­ <lb/> teat misceri pedes; et quod ad metrorum attinet co­ <lb/>
-						puJationem, nonnulla dicenda sunt cum de versibus <lb/> disserere coeperimus
-						: junguntur enim sibi pedes <lb/> atque miscentur secundum regulas, quas in
-						secundo <lb/> sermone aperuimus. In hoc autcm illud sciendum est, <lb/>
-						Metri quæque genera quæ a poetis jam celebrata sunt, <lb/> habuisse auctores
-						et inventores suos, a quibus quas­ <lb/> dam certas leges positas convellere
+					<p>30. Nunc de pedum commixtione, et de ipsorum<lb/>metrorum copulatione pauca
+						dicamus : quoniam jam<lb/>multa dicta sunt cum quaereremus, quos sibimet
+						opor­<lb/>teat misceri pedes; et quod ad metrorum attinet co­<lb/>
+						puJationem, nonnulla dicenda sunt cum de versibus<lb/>disserere coeperimus
+						: junguntur enim sibi pedes<lb/>atque miscentur secundum regulas, quas in
+						secundo<lb/>sermone aperuimus. In hoc autcm illud sciendum est,<lb/>
+						Metri quaeque genera quae a poetis jam celebrata sunt,<lb/>habuisse auctores
+						et inventores suos, a quibus quas­<lb/>dam certas leges positas convellere
 						prohibemur; non <note type="footnote">I Apud toY. omittitur, in <hi
-								rend="italic">medio et,</hi> quod restituimus ex <lb/> Mss. At .pad
+								rend="italic">medio et,</hi> quod restituimus ex<lb/>Mss. At .pad
 							Er. legitur, <hi rend="italic">vei etiamante finem sUealur.</hi>
 						</note><note type="footnote"> I Mss. cum Ain. Labent, <hi rend="italic"
 								>deberi.</hi>
 						</note><note type="footnote"> • in B., supradictis. Mss. A et <hi
 								rend="italic">B, supracditis,</hi> correctius. M. </note>
-						<lb/> enim oportet, cum illi eas ratione fixcrint aliquid ibi <lb/> mutare
-						quamvis secundum rationem sine aurium of. <lb/> fensione possimus t. Cujus
-						rei cognilio non arte, sed <lb/> historia traditur; unde creditur potius
-						quam cognosci­ <lb/> tur. Neque enim si Phaliscus, nescio qui, metra 2 ita
-						<lb/> composuit, ut hæc sonant, <lb/> Quando flagella ligas, ita liga, <lb/>
-						vitis et ulmus uti simul eant; <lb/> scire hoc possumus ; sed tantummodo
-						credere au. <lb/> diendo ct legendo. Illud cst disciplinæ. quod ad nos <lb/>
-						pertinet; videre utrum hoc tribus dactylis constet et <lb/> pyrrhichio
-						ultimo, ul plerique musicae imperiti autu­ <lb/> mant ; non enim sentiunt
-						pyrrhichium poni non posse <lb/> post dactylum : an ut ratio docet, primus
-						pes sit in <lb/> hoc metro choriambus, secundus ionicus longa syl­ <lb/>
-						laba in duas soluta breves, ultimus iambus, post quem <lb/> tria tempora
-						silebuntur : quod semidocti homines <lb/> sentire possent, si a docto
-						secundum utramque legein <lb/> pronuntiaretur et pJauderetur. Ita enim
-						nalurali ct <lb/> communi sensu judicarent, quid disciplinæ norma <lb/>
-						præscriberet.</p>
-					<p>3i. Verumtamen quod poeta illc hos numeros im­ <lb/> . mobilcsesse voluit,
-						cum hoc metro utimur, custo­ <lb/> diendum est: non enim fraudat auditum ;
-						quanquam <lb/> æque nihil fraudarct, si vel pro choriambo diiambum, <lb/>
-						vel ipsum ionicum nulla in breves facta solutione <lb/> poneremus, et
-						quidqnid aliud congruisset. In hoc igi­ <lb/> tar metro nihil mulabitur; non
-						ea ratione qua in­ <lb/> æqualitatem vitamus, sed ca qua observamus auctori-
-						<lb/> talem. Docet sane ratio, alia institui metra immobilia, <lb/> id est
-						in quibus mutari nihil oportet, ut hoc ipsum <lb/> cst de quo salis locuti
-						sumus ; alia mobilia, in quibus <lb/> locare pedes alios pro aliis licct,
-						sicuti est ; <hi rend="italic">Trojæ qui <lb/> primus ab oris, arma virumque
-							cano.</hi> Nani hic pro <lb/> spondco anapæstum quolibet loco licct
-						ponere. Alia <lb/> nec tota immobilia, nec tota mobilia, ut est: <lb/>
-						Pendeat ex humeris dulcis chelys, <lb/> Et numcros edat varios, quibus <lb/>
-						Assonel onme virens late nemus, <lb/> Et tortis errans qui flexibus. <lb/> (
-							<hi rend="italic">Terentianus</hi> ex rompomo.) <lb/> Vides hic enim
-						ubique et spondeos et dactylos poni <lb/> posse, præter ultimum pedem, quem
-						metri auctor <lb/> semper esse dactylum voluit. Etin iis quidem generi­
-						<lb/> bus tribus nonnihil valere auctoritatem vidcs.</p>
-					<p>32. Quod autem in pedum commixtione ad ratio­ <lb/> nem solam pertinet de iis
-						rebus quæ sentiuntur judi­ <lb/> cantem; sciendum est cas partes pedum, qu:c
-						post <lb/> certos pedes silentio restante suaviter locantur, ut <lb/> iambos
-						post dichorium atque secundum epitritum, et <lb/> spondeus post antispastum,
-						etiam post alios pedes <lb/> male locarit quibus isti permixti fuerint : nam
-						mani­ <lb/> festum est iambum post molossum bene poni, sicut <lb/> hoc
-						exemplum indicat sæpe repetitum cum silentio in <lb/> fine temporum trium,
-							<hi rend="italic">Ver blandum viret floribus :</hi> at <lb/> si pro
-						molosso primum dichorium constituas, ut cst, <lb/>
+						<lb/>enim oportet, cum illi eas ratione fixcrint aliquid ibi<lb/>mutare
+						quamvis secundum rationem sine aurium of.<lb/>fensione possimus t. Cujus
+						rei cognilio non arte, sed<lb/>historia traditur; unde creditur potius
+						quam cognosci­<lb/>tur. Neque enim si Phaliscus, nescio qui, metra 2 ita
+						<lb/>composuit, ut haec sonant,<lb/>Quando flagella ligas, ita liga,<lb/>
+						vitis et ulmus uti simul eant;<lb/>scire hoc possumus ; sed tantummodo
+						credere au.<lb/>diendo ct legendo. Illud cst disciplinae. quod ad nos<lb/>
+						pertinet; videre utrum hoc tribus dactylis constet et<lb/>pyrrhichio
+						ultimo, ul plerique musicae imperiti autu­<lb/>mant ; non enim sentiunt
+						pyrrhichium poni non posse<lb/>post dactylum : an ut ratio docet, primus
+						pes sit in<lb/>hoc metro choriambus, secundus ionicus longa syl­<lb/>
+						laba in duas soluta breves, ultimus iambus, post quem<lb/>tria tempora
+						silebuntur : quod semidocti homines<lb/>sentire possent, si a docto
+						secundum utramque legein<lb/>pronuntiaretur et pJauderetur. Ita enim
+						nalurali ct<lb/>communi sensu judicarent, quid disciplinae norma<lb/>
+						praescriberet.</p>
+					<p>3i. Verumtamen quod poeta illc hos numeros im­<lb/>. mobilcsesse voluit,
+						cum hoc metro utimur, custo­<lb/>diendum est: non enim fraudat auditum ;
+						quanquam<lb/>aeque nihil fraudarct, si vel pro choriambo diiambum,<lb/>
+						vel ipsum ionicum nulla in breves facta solutione<lb/>poneremus, et
+						quidqnid aliud congruisset. In hoc igi­<lb/>tar metro nihil mulabitur; non
+						ea ratione qua in­<lb/>aequalitatem vitamus, sed ca qua observamus auctori-
+						<lb/>talem. Docet sane ratio, alia institui metra immobilia,<lb/>id est
+						in quibus mutari nihil oportet, ut hoc ipsum<lb/>cst de quo salis locuti
+						sumus ; alia mobilia, in quibus<lb/>locare pedes alios pro aliis licct,
+						sicuti est ; <hi rend="italic">Trojae qui<lb/>primus ab oris, arma virumque
+							cano.</hi> Nani hic pro<lb/>spondco anapaestum quolibet loco licct
+						ponere. Alia<lb/>nec tota immobilia, nec tota mobilia, ut est:<lb/>
+						Pendeat ex humeris dulcis chelys,<lb/>Et numcros edat varios, quibus<lb/>
+						Assonel onme virens late nemus,<lb/>Et tortis errans qui flexibus.<lb/>(
+							<hi rend="italic">Terentianus</hi> ex rompomo.)<lb/>Vides hic enim
+						ubique et spondeos et dactylos poni<lb/>posse, praeter ultimum pedem, quem
+						metri auctor<lb/>semper esse dactylum voluit. Etin iis quidem generi­
+						<lb/>bus tribus nonnihil valere auctoritatem vidcs.</p>
+					<p>32. Quod autem in pedum commixtione ad ratio­<lb/>nem solam pertinet de iis
+						rebus quae sentiuntur judi­<lb/>cantem; sciendum est cas partes pedum, qu:c
+						post<lb/>certos pedes silentio restante suaviter locantur, ut<lb/>iambos
+						post dichorium atque secundum epitritum, et<lb/>spondeus post antispastum,
+						etiam post alios pedes<lb/>male locarit quibus isti permixti fuerint : nam
+						mani­<lb/>festum est iambum post molossum bene poni, sicut<lb/>hoc
+						exemplum indicat saepe repetitum cum silentio in<lb/>fine temporum trium,
+							<hi rend="italic">Ver blandum viret floribus :</hi> at<lb/>si pro
+						molosso primum dichorium constituas, ut cst,<lb/>
 						<hi rend="italic">Vere terra viret floribus,</hi> respuit hoc auditus atque
 						con - <note type="footnote"> I Mss. A et B concordant in lectionem hanc :
-							Non ewfrn <lb/>
+							Non ewfrn<lb/>
 							<hi rend="italic">oportet, non illi eas ratione fixcrint : quanuis ibi
-								aliquid <lb/> secundum rationem nittt:l1"e une aMrt:w! offensione
+								aliquid<lb/>secundum rationem nittt:l1"e une aMrt:w! offensione
 								possifiius</hi>
-							<lb/> Er. Lugd. ven. legiuit. <hi rend="italic">finxerint.</hi> M.
+							<lb/>Er. Lugd. ven. legiuit. <hi rend="italic">finxerint.</hi> M.
 							</note><note type="footnote">
 							<hi rend="italic">9 Jiictrum,</hi> juxta ix. I ugd. vcn. Lov. et )!s. A.
 							M. </note>
 						<lb/>
-						<pb n="1145"/> demnat. Id eliam in cadem sensu explorante facile <lb/> est
-						experiri. Ratio namque certissima cst, cum sibi <lb/> copulantur qui inter
-						se sunt copulabiles pedes, eas <lb/> partes debere in fine subjungi quæ
-						omnibus conve­ <lb/> niunt in illa serie collocatis, ne inter socios quodam­
-						<lb/> modo discordiae aliquid oriatur.</p>
-					<p>33. Illud magis mirandum est, quod cum spondeus <lb/> et diiambum et
-						dichorium suaviter claudat, tamen cum <lb/> hi duo pedes sive soli, sive cum
-						aliis copulabilibus <lb/> quoquo modo mixtis in una serie fuerint, spondeus
-						in <lb/> fine, approbante sensu, poni non potest. Quis enun <lb/> dubitet
-						aures libenter accipere ista singula repetita, <lb/>
+						<pb n="1145"/> demnat. Id eliam in cadem sensu explorante facile<lb/>est
+						experiri. Ratio namque certissima cst, cum sibi<lb/>copulantur qui inter
+						se sunt copulabiles pedes, eas<lb/>partes debere in fine subjungi quae
+						omnibus conve­<lb/>niunt in illa serie collocatis, ne inter socios quodam­
+						<lb/>modo discordiae aliquid oriatur.</p>
+					<p>33. Illud magis mirandum est, quod cum spondeus<lb/>et diiambum et
+						dichorium suaviter claudat, tamen cum<lb/>hi duo pedes sive soli, sive cum
+						aliis copulabilibus<lb/>quoquo modo mixtis in una serie fuerint, spondeus
+						in<lb/>fine, approbante sensu, poni non potest. Quis enun<lb/>dubitet
+						aures libenter accipere ista singula repetita,<lb/>
 						<hi rend="italic">Timenda</hi> res <hi rend="italic">non eat :</hi> et item
-						separatim, <hi rend="italic">Jam timcre<lb/> noli?</hi> At si ita jungas,
+						separatim, <hi rend="italic">Jam timcre<lb/>noli?</hi> At si ita jungas,
 						Timenda <hi rend="italic">rea, jam</hi> timere <hi rend="italic">noli ;</hi>
-						<lb/> nisi in soluta oratione audire nolim. Nec absurdum <lb/> minus est, si
-						quolibet loco alium connectas, veluti <lb/> molossum hoc modo : <hi
-							rend="italic">Vir fortia, timenda res, jam</hi> ti­ <lb/>
+						<lb/>nisi in soluta oratione audire nolim. Nec absurdum<lb/>minus est, si
+						quolibet loco alium connectas, veluti<lb/>molossum hoc modo : <hi
+							rend="italic">Vir fortia, timenda res, jam</hi> ti­<lb/>
 						<hi rend="italic">mere noli.</hi> Vel ita : <hi rend="italic">Timenda</hi>
-						res, <hi rend="italic">vir fortis, jam timere<lb/> voli.</hi> Vel etiam ita
+						res, <hi rend="italic">vir fortis, jam timere<lb/>voli.</hi> Vel etiam ita
 						: <hi rend="italic">Timenda res, jam timere vir fortis</hi>
-						<lb/> noli. Cujus absurditatis causa est, qnod pes diiambus <lb/> etiam ad
-						duplum et simp'um plaudi potest, ut ad sim­ <lb/> plum et duplum dichorius :
-						spondens autem duplre <lb/> parti corum sequalis est; sed cum eum ille
-						trabit ad <lb/> primam, hic ad extremam, existit nonnulla discordia; <lb/>
+						<lb/>noli. Cujus absurditatis causa est, qnod pes diiambus<lb/>etiam ad
+						duplum et simp'um plaudi potest, ut ad sim­<lb/>plum et duplum dichorius :
+						spondens autem duplre<lb/>parti corum sequalis est; sed cum eum ille
+						trabit ad<lb/>primam, hic ad extremam, existit nonnulla discordia;<lb/>
 						et ita ratio tollit admirationcm.</p>
-					<p>34. Nec minus miraculum edit antispastus, cui si <lb/> nullus alius pedum,
-						aut certe solus diiambus miscea­ <lb/> tur, pntitur iambo metrum claudi, cum
-						aliis autem po­ <lb/> situs nullo modo; et cum dichorio quidem propter <lb/>
-						ipsum dichorium; itaque hoc minime miror. Cum <lb/> cæteris vero senum
-						temporum pedibus, cur memo­ <lb/> ratum trium temporum pedem in fine
-						repudiet, nescio <lb/> quæ est causa secretior fortasse quam ut a nobis erui
-						<lb/> atque ostendi queat : sed hoc ita esse bis exemplis <lb/> proto. Nam
-						ista duo metra, <hi rend="italic">Potestate placet, potestate <lb/>
-							potentium placet,</hi> nemo ambigit suaviter singula repcu <lb/> cum
-						silentio trium temporum in fine. At ista insuavi­ <lb/> ter cum eodem
-						silentia : <hi rend="italic">Potestate præclara placet.</hi> Po­ <lb/>
+					<p>34. Nec minus miraculum edit antispastus, cui si<lb/>nullus alius pedum,
+						aut certe solus diiambus miscea­<lb/>tur, pntitur iambo metrum claudi, cum
+						aliis autem po­<lb/>situs nullo modo; et cum dichorio quidem propter<lb/>
+						ipsum dichorium; itaque hoc minime miror. Cum<lb/>caeteris vero senum
+						temporum pedibus, cur memo­<lb/>ratum trium temporum pedem in fine
+						repudiet, nescio<lb/>quae est causa secretior fortasse quam ut a nobis erui
+						<lb/>atque ostendi queat : sed hoc ita esse bis exemplis<lb/>proto. Nam
+						ista duo metra, <hi rend="italic">Potestate placet, potestate<lb/>
+							potentium placet,</hi> nemo ambigit suaviter singula repcu<lb/>cum
+						silentio trium temporum in fine. At ista insuavi­<lb/>ter cum eodem
+						silentia : <hi rend="italic">Potestate praeclara placet.</hi> Po­<lb/>
 						testate <hi rend="italic">tibi multum placet. Potestate jam tibi sic
 							placet.</hi>
-						<lb/> 'Potestate <hi rend="italic">multum tibi placet. Potestatis magnitudo
-							pla­<lb/> cet.</hi> Quod ad sensum attinet, peregit officium suum in
-						<lb/> hac quæstione, et quid acceperit, et quid exploserit <lb/> indicavit:
-						sed de causa cur ita sit, ratio consulenda <lb/> est. Ac mea 1 quidem in
-						tanta obscuri:atc nihil aliud <lb/> videl, nisi cum diiambo anlispastum
-						dimidiam par­ <lb/> tem priorem babere communem : nam uterque a <lb/> brevi
-						et longa incipit; posteriorem autem cum dicho­ <lb/> rio • longa cnim et
-						brev i ambo finiuntur. Itaque anti­ <lb/> spastus vul solus tanquam suam
-						priorem dimidiam, <lb/> vel cum diiambo cum quo eam communiter habet, <lb/>
-						collocatus, patitur in fine metri esse iambum ; clcum <lb/> dichorio
-						pateretur, si eidem dichorio talis terminus <lb/> conveniret: cum cæteris
-						autem non patitur, quibus <lb/> tali societate non 2 jungitur.</p>
+						<lb/>'Potestate <hi rend="italic">multum tibi placet. Potestatis magnitudo
+							pla­<lb/>cet.</hi> Quod ad sensum attinet, peregit officium suum in
+						<lb/>hac quaestione, et quid acceperit, et quid exploserit<lb/>indicavit:
+						sed de causa cur ita sit, ratio consulenda<lb/>est. Ac mea 1 quidem in
+						tanta obscuri:atc nihil aliud<lb/>videl, nisi cum diiambo anlispastum
+						dimidiam par­<lb/>tem priorem babere communem : nam uterque a<lb/>brevi
+						et longa incipit; posteriorem autem cum dicho­<lb/>rio • longa cnim et
+						brev i ambo finiuntur. Itaque anti­<lb/>spastus vul solus tanquam suam
+						priorem dimidiam,<lb/>vel cum diiambo cum quo eam communiter habet,<lb/>
+						collocatus, patitur in fine metri esse iambum ; clcum<lb/>dichorio
+						pateretur, si eidem dichorio talis terminus<lb/>conveniret: cum caeteris
+						autem non patitur, quibus<lb/>tali societate non 2 jungitur.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT XVII. — <hi rend="italic">De metrorum
 								copulatione.</hi>
 						</title>
 					</ab>
-					<p>55. Quod vero ad metrorum copulationem attinet, <lb/> satis est in præsentia
+					<p>55. Quod vero ad metrorum copulationem attinet,<lb/>satis est in praesentia
 						vidcre, posse sibi diversa metra <note type="footnote">» MS. A addit, <hi
 								rend="italic">ratio.</hi> M. </note><note type="footnote">* Fjt. et
-							Lov. omittunt liic ncgationcm, quam tamcn ex­ <lb/> bibent Мss et Am. </note>
-						<lb/> copulari, quæ tamen plausu, id est levatione ac posi­ <lb/> tione
-						conveniant. Diversa sunt autem vel quantitate, <lb/> ut cum majora
-						copulantur minoribus, qualia ista sunt, <lb/> videlicet: <lb/> Jam satis
-						terris ulvis atque diræ <lb/> Grandinis misit rater, et rubente <lb/>
-						Dextera sacras jaculatus arces, <lb/> Terruit urhcm. <lb/>
+							Lov. omittunt liic ncgationcm, quam tamcn ex­<lb/>bibent Мss et Am. </note>
+						<lb/>copulari, quae tamen plausu, id est levatione ac posi­<lb/>tione
+						conveniant. Diversa sunt autem vel quantitate,<lb/>ut cum majora
+						copulantur minoribus, qualia ista sunt,<lb/>videlicet:<lb/>Jam satis
+						terris ulvis atque dirae<lb/>Grandinis misit rater, et rubente<lb/>
+						Dextera sacras jaculatus arces,<lb/>Terruit urhcm.<lb/>
 						<hi rend="italic">(Horat. lib.</hi> i <hi rend="italic">carminum, ode</hi>
-						2.) <lb/> Nam hoc quartum, quod uno choriambo et una in fine <lb/> longa
-						terminatur, quam parvum sit tribus superiori­ <lb/> bus inter se aequalibus
-						subjectum vides. Vel pedibus <lb/> sicuti hæc : <lb/> Grato Pyrrba sub
-						antro, <lb/> Cui Oavam religas comam. <lb/>
+						2.)<lb/>Nam hoc quartum, quod uno choriambo et una in fine<lb/>longa
+						terminatur, quam parvum sit tribus superiori­<lb/>bus inter se aequalibus
+						subjectum vides. Vel pedibus<lb/>sicuti haec :<lb/>Grato Pyrrba sub
+						antro,<lb/>Cui Oavam religas comam.<lb/>
 						<hi rend="italic">( norat. lib.</hi> i <hi rend="italic">carminum, ode
 							5.)</hi>
-						<lb/> Cernis quippe horum dnorum superius constare spon­ <lb/> deo et
-						choriambo, et longa ultima, quae ad sex tem­ <lb/> pora implenda spondeo d
-							<unclear>ubebatur</unclear> : hoc autem poste­ <lb/> rius spondeo et
-						choriambo, et duabus ultimis brevi­ <lb/> bus, quae item cum primo spondeo
-						implent sex tem­ <lb/> pora. Paria sunt ergo ista temporibus, sed in pedibus
-						<lb/> nonnihil diversitatis tenent.</p>
-					<p>56. Est et alia differentia istarum copulationum, <lb/> quod alia ita
-						copulentur, ut nulla sibi silentia inter­ <lb/> poni velint, sicut hæc duo
-						recentissima; alia inter se <lb/> sileri aliquid postulent, sicut haec :
-						<lb/> vides ut alta stet nive candidum <lb/> Soracte, nee jam sustineant
-						onus <lb/> silvae laborantes, geluque <lb/> Flumina constiterint acuto. <lb/>
+						<lb/>Cernis quippe horum dnorum superius constare spon­<lb/>deo et
+						choriambo, et longa ultima, quae ad sex tem­<lb/>pora implenda spondeo d
+							<unclear>ubebatur</unclear> : hoc autem poste­<lb/>rius spondeo et
+						choriambo, et duabus ultimis brevi­<lb/>bus, quae item cum primo spondeo
+						implent sex tem­<lb/>pora. Paria sunt ergo ista temporibus, sed in pedibus
+						<lb/>nonnihil diversitatis tenent.</p>
+					<p>56. Est et alia differentia istarum copulationum,<lb/>quod alia ita
+						copulentur, ut nulla sibi silentia inter­<lb/>poni velint, sicut haec duo
+						recentissima; alia inter se<lb/>sileri aliquid postulent, sicut haec :
+						<lb/>vides ut alta stet nive candidum<lb/>Soracte, nee jam sustineant
+						onus<lb/>silvae laborantes, geluque<lb/>Flumina constiterint acuto.<lb/>
 						<hi rend="italic">(Horat. lib.</hi> i <hi rend="italic">carminum, ode
 							9.)</hi>
-						<lb/> Nam si hæc singula rcpelanlur, priora duo unum lem­ <lb/> pus in fine
-						sileri flagitant, tertium duo, quartum tria. <lb/> Copulata vero a primo ad
-						secundum transeintem, <lb/> unum tempus silere cogunt; a secundo ad tertium
-						<lb/> duo, a tertio ad quartum tria. A quarto autem si ad <lb/> primum
-						redeas, tempus unum silebis. Sed qu:c est ra­ <lb/> tio est'redeundi ad
-						primum, eadem est ad aliam talem <lb/> copulationem transeundi. Hoc genus
-						copulaLionum <lb/> recte nos appellamus circuitum, qui <foreign
-							xml:lang="grc">περιόδος</foreign> graece di­ <lb/> citur. Circuitus
-						ergo minor esse non potest, quam <lb/> qui duobus meanbris constat, id est
-						duobus metris : <lb/> nec esse majorem volucrunL eo qui usque ad quatuor
-						<lb/> membra procedit. Licet igitur minimum bimembrem, <lb/> medium
-						trimembrem, et ultimum quadrimembrem <lb/> vocare; hos enim Graeci <foreign
+						<lb/>Nam si haec singula rcpelanlur, priora duo unum lem­<lb/>pus in fine
+						sileri flagitant, tertium duo, quartum tria.<lb/>Copulata vero a primo ad
+						secundum transeintem,<lb/>unum tempus silere cogunt; a secundo ad tertium
+						<lb/>duo, a tertio ad quartum tria. A quarto autem si ad<lb/>primum
+						redeas, tempus unum silebis. Sed qu:c est ra­<lb/>tio est'redeundi ad
+						primum, eadem est ad aliam talem<lb/>copulationem transeundi. Hoc genus
+						copulaLionum<lb/>recte nos appellamus circuitum, qui <foreign
+							xml:lang="grc">περιόδος</foreign> graece di­<lb/>citur. Circuitus
+						ergo minor esse non potest, quam<lb/>qui duobus meanbris constat, id est
+						duobus metris :<lb/>nec esse majorem volucrunL eo qui usque ad quatuor
+						<lb/>membra procedit. Licet igitur minimum bimembrem,<lb/>medium
+						trimembrem, et ultimum quadrimembrem<lb/>vocare; hos enim Graeci <foreign
 							xml:lang="grc">δίϰωλον, τρίϰωλον, τετράϰωλον</foreign>
-						<lb/> vocant. De quo toto genere quoniam diligentius tra­ <lb/> ctaturi
-						sumus, ut dixi, in eo sermone qui nobis de ver­ <lb/> sibus erit, nunc
+						<lb/>vocant. De quo toto genere quoniam diligentius tra­<lb/>ctaturi
+						sumus, ut dixi, in eo sermone qui nobis de ver­<lb/>sibus erit, nunc
 						interim hoc satis sit.</p><!-- Reprendre ici -->
-					<p>57. Sane arbitror jam te intelligcre, innumerabilia <lb/> genera esse
-						metrorum, quae quingenta sexaginta octo <lb/> inverieramus *, cum et de
-						silentiis non nisi finalibus <lb/> exempla essent data, et nulla pedum
-						commixtio facta <lb/> esset, et nulla solutio longarum in duas breves, quæ
-						<lb/> pedem ultra syllabas quatuor porrigeret. At si adhi­ <lb/> bita omni
-						silentiorum interpositione, et omni pedum <lb/> commixtione, et omni
-						solutione longarum colligere <lb/> numerum metrorum velis; tantus existit,
-						ut nomen <lb/> cjus fortasse non suppetat. Sed haec exempla quae a <note
+					<p>57. Sane arbitror jam te intelligcre, innumerabilia<lb/>genera esse
+						metrorum, quae quingenta sexaginta octo<lb/>inverieramus *, cum et de
+						silentiis non nisi finalibus<lb/>exempla essent data, et nulla pedum
+						commixtio facta<lb/>esset, et nulla solutio longarum in duas breves, quae
+						<lb/>pedem ultra syllabas quatuor porrigeret. At si adhi­<lb/>bita omni
+						silentiorum interpositione, et omni pedum<lb/>commixtione, et omni
+						solutione longarum colligere<lb/>numerum metrorum velis; tantus existit,
+						ut nomen<lb/>cjus fortasse non suppetat. Sed haec exempla quae a <note
 							type="footnote"> 1 in prius vulgatis et pluribus Mss. habetur, <hi
-								rend="italic">quadraginta<lb/> septem inveneranms.</hi> sed legendum
-							cum Albinensi codice , <lb/>
+								rend="italic">quadraginta<lb/>septem inveneranms.</hi> sed legendum
+							cum Albinensi codice ,<lb/>
 							<hi rend="italic">sexaginta octo.</hi> Confer locum lib. 4, nn. iS et
-							16, ubi me­ <lb/> troruin isthæc SUDlIUa censetur. </note>
+							16, ubi me­<lb/>troruin isthaec SUDlIUa censetur. </note>
 						<lb/>
-						<pb n="1147"/> nobis sunt posita, et quæcumque alia poni possunt, <lb/>
-						quanquam ea et poeta in erOciendo approbel. et in <lb/> audicndo 1 natura
+						<pb n="1147"/> nobis sunt posita, et quaecumque alia poni possunt,<lb/>
+						quanquam ea et poeta in erOciendo approbel. et in<lb/>audicndo 1 natura
 						communis; tamen nisi ea docti et <note type="footnote"> 1 ita Mss. At Am.
-							Er. et Lov.: Quanquam <hi rend="italic">ea et appetat</hi> in <lb/>
+							Er. et Lov.: Quanquam <hi rend="italic">ea et appetat</hi> in<lb/>
 							<hi rend="italic">efficiendo, et approbet</hi> in audiendo. </note>
-						<lb/> exercitati hominis pronuntiatio commendet auribus , <lb/> sensusque
-						audientium non sit tardior quam humanitas <lb/> postulat, non possunt ea
-						quae tractavimus vera judi - <lb/> cari. Sed quiescamus aliquantulum, et de
-						versu dein­ <lb/> ceps disseramus. <hi rend="italic">D.</hi> Ita fiat.</p>
+						<lb/>exercitati hominis pronuntiatio commendet auribus ,<lb/>sensusque
+						audientium non sit tardior quam humanitas<lb/>postulat, non possunt ea
+						quae tractavimus vera judi<lb/>cari. Sed quiescamus aliquantulum, et de
+						versu dein­<lb/>ceps disseramus. <hi rend="italic">D.</hi> Ita fiat.</p>
 				</div>
 				<div type="textpart" subtype="book">
 					<head>
@@ -3839,102 +3839,102 @@
 								rhythmus ,</hi> metrum <hi rend="italic">et versus.</hi>
 						</title>
 					</ab>
-					<div type="textpart" subtype="dialog"><p>1. M. Quid sit versus, inter doctos veteres non <lb/> parva luctatione
-						quæsitum est, nIC' fructus defuit. <lb/> Nam inventa res est, ei ad notitiam
-						posterorum man­ <lb/> data liueris, gravi atque certa non tantum auctori­
-						<lb/> tate, verum etiam ratione firmata est. Interesse igitur <lb/>
-						animadverterunt inter rhythmum et metrum aliquid, <lb/> ut omne metrum
-						rhythmus, non etiam omnis rhyth­ <lb/> mus metrum sit. Omnis enim legitima
-						pedum con­ <lb/> nexio numerosa est'; quam quoniam metrum babet, <lb/> non
-						esse numerus nullo modo potest, id est non esse <lb/> rhythmus. Sed quoniam
-						non est idem, quamvis legi­ <lb/> timis pedibus, nullo tamen certo fine
-						provolvi, ct <lb/> item legitimis progredi pedibus , sed certo fine coer-
-						<lb/> cert; hæc duo genera etiam vocabulis discernenda <lb/> erant, ut illud
-						superius rhythmus tantum proprio <lb/> jam nomine, hoc autcm alterum ita
-						rhythmus ut me­ <lb/> trum ctiam vocaretur. Rursus, quoniam eorum nu­ <lb/>
-						merorum qui certo fine clauduntur, id est metrorum, <lb/> alia sunt in
-						quibus non habetur ratio cujusdam divi­ <lb/> sionis circa medium, alia in
-						quibus sedulo habctur; <lb/> erat etiam hæc differentia notanda vocabulis.
-						Qua­ <lb/> propter illud, ubi non habetur hæc ralio, rhythmi ge­ <lb/> nus
-						proprie metrum vocatum est: hoc autem ubi ha­ <lb/> betur, versum
-						nominaverunt. Cnjus appellationis <lb/> originem fortasse progredientibus
-						nobis ratio ipsa <lb/> monstrabit. Neque hoc ila præscriptum putes, ut illa
-						<lb/> cHam metra versus vocare non liceat. Sed aliud est <lb/> cum abutimur
-						nomine, licentia cujusdam vicinitatis ; <lb/> aliud, cum rem vocabulo suo
-						enuntiamus. Sed nomi­ <lb/> num commemoratio hactenus facia sit; in quibus,
-						ut <lb/> jam didicimns, concessio interloquentium 2 et vetu­ <lb/> statis
-						auctoritas totum valet. Cætera, si placet, more <lb/> nostro investigemus
-						sensu nuntio, indice rationc; ut il­ <lb/> los etiam vetercs auctores non
-						inslituissc i£ta quasi quæ <lb/> in natura rerum integra et perfecta non
-						fuerint, sed ra­ <lb/> tiocinando invenisse, et appellando
+					<div type="textpart" subtype="dialog"><p>1. M. Quid sit versus, inter doctos veteres non<lb/>parva luctatione
+						quaesitum est, nIC' fructus defuit.<lb/>Nam inventa res est, ei ad notitiam
+						posterorum man­<lb/>data liueris, gravi atque certa non tantum auctori­
+						<lb/>tate, verum etiam ratione firmata est. Interesse igitur<lb/>
+						animadverterunt inter rhythmum et metrum aliquid,<lb/>ut omne metrum
+						rhythmus, non etiam omnis rhyth­<lb/>mus metrum sit. Omnis enim legitima
+						pedum con­<lb/>nexio numerosa est'; quam quoniam metrum babet,<lb/>non
+						esse numerus nullo modo potest, id est non esse<lb/>rhythmus. Sed quoniam
+						non est idem, quamvis legi­<lb/>timis pedibus, nullo tamen certo fine
+						provolvi, ct<lb/>item legitimis progredi pedibus , sed certo fine coer-
+						<lb/>cert; haec duo genera etiam vocabulis discernenda<lb/>erant, ut illud
+						superius rhythmus tantum proprio<lb/>jam nomine, hoc autcm alterum ita
+						rhythmus ut me­<lb/>trum ctiam vocaretur. Rursus, quoniam eorum nu­<lb/>
+						merorum qui certo fine clauduntur, id est metrorum,<lb/>alia sunt in
+						quibus non habetur ratio cujusdam divi­<lb/>sionis circa medium, alia in
+						quibus sedulo habctur;<lb/>erat etiam haec differentia notanda vocabulis.
+						Qua­<lb/>propter illud, ubi non habetur haec ralio, rhythmi ge­<lb/>nus
+						proprie metrum vocatum est: hoc autem ubi ha­<lb/>betur, versum
+						nominaverunt. Cnjus appellationis<lb/>originem fortasse progredientibus
+						nobis ratio ipsa<lb/>monstrabit. Neque hoc ila praescriptum putes, ut illa
+						<lb/>cHam metra versus vocare non liceat. Sed aliud est<lb/>cum abutimur
+						nomine, licentia cujusdam vicinitatis ;<lb/>aliud, cum rem vocabulo suo
+						enuntiamus. Sed nomi­<lb/>num commemoratio hactenus facia sit; in quibus,
+						ut<lb/>jam didicimns, concessio interloquentium 2 et vetu­<lb/>statis
+						auctoritas totum valet. Caetera, si placet, more<lb/>nostro investigemus
+						sensu nuntio, indice rationc; ut il­<lb/>los etiam vetercs auctores non
+						inslituissc i£ta quasi quae<lb/>in natura rerum integra et perfecta non
+						fuerint, sed ra­<lb/>tiocinando invenisse, et appellando
 						notassecognoscas.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT II. <hi rend="italic">— Metro in duas partes</hi>
-							divisibilia <hi rend="italic">cæteris</hi> præstant.</title>
+							divisibilia <hi rend="italic">caeteris</hi> praestant.</title>
 					</ab>
-					<div type="textpart" subtype="dialog"><p>2. Quare primum a te quæro, utram ob aliud pes <lb/> aurem mulceat, nisi quod
-						in eo duae illæ partes, qua­ <lb/> rum una in levatione, altera in positione
-						cst, nume­ <lb/> rosa sibi concinnitate respondent? D. Jam hoc quidcm <lb/>
+					<div type="textpart" subtype="dialog"><p>2. Quare primum a te quaero, utram ob aliud pes<lb/>aurem mulceat, nisi quod
+						in eo duae illae partes, qua­<lb/>rum una in levatione, altera in positione
+						cst, nume­<lb/>rosa sibi concinnitate respondent? D. Jam hoc quidcm<lb/>
 						mihi ante persuasum est atque compertum. <hi rend="italic">M.</hi> Quid?
-						<lb/> metrum, quod manifestum est pedum collatione con­ <lb/> fici, num ex
+						<lb/>metrum, quod manifestum est pedum collatione con­<lb/>fici, num ex
 						co rerum genere esse arbitrandum est <note type="footnote"> ' An. Er. et
-							Lov., numerus est. Sed melius Mss.,numerosa <lb/> ,M. </note><note
+							Lov., numerus est. Sed melius Mss.,numerosa<lb/>,M. </note><note
 							type="footnote">I <hi rend="italic">mer se loqucniium,</hi> juxta Tauc.
 							M.</note>
-						<lb/> quod dividi non potest ; cum omnino et nihil indivi <lb/> duum per
-						tempus tendi queat, et quod ex dividuis <lb/> pedibus constat, absurdissime
-						individuum putetur ? <lb/> D. Nullo modo hoc genu. divisionem recipere
-						abnuc­ <lb/> rim. <hi rend="italic">M.</hi> At omnia quæ recipiunt
-						divisionem, nonne <lb/> pulchriora sunt si eorum partes aliqua pariiitate
-						con­ <lb/> cordent, quam si discordes et dissonae sint? <hi rend="italic"
-							>D.</hi> NuiK <lb/> ' dubium est. <hi rend="italic">M.</hi> Quid ?
-						ipsius parilis divisionis qui <lb/> tandem numerus auctor est? an dualis? D.
-						Ita est. <lb/>
+						<lb/>quod dividi non potest ; cum omnino et nihil indivi<lb/>duum per
+						tempus tendi queat, et quod ex dividuis<lb/>pedibus constat, absurdissime
+						individuum putetur ?<lb/>D. Nullo modo hoc genu. divisionem recipere
+						abnuc­<lb/>rim. <hi rend="italic">M.</hi> At omnia quae recipiunt
+						divisionem, nonne<lb/>pulchriora sunt si eorum partes aliqua pariiitate
+						con­<lb/>cordent, quam si discordes et dissonae sint? <hi rend="italic"
+							>D.</hi> NuiK<lb/>' dubium est. <hi rend="italic">M.</hi> Quid ?
+						ipsius parilis divisionis qui<lb/>tandem numerus auctor est? an dualis? D.
+						Ita est.<lb/>
 						<hi rend="italic">M.</hi> Ut ergo in duas partes concinentes dividi pedem
-						<lb/> et eo ipso aurem delectare comperimus; si eliam me­ <lb/> trum tale
-						inveniamus, nonne cæteris non talibus jure <lb/> anteponetur? <hi
+						<lb/>et eo ipso aurem delectare comperimus; si eliam me­<lb/>trum tale
+						inveniamus, nonne caeteris non talibus jure<lb/>anteponetur? <hi
 							rend="italic">D.</hi> Assentior.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT III. — <hi rend="italic">Versus unde dictus.</hi>
 						</title>
 					</ab>
-					<div type="textpart" subtype="dialog"><p>3. <hi rend="italic">M.</hi> Recte sane. Quare jam illud responde, cum <lb/>
-						in omnibus quæ aliqua temporis parte metimur, aliud <lb/> priccedat, aliud
-						subsequatur, aliud incipiat, aliud <lb/> terminet ; nihilne libi videatur
-						inter partem præce­ <lb/> dentem atque incipientem, et iIlam quae
-						subsequatur <lb/> ac terminet I, interesse oportere. <hi rend="italic"
-							>D.</hi> Interesse arbi­ <lb/> tror. <hi rend="italic">M.</hi> Dic ergo
-						quid intersit inter has duas partes <lb/> versus, quarum una est, <hi
-							rend="italic">Cornua velalarum;</hi> altera vero <lb/> est, <hi
-							rend="italic">vertimus antennarum (Æneid. lib. 3,</hi> v. 549). <lb/>
+					<div type="textpart" subtype="dialog"><p>3. <hi rend="italic">M.</hi> Recte sane. Quare jam illud responde, cum<lb/>
+						in omnibus quae aliqua temporis parte metimur, aliud<lb/>priccedat, aliud
+						subsequatur, aliud incipiat, aliud<lb/>terminet ; nihilne libi videatur
+						inter partem praece­<lb/>dentem atque incipientem, et iIlam quae
+						subsequatur<lb/>ac terminet I, interesse oportere. <hi rend="italic"
+							>D.</hi> Interesse arbi­<lb/>tror. <hi rend="italic">M.</hi> Dic ergo
+						quid intersit inter has duas partes<lb/>versus, quarum una est, <hi
+							rend="italic">Cornua velalarum;</hi> altera vero<lb/>est, <hi
+							rend="italic">vertimus antennarum (aeneid. lib. 3,</hi> v. 549).<lb/>
 						Non cnim ut idem poeta, <hi rend="italic">obvertimus,</hi> sed si ita versus
-						<lb/> enuntictur, <hi rend="italic">Cornua velatarum vertimus
+						<lb/>enuntictur, <hi rend="italic">Cornua velatarum vertimus
 							antennarum;</hi>
-						<lb/> nonne sæpius repetendo efficitur incertum, quæ pars <lb/> prior sil,
-						quæ posterior? Neque enin minus idem stat <lb/> versus, cum ita profertur :
+						<lb/>nonne saepius repetendo efficitur incertum, quae pars<lb/>prior sil,
+						quae posterior? Neque enin minus idem stat<lb/>versus, cum ita profertur :
 							<hi rend="italic">Vertimus antennarum cor­</hi>
-						<lb/> nua <hi rend="italic">velatarum. D.</hi> Plane incertum fieri video.
-						M. Cen­ <lb/> sesne vitandum? <hi rend="italic">D.</hi> Censeo. <hi
-							rend="italic">M.</hi> Vide igitur utrumhic <lb/> satis vitatum sit. Una
-						pars versus cst et ca præce- v <lb/> cedens , <hi rend="italic">Arma
-							virumque cano;</hi> altera subsequens, <lb/>
+						<lb/>nua <hi rend="italic">velatarum. D.</hi> Plane incertum fieri video.
+						M. Cen­<lb/>sesne vitandum? <hi rend="italic">D.</hi> Censeo. <hi
+							rend="italic">M.</hi> Vide igitur utrumhic<lb/>satis vitatum sit. Una
+						pars versus cst et ca praece- v<lb/>cedens , <hi rend="italic">Arma
+							virumque cano;</hi> altera subsequens,<lb/>
 						<hi rend="italic">Trojm qui</hi> priMus <hi rend="italic">ab oris;</hi> qu.c
-						usquc adeo interse dif­ <lb/> ferunt, ut si ordincm vertas, et hoc modo
-						pronun­ <lb/> ties , <hi rend="italic">Troja qui primus ab oria, arma
+						usquc adeo interse dif­<lb/>ferunt, ut si ordincm vertas, et hoc modo
+						pronun­<lb/>ties , <hi rend="italic">Troja qui primus ab oria, arma
 							virumque cano,</hi>
-						<lb/> alios pedes mctiri' necesse sit. <hi rend="italic">D.</hi> Intelligo.
-						M. At <lb/> vide, utrum ista ratio in aliis servata sit. Nam cujus <lb/>
+						<lb/>alios pedes mctiri' necesse sit. <hi rend="italic">D.</hi> Intelligo.
+						M. At<lb/>vide, utrum ista ratio in aliis servata sit. Nam cujus<lb/>
 						dimensionis est pars incipiens, <hi rend="italic">Arma virumque caRo,</hi>
-						<lb/> ejusdem esse agnoscis, <hi rend="italic">llaliam fato. Littora</hi>
-						multum <lb/>
-						<hi rend="italic">ille et. Vi superum sævæ. Multa quoque et bello. Infer­
-							<lb/> reique deos. Albanique patres.</hi> Ne multa, persequere <lb/>
-						cæteros quantum voles, has priores partes versuum <lb/> ejusdem dimensionis
-						invenies, id cst quinto semipede <lb/> articulatas a. Rarissime omnino si
-						non hoc ita cst; <lb/> ila ut posteriores sint istac non minus inter se
-						prriles: <lb/>
-						<hi rend="italic">Trojæ qui</hi> primus <hi rend="italic">ab oris. Profugus
-							Lavinaque venit. <lb/> Terris jactatus et alto. Memorcm Junonis ob iram.
+						<lb/>ejusdem esse agnoscis, <hi rend="italic">llaliam fato. Littora</hi>
+						multum<lb/>
+						<hi rend="italic">ille et. Vi superum saevae. Multa quoque et bello. Infer­
+							<lb/>reique deos. Albanique patres.</hi> Ne multa, persequere<lb/>
+						caeteros quantum voles, has priores partes versuum<lb/>ejusdem dimensionis
+						invenies, id cst quinto semipede<lb/>articulatas a. Rarissime omnino si
+						non hoc ita cst;<lb/>ila ut posteriores sint istac non minus inter se
+						prriles:<lb/>
+						<hi rend="italic">Trojae qui</hi> primus <hi rend="italic">ab oris. Profugus
+							Lavinaque venit.<lb/>Terris jactatus et alto. Memorcm Junonis ob iram.
 							Pas-</hi>
 						<note type="footnote"><hi rend="italic">1 SubseQuitur ac</hi> terminat,
 							juxta vatic. et lis. A. a. </note><note type="footnote"> * <hi
@@ -3943,279 +3943,279 @@
 								terminatas.</hi> )L </note>
 						<lb/>
 						<pb n="1149"/> sus <hi rend="italic">dum conderet</hi> urbem. <hi
-							rend="italic">Latio genus unde Latinum. <lb/> Atque altce mænia Romæ.
+							rend="italic">Latio genus unde Latinum.<lb/>Atque altce maenia Romae.
 							D.</hi> Manifestissimum est.</p>
-					</div><div type="textpart" subtype="dialog"><p>4. <hi rend="italic">M</hi> Quinque igitur et septem semipedes versum <lb/>
-						heroicum in duo membra partiuntur, quem sex pedi­ <lb/> bus quaternorum
-						temporum constare notissimum est1: <lb/> et sine concinnitate quidem duorum
-						membrorum, <lb/> sive ista, sive aliqua alia, versus nullus est. In qui­
-						<lb/> busomnibus hoc ratio demonstravit esse servandum, <lb/> ut non possit
-						pars prior in posteriore, et posterior in <lb/> priore loco poni. Qnod si
-						aliter fuerit, non jam ver­ <lb/> sus, nisi nominis abusione, dicetur : erit
-						autem <lb/> rhythmus et metrum , qualia rarissime longis carmi­ <lb/> nibus
-						interponere quæ versibus contexuntur, non in­ <lb/> decorum est : quale idem
-						ipsum est quod paulo ante <lb/> commemoravi : <hi rend="italic">Cornua
+					</div><div type="textpart" subtype="dialog"><p>4. <hi rend="italic">M</hi> Quinque igitur et septem semipedes versum<lb/>
+						heroicum in duo membra partiuntur, quem sex pedi­<lb/>bus quaternorum
+						temporum constare notissimum est1:<lb/>et sine concinnitate quidem duorum
+						membrorum,<lb/>sive ista, sive aliqua alia, versus nullus est. In qui­
+						<lb/>busomnibus hoc ratio demonstravit esse servandum,<lb/>ut non possit
+						pars prior in posteriore, et posterior in<lb/>priore loco poni. Qnod si
+						aliter fuerit, non jam ver­<lb/>sus, nisi nominis abusione, dicetur : erit
+						autem<lb/>rhythmus et metrum , qualia rarissime longis carmi­<lb/>nibus
+						interponere quae versibus contexuntur, non in­<lb/>decorum est : quale idem
+						ipsum est quod paulo ante<lb/>commemoravi : <hi rend="italic">Cornua
 							velatarum vertimus antennarum.</hi>
-						<lb/> Quamobrem non mihi versus ex eo appellatus videtur, <lb/> ut nonnulli
-						putant, quod a certo fine ad ejusdem nu­ <lb/> meri caput reditur, ut nomen
-						ductum sit ab i s qui se <lb/> vertunt dum via redeunt; nam hoc illi cum bis
-						etiam <lb/> metris, quæ versus non sunt, apparet esse commune: <lb/> scd
-						magis fortasse a contrario nomen invenit, lit <lb/> quemadmodum grammatici
-						deponens verbum quod r <lb/> litteram nou deponit, sicuti est, lucror, et,
+						<lb/>Quamobrem non mihi versus ex eo appellatus videtur,<lb/>ut nonnulli
+						putant, quod a certo fine ad ejusdem nu­<lb/>meri caput reditur, ut nomen
+						ductum sit ab i s qui se<lb/>vertunt dum via redeunt; nam hoc illi cum bis
+						etiam<lb/>metris, quae versus non sunt, apparet esse commune:<lb/>scd
+						magis fortasse a contrario nomen invenit, lit<lb/>quemadmodum grammatici
+						deponens verbum quod r<lb/>litteram nou deponit, sicuti est, lucror, et,
 							<hi rend="italic">conqueror,</hi>
-						<lb/> appellaverunt; ita quod duobus membris confit, quo­ <lb/> rum neutrum
-						in alterius loco salva lege numerorum <lb/> constituitur , quia verti non
-						potest, versus vocetur. <lb/> Sed utramlibet harum origincm vocabuli tu
-						licet pro­ <lb/> bes, vel utramque improbes, et aliam quæras, aut <lb/>
-						contemnas mecum tutum hoc quæstionis genus; nihil <lb/> ad boc tempus
-						pertinet. Cum enim satis res ipsa <lb/> quæ hoc nomine significatur,
-						appareat, non est de <lb/> verbi stirpc laborandum. Nisi quid habes ad bac.
-						<lb/> D. Ego vero nihil, sed perge ad cætera.</p>
+						<lb/>appellaverunt; ita quod duobus membris confit, quo­<lb/>rum neutrum
+						in alterius loco salva lege numerorum<lb/>constituitur , quia verti non
+						potest, versus vocetur.<lb/>Sed utramlibet harum origincm vocabuli tu
+						licet pro­<lb/>bes, vel utramque improbes, et aliam quaeras, aut<lb/>
+						contemnas mecum tutum hoc quaestionis genus; nihil<lb/>ad boc tempus
+						pertinet. Cum enim satis res ipsa<lb/>quae hoc nomine significatur,
+						appareat, non est de<lb/>verbi stirpc laborandum. Nisi quid habes ad bac.
+						<lb/>D. Ego vero nihil, sed perge ad caetera.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT IV. — <hi rend="italic">Terminus versuum
 								varius.</hi>
 						</title>
 					</ab>
-					<div type="textpart" subtype="dialog"><p>5. <hi rend="italic">II.</hi> Sequitur ut de versus termino requiramus. <lb/>
-						Nam et hunc aliqua differentia noUtum atque insigni­ <lb/> tum esse
-						voluernut, vel potius ipsa ratio. An tu not <lb/> arbitraris melius esse ut
-						finis, quo provolutio numen <lb/> coercetur, non perturbata temporum
-						aequalitate, ta­ <lb/> men I cmineal; quam si cum cxteris par:ibus quae
-						<lb/> finem non faciunt, confundatur? D. Quis dubitat hoc <lb/> esse melius,
-						quod est evidentius? M. Considera ergo, <lb/> utrum recte insignem linem
-						versus heroici spondeum <lb/> pedem quidam esse voluerint. Nam in quinque
-						aliis <lb/> locis vel hunc vel dactylum licet ponere; ; in line au­ <lb/>
-						tem non nisi spondeum; nam quod trochaeum putant, <lb/> propter
-						indifferentiam fit ultimæ syllabæ, de qua in <lb/> metris satis locuti
-						sumus. Sed secundum hos iambi­ <lb/> cus- scnarius aut non erit versus, aut
-						erit sinc isla <lb/> finis eminentia ; utrumque autem absurdum est. Nam
-						<lb/> neque quisquam unquam , sive doctissimorum homi­ <lb/> num, sive
-						mediocriter, vel etiam tenuiter eruditorum <lb/> versum esse dubitavit, <hi
-							rend="italic">Phaselus ille quem videtis</hi> ho­ <lb/> spite. <hi
+					<div type="textpart" subtype="dialog"><p>5. <hi rend="italic">II.</hi> Sequitur ut de versus termino requiramus.<lb/>
+						Nam et hunc aliqua differentia noUtum atque insigni­<lb/>tum esse
+						voluernut, vel potius ipsa ratio. An tu not<lb/>arbitraris melius esse ut
+						finis, quo provolutio numen<lb/>coercetur, non perturbata temporum
+						aequalitate, ta­<lb/>men I cmineal; quam si cum cxteris par:ibus quae
+						<lb/>finem non faciunt, confundatur? D. Quis dubitat hoc<lb/>esse melius,
+						quod est evidentius? M. Considera ergo,<lb/>utrum recte insignem linem
+						versus heroici spondeum<lb/>pedem quidam esse voluerint. Nam in quinque
+						aliis<lb/>locis vel hunc vel dactylum licet ponere; ; in line au­<lb/>
+						tem non nisi spondeum; nam quod trochaeum putant,<lb/>propter
+						indifferentiam fit ultimae syllabae, de qua in<lb/>metris satis locuti
+						sumus. Sed secundum hos iambi­<lb/>cus- scnarius aut non erit versus, aut
+						erit sinc isla<lb/>finis eminentia ; utrumque autem absurdum est. Nam
+						<lb/>neque quisquam unquam , sive doctissimorum homi­<lb/>num, sive
+						mediocriter, vel etiam tenuiter eruditorum<lb/>versum esse dubitavit, <hi
+							rend="italic">Phaselus ille quem videtis</hi> ho­<lb/>spite. <hi
 							rend="italic">(Catullus);</hi> ct quidquid in verbis est tali nume­
-						<lb/> rositate formatum : et gravissimi auctores eo quo pe­ <lb/> ritissimi,
-						nullum sine insigni fine versum pntandum <lb/> esse censuerunt. <note
+						<lb/>rositate formatum : et gravissimi auctores eo quo pe­<lb/>ritissimi,
+						nullum sine insigni fine versum pntandum<lb/>esse censuerunt. <note
 							type="footnote"> • sEquissimum <hi rend="italic">at,</hi> juxta vatic.
 							II. </note><note type="footnote"> ' Tunc, juxta vttic. M. </note>
 					</p>
-					</div><div type="textpart" subtype="dialog"><p>6. D. Verum dicis. Quare aliam termini hujus <lb/> notam quærendam esse
-						autumo, non hanc quas in <lb/> spondeo ponitur approbandam. <hi
-							rend="italic">M.</hi> Quid hoc? num <lb/> dubitas, quæcumque ista sit,
-						ant in pedis esse, <lb/> aut in temporis differentia, aut in utroque? D. Qui
-						<lb/> aliter potest? M. Quid tandem horum trium pro­ <lb/> bas? Ego enim,
-						quoniam idipsum finire versum <lb/> ne longins quam oportet excurrat, non
-						pertinet <lb/> nisi ad temporis modum; non arbitror aliunde istam <lb/>
-						notam debcre sumi quam ex tempore. An tibi aliud <lb/> placet? D. Imo
-						assentior. <hi rend="italic">M.</hi> Videsne etiam illud, <lb/> cum tempus
-						hic differentiam babere non possit, nisi <lb/> quod aliud cst longius, aliud
-						brevias; quia cum ver­ <lb/> sus finitur , id agitur ne pergat longius , in
-						breviore <lb/> tempore notam finis esse oportere? <hi rend="italic">D.</hi>
-						Video quidem : <lb/> sed quo pertinet quod additum est, Hic? M. Eo sci­
-						<lb/> licet quod non ubique temporis differentiam in sola <lb/> brevitate ac
-						longitudine accipimus. An tu æstatis ac <lb/> hiemis differentiam, aut esse
-						temporis ncgas, aut in <lb/> spatio potius breviore vel longiore, ac non in
-						vi fri­ <lb/> goris calorisque constituis, vel humoris et siccitatis1, <lb/>
+					</div><div type="textpart" subtype="dialog"><p>6. D. Verum dicis. Quare aliam termini hujus<lb/>notam quaerendam esse
+						autumo, non hanc quas in<lb/>spondeo ponitur approbandam. <hi
+							rend="italic">M.</hi> Quid hoc? num<lb/>dubitas, quaecumque ista sit,
+						ant in pedis esse,<lb/>aut in temporis differentia, aut in utroque? D. Qui
+						<lb/>aliter potest? M. Quid tandem horum trium pro­<lb/>bas? Ego enim,
+						quoniam idipsum finire versum<lb/>ne longins quam oportet excurrat, non
+						pertinet<lb/>nisi ad temporis modum; non arbitror aliunde istam<lb/>
+						notam debcre sumi quam ex tempore. An tibi aliud<lb/>placet? D. Imo
+						assentior. <hi rend="italic">M.</hi> Videsne etiam illud,<lb/>cum tempus
+						hic differentiam babere non possit, nisi<lb/>quod aliud cst longius, aliud
+						brevias; quia cum ver­<lb/>sus finitur , id agitur ne pergat longius , in
+						breviore<lb/>tempore notam finis esse oportere? <hi rend="italic">D.</hi>
+						Video quidem :<lb/>sed quo pertinet quod additum est, Hic? M. Eo sci­
+						<lb/>licet quod non ubique temporis differentiam in sola<lb/>brevitate ac
+						longitudine accipimus. An tu aestatis ac<lb/>hiemis differentiam, aut esse
+						temporis ncgas, aut in<lb/>spatio potius breviore vel longiore, ac non in
+						vi fri­<lb/>goris calorisque constituis, vel humoris et siccitatis1,<lb/>
 						ct si quid tale aliud? <hi rend="italic">D.</hi> Jam intelligo, et hanc quam
-						<lb/> quærimus termini notam, a temporis brevitate ducen­ <lb/> dam esse
+						<lb/>quaerimus termini notam, a temporis brevitate ducen­<lb/>dam esse
 						consentio.</p>
-					</div><div type="textpart" subtype="dialog"><p>7. M. Attende igitur hunc versum, <hi rend="italic">Roma, Roma, <lb/> cerne
-							quanta sit deum benignitas,</hi> qui trochaicus dici­ <lb/> tur, et
-						metire illum, atque responde quod inveneris <lb/> de membris ejus et numcro
-						pedum. D. De pedibus <lb/> qnidem facile responderim : liquet enim eos
-						septem <lb/> et semis esse. De membris autem non satis aperta <lb/> res est;
-						multis enim locis partem orationis liniri vi­ <lb/> deo : verumtamen opinor
-						esse istam partitionem in <lb/> octavo semipede, ut præcedens membrum sit,
-						Roma, <lb/>
+					</div><div type="textpart" subtype="dialog"><p>7. M. Attende igitur hunc versum, <hi rend="italic">Roma, Roma,<lb/>cerne
+							quanta sit deum benignitas,</hi> qui trochaicus dici­<lb/>tur, et
+						metire illum, atque responde quod inveneris<lb/>de membris ejus et numcro
+						pedum. D. De pedibus<lb/>qnidem facile responderim : liquet enim eos
+						septem<lb/>et semis esse. De membris autem non satis aperta<lb/>res est;
+						multis enim locis partem orationis liniri vi­<lb/>deo : verumtamen opinor
+						esse istam partitionem in<lb/>octavo semipede, ut praecedens membrum sit,
+						Roma,<lb/>
 						<hi rend="italic">Roma, cerne quanta;</hi> subsequens autem; <hi
 							rend="italic">sit deum beni­</hi>
-						<lb/> gnitas. <hi rend="italic">II.</hi> Quot semi pedes habet! <hi
+						<lb/>gnitas. <hi rend="italic">II.</hi> Quot semi pedes habet! <hi
 							rend="italic">D.</hi> Septem. <hi rend="italic">M.</hi>
-						<lb/> Ipsa ratio te duxit omnino. Cum enim nihil sit aqua­ <lb/> litate
-						melius, caroque in dividendo appetere oporteat; <lb/> si minus potuerit
-						obtineri, vicinitas ejus quærenda est, <lb/> ne ab ea longius aberremus.
-						Itaque cum hic versus <lb/> omnes quindecim semipedes habcat, non potuit
-						<lb/> æquius quam in octo et septem dividi: nam cadem <lb/> est in septem et
-						octo vicinitas. Sed ita non servaretur <lb/> nota finis in tempore breviore,
-						ut eam servandam ra­ <lb/> tio ipsa præcipit : nam si talis versus esset,
+						<lb/>Ipsa ratio te duxit omnino. Cum enim nihil sit aqua­<lb/>litate
+						melius, caroque in dividendo appetere oporteat;<lb/>si minus potuerit
+						obtineri, vicinitas ejus quaerenda est,<lb/>ne ab ea longius aberremus.
+						Itaque cum hic versus<lb/>omnes quindecim semipedes habcat, non potuit
+						<lb/>aequius quam in octo et septem dividi: nam cadem<lb/>est in septem et
+						octo vicinitas. Sed ita non servaretur<lb/>nota finis in tempore breviore,
+						ut eam servandam ra­<lb/>tio ipsa praecipit : nam si talis versus esset,
 							<hi rend="italic">Roma</hi>
-						<lb/> cerne <hi rend="italic">quanta</hi> sit <hi rend="italic">tibi deum
-							benignitas,</hi> ut inciperet <lb/> membrum in his semipedibus septem ,
-							<hi rend="italic">Roma cerne<lb/> quanta sit,</hi> et in his octo
-						alterum terminaretur, <hi rend="italic">tibi <lb/> deum benignitas;</hi> non
-						posset versum semipes claudere: <lb/> octo enim scmipcdes quatuor integros
-						pedes faciunt. <lb/> Simul incideret alia deformitas, ut non eosdem pedes
-						<lb/> in membro extremo quos in primo metiremur, et <lb/> prius membrum
-						potius finirctur nota brevioris tempo­ <lb/> ris, id est semipede, quam
-						posterius, cui hoc finis <lb/> jure debetur. Nam in illo tres trochæi semis,
-							<hi rend="italic">Roma<lb/> cerne quanta sit:</hi> in hoc quatuor iambi
-						scanderentur, <lb/>
-						<hi rend="italic">tibi deum</hi> benignitas. Nunc vero et trochæos in
-						utroque <lb/> membro scandimus, et semipede versus clauditur, ut <lb/>
+						<lb/>cerne <hi rend="italic">quanta</hi> sit <hi rend="italic">tibi deum
+							benignitas,</hi> ut inciperet<lb/>membrum in his semipedibus septem ,
+							<hi rend="italic">Roma cerne<lb/>quanta sit,</hi> et in his octo
+						alterum terminaretur, <hi rend="italic">tibi<lb/>deum benignitas;</hi> non
+						posset versum semipes claudere:<lb/>octo enim scmipcdes quatuor integros
+						pedes faciunt.<lb/>Simul incideret alia deformitas, ut non eosdem pedes
+						<lb/>in membro extremo quos in primo metiremur, et<lb/>prius membrum
+						potius finirctur nota brevioris tempo­<lb/>ris, id est semipede, quam
+						posterius, cui hoc finis<lb/>jure debetur. Nam in illo tres trochaei semis,
+							<hi rend="italic">Roma<lb/>cerne quanta sit:</hi> in hoc quatuor iambi
+						scanderentur,<lb/>
+						<hi rend="italic">tibi deum</hi> benignitas. Nunc vero et trochaeos in
+						utroque<lb/>membro scandimus, et semipede versus clauditur, ut<lb/>
 						spatii brevioris notam terminus teneat. Nam sunt in <note type="footnote">1
 							in B., ,<hi rend="italic">vel siccitatis.</hi> Rectius ex Ms. A, et
 							siecttaUs. II. </note>
 						<lb/>
 						<pb n="1151"/> priore quatuor, <hi rend="italic">Roma,</hi> Roma <hi
-							rend="italic">cerne quanta;</hi> iu posteriore <lb/> autem tres semis,
-							<hi rend="italic">sit deum</hi> benignitas. An contradicere <lb/>
+							rend="italic">cerne quanta;</hi> iu posteriore<lb/>autem tres semis,
+							<hi rend="italic">sit deum</hi> benignitas. An contradicere<lb/>
 						aliquid paras? <hi rend="italic">D.</hi> Nihil omnino, et libenter
 						assentior.</p>
-					</div><div type="textpart" subtype="dialog"><p>8. <hi rend="italic">M.</hi> Teneamus igitur has leges inconcussas, si <lb/>
-						placet, ut neque membrorum duorum tendens ad <lb/> aequalitatem partitio
-						versui desit, sicuti huic deest, <lb/>
+					</div><div type="textpart" subtype="dialog"><p>8. <hi rend="italic">M.</hi> Teneamus igitur has leges inconcussas, si<lb/>
+						placet, ut neque membrorum duorum tendens ad<lb/>aequalitatem partitio
+						versui desit, sicuti huic deest,<lb/>
 						<hi rend="italic">Cornua velatarum obvertimus antennarum.</hi> Neque ipsa
-						<lb/> æqualitas membrorum conversibilem , ut ita dicam, <lb/> faciat
-						partitionem, ut in hoc facit, <hi rend="italic">Cornua velaturum <lb/>
-							vertimus antennarum.</hi> Neque cum ista vitatur conver­ <lb/> sio,
-						nimis a se membra discedant, sed quantum. pos­ <lb/> sunt proximis numeris
-						prope aequentur, ne dicamus <lb/> haec ita posse dividi, ut octo semipedes
-						præcedant, <lb/>
+						<lb/>aequalitas membrorum conversibilem , ut ita dicam,<lb/>faciat
+						partitionem, ut in hoc facit, <hi rend="italic">Cornua velaturum<lb/>
+							vertimus antennarum.</hi> Neque cum ista vitatur conver­<lb/>sio,
+						nimis a se membra discedant, sed quantum. pos­<lb/>sunt proximis numeris
+						prope aequentur, ne dicamus<lb/>haec ita posse dividi, ut octo semipedes
+						praecedant,<lb/>
 						<hi rend="italic">Cornua velatarum vertimus;</hi> et quatuor subsequantur,
-						<lb/> id est, <hi rend="italic">antennarum.</hi> Nec membrum posterius p
-						iris nu­ <lb/> meri semipedes habeat, sicuti est, <hi rend="italic">tibi
+						<lb/>id est, <hi rend="italic">antennarum.</hi> Nec membrum posterius p
+						iris nu­<lb/>meri semipedes habeat, sicuti est, <hi rend="italic">tibi
 							deum benignitas,</hi>
-						<lb/> ne pleno pede versus finitus non babeat terminum bre­ <lb/> viore
-						tempore notatum. <hi rend="italic">D.</hi> Habeo jam ista, et mando <lb/>
+						<lb/>ne pleno pede versus finitus non babeat terminum bre­<lb/>viore
+						tempore notatum. <hi rend="italic">D.</hi> Habeo jam ista, et mando<lb/>
 						memoriae quantum valeo.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT V. — <hi rend="italic">Heroici</hi> finis.</title>
 					</ab>
 					<div type="textpart" subtype="dialog"><p>9. <hi rend="italic">M.</hi> Quoniam igitur jam tenemus, non debere ver­
-						<lb/> sum Gniri pleno pede, quomodo nobis heroicum ver­ <lb/> sum metiendum
-						putas, ut ct membrorum lex illa ser­ <lb/> vetnr, et hæc termini nota ? <hi
-							rend="italic">D.</hi> Video duodecim esse <lb/> semipedes; et quia
-						propter illam conversionem vi­ <lb/> tandam senos semipedes habere membra
-						non possunt; <lb/> neque a se longe oportet discedere ut sint tres et no­
-						<lb/> vem, aut novem et tres ; neque paris numeri semipe­ <lb/> des
-						posteriori membro dandi sunt ut sint octo et <lb/> quatuor, aut quatuor et
-						octo, ne pleno pede versus <lb/> liniatur : in quinque ct septem, aut septem
-						et quinque <lb/> divisio facienda est. Nam et hi numeri sunt ambo im­ <lb/>
-						pares proximi, et certe propinquius sibi accedunt <lb/> membra quam in
-						quaternario et octonario numeris <lb/> accederent. Quod ut firmissimum
-						teneam , video par­ <lb/> tem orationis in quinto semipede semper aut pene
-						<lb/> semper terminari, ut est in primo Virgilii versu, <lb/> Arma <hi
+						<lb/>sum Gniri pleno pede, quomodo nobis heroicum ver­<lb/>sum metiendum
+						putas, ut ct membrorum lex illa ser­<lb/>vetnr, et haec termini nota ? <hi
+							rend="italic">D.</hi> Video duodecim esse<lb/>semipedes; et quia
+						propter illam conversionem vi­<lb/>tandam senos semipedes habere membra
+						non possunt;<lb/>neque a se longe oportet discedere ut sint tres et no­
+						<lb/>vem, aut novem et tres ; neque paris numeri semipe­<lb/>des
+						posteriori membro dandi sunt ut sint octo et<lb/>quatuor, aut quatuor et
+						octo, ne pleno pede versus<lb/>liniatur : in quinque ct septem, aut septem
+						et quinque<lb/>divisio facienda est. Nam et hi numeri sunt ambo im­<lb/>
+						pares proximi, et certe propinquius sibi accedunt<lb/>membra quam in
+						quaternario et octonario numeris<lb/>accederent. Quod ut firmissimum
+						teneam , video par­<lb/>tem orationis in quinto semipede semper aut pene
+						<lb/>semper terminari, ut est in primo Virgilii versu,<lb/>Arma <hi
 							rend="italic">virumque cano</hi> : et. in secundo, <hi rend="italic"
-							>Italiam fato</hi> : et <lb/> in tertio, <hi rend="italic">Littora</hi>
+							>Italiam fato</hi> : et<lb/>in tertio, <hi rend="italic">Littora</hi>
 						multum <hi rend="italic">ille et :</hi> in quarto item, <hi rend="italic"
-							>Vi<lb/> superum sævæ</hi> : atque ita deinceps in toto pene car­ <lb/>
-						mine. M. Verum dicis : sed videndum tibi est, quos 1 <lb/> pedes metiaris,
-						ut nihil superiorum legum jam in­ <lb/> concusse coatstitutarum violare
-						audeas. <hi rend="italic">D.</hi> Quanquam <lb/> niihi satis ratio appareat,
-						tamen novitate conturbor. <lb/> Nen enim solemus in hoc gencre nisi spondeum
-						pc­ <lb/> dem et dactylum scandere, quod nemo fere cst tam <lb/> indoctus
-						quin 2 audierit , ctiamsi minus id facere pos­ <lb/> sit. Hanc ergo
-						pervulgatissimam consuetudinem, nunc <lb/> si sequi voluero, lex illa
-						termini est abrogand ia; præ­ <lb/> cedens enim membrum semipede
-						clauderetur, poste­ <lb/> rius autem pleno pede; quod contra esse debuit.
-						Sed <lb/> quia illum legein iniquissimum est tollere, et in nu­ <lb/> meris
-						jam didici posse fieri, ut a non pleno pedc or­ <lb/> diamur 4; restat ut
-						non hic dactylum cum spondeo, <lb/> sed anapæstum locari judicemus; ut
-						incipiat varsus a <lb/> longa una syllaba, deinde duo pedes vel spondci vel
+							>Vi<lb/>superum saevae</hi> : atque ita deinceps in toto pene car­<lb/>
+						mine. M. Verum dicis : sed videndum tibi est, quos 1<lb/>pedes metiaris,
+						ut nihil superiorum legum jam in­<lb/>concusse coatstitutarum violare
+						audeas. <hi rend="italic">D.</hi> Quanquam<lb/>niihi satis ratio appareat,
+						tamen novitate conturbor.<lb/>Nen enim solemus in hoc gencre nisi spondeum
+						pc­<lb/>dem et dactylum scandere, quod nemo fere cst tam<lb/>indoctus
+						quin 2 audierit , ctiamsi minus id facere pos­<lb/>sit. Hanc ergo
+						pervulgatissimam consuetudinem, nunc<lb/>si sequi voluero, lex illa
+						termini est abrogand ia; prae­<lb/>cedens enim membrum semipede
+						clauderetur, poste­<lb/>rius autem pleno pede; quod contra esse debuit.
+						Sed<lb/>quia illum legein iniquissimum est tollere, et in nu­<lb/>meris
+						jam didici posse fieri, ut a non pleno pedc or­<lb/>diamur 4; restat ut
+						non hic dactylum cum spondeo,<lb/>sed anapaestum locari judicemus; ut
+						incipiat varsus a<lb/>longa una syllaba, deinde duo pedes vel spondci vel
 							<note type="footnote"> 1 <hi rend="italic">Qttos,</hi> juxta vatic. M.
 							</note><note type="footnote"> I Qui <hi rend="italic">ROn,</hi> juxia
 							vatic. M. </note><note type="footnote"> * sic Vatic. : <hi rend="italic"
 								>Lex Ula terminata est abroganda.</hi> M. </note><note
 							type="footnote">4 sic ex 'atie. In B., <hi rend="italic">non a pleno
 								pede ordiamur.</hi> M. </note>
-						<lb/> anapæsti vel altemi1 membrum superius terminent <lb/> tum I tres
-						rursus alterum vel anapaesti vel quolibet. <lb/> loco spondeus , sive
-						omnibus, et in fnc una syllaba, <lb/> qua versus legitime terminatur.
+						<lb/>anapaesti vel altemi1 membrum superius terminent<lb/>tum I tres
+						rursus alterum vel anapaesti vel quolibet.<lb/>loco spondeus , sive
+						omnibus, et in fnc una syllaba,<lb/>qua versus legitime terminatur.
 						Probasne et id?</p>
-					</div><div type="textpart" subtype="dialog"><p>10. <hi rend="italic">M.</hi> Ego quoquc rectissimum esse judlco, sed <lb/>
-						non facile ista populo persuadentur. Tanta cnim est <lb/> vis consueludinis
-						, ut ca inveterata , si falsa opinione <lb/> gcnita est, nihil sit inimicius
-						veritati. Namque ad fa­ <lb/> ciendum versum nihil interesse intelligis,
-						utruin in <lb/> hoc genere anapæstus cum spondeo, an d ctylus col­ <lb/>
-						locetur : ad metiendum tamen rationabiliter I, quod <lb/> non aurium sed
-						mentis est proprium, vcra et certa ra­ <lb/> tione hoc, non irrationabili
-						opinione discernitur4: nc­ <lb/> que nunc a nobis primum inventa est, sed
-						multo c t <lb/> hac inveterata consuetudine antiquius animadversa 3, <lb/>
-						Quare si eos legant qui vel in greca vel in latina lin­ <lb/> gua
-						disciplinæhujus doctissimi fucrunt, non mira­ <lb/> buntur nimis qui forte
-						hoc audierint: quanquam pu­ <lb/> det imbecillitatis, cum rationi roborandæ
-						hominum <lb/> auctoritasquneritur, cum ipsius rationis ac veritatis an­
-						<lb/> ctoritate, quæ profecto est omni homine melior, nihil <lb/> deberet
-						esse præstantius. Non cnim ut in producenda <lb/> corripiendave syllaba non
-						nisi auctoritatem veterum <lb/> hon.inum quærimus, ut quemadmodum suntisi
-						verbis <lb/> quibus nos quoque loquimur, ita et nnsutamur; quia in <lb/>
-						hujuscemodi re et nullam observationem sequi disidiae <lb/> est, et novam
-						instituere licentiæ : ita in metiendo versu <lb/> inveterata voluntas
-						hominum, ac non æterna rerum <lb/> ratio cogitanda est, cum et modcratam
-						ejus longitudi­ <lb/> nem prius naturaliter aure sentiamus, dcinde appro­
-						<lb/> bemus rationabili consideratione numerorum, et eum <lb/> insigni fine
-						claudendum esse judiccl quisquis judicat <lb/> certius eum quam cætera metra
-						esse finiendum, eum­ <lb/> que finem in breviore tempore notandum esse
-						manife­ <lb/> stum sit; siquidem temporis longitudinem coercet et <lb/>
+					</div><div type="textpart" subtype="dialog"><p>10. <hi rend="italic">M.</hi> Ego quoquc rectissimum esse judlco, sed<lb/>
+						non facile ista populo persuadentur. Tanta cnim est<lb/>vis consueludinis
+						, ut ca inveterata , si falsa opinione<lb/>gcnita est, nihil sit inimicius
+						veritati. Namque ad fa­<lb/>ciendum versum nihil interesse intelligis,
+						utruin in<lb/>hoc genere anapaestus cum spondeo, an d ctylus col­<lb/>
+						locetur : ad metiendum tamen rationabiliter I, quod<lb/>non aurium sed
+						mentis est proprium, vcra et certa ra­<lb/>tione hoc, non irrationabili
+						opinione discernitur4: nc­<lb/>que nunc a nobis primum inventa est, sed
+						multo c t<lb/>hac inveterata consuetudine antiquius animadversa 3,<lb/>
+						Quare si eos legant qui vel in greca vel in latina lin­<lb/>gua
+						disciplinaehujus doctissimi fucrunt, non mira­<lb/>buntur nimis qui forte
+						hoc audierint: quanquam pu­<lb/>det imbecillitatis, cum rationi roborandae
+						hominum<lb/>auctoritasquneritur, cum ipsius rationis ac veritatis an­
+						<lb/>ctoritate, quae profecto est omni homine melior, nihil<lb/>deberet
+						esse praestantius. Non cnim ut in producenda<lb/>corripiendave syllaba non
+						nisi auctoritatem veterum<lb/>hon.inum quaerimus, ut quemadmodum suntisi
+						verbis<lb/>quibus nos quoque loquimur, ita et nnsutamur; quia in<lb/>
+						hujuscemodi re et nullam observationem sequi disidiae<lb/>est, et novam
+						instituere licentiae : ita in metiendo versu<lb/>inveterata voluntas
+						hominum, ac non aeterna rerum<lb/>ratio cogitanda est, cum et modcratam
+						ejus longitudi­<lb/>nem prius naturaliter aure sentiamus, dcinde appro­
+						<lb/>bemus rationabili consideratione numerorum, et eum<lb/>insigni fine
+						claudendum esse judiccl quisquis judicat<lb/>certius eum quam caetera metra
+						esse finiendum, eum­<lb/>que finem in breviore tempore notandum esse
+						manife­<lb/>stum sit; siquidem temporis longitudinem coercet et<lb/>
 						frenat quodammodo.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT VI. — <hi rend="italic">Rursus de fine versus.</hi>
 						</title>
 					</ab>
-					<div type="textpart" subtype="dialog"><p>11. Quæ cum ita sint, qui potest posterius ejus mem­ <lb/> brum nisi non
-						pleno terminari pede? Prioris autem <lb/> membri exordium aut plenum pedem
-						esse, ut in ilio <lb/> trochaico, <hi rend="italic">Roma,</hi> Roma, <hi
-							rend="italic">cerne quanta sit deum benigni­<lb/> tas;</hi> aut partem
-						pedis oportet, ut in heroico, <hi rend="italic">Arma</hi> vi­ <lb/>
+					<div type="textpart" subtype="dialog"><p>11. Quae cum ita sint, qui potest posterius ejus mem­<lb/>brum nisi non
+						pleno terminari pede? Prioris autem<lb/>membri exordium aut plenum pedem
+						esse, ut in ilio<lb/>trochaico, <hi rend="italic">Roma,</hi> Roma, <hi
+							rend="italic">cerne quanta sit deum benigni­<lb/>tas;</hi> aut partem
+						pedis oportet, ut in heroico, <hi rend="italic">Arma</hi> vi­<lb/>
 						<hi rend="italic">rumque cano, Trojx qui primus ab oris.</hi> Quapropter,
-						<lb/> omni jam dubitatione sublata, etiam istum versum <lb/> metire, si
-						placet, et mihi de membris ejus pedibusque <lb/> responde, <hi rend="italic"
-							>Phaselus ille quem adetis, hospitcs. D.</hi> Mem­ <lb/> braquidem hujus
-						in quinque et septem scmipedes vi­ <lb/> deo distributa, ut prius sit, <hi
-							rend="italic">Phaselus ille;</hi> posterius <lb/> autem, <hi
+						<lb/>omni jam dubitatione sublata, etiam istum versum<lb/>metire, si
+						placet, et mihi de membris ejus pedibusque<lb/>responde, <hi rend="italic"
+							>Phaselus ille quem adetis, hospitcs. D.</hi> Mem­<lb/>braquidem hujus
+						in quinque et septem scmipedes vi­<lb/>deo distributa, ut prius sit, <hi
+							rend="italic">Phaselus ille;</hi> posterius<lb/>autem, <hi
 							rend="italic">quem videtis, hospites:</hi> edes vero iambos cerno-</p>
 					<p><note type="footnote"> I sic ex vatic. et Ms. A. In B., <hi rend="italic">vel
-								anapcestiattenan mem-<lb/> Mum.</hi> M. </note><note type="footnote"
+								anapcestiattenan mem<lb/>Mum.</hi> M. </note><note type="footnote"
 							> I In a., <hi rend="italic">cum.</hi> vatic., <hi rend="italic"
 								>dum.</hi> Dis, A, <hi rend="italic">tum.</hi> M. </note><note
 							type="footnote"> 8 <hi rend="italic">Rationaliter,</hi> juxta vatic. M.
 							</note><note type="footnote"> * Mss. veteres sic babent: <hi
-								rend="italic">rropvium, twiii.tm, quantam<lb/> hæc ratio ab illa
-								opiniane dUcernitur.</hi> — Juxta vatic. : .Y;­ <lb/>
+								rend="italic">rropvium, twiii.tm, quantam<lb/>haec ratio ab illa
+								opiniane dUcernitur.</hi> — Juxta vatic. : .Y;­<lb/>
 							<hi rend="italic">mium lucc ratio ab illa opinione discewitur.</hi> M.
 							</note><note type="footnote"> I sic vatic. : <hi rend="italic">sed multo
-								hæc est <foreign xml:lang="grc">ι</foreign>nverata comuetudine<lb/>
+								haec est <foreign xml:lang="grc">ι</foreign>nverata comuetudine<lb/>
 								antiquis animadversa.</hi> M. </note><note type="footnote"> 6 Lov.:
 								<hi rend="italic">Qvisquti judicat certius: eumque quam c(etera</hi>
-							me­ <lb/>
+							me­<lb/>
 							<hi rend="italic">tra esse insigniter fmendum, qui finem</hi> fiahct in
 								<hi rend="italic">breviore</hi>
-							<lb/> temporum notarum <hi rend="italic">tnanifeslum : siqmdem,</hi>
-							etc. Ita quoque <lb/> cditiones aliæ, nisi quod hahet Am., <hi
+							<lb/>temporum notarum <hi rend="italic">tnanifeslum : siqmdem,</hi>
+							etc. Ita quoque<lb/>cditiones aliae, nisi quod hahet Am., <hi
 								rend="italic">notatum manifestum fit;</hi>
-							<lb/> Er., <hi rend="italic">notartwi manifestum sit.</hi> sed pricstal
-							Mss. leclio quam. <lb/> huc revocavimus. </note>
-						<pb n="1153"/> M. Quali o, nihilne caves pede pleno versum terminare? <lb/>
-						D. Verum dicis, et ubi fuerim nescio. Quis enim non <lb/> videret sicut in
-						heroico exordiendum esse a semi pede ? <lb/> quod cum in boc genere fit, non
-						jam iambis, sed trochaeis <lb/> versum metimur, ut eum legitime semipes
+							<lb/>Er., <hi rend="italic">notartwi manifestum sit.</hi> sed pricstal
+							Mss. leclio quam.<lb/>huc revocavimus. </note>
+						<pb n="1153"/> M. Quali o, nihilne caves pede pleno versum terminare?<lb/>
+						D. Verum dicis, et ubi fuerim nescio. Quis enim non<lb/>videret sicut in
+						heroico exordiendum esse a semi pede ?<lb/>quod cum in boc genere fit, non
+						jam iambis, sed trochaeis<lb/>versum metimur, ut eum legitime semipes
 						claudat.</p>
 					</div><div type="textpart" subtype="dialog"><p>12. <hi rend="italic">M.</hi> Ita est ut dicis : sed vide quid tibi de hoc
-						<lb/> respondendum putes, quem asclepiadæum vocant, <lb/>
-						<hi rend="italic">Mæcenas atavis edite regibus ( Norat, lib.</hi> i <hi
-							rend="italic">Carminum,<lb/> ode</hi> 1). Nam pars orationis in sexta
-						syllaba terminatur, <lb/> neque inconstanter, sed in omnibus fere hujus
-						gene­ <lb/> ris versibus. Itaque ejus primum est membrum, Mæ­ <lb/> cenas
-						atavis : secundum, <hi rend="italic">edite rrgibus,</hi> quod quanam <lb/>
-						ratione fiat dubitari potest. Si enim metiaris in hoc <lb/> pedes
-						quaternorum temporum, erunt quinque in <lb/> priore, in posteriore autem
-						membro quatuor semipe­ <lb/> des: lex autem vetat membrum posterius pari
-						nupero <lb/> constare semipedum, ne pleno pede versus termine­ <lb/> tur.
-						Restat ut pedes consideremus senorum tempo­ <lb/> rum, ex quo fit ut membrum
-						utrumque ternis semipe­ <lb/> dibus constet. Nam ut integro pede praecedens
-						mem­ <lb/> brum finiatur, a duabus longis incipiendum est : deinde <lb/>
-						totus choriambus versum dividit, ut sequente etiam <lb/> alio choriambo
-						membrum posterius inchoctur, clau­ <lb/> dente versum semipede in duabus
-						brevibus syllabis : <lb/> tot enim tempora cum spondeo in capite locato, im­
-						<lb/> plent sex temporum pedem. Nisi quid habes ad haec. <lb/>
+						<lb/>respondendum putes, quem asclepiadaeum vocant,<lb/>
+						<hi rend="italic">Maecenas atavis edite regibus ( Norat, lib.</hi> i <hi
+							rend="italic">Carminum,<lb/>ode</hi> 1). Nam pars orationis in sexta
+						syllaba terminatur,<lb/>neque inconstanter, sed in omnibus fere hujus
+						gene­<lb/>ris versibus. Itaque ejus primum est membrum, Mae­<lb/>cenas
+						atavis : secundum, <hi rend="italic">edite rrgibus,</hi> quod quanam<lb/>
+						ratione fiat dubitari potest. Si enim metiaris in hoc<lb/>pedes
+						quaternorum temporum, erunt quinque in<lb/>priore, in posteriore autem
+						membro quatuor semipe­<lb/>des: lex autem vetat membrum posterius pari
+						nupero<lb/>constare semipedum, ne pleno pede versus termine­<lb/>tur.
+						Restat ut pedes consideremus senorum tempo­<lb/>rum, ex quo fit ut membrum
+						utrumque ternis semipe­<lb/>dibus constet. Nam ut integro pede praecedens
+						mem­<lb/>brum finiatur, a duabus longis incipiendum est : deinde<lb/>
+						totus choriambus versum dividit, ut sequente etiam<lb/>alio choriambo
+						membrum posterius inchoctur, clau­<lb/>dente versum semipede in duabus
+						brevibus syllabis :<lb/>tot enim tempora cum spondeo in capite locato, im­
+						<lb/>plent sex temporum pedem. Nisi quid habes ad haec.<lb/>
 						<hi rend="italic">D.</hi> Nihil prorsus. <hi rend="italic">M.</hi> Placet
-						ergo, totidem semipedi­ <lb/> bus constare utrumque membrum. <hi
-							rend="italic">D.</hi> Cur non pla­ <lb/> ceat? Neque enim metucnda est
-						hic illa conversio, <lb/> quia posito posteriore membro in præcedentis loco,
-						<lb/> ila ut quod est primum, secundum fiat, non eadem lex <lb/> manebit
-						pedum. Quapropter nul'a causa est, cur idem <lb/> semipedum numerus in hoc
-						genere membris negetur; <lb/> cum sine ullo conversionis vitio parilitas
-						ista possit <lb/> teneri, finis etiam insignioris lege servata, cum versus
-						<lb/> non pleno pede terminatur, quod constantissime ser­ <lb/> vandum
+						ergo, totidem semipedi­<lb/>bus constare utrumque membrum. <hi
+							rend="italic">D.</hi> Cur non pla­<lb/>ceat? Neque enim metucnda est
+						hic illa conversio,<lb/>quia posito posteriore membro in praecedentis loco,
+						<lb/>ila ut quod est primum, secundum fiat, non eadem lex<lb/>manebit
+						pedum. Quapropter nul'a causa est, cur idem<lb/>semipedum numerus in hoc
+						genere membris negetur;<lb/>cum sine ullo conversionis vitio parilitas
+						ista possit<lb/>teneri, finis etiam insignioris lege servata, cum versus
+						<lb/>non pleno pede terminatur, quod constantissime ser­<lb/>vandum
 						est1.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT VII.<hi rend="italic">Quomodo semipedum imparilitas
@@ -4225,140 +4225,140 @@
 								et trium.</hi>
 						</title>
 					</ab>
-					<div type="textpart" subtype="dialog"><p>13. <hi rend="italic">M.</hi> Rem ipsam omnino vidisti : quare jam quo­ <lb/>
-						niam comperit ratio versuum esse duo ginera, unum <lb/> in quo idem numerus
-						semipedum, aliud in quo dispar <lb/> in membris sit; diligenter
-						consideremus, si placet, <lb/> quonam modo ista imparilitas semipedum ad
-						quam­ <lb/> dam parilitatem referatur, obscuriore aliquantum, sed <lb/> sane
-						I subtilissima ratione numerorum. Nam quæro <lb/> ex te, cum duo et tria
-						dicam , quot numeros dicam- <lb/> D. Duos scilicet. <hi rend="italic"
-							>M.</hi> Ergo et duo unus, et tria unus <lb/> est numerus; et quemlibet
-						alium dixerimus. <hi rend="italic">D.</hi> Iia <lb/> est. M. Nonne tibi ex
-						hoc videlur unum cum quolibet <lb/> numero non absurde posse conferri ?
-						Siquidem unum <lb/> duo esse non possemus dicere ; duo autem unum <lb/> esse
-						quodammodo : et itejn tria et quatuor unum <lb/> esse, non falso diri <hi
+					<div type="textpart" subtype="dialog"><p>13. <hi rend="italic">M.</hi> Rem ipsam omnino vidisti : quare jam quo­<lb/>
+						niam comperit ratio versuum esse duo ginera, unum<lb/>in quo idem numerus
+						semipedum, aliud in quo dispar<lb/>in membris sit; diligenter
+						consideremus, si placet,<lb/>quonam modo ista imparilitas semipedum ad
+						quam­<lb/>dam parilitatem referatur, obscuriore aliquantum, sed<lb/>sane
+						I subtilissima ratione numerorum. Nam quaero<lb/>ex te, cum duo et tria
+						dicam , quot numeros dicam<lb/>D. Duos scilicet. <hi rend="italic"
+							>M.</hi> Ergo et duo unus, et tria unus<lb/>est numerus; et quemlibet
+						alium dixerimus. <hi rend="italic">D.</hi> Iia<lb/>est. M. Nonne tibi ex
+						hoc videlur unum cum quolibet<lb/>numero non absurde posse conferri ?
+						Siquidem unum<lb/>duo esse non possemus dicere ; duo autem unum<lb/>esse
+						quodammodo : et itejn tria et quatuor unum<lb/>esse, non falso diri <hi
 							rend="italic">potest. D.</hi> Assentior. <hi rend="italic">M.</hi>
-						Attende <lb/> aliud : dic mibi, duo ter ducta, quid faciunt in summa? <note
+						Attende<lb/>aliud : dic mibi, duo ter ducta, quid faciunt in summa? <note
 							type="footnote"> I <hi rend="italic">servatidumesse perplacet,</hi>
 							jutta omnes Edd. et Me. A. M. </note><note type="footnote"> I <hi
 								rend="italic">Ttunen,</hi> juxta vatic. M. </note>
 						<lb/>
 						<hi rend="italic">D.</hi> Sex. <hi rend="italic">M.</hi> Num sex et tria
-						totidem sunt? D. Nullo <lb/> modo. <hi rend="italic">M.</hi> Nunc tria
-						quater ducas velim, summamque <lb/> respondeas. <hi rend="italic">D.</hi>
-						Duodecim. <hi rend="italic">M.</hi> Vides item duodecim <lb/> plures esse
-						quam quatuor. D. Et longe sane. <hi rend="italic">M.</hi> Jam <lb/> ne
-						immorer 1, figenda regula est : A duobus , et <lb/> deinceps quoslibet
-						numeros duos constitueris, minor <lb/> per majorem multiplicatus , eum
-						excedat necesse <lb/> est. <hi rend="italic">D.</hi> Quis hoc dubitaverit ?
-						Quid enim tam parvum <lb/> in plurali numero quam duo? quem tamen numerum
-						<lb/> si millies duxero, ita excedet mille, ut duplum fiat. <lb/> M. Verum
-						dicis : sed constitue unum, et quemlibet <lb/> deinde majorem numerum, et
-						quemadmodum in illis <lb/> faciebamus, minorem per majorem multiplica, num
-						<lb/> eodem modo major superabitur? <hi rend="italic">D.</hi> Non plane, sed
-						<lb/> majori minor æquabitur. Nam unum bis, duo; et unum <lb/> decies,
-						decem; et unum millies, mille; et per quemlibet <lb/> aliurn numerum
-						multiplicavero, un am neresse est æque <lb/> tur. <hi rend="italic">II.</hi>
-						Habet ergo unum cum cæteris numeris jus <lb/> quoddam æqualitatis; non modo
-						quod quicumque' <lb/> numerus est, sed etiam quod toties ductus tantumdem
-						<lb/> facit. <hi rend="italic">D.</hi> Manifestissimum est.</p>
-					</div><div type="textpart" subtype="dialog"><p>14. <hi rend="italic">M.</hi> Age nunc, refer animum ad semipedum <lb/>
-						numeros, quibus in versu fiunt membra inæqualia, et <lb/> miram quamdam
-						æqualitatem ista quam tractavimus <lb/> ratione reperies. Nam, uL opinor,
-						versus minimus <lb/> inæquali semipedum numero in membris est duobus, <lb/>
+						totidem sunt? D. Nullo<lb/>modo. <hi rend="italic">M.</hi> Nunc tria
+						quater ducas velim, summamque<lb/>respondeas. <hi rend="italic">D.</hi>
+						Duodecim. <hi rend="italic">M.</hi> Vides item duodecim<lb/>plures esse
+						quam quatuor. D. Et longe sane. <hi rend="italic">M.</hi> Jam<lb/>ne
+						immorer 1, figenda regula est : A duobus , et<lb/>deinceps quoslibet
+						numeros duos constitueris, minor<lb/>per majorem multiplicatus , eum
+						excedat necesse<lb/>est. <hi rend="italic">D.</hi> Quis hoc dubitaverit ?
+						Quid enim tam parvum<lb/>in plurali numero quam duo? quem tamen numerum
+						<lb/>si millies duxero, ita excedet mille, ut duplum fiat.<lb/>M. Verum
+						dicis : sed constitue unum, et quemlibet<lb/>deinde majorem numerum, et
+						quemadmodum in illis<lb/>faciebamus, minorem per majorem multiplica, num
+						<lb/>eodem modo major superabitur? <hi rend="italic">D.</hi> Non plane, sed
+						<lb/>majori minor aequabitur. Nam unum bis, duo; et unum<lb/>decies,
+						decem; et unum millies, mille; et per quemlibet<lb/>aliurn numerum
+						multiplicavero, un am neresse est aeque<lb/>tur. <hi rend="italic">II.</hi>
+						Habet ergo unum cum caeteris numeris jus<lb/>quoddam aequalitatis; non modo
+						quod quicumque'<lb/>numerus est, sed etiam quod toties ductus tantumdem
+						<lb/>facit. <hi rend="italic">D.</hi> Manifestissimum est.</p>
+					</div><div type="textpart" subtype="dialog"><p>14. <hi rend="italic">M.</hi> Age nunc, refer animum ad semipedum<lb/>
+						numeros, quibus in versu fiunt membra inaequalia, et<lb/>miram quamdam
+						aequalitatem ista quam tractavimus<lb/>ratione reperies. Nam, uL opinor,
+						versus minimus<lb/>inaequali semipedum numero in membris est duobus,<lb/>
 						habens semipedes quatuor et tres, ut in hoc, <hi rend="italic">Hospes.<lb/>
-							ille quem vides ;</hi> cujus primum membrum quod est, <lb/>
+							ille quem vides ;</hi> cujus primum membrum quod est,<lb/>
 						<hi rend="italic">Hospes ille,</hi> secari aequaliter potest in duas partes
-						<lb/> binorum semipedum : secundum autem quod est, <lb/>
+						<lb/>binorum semipedum : secundum autem quod est,<lb/>
 						<hi rend="italic">quem</hi> vides, ita dividitur, ut una pars duos semipedes
-						<lb/> babeat, altera unum; quod ita est, quasi duo et duo <lb/> sint, jure
-						illo aequalitatis, de quo satis egimus, quod <lb/> habet unum cum omnibus
-						numeris. Ex quo fit ut ista <lb/> divisione tantum sit quodammodo superius
-						membrum <lb/> quantum posterius. Itaque ubi fuerint quatuor et quin­ <lb/>
-						que semipedes, sicut hoc est, Roma, Roma, <hi rend="italic">cerne <lb/>
-							quanta sit;</hi> non ita probatur, et propterea metrum <lb/> erit potius
-						quam versus, quia ita sunt membra in. <lb/> æqualia ut ad nullam aqualitatis
-						legem sectione aliqua <lb/> possint referri. Cernis quippe, ut opiuor,
-						superioris <lb/> membri quatuor semipedes, <hi rend="italic">Roma,
-							Roma,</hi> in binos <lb/> posse discederc8 : quinque autem posteriores,
-							<hi rend="italic">cerne<lb/> quanta sit,</hi> in duos et tres semipedes
-						dividi; ubi nullo <lb/> jure apparet aequalitas. Neque enim possunt aliquo
-						<lb/> modo tantum valere quinque semipedes propter duos <lb/> et tres,
-						quantum quatuor valent; quomodo inveni­ <lb/> mus superius in breviore versu
-						tantum valere tres se­ <lb/> mipedes propter unum et duo, quantum quatuor
-						va­ <lb/> lent. An aliquid non es assecutus, aut non placet? <lb/>
+						<lb/>babeat, altera unum; quod ita est, quasi duo et duo<lb/>sint, jure
+						illo aequalitatis, de quo satis egimus, quod<lb/>habet unum cum omnibus
+						numeris. Ex quo fit ut ista<lb/>divisione tantum sit quodammodo superius
+						membrum<lb/>quantum posterius. Itaque ubi fuerint quatuor et quin­<lb/>
+						que semipedes, sicut hoc est, Roma, Roma, <hi rend="italic">cerne<lb/>
+							quanta sit;</hi> non ita probatur, et propterea metrum<lb/>erit potius
+						quam versus, quia ita sunt membra in.<lb/>aequalia ut ad nullam aqualitatis
+						legem sectione aliqua<lb/>possint referri. Cernis quippe, ut opiuor,
+						superioris<lb/>membri quatuor semipedes, <hi rend="italic">Roma,
+							Roma,</hi> in binos<lb/>posse discederc8 : quinque autem posteriores,
+							<hi rend="italic">cerne<lb/>quanta sit,</hi> in duos et tres semipedes
+						dividi; ubi nullo<lb/>jure apparet aequalitas. Neque enim possunt aliquo
+						<lb/>modo tantum valere quinque semipedes propter duos<lb/>et tres,
+						quantum quatuor valent; quomodo inveni­<lb/>mus superius in breviore versu
+						tantum valere tres se­<lb/>mipedes propter unum et duo, quantum quatuor
+						va­<lb/>lent. An aliquid non es assecutus, aut non placet?<lb/>
 						<hi rend="italic">D.</hi> Imo vero et manifesta omnia et rata sunt.</p>
-					</div><div type="textpart" subtype="dialog"><p>15. <hi rend="italic">M.</hi> Age, nunc quinque et tres semipedes con­ <lb/>
-						sideremus, qualis est ille versiculus, <hi rend="italic">Phaselus ille <lb/>
-							quem vides :</hi> et videamus quomodo ista insequalitas <lb/> aliquo
-						aequalitatis jure teneatur : nam boc genus non <lb/> solum metrum, sed etiam
+					</div><div type="textpart" subtype="dialog"><p>15. <hi rend="italic">M.</hi> Age, nunc quinque et tres semipedes con­<lb/>
+						sideremus, qualis est ille versiculus, <hi rend="italic">Phaselus ille<lb/>
+							quem vides :</hi> et videamus quomodo ista insequalitas<lb/>aliquo
+						aequalitatis jure teneatur : nam boc genus non<lb/>solum metrum, sed etiam
 						versum esse, omnes con- <note type="footnote">1 Locum hunc restituimus ex
 							lis. A. Sic in B. : <hi rend="italic">Et ionge. II.</hi>
-							<lb/> sane, ne jam inarnorer. M. </note><note type="footnote"> * <hi
+							<lb/>sane, ne jam inarnorer. M. </note><note type="footnote"> * <hi
 								rend="italic">cwuscumque,</hi> juxta vatic. II. </note><note
 							type="footnote"> I <hi rend="italic">Discindere,</hi> juxta vatic. II. </note>
 						<lb/>
-						<pb n="1155"/> sentiunt. Itaque cum prirnum membrum in semipedes <lb/> duos
-						et ires secueris, et secundum in duos et unum ; <lb/> conjungas particulas
-						quas ID utroque pares inveneris1, <lb/> quia et in primo membro habemus duo,
-						et in secundo <lb/> restaNt dux particulae, una in tribus semipedibus de
-						<lb/> priore membro, altera in uno de posteriore. Has <lb/> ergo et
-						sociabililor jungimus, quia unum cum omni­ <lb/> bus habet societatem I; et
-						in summa unum et tria, <lb/> quatuor fiunt, quod est tantumdem quantum duo
-						et <lb/> duo. Per hanc igitur sectionem eliam quinque et tres <lb/>
-						semipcdes ad concordiam rediguntur. Sed responde, <lb/> utrum intellexeris.
+						<pb n="1155"/> sentiunt. Itaque cum prirnum membrum in semipedes<lb/>duos
+						et ires secueris, et secundum in duos et unum ;<lb/>conjungas particulas
+						quas ID utroque pares inveneris1,<lb/>quia et in primo membro habemus duo,
+						et in secundo<lb/>restaNt dux particulae, una in tribus semipedibus de
+						<lb/>priore membro, altera in uno de posteriore. Has<lb/>ergo et
+						sociabililor jungimus, quia unum cum omni­<lb/>bus habet societatem I; et
+						in summa unum et tria,<lb/>quatuor fiunt, quod est tantumdem quantum duo
+						et<lb/>duo. Per hanc igitur sectionem eliam quinque et tres<lb/>
+						semipcdes ad concordiam rediguntur. Sed responde,<lb/>utrum intellexeris.
 							<hi rend="italic">D.</hi> Ila vero, et admodum probo.</p>
 					<p>CAPUT VIII.— <hi rend="italic">Membra semipedum quinque et septem.</hi>
 					</p>
 					<div type="textpart" subtype="dialog"><p>16. <hi rend="italic">M.</hi> Sequitur ut de quinque et septem semipedi­
-						<lb/> bus disseramus, quales sunt versus duo illi nobilis­ <lb/> sini ,
-						heroicus et quem iambicum vulgo vocant, etiam <lb/> ipse senarius. Nam, <hi
-							rend="italic">Arma virumque cano, Trojæ qui</hi>
-						<lb/> primus <hi rend="italic">ab</hi> oria, ita dividitur ut primum ejus
-						membrum <lb/> sit,Arma <hi rend="italic">virumque cano,</hi> qui sunt
-						quinque; et secun­ <lb/> dum, <hi rend="italic">Trojce qui</hi> primus <hi
-							rend="italic">ab</hi> oria, qui sunt septem se­ <lb/> mipedes. Et, <hi
-							rend="italic">Phaselus ille quem videtis, hospites,</hi> pri­ <lb/> mum
-						membrum habet, <hi rend="italic">Phaselus ille,</hi> in semipedibus <lb/>
+						<lb/>bus disseramus, quales sunt versus duo illi nobilis­<lb/>sini ,
+						heroicus et quem iambicum vulgo vocant, etiam<lb/>ipse senarius. Nam, <hi
+							rend="italic">Arma virumque cano, Trojae qui</hi>
+						<lb/>primus <hi rend="italic">ab</hi> oria, ita dividitur ut primum ejus
+						membrum<lb/>sit,Arma <hi rend="italic">virumque cano,</hi> qui sunt
+						quinque; et secun­<lb/>dum, <hi rend="italic">Trojce qui</hi> primus <hi
+							rend="italic">ab</hi> oria, qui sunt septem se­<lb/>mipedes. Et, <hi
+							rend="italic">Phaselus ille quem videtis, hospites,</hi> pri­<lb/>mum
+						membrum habet, <hi rend="italic">Phaselus ille,</hi> in semipedibus<lb/>
 						quinque ; secundum in septem, <hi rend="italic">quem videtis, hos­</hi>
-						<lb/> pites. Sed tanta illa nobilitas in loge ista æqualitatis <lb/>
-						laborat. Cnm enim superiores quinque semipedes in <lb/> duos et tres
-						diviserimus, posteriores autem septem in <lb/> tres et quatuor; congruent
-						sibi quidem particulæ terno­ <lb/> rum semipcdum : sed si duae reliquae ita
-						convenirent, <lb/> ut una earum constaret uno semipede, alia quinque; <lb/>
-						conjungerentur lege illa qua unum cum omnibus nu­ <lb/> meris conjungi
-						potest, et in summa sex fierent, quod <lb/> sunt etiam tres ct tres : nunc
-						vero quia duo et qua­ <lb/> tuor inveniuntur, summam quidem reddent
-						senariam; <lb/> sed nullo æqualitatis jure tantum valent duo quantum <lb/>
-						quatuor, ut in hujuscemodi quasi necessitudine copu­ <lb/> lentur. Nisi
-						forte quis dixerit salis esse ad aliquam <lb/> regulam parilitatis, quod ut
-						tres et tres, ita duo et <lb/> quatuor sex fiunt. Cui rationi repugnandum
-						non arbi­ <lb/> tror : est enim ct haec aliqua aequalitas. Sed illud <lb/>
-						nollem ut majore congruentia quinque et tres quam <lb/> quinque et septem
-						semipedes convenirent. Non enim <lb/> tantum nomen est illius versus quantum
-						istorum ; et <lb/> vides in illo non modo tantam summam inventam <lb/>
-						collatis uno et tribus, quanta est in duobus et duo­ <lb/> bus; sed etiam
-						multo concordiores partes esse, cum <lb/> junguntur unum et tria, propter
-						illam unius cum cæ­ <lb/> teris omnibus numeris amicitiam, quam cum duo et
-						<lb/> quatuor copulantur, sicut in istis est. An tibi aliquid <lb/> obscurum
-						est ? <hi rend="italic">D.</hi> Nihil prorsus. Sed nescio quomodo <lb/> me
-						offendit, quod isti senarii cum sint celebratiores <lb/> cæteris generibus,
-						et principatum quemdam in versi­ <lb/> bus habere dicantur, aliquid in
-						membrorum concor­ <lb/> dia minus habent, quam illi famæ obscurioris versus.
-						<lb/> II. Bono animo esto : nam ego tibi tantam in illisos­ <lb/> tendam
-						concordiam, quantam soli ex omnibus habere <lb/> meruerunt, ut videas, non
-						injuria cos esse prælatos. <note type="footnote"> I SIc Vatic.: <hi
+						<lb/>pites. Sed tanta illa nobilitas in loge ista aequalitatis<lb/>
+						laborat. Cnm enim superiores quinque semipedes in<lb/>duos et tres
+						diviserimus, posteriores autem septem in<lb/>tres et quatuor; congruent
+						sibi quidem particulae terno­<lb/>rum semipcdum : sed si duae reliquae ita
+						convenirent,<lb/>ut una earum constaret uno semipede, alia quinque;<lb/>
+						conjungerentur lege illa qua unum cum omnibus nu­<lb/>meris conjungi
+						potest, et in summa sex fierent, quod<lb/>sunt etiam tres ct tres : nunc
+						vero quia duo et qua­<lb/>tuor inveniuntur, summam quidem reddent
+						senariam;<lb/>sed nullo aequalitatis jure tantum valent duo quantum<lb/>
+						quatuor, ut in hujuscemodi quasi necessitudine copu­<lb/>lentur. Nisi
+						forte quis dixerit salis esse ad aliquam<lb/>regulam parilitatis, quod ut
+						tres et tres, ita duo et<lb/>quatuor sex fiunt. Cui rationi repugnandum
+						non arbi­<lb/>tror : est enim ct haec aliqua aequalitas. Sed illud<lb/>
+						nollem ut majore congruentia quinque et tres quam<lb/>quinque et septem
+						semipedes convenirent. Non enim<lb/>tantum nomen est illius versus quantum
+						istorum ; et<lb/>vides in illo non modo tantam summam inventam<lb/>
+						collatis uno et tribus, quanta est in duobus et duo­<lb/>bus; sed etiam
+						multo concordiores partes esse, cum<lb/>junguntur unum et tria, propter
+						illam unius cum cae­<lb/>teris omnibus numeris amicitiam, quam cum duo et
+						<lb/>quatuor copulantur, sicut in istis est. An tibi aliquid<lb/>obscurum
+						est ? <hi rend="italic">D.</hi> Nihil prorsus. Sed nescio quomodo<lb/>me
+						offendit, quod isti senarii cum sint celebratiores<lb/>caeteris generibus,
+						et principatum quemdam in versi­<lb/>bus habere dicantur, aliquid in
+						membrorum concor­<lb/>dia minus habent, quam illi famae obscurioris versus.
+						<lb/>II. Bono animo esto : nam ego tibi tantam in illisos­<lb/>tendam
+						concordiam, quantam soli ex omnibus habere<lb/>meruerunt, ut videas, non
+						injuria cos esse praelatos. <note type="footnote"> I SIc Vatic.: <hi
 								rend="italic">conjungens</hi> particulas, quasab <hi rend="italic"
 								>mraqueparte</hi>
-							<lb/> vtvenerts. II. </note><note type="footnote"> I <hi rend="italic"
+							<lb/>vtvenerts. II. </note><note type="footnote"> I <hi rend="italic"
 								>consocietatem,</hi> juxta vatIc. M. </note>
-						<lb/> Sed quia ipsa tractatio aliquanto est longior, quam­ <lb/> vis omnino
-						jucundior, restare nobis debet extrema, ut <lb/> cum de cæteris, quantum
-						satis videbitur, disputave­ <lb/> rimus, jam omni cura liberati, ad horum
-						scrutanda <lb/> penetralia veniamus. <hi rend="italic">D.</hi> Mibi vero
-						placet : sed jain <lb/> vellem ut ista quae priora suscepimus, explicata es­
-						<lb/> sent, ut jam illud audirem commodius. <hi rend="italic">M.</hi>
-						Istorum <lb/> comparatione quæ ante disseruimus, fiunt itia dul­ <lb/> ciora
+						<lb/>Sed quia ipsa tractatio aliquanto est longior, quam­<lb/>vis omnino
+						jucundior, restare nobis debet extrema, ut<lb/>cum de caeteris, quantum
+						satis videbitur, disputave­<lb/>rimus, jam omni cura liberati, ad horum
+						scrutanda<lb/>penetralia veniamus. <hi rend="italic">D.</hi> Mibi vero
+						placet : sed jain<lb/>vellem ut ista quae priora suscepimus, explicata es­
+						<lb/>sent, ut jam illud audirem commodius. <hi rend="italic">M.</hi>
+						Istorum<lb/>comparatione quae ante disseruimus, fiunt itia dul­<lb/>ciora
 						qu:e exspectas.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT IX. — <hi rend="italic">Membra semipedum sex et
@@ -4366,64 +4366,64 @@
 								septem.</hi>
 						</title>
 					</ab>
-					<div type="textpart" subtype="dialog"><p>17. Nunc itaque considera, utrum in duobus mem­ <lb/> bris quorum primum
-						cxhibeat semipedes sex, alte. <lb/> rum septem, reperiatur ea æqualitas ut
-						rile es se ver. <lb/> sus queat. Nam post quinque ct septem semipedes <lb/>
-						hunc esse discutiendum vides. Ilujus autem exem­ <lb/> plum est : <hi
-							rend="italic">Roma, cerne quanta sit deum benignitas. <lb/> D.</hi>
-						Video primum membrum posse in partes distribui, <lb/> quæ habeant ternos
-						semipedes, secundum in tres et <lb/> quatuor. Quare junctis aequalibus fiunt
-						sex semipe­ <lb/> des, tres vero et quatuor septem sunt, et non a'quan­
-						<lb/> tur illi numero. Sed si duo et duo in ea parte ubi <lb/> quatuor sunt,
-						et duo et unum in ea parte ubi tres <lb/> sunt, consideremus, junctis
-						portibus quae binos ha­ <lb/> bent, tit summa quaternaria : junctis autem
-						illis <lb/> quarum in una duo sunt, in alia unum, si etiam ista <lb/>
-						tanquam sint quatuor accipiamus , propter unius cum <lb/> cæteris numeris
-						concordiam, octo simul fiunt, ma­ <lb/> gisque excedunt summam scnariam,
-						quam cum se­ <lb/> ptem fuissent.</p>
+					<div type="textpart" subtype="dialog"><p>17. Nunc itaque considera, utrum in duobus mem­<lb/>bris quorum primum
+						cxhibeat semipedes sex, alte.<lb/>rum septem, reperiatur ea aequalitas ut
+						rile es se ver.<lb/>sus queat. Nam post quinque ct septem semipedes<lb/>
+						hunc esse discutiendum vides. Ilujus autem exem­<lb/>plum est : <hi
+							rend="italic">Roma, cerne quanta sit deum benignitas.<lb/>D.</hi>
+						Video primum membrum posse in partes distribui,<lb/>quae habeant ternos
+						semipedes, secundum in tres et<lb/>quatuor. Quare junctis aequalibus fiunt
+						sex semipe­<lb/>des, tres vero et quatuor septem sunt, et non a'quan­
+						<lb/>tur illi numero. Sed si duo et duo in ea parte ubi<lb/>quatuor sunt,
+						et duo et unum in ea parte ubi tres<lb/>sunt, consideremus, junctis
+						portibus quae binos ha­<lb/>bent, tit summa quaternaria : junctis autem
+						illis<lb/>quarum in una duo sunt, in alia unum, si etiam ista<lb/>
+						tanquam sint quatuor accipiamus , propter unius cum<lb/>caeteris numeris
+						concordiam, octo simul fiunt, ma­<lb/>gisque excedunt summam scnariam,
+						quam cum se­<lb/>ptem fuissent.</p>
 					</div><div type="textpart" subtype="dialog"><p>18. <hi rend="italic">M.</hi> Ita est, ut dicis: et idco isto genere copu­
-						<lb/> lationis a lege versuum separato, attende ut ordo po­ <lb/> stulat, in
-						ea nunc membra, quorum primum habet <lb/> octo semipedes, septem secundum.
-						Ista vero copulatio <lb/> habet quod quaerimus. Nam pracedentis membri par­
-						<lb/> tem dimidiam cum parlc subsequentis majore, quae <lb/> dimidiae
-						proxima est, jungens, quoniam quaterni se­ <lb/>
-						<lb/> mipedes sunt, octonarii numeri summam facio. Re­ <lb/> stant ergo
-						quatuor semipedes de priore, tres de poste­ <lb/> riore membro. Duo inde, et
-						duo hinc copulati, fiunt <lb/> quatuor. Duo rursus inde residui, et unus
-						hinc, ad <lb/> legem illius convenientiae copulati, qua 'unum reliquis <lb/>
-						par est, quodammodo sumuntur pro quatuor. Ita jam <lb/> octonarius superiori
-						oclouario congruit. D. Sed cur <lb/> hujus exemplum non audio? M. Quia sæpe
-						comme­ <lb/> moratum est : tamen ne suo loco prætermissum pu­ <lb/> tes,
+						<lb/>lationis a lege versuum separato, attende ut ordo po­<lb/>stulat, in
+						ea nunc membra, quorum primum habet<lb/>octo semipedes, septem secundum.
+						Ista vero copulatio<lb/>habet quod quaerimus. Nam pracedentis membri par­
+						<lb/>tem dimidiam cum parlc subsequentis majore, quae<lb/>dimidiae
+						proxima est, jungens, quoniam quaterni se­<lb/>
+						<lb/>mipedes sunt, octonarii numeri summam facio. Re­<lb/>stant ergo
+						quatuor semipedes de priore, tres de poste­<lb/>riore membro. Duo inde, et
+						duo hinc copulati, fiunt<lb/>quatuor. Duo rursus inde residui, et unus
+						hinc, ad<lb/>legem illius convenientiae copulati, qua 'unum reliquis<lb/>
+						par est, quodammodo sumuntur pro quatuor. Ita jam<lb/>octonarius superiori
+						oclouario congruit. D. Sed cur<lb/>hujus exemplum non audio? M. Quia saepe
+						comme­<lb/>moratum est : tamen ne suo loco praetermissum pu­<lb/>tes,
 						ipsum est, <hi rend="italic">Roma, Roma, cerne</hi> quanta <hi rend="italic"
-							>sit deum <lb/> benignitas;</hi> vel hoc etiam, <hi rend="italic"
+							>sit deum<lb/>benignitas;</hi> vel hoc etiam, <hi rend="italic"
 							>Optimus beatus ille qui pro­</hi>
-						<lb/> cul <hi rend="italic">negotio.</hi>
+						<lb/>cul <hi rend="italic">negotio.</hi>
 					</p>
-					</div><div type="textpart" subtype="dialog"><p>19. Quare jam inspice novem et septem semipedum, <lb/> connexionem, cujus
+					</div><div type="textpart" subtype="dialog"><p>19. Quare jam inspice novem et septem semipedum,<lb/>connexionem, cujus
 						exemplum est : <hi rend="italic">Vir</hi> optiMus <hi rend="italic"
-							>beatus<lb/> ille qui procul negotio. D.</hi> Facilis est cognitu ista
-						coa­ <lb/> gruenLia: superius enim membrum in quatuor et quin­ <lb/> que,
+							>beatus<lb/>ille qui procul negotio. D.</hi> Facilis est cognitu ista
+						coa­<lb/>gruenLia: superius enim membrum in quatuor et quin­<lb/>que,
 						posterius inf tres et quatuor semipedes dividitur. <note type="footnote"> 1
 							In B., <hi rend="italic">roma,</hi> Roma, <hi rend="italic">cerne quanta
 								sit deum bmignila. :</hi>
-							<lb/> mala repetitione vocis, RDmIl, nam priori membro octo se­ <lb/>
-							mipedes concedit, septem vero posteriori: quod renugiiat <lb/>
+							<lb/>mala repetitione vocis, RDmIl, nam priori membro octo se­<lb/>
+							mipedes concedit, septem vero posteriori: quod renugiiat<lb/>
 							explicationi ab Augustino paulo post subjectae. II. </note><note
 							type="footnote"> I <hi rend="italic">Qttiu,</hi> juxta vatic. </note>
 						<lb/>
-						<pb n="1157"/> Pars ergosuperioris minor cum parte posterioris majore <lb/>
-						conjuncta, octonarium numerum facil : et inajor supe.. <lb/> rioris cum
-						minore posterioris, item octonarium : nam <lb/> illa conjunctio est quatuor
-						et quatuor, ista quinque <lb/> et tres semipedes. Huc accedit, quod quinque
-						in duo <lb/> et tres semi pedes, tres autem in duo et unum si divi­ <lb/>
-						seris, apparet alia convenientia duorum cum duobus, <lb/> et unius cum
-						tribus, quia unum cum omnibus numeris <lb/> supcrius commemorata lege
-						confertur. Sed nisi me <lb/> ratio fallit, nihil restat ulterius quod de
-						membrorum <lb/> copulatione requiramus : jam enim ad octo perven­ <lb/> tum
-						est pedes, quem numerum versui , sicut satis co­ <lb/> gnovimus, non fas est
-						excedere. Quare jam nac, illa <lb/> senariorum versuum heroici et ialnbici
-						vel trochaici, <lb/> quo intentionem meam et excitasti et distulisti, pande
-						<lb/> secreta.</p>
+						<pb n="1157"/> Pars ergosuperioris minor cum parte posterioris majore<lb/>
+						conjuncta, octonarium numerum facil : et inajor supe..<lb/>rioris cum
+						minore posterioris, item octonarium : nam<lb/>illa conjunctio est quatuor
+						et quatuor, ista quinque<lb/>et tres semipedes. Huc accedit, quod quinque
+						in duo<lb/>et tres semi pedes, tres autem in duo et unum si divi­<lb/>
+						seris, apparet alia convenientia duorum cum duobus,<lb/>et unius cum
+						tribus, quia unum cum omnibus numeris<lb/>supcrius commemorata lege
+						confertur. Sed nisi me<lb/>ratio fallit, nihil restat ulterius quod de
+						membrorum<lb/>copulatione requiramus : jam enim ad octo perven­<lb/>tum
+						est pedes, quem numerum versui , sicut satis co­<lb/>gnovimus, non fas est
+						excedere. Quare jam nac, illa<lb/>senariorum versuum heroici et ialnbici
+						vel trochaici,<lb/>quo intentionem meam et excitasti et distulisti, pande
+						<lb/>secreta.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT X.— <hi rend="italic">De senariorum versuum
 								excel/entia : eoa decentissimos non esse,</hi> nisi <hi
@@ -4431,206 +4431,206 @@
 								iambici.</hi>
 						</title>
 					</ab>
-					<div type="textpart" subtype="dialog"><p>20. <hi rend="italic">M.</hi> Faciam, imo faciet ipsa ratio,quæ mihi <lb/>
-						tibiquc communis est. Sed meministine, quæso, cum <lb/> ageremus de metris,
-						dixisse nos et ipso sensu admo­ <lb/> dum probasse, illos pcdes quorum
-						partes ad sesqua <lb/> conveniunt, sive in duobus et tribus, ut est creticus
-						<lb/> vel paeones, sive in tribus et quatuor, ut epitriti, exclu­ <lb/> sos
-						a poetis propter minoris veuustaLis sonum, solutæ <lb/> orationis
-						severitatem decorare congruentius, cum his <lb/> clausulæ colligantur? <hi
-							rend="italic">D.</hi> Memini : sed quorsum hæc <lb/> spectant? <hi
-							rend="italic">M.</hi> Quoniam illud volo prius intelligamus, <lb/>
-						hujuscemodi pedibus a poetarum tractatione sejunctis, <lb/> non remanere,
-						nisi eos quibus ad tantumdem, ut spon­ <lb/> deus est ; aut eos quibus ad
-						duplum , ut iambus; aut <lb/> eos quibus ad utrumque partes conveniunt, ut
-						chor­ <lb/> iambus. <hi rend="italic">D</hi> Ita est. <hi rend="italic"
-							>M.</hi> At si hæc est poetarum mate­ <lb/> ries, et soluta oratio
-						versibus inimica est, non versus <lb/> ullus nisi ex hoc genere pedum
-						faciendus cst. <hi rend="italic">D.</hi> As­ <lb/> sentior. Vidco cnim
-						poemata versibus quam aliis ly­ <lb/> ricorum poetarum metris fieri
-						grandiora, sed adhuc <lb/> quo ratio ista tendat, ignoro.</p>
-					</div><div type="textpart" subtype="dialog"><p>- 21. M. Ne propera : disputamus euim jam de sena­ <lb/> riorum. versuum
-						excellentia, ct prius tibi cupio de­ <lb/> monstrare, si potero,
-						decentissimos senarios, nisi <lb/> duorum istorum generum esse nun posse,
-						qiue omnium <lb/> etiam sunt celeberrima, quorum unum cst heroicum, <lb/>
+					<div type="textpart" subtype="dialog"><p>20. <hi rend="italic">M.</hi> Faciam, imo faciet ipsa ratio,quae mihi<lb/>
+						tibiquc communis est. Sed meministine, quaeso, cum<lb/>ageremus de metris,
+						dixisse nos et ipso sensu admo­<lb/>dum probasse, illos pcdes quorum
+						partes ad sesqua<lb/>conveniunt, sive in duobus et tribus, ut est creticus
+						<lb/>vel paeones, sive in tribus et quatuor, ut epitriti, exclu­<lb/>sos
+						a poetis propter minoris veuustaLis sonum, solutae<lb/>orationis
+						severitatem decorare congruentius, cum his<lb/>clausulae colligantur? <hi
+							rend="italic">D.</hi> Memini : sed quorsum haec<lb/>spectant? <hi
+							rend="italic">M.</hi> Quoniam illud volo prius intelligamus,<lb/>
+						hujuscemodi pedibus a poetarum tractatione sejunctis,<lb/>non remanere,
+						nisi eos quibus ad tantumdem, ut spon­<lb/>deus est ; aut eos quibus ad
+						duplum , ut iambus; aut<lb/>eos quibus ad utrumque partes conveniunt, ut
+						chor­<lb/>iambus. <hi rend="italic">D</hi> Ita est. <hi rend="italic"
+							>M.</hi> At si haec est poetarum mate­<lb/>ries, et soluta oratio
+						versibus inimica est, non versus<lb/>ullus nisi ex hoc genere pedum
+						faciendus cst. <hi rend="italic">D.</hi> As­<lb/>sentior. Vidco cnim
+						poemata versibus quam aliis ly­<lb/>ricorum poetarum metris fieri
+						grandiora, sed adhuc<lb/>quo ratio ista tendat, ignoro.</p>
+					</div><div type="textpart" subtype="dialog"><p>- 21. M. Ne propera : disputamus euim jam de sena­<lb/>riorum. versuum
+						excellentia, ct prius tibi cupio de­<lb/>monstrare, si potero,
+						decentissimos senarios, nisi<lb/>duorum istorum generum esse nun posse,
+						qiue omnium<lb/>etiam sunt celeberrima, quorum unum cst heroicum,<lb/>
 						ut, <hi rend="italic">Arma virumque cano, Trojce qui primus ab ons,</hi>
-						<lb/> quod usus metitur spondeo et dactylo, subtilior ratio <lb/> spondeo et
-						anapæsto : alterum quod iambicum dici­ <lb/> tur, et eadem ratione invenitur
-						trochaicum Nam credo <lb/> libi manifestum esse longis syllabis, nisi breves
-						in­ <lb/> terponantur, obtundi quodam modo spatia sonorum; <lb/> item nisi
-						brevibus longae, nimis concisa et quasi tre­ <lb/> mula fieri; neutra esse
-						temperata, quamvis temporum <lb/> aequalitate aures impleant'. Quamobrem nec
-						illi ver­ <lb/> sus qui sex pyrrhichios, et sex proceleumaticos ha­ <lb/>
-						bent, aspirant ad heroici dignitatem, nec illi ad tro­ <lb/> ehaici qui sex
-						tribrachos habent. Huc accedit, quia <lb/> in istis quos caeteris ipsa ratio
-						præponit, si membra <lb/> praeposteres , totum ita commutabitur, ut alios
+						<lb/>quod usus metitur spondeo et dactylo, subtilior ratio<lb/>spondeo et
+						anapaesto : alterum quod iambicum dici­<lb/>tur, et eadem ratione invenitur
+						trochaicum Nam credo<lb/>libi manifestum esse longis syllabis, nisi breves
+						in­<lb/>terponantur, obtundi quodam modo spatia sonorum;<lb/>item nisi
+						brevibus longae, nimis concisa et quasi tre­<lb/>mula fieri; neutra esse
+						temperata, quamvis temporum<lb/>aequalitate aures impleant'. Quamobrem nec
+						illi ver­<lb/>sus qui sex pyrrhichios, et sex proceleumaticos ha­<lb/>
+						bent, aspirant ad heroici dignitatem, nec illi ad tro­<lb/>ehaici qui sex
+						tribrachos habent. Huc accedit, quia<lb/>in istis quos caeteris ipsa ratio
+						praeponit, si membra<lb/>praeposteres , totum ita commutabitur, ut alios
 						etiam <note type="footnote"> I <hi rend="italic">impleantiar,</hi> juxta
 							vatic4 M. </note>
-						<lb/> pedes necessario metiamur. Itaque inconversibiliores, <lb/> ut ita
-						dicam, sunt quam illi qui aut omnibus bre­ <lb/> vibus, aut longis omnibus
-						constant. Et ideo sive quin­ <lb/> que et septem, sive septem et quinque
-						semipedibus <lb/> membra in his temperatioribus ordinentur I, nihil <lb/>
-						interest: neutro enim horum ordine converti versus <lb/> potest sine tanta
-						commutatione, ut aliis pedibus cur­ <lb/> rere videatur. In illis autem si
-						carmen coeptum erit <lb/> talibus versibus, quorum priora membra quinos
-						semi­ <lb/> pedes habeant, non oporteat eos miscere in quibus <lb/> septeni
-						priores sunt, ne jam liceal omnes convertere: <lb/> non eniin a conversione
-						revocat ulla pedum commu­ <lb/> tatio. Sed tamen heroicis conceditur
-						spondcos omnes <lb/> rarissime interponere, quod quidem posterior ætas <lb/>
-						haec nostra minime- probavit. Trochaicis autem sive <lb/> iambicis, cum
-						pedem tribrachum quolibet loco inter­ <lb/> ponere liceat, babere tamen in
-						hujuscemodi carmini­ <lb/> bus versum solutum in omnes breves, turpissimum
-						<lb/> judicatum est.</p>
-					</div><div type="textpart" subtype="dialog"><p>22. Remotis igitur epitritis pcdibus a lege versuum <lb/> senaria, non solum
-						quod solutæ orationi sunt aptio­ <lb/> res, verum etiam quod si sex fuerint,
-						triginta ct duo <lb/> tempora excedunt, sicut dispondei; remotis eMam <lb/>
-						quinum temporum pedibus, quod sibi cos libentius ad <lb/> chiusulas
-						vindicavit oratio; molossis item et aliis tem­ <lb/> porum senum , quamvis
-						in poematis vcnustissime vi­ <lb/> gcant, ab hoc de quo none agimus numero
-						temporum <lb/> exclusis; restant versus omnium brevium syllabarum, <lb/> qui
-						vel pyrrhichios vel proceleumaticos vel tribrachos <lb/> habent, et omnium
-						longarum qui spondeos. Qui quan­ <lb/> quam admittantur ad senarium modum,
-						dignilali ta­ <lb/> men ct temperationi horum qui brevibus longisque <lb/>
-						variantur; et ob hoc multo minus converti possunt, <lb/> cedant necesse
+						<lb/>pedes necessario metiamur. Itaque inconversibiliores,<lb/>ut ita
+						dicam, sunt quam illi qui aut omnibus bre­<lb/>vibus, aut longis omnibus
+						constant. Et ideo sive quin­<lb/>que et septem, sive septem et quinque
+						semipedibus<lb/>membra in his temperatioribus ordinentur I, nihil<lb/>
+						interest: neutro enim horum ordine converti versus<lb/>potest sine tanta
+						commutatione, ut aliis pedibus cur­<lb/>rere videatur. In illis autem si
+						carmen coeptum erit<lb/>talibus versibus, quorum priora membra quinos
+						semi­<lb/>pedes habeant, non oporteat eos miscere in quibus<lb/>septeni
+						priores sunt, ne jam liceal omnes convertere:<lb/>non eniin a conversione
+						revocat ulla pedum commu­<lb/>tatio. Sed tamen heroicis conceditur
+						spondcos omnes<lb/>rarissime interponere, quod quidem posterior aetas<lb/>
+						haec nostra minime- probavit. Trochaicis autem sive<lb/>iambicis, cum
+						pedem tribrachum quolibet loco inter­<lb/>ponere liceat, babere tamen in
+						hujuscemodi carmini­<lb/>bus versum solutum in omnes breves, turpissimum
+						<lb/>judicatum est.</p>
+					</div><div type="textpart" subtype="dialog"><p>22. Remotis igitur epitritis pcdibus a lege versuum<lb/>senaria, non solum
+						quod solutae orationi sunt aptio­<lb/>res, verum etiam quod si sex fuerint,
+						triginta ct duo<lb/>tempora excedunt, sicut dispondei; remotis eMam<lb/>
+						quinum temporum pedibus, quod sibi cos libentius ad<lb/>chiusulas
+						vindicavit oratio; molossis item et aliis tem­<lb/>porum senum , quamvis
+						in poematis vcnustissime vi­<lb/>gcant, ab hoc de quo none agimus numero
+						temporum<lb/>exclusis; restant versus omnium brevium syllabarum,<lb/>qui
+						vel pyrrhichios vel proceleumaticos vel tribrachos<lb/>habent, et omnium
+						longarum qui spondeos. Qui quan­<lb/>quam admittantur ad senarium modum,
+						dignilali ta­<lb/>men ct temperationi horum qui brevibus longisque<lb/>
+						variantur; et ob hoc multo minus converti possunt,<lb/>cedant necesse
 						est.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT XI. — <hi rend="italic">Senarii quomodo</hi>
 							commodius <hi rend="italic">metiendi.</hi>
 						</title>
 					</ab>
-					</div><div type="textpart" subtype="dialog"><p>23. Sed quæri potest cur meliores versus judicati ' <lb/> sintsenarii, in
-						quibus anapæstum subtilis illa ratio <lb/> metitur, et ii in quibus trochæum
-						; quam si dactylum <lb/> ibi, ct hic iambum metiretur. Sine praejudicio caim
-						<lb/> sententiæ, quoniam nunc de numeris agimus, si ver­ <lb/> sus ita esset
+					</div><div type="textpart" subtype="dialog"><p>23. Sed quaeri potest cur meliores versus judicati '<lb/>sintsenarii, in
+						quibus anapaestum subtilis illa ratio<lb/>metitur, et ii in quibus trochaeum
+						; quam si dactylum<lb/>ibi, ct hic iambum metiretur. Sine praejudicio caim
+						<lb/>sententiae, quoniam nunc de numeris agimus, si ver­<lb/>sus ita esset
 						: <hi rend="italic">Trojae qui</hi> primus <hi rend="italic">ab oris arma
-							virumque<lb/> cano,</hi> vel de illo genere : Qui <hi rend="italic"
-							>procul malo</hi> pius <hi rend="italic">beatus <lb/> ille;</hi> uterque
-						horum nec minus scnarius esset, nec <lb/> minus brevium longarumque
-						syllabarum temperatione <lb/> moderatus, nee magis converti poterat; et in
-						utroque <lb/> membra ila ordiuata sunt, ut et in quinto et in septi­ <lb/>
-						mo semipede pars orationis termiuctur : cur ergo <lb/> meliores istis
-						putentur, si potius ita sint, Armavi­ <lb/>
-						<hi rend="italic">rumque cano, Trojæ qui</hi> primus <hi rend="italic">ab
+							virumque<lb/>cano,</hi> vel de illo genere : Qui <hi rend="italic"
+							>procul malo</hi> pius <hi rend="italic">beatus<lb/>ille;</hi> uterque
+						horum nec minus scnarius esset, nec<lb/>minus brevium longarumque
+						syllabarum temperatione<lb/>moderatus, nee magis converti poterat; et in
+						utroque<lb/>membra ila ordiuata sunt, ut et in quinto et in septi­<lb/>
+						mo semipede pars orationis termiuctur : cur ergo<lb/>meliores istis
+						putentur, si potius ita sint, Armavi­<lb/>
+						<hi rend="italic">rumque cano, Trojae qui</hi> primus <hi rend="italic">ab
 							oris. Beatus ille qui</hi>
-						<lb/> procul pius <hi rend="italic">malo ?</hi> In qua quæstione facilius et
-						procli­ <lb/> vius dixerim forte evenisse, ut i£ ti prius animadver­ <lb/>
-						terentur et frequentarentur2; aut si id non cst fortui- <lb/> lum, melius
-						credo visum fuisse, ut heroicus duabus <lb/> longis, quam duabus brevibus et
-						longa clauderetur, <lb/> quod in longis aurcs commodins acquiescunt : ille
-						au­ <lb/> tem alter in finali semipede longam syllabam potius <lb/> haberet
+						<lb/>procul pius <hi rend="italic">malo ?</hi> In qua quaestione facilius et
+						procli­<lb/>vius dixerim forte evenisse, ut i£ ti prius animadver­<lb/>
+						terentur et frequentarentur2; aut si id non cst fortui<lb/>lum, melius
+						credo visum fuisse, ut heroicus duabus<lb/>longis, quam duabus brevibus et
+						longa clauderetur,<lb/>quod in longis aurcs commodins acquiescunt : ille
+						au­<lb/>tem alter in finali semipede longam syllabam potius<lb/>haberet
 						quam brevem. Res quidcm sic se babet, ut <note type="footnote">
 							<hi rend="italic">' remperaltonibaa ordinentur,</hi> juxta vatic. II.
 							</note><note type="footnote"> I In B., aut frequentarecutur. vatic. et
-							MSs. A, <hi rend="italic">ct frequenta­ <lb/> rentur.</hi> AI. </note>
+							MSs. A, <hi rend="italic">ct frequenta­<lb/>rentur.</hi> AI. </note>
 						<lb/>
-						<pb n="1159"/> quicumque horum priores eligcrentur, neccssario aliis <lb/>
-						auferrent locum, qui membris iisdem præposteratis <lb/> fieri possent.
-						Quocirca si melior judicatus est, cujus <lb/> exemplum est, <hi
-							rend="italic">Arma virumque cano, Trojce qui primus<lb/> ab oris;</hi>
-						inepte jam fieret isto converso aliud genus, si­ <lb/> cuti es!, <hi
+						<pb n="1159"/> quicumque horum priores eligcrentur, neccssario aliis<lb/>
+						auferrent locum, qui membris iisdem praeposteratis<lb/>fieri possent.
+						Quocirca si melior judicatus est, cujus<lb/>exemplum est, <hi
+							rend="italic">Arma virumque cano, Trojce qui primus<lb/>ab oris;</hi>
+						inepte jam fieret isto converso aliud genus, si­<lb/>cuti es!, <hi
 							rend="italic">Trojce</hi> qui <hi rend="italic">primus ab oris, arma
 							virumque cano.</hi>
-						<lb/> Quod etiam de trochaico genere intcUigendunl est. Nam <lb/> si est
+						<lb/>Quod etiam de trochaico genere intcUigendunl est. Nam<lb/>si est
 						honestior, <hi rend="italic">Beatus ille qui procul negotio</hi> : qnod
-						<lb/> genus isto prærposterato fiercl, ut est, <hi rend="italic">Qui procul
-							negotio<lb/> beatus ille,</hi> fieri profecto non oportet1: tamen si
-						quis <lb/> audeat et faciat tales versus, manifestum est cum alia <lb/>
-						gerera senariorum esse facturum, quibus sint ista <lb/> meliora.</p>
-					</div><div type="textpart" subtype="dialog"><p>24. Ili ergo senariorum omnium pulcherrimi, non <lb/> potuerunt ambo obtinere
-						sinceritatem suam adversus <lb/> hominum licentiam. Nam in trochaico geuere,
-						non <lb/> senario solo, sed unde minus incipit usque ad magni­ <lb/> tudinem
-						extremam quae ocio pedes habet, miscendus <lb/> poctæ putaverunt quatuor
-						temporum pedes omnes, <lb/> qui adhibentur ad numeros: ct Græci quidem
-						alternis <lb/> locis primo et tertio, et ita deinceps, si a semipede <lb/>
-						versus incipit: sin ab integra trochæo, secundo et <lb/> quarto loco, atque
-						ita deinceps servatis intervallis, <lb/> memorati longiores collocantur
-						pedcs. Quæ corruptio <lb/> ut tolerabilis fieret, non singulos pedes in duas
-						par­ <lb/> tes, quorum una lcvationis, altera positionis est, <lb/> plaudc;
-						do diviserunt; sed unuin peJein lcvanles, al­ <lb/> terum poucnles, unde
-						ipsum senarium trimetrum vo­ <lb/> cant, ad epitritorum divisionem plausum
-						rctulerunt. <lb/> Sed si hoc sultem constanter tcnerclur, quamvis pe­ <lb/>
-						des epitriti magis orationis siat quam poematis, nec <lb/> jam senarius, scd
-						ternarius versus inveniretur; non <lb/> tamen omnimodo illa n imerorum
-						labefactaretur æqua­ <lb/> litas. Nunc vero quatuor temporum pedes, dummodo
-						<lb/> in locis memoratis ponantur, licet non solum in om­ <lb/> nibus
-						ponere, sed ubi libet eorum, et quoties libet. <lb/> Nostri veru veteres,
-						nec ipsa locorum intervalla in­ <lb/> termiscendis hujuscemodi pedibus,
-						servare potuerunt. <lb/> Quare in hoc genere poetæ ista corruptione atque
-						li­ <lb/> centia plane assecuti sunt, quod eos voluisse arbitran­ <lb/> dum
-						cst, ut essent in fabulis poemata solutae orationi <lb/> simillima. Se d
-						quoniam satis dictum est cur inter se­ <lb/> narios isti versus magis
-						nobilitati sint, nunc videa­ <lb/> mus cur ipsi senarii meliores sint versus
-						quam caeteri <lb/> in quolibet alio pedum numero constituti. Nisi quid <lb/>
-						habes adversus ista quædisseras. 'B. Prorsus assen­ <lb/> tiur : et jam
-						illam membrorum æqualitatem, cui me <lb/> attentissimum paulo ante
-						reddidisti, si vel nunc fas <lb/> est, cognoscere vehementer exspecto.</p>
+						<lb/>genus isto praerposterato fiercl, ut est, <hi rend="italic">Qui procul
+							negotio<lb/>beatus ille,</hi> fieri profecto non oportet1: tamen si
+						quis<lb/>audeat et faciat tales versus, manifestum est cum alia<lb/>
+						gerera senariorum esse facturum, quibus sint ista<lb/>meliora.</p>
+					</div><div type="textpart" subtype="dialog"><p>24. Ili ergo senariorum omnium pulcherrimi, non<lb/>potuerunt ambo obtinere
+						sinceritatem suam adversus<lb/>hominum licentiam. Nam in trochaico geuere,
+						non<lb/>senario solo, sed unde minus incipit usque ad magni­<lb/>tudinem
+						extremam quae ocio pedes habet, miscendus<lb/>poctae putaverunt quatuor
+						temporum pedes omnes,<lb/>qui adhibentur ad numeros: ct Graeci quidem
+						alternis<lb/>locis primo et tertio, et ita deinceps, si a semipede<lb/>
+						versus incipit: sin ab integra trochaeo, secundo et<lb/>quarto loco, atque
+						ita deinceps servatis intervallis,<lb/>memorati longiores collocantur
+						pedcs. Quae corruptio<lb/>ut tolerabilis fieret, non singulos pedes in duas
+						par­<lb/>tes, quorum una lcvationis, altera positionis est,<lb/>plaudc;
+						do diviserunt; sed unuin peJein lcvanles, al­<lb/>terum poucnles, unde
+						ipsum senarium trimetrum vo­<lb/>cant, ad epitritorum divisionem plausum
+						rctulerunt.<lb/>Sed si hoc sultem constanter tcnerclur, quamvis pe­<lb/>
+						des epitriti magis orationis siat quam poematis, nec<lb/>jam senarius, scd
+						ternarius versus inveniretur; non<lb/>tamen omnimodo illa n imerorum
+						labefactaretur aequa­<lb/>litas. Nunc vero quatuor temporum pedes, dummodo
+						<lb/>in locis memoratis ponantur, licet non solum in om­<lb/>nibus
+						ponere, sed ubi libet eorum, et quoties libet.<lb/>Nostri veru veteres,
+						nec ipsa locorum intervalla in­<lb/>termiscendis hujuscemodi pedibus,
+						servare potuerunt.<lb/>Quare in hoc genere poetae ista corruptione atque
+						li­<lb/>centia plane assecuti sunt, quod eos voluisse arbitran­<lb/>dum
+						cst, ut essent in fabulis poemata solutae orationi<lb/>simillima. Se d
+						quoniam satis dictum est cur inter se­<lb/>narios isti versus magis
+						nobilitati sint, nunc videa­<lb/>mus cur ipsi senarii meliores sint versus
+						quam caeteri<lb/>in quolibet alio pedum numero constituti. Nisi quid<lb/>
+						habes adversus ista quaedisseras. 'B. Prorsus assen­<lb/>tiur : et jam
+						illam membrorum aequalitatem, cui me<lb/>attentissimum paulo ante
+						reddidisti, si vel nunc fas<lb/>est, cognoscere vehementer exspecto.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT XII. — <hi rend="italic">Senarii versus cur aliis
-								præstantiores.</hi>
+								praestantiores.</hi>
 						</title>
 					</ab>
-					<div type="textpart" subtype="dialog"><p>25. M. Totus ergo adesto, atque responde, utrum <lb/> tibi videatur qunelibet
-						longitudo posse in quotlibet par­ <lb/> tes secari. <hi rend="italic"
-							>D.</hi> Satis milii ista persuasa suut: nee du­ <lb/> bitari posse
-						arbitror, quin omnis longitudo quæ linea <lb/> dicitur, habeat dimidiam sui
-						partem I, ac per hoc in <lb/> dura lineas dccussatim secari queat : et quia
-						ipsæ duæ <note type="footnote">1 In <hi rend="italic">K.toportere(.</hi>
+					<div type="textpart" subtype="dialog"><p>25. M. Totus ergo adesto, atque responde, utrum<lb/>tibi videatur qunelibet
+						longitudo posse in quotlibet par­<lb/>tes secari. <hi rend="italic"
+							>D.</hi> Satis milii ista persuasa suut: nee du­<lb/>bitari posse
+						arbitror, quin omnis longitudo quae linea<lb/>dicitur, habeat dimidiam sui
+						partem I, ac per hoc in<lb/>dura lineas dccussatim secari queat : et quia
+						ipsae duae <note type="footnote">1 In <hi rend="italic">K.toportere(.</hi>
 							vatic., <hi rend="italic">oportet.</hi> M. </note><note type="footnote">
 							* <hi rend="italic">Uabeul dimensam</hi> partem, juxta vatic. II. </note>
-						<lb/> lineæ quæ ista sectione fiunt1, procul dubio lineae <lb/> sunt, etiam
-						in ipsis hoc fieri posse manifestum est. <lb/> Itaque et quantulacumque
-						longitudo in quotlibet par. <lb/> tes secari potest. <hi rend="italic"
-							>M.</hi> Expeditissime atque verissime. <lb/> Quare nunc illud vide,
-						utrum recte asseveretur, om­ <lb/> nem longitudinem ad latitudinem
-						porrigendam, quæ <lb/> ab ipsa oritur, tantum valere quantum latitudinis
-						qua­ <lb/> dratum occupat. Si enim minus aut amplius in latum <lb/> spatium
-						proceditur quam longa est linea unde proce­ <lb/> ditur, quadratum non fit;
-						sin tantum, nibilaliud quam <lb/> quadratum fit. <hi rend="italic">D.</hi>
-						Intelligo et assentior: quid enim <lb/> verius? <hi rend="italic">M.</hi>
-						Illud ergo jam sequi, ut opinor, vides, ut <lb/> si pro linea in longum
-						ordinati calculi pares ponantur, <lb/> non perveniat illa longitudo ad
-						quadratam forlnam, <lb/> nisi per eumdem numerum multiplicati calculi
-						fuerint: <lb/> ut si verbi gratia duos calculos ponas, quadratum nou <lb/>
-						facias, nisi aliis duobus ad latitudinem adjunctis: sin <lb/> tres, sex
-						adjungendi sunt, sed terni distributi ad duos <lb/> ordines similiter in
-						lalitudinem2 : si enim ad longitu­ <lb/> dinem additi fuerint, nulla figura
-						fit. Longitudo enim <lb/> sine latitudine figura non est*. Atque ita
-						proportiono <lb/> licet considerare alios numeros: ut enim bis bina, et
-						<lb/> ter terna quadratas figuras in numeris faciunt, ita qua­ <lb/> ter
-						quaterna, quinquics quina, sexies sena, atque ita <lb/> per infinitum in
-						cæteris. <hi rend="italic">D.</hi> Etium ista rata et mani­ <lb/> festa
+						<lb/>lineae quae ista sectione fiunt1, procul dubio lineae<lb/>sunt, etiam
+						in ipsis hoc fieri posse manifestum est.<lb/>Itaque et quantulacumque
+						longitudo in quotlibet par.<lb/>tes secari potest. <hi rend="italic"
+							>M.</hi> Expeditissime atque verissime.<lb/>Quare nunc illud vide,
+						utrum recte asseveretur, om­<lb/>nem longitudinem ad latitudinem
+						porrigendam, quae<lb/>ab ipsa oritur, tantum valere quantum latitudinis
+						qua­<lb/>dratum occupat. Si enim minus aut amplius in latum<lb/>spatium
+						proceditur quam longa est linea unde proce­<lb/>ditur, quadratum non fit;
+						sin tantum, nibilaliud quam<lb/>quadratum fit. <hi rend="italic">D.</hi>
+						Intelligo et assentior: quid enim<lb/>verius? <hi rend="italic">M.</hi>
+						Illud ergo jam sequi, ut opinor, vides, ut<lb/>si pro linea in longum
+						ordinati calculi pares ponantur,<lb/>non perveniat illa longitudo ad
+						quadratam forlnam,<lb/>nisi per eumdem numerum multiplicati calculi
+						fuerint:<lb/>ut si verbi gratia duos calculos ponas, quadratum nou<lb/>
+						facias, nisi aliis duobus ad latitudinem adjunctis: sin<lb/>tres, sex
+						adjungendi sunt, sed terni distributi ad duos<lb/>ordines similiter in
+						lalitudinem2 : si enim ad longitu­<lb/>dinem additi fuerint, nulla figura
+						fit. Longitudo enim<lb/>sine latitudine figura non est*. Atque ita
+						proportiono<lb/>licet considerare alios numeros: ut enim bis bina, et
+						<lb/>ter terna quadratas figuras in numeris faciunt, ita qua­<lb/>ter
+						quaterna, quinquics quina, sexies sena, atque ita<lb/>per infinitum in
+						caeteris. <hi rend="italic">D.</hi> Etium ista rata et mani­<lb/>festa
 						sunt. <hi rend="italic">JI.</hi> Attende nunc utrum sit aliqua temporis
-						<lb/> longitudo. <hi rend="italic">D.</hi> Quis dubitaverit nullum esse
-						tempus <lb/> sine aliqua longitudine? <hi rend="italic">M.</hi> Quid? versus
-						potestne non <lb/> obtinere aliquam temporis longitudinem? D. Imo ne­ <lb/>
+						<lb/>longitudo. <hi rend="italic">D.</hi> Quis dubitaverit nullum esse
+						tempus<lb/>sine aliqua longitudine? <hi rend="italic">M.</hi> Quid? versus
+						potestne non<lb/>obtinere aliquam temporis longitudinem? D. Imo ne­<lb/>
 						cesse est obtineat. <hi rend="italic">M.</hi> Quid in ca longitudine pro
-						cal­ <lb/> cutis melius collocamus? pcdesne, qui duas in partes. <lb/> id
-						est levationcm et positionem neccssario distrihuun­ <lb/> tur4; an ipsos
-						semipedcs potius, qui singulas levalio­ <lb/> ncs positionesque obtinent?
-							<hi rend="italic">D.</hi> Semipedes congruen­ <lb/> lius judico pro
+						cal­<lb/>cutis melius collocamus? pcdesne, qui duas in partes.<lb/>id
+						est levationcm et positionem neccssario distrihuun­<lb/>tur4; an ipsos
+						semipedcs potius, qui singulas levalio­<lb/>ncs positionesque obtinent?
+							<hi rend="italic">D.</hi> Semipedes congruen­<lb/>lius judico pro
 						illis calculis poni.</p>
-					</div><div type="textpart" subtype="dialog"><p>26. <hi rend="italic">M.</hi> Age, nunc commemora membrum versus <lb/>
-						hcroici brevius, quot semipcdes habcat. <hi rend="italic">D.</hi> Quinque. <lb/>
+					</div><div type="textpart" subtype="dialog"><p>26. <hi rend="italic">M.</hi> Age, nunc commemora membrum versus<lb/>
+						hcroici brevius, quot semipcdes habcat. <hi rend="italic">D.</hi> Quinque.<lb/>
 						<hi rend="italic">M.</hi> Dic exemplum. <hi rend="italic">D. Arma virumque
-							cano. M.</hi> Num <lb/> igitur aliud dcsidcras, nisi ut alii septem
-						semipedes <lb/> cum istis quinque aliqua æqualitate conveniant? <hi
+							cano. M.</hi> Num<lb/>igitur aliud dcsidcras, nisi ut alii septem
+						semipedes<lb/>cum istis quinque aliqua aequalitate conveniant? <hi
 							rend="italic">D.</hi>
-						<lb/> Nihil prorsus aliud. M. Quid? septem semipedes pos­ <lb/> suntne
-						aliquem versum complere per se? <hi rend="italic">D.</hi> Possunt <lb/>
-						vero: nam lot semipedes habet primus ac minimus <lb/> versus, annumerato in
-						fine silentio. <hi rend="italic">M.</hi> Rectc dicis : <lb/> sed ut versus
-						esse possit, quomodo in duo membra <lb/> dividitur? <hi rend="italic"
-							>D.</hi> In quatuor scilicet, et tres semipedes. <lb/>
+						<lb/>Nihil prorsus aliud. M. Quid? septem semipedes pos­<lb/>suntne
+						aliquem versum complere per se? <hi rend="italic">D.</hi> Possunt<lb/>
+						vero: nam lot semipedes habet primus ac minimus<lb/>versus, annumerato in
+						fine silentio. <hi rend="italic">M.</hi> Rectc dicis :<lb/>sed ut versus
+						esse possit, quomodo in duo membra<lb/>dividitur? <hi rend="italic"
+							>D.</hi> In quatuor scilicet, et tres semipedes.<lb/>
 						<hi rend="italic">M.</hi> Duc ergo in legem quadrati has partes singulas, et
-						<lb/> vide quid faciant quatuor quater. <hi rend="italic">D.</hi> Sexdecim.
+						<lb/>vide quid faciant quatuor quater. <hi rend="italic">D.</hi> Sexdecim.
 							<hi rend="italic">M.</hi>
-						<lb/> Quid tria ter? <hi rend="italic">D.</hi> Novem. <hi rend="italic"
+						<lb/>Quid tria ter? <hi rend="italic">D.</hi> Novem. <hi rend="italic"
 							>M.</hi> Quid totum simul? <hi rend="italic">D.</hi>
-						<lb/> Viginti quinque. <hi rend="italic">M.</hi> Septem ergo scmipedes
-						quoniam <lb/> possunt habere duo membra, singulis membris suis <lb/> ad
-						quadratorum rationem rclatis, vigesimum quintum <lb/> numerum in summa
-						faciunt; et est una pars versus <lb/> heroici. <hi rend="italic">D.</hi> Ita
-						est. <hi rend="italic">M.</hi> Altera igitur pars quæ babeL <lb/> quinque
+						<lb/>Viginti quinque. <hi rend="italic">M.</hi> Septem ergo scmipedes
+						quoniam<lb/>possunt habere duo membra, singulis membris suis<lb/>ad
+						quadratorum rationem rclatis, vigesimum quintum<lb/>numerum in summa
+						faciunt; et est una pars versus<lb/>heroici. <hi rend="italic">D.</hi> Ita
+						est. <hi rend="italic">M.</hi> Altera igitur pars quae babeL<lb/>quinque
 						semipedes, quoniam non potest in duo mem- <note type="footnote">
 							<hi rend="italic">I secatione fiimt,</hi> juxta vatic. M. </note><note
 							type="footnote"> * <hi rend="italic">Ad</hi> latitudinem, juXta vttic.
@@ -4638,71 +4638,71 @@
 							<hi rend="italic">I Figuratio est,</hi> juxta vatic. M. </note><note
 							type="footnote"> 4 <hi rend="italic">iribuimlur,</hi> juxta Ms. A. M. </note>
 						<lb/>
-						<pb n="1161"/> brt dividi, ct debet aliqua æqualitate concinere, nonne <lb/>
+						<pb n="1161"/> brt dividi, ct debet aliqua aequalitate concinere, nonne<lb/>
 						tota in quadratum ducenda est? <hi rend="italic">D.</hi> Nihil aliud omnino
-						<lb/> censeo, et jam tandem agnosco æqualitatem mirabi­ <lb/> lem. Quinque
-						enim quinquics ducta cadem viginti <lb/> quinque consummant. Nec ergo
-						immerito senarii ver­ <lb/> sus cæteris celebraLiores nobilioresque facti
-						sunt: <lb/> dici enim vix potest quantum inter illorum æquali­ <lb/> tatem
-						in membris imparibus, et aliorum omnium <lb/> intersit.</p>
+						<lb/>censeo, et jam tandem agnosco aequalitatem mirabi­<lb/>lem. Quinque
+						enim quinquics ducta cadem viginti<lb/>quinque consummant. Nec ergo
+						immerito senarii ver­<lb/>sus caeteris celebraLiores nobilioresque facti
+						sunt:<lb/>dici enim vix potest quantum inter illorum aequali­<lb/>tatem
+						in membris imparibus, et aliorum omnium<lb/>intersit.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT XIII. — <hi rend="italic">Epiloqus.</hi>
 						</title>
 					</ab>
 					</div><div type="textpart" subtype="dialog"><p>27. <hi rend="italic">M.</hi> Non te ergo fefellit pollicitatio mea, vel
-						<lb/> polius ipsa nos, quam uterque nostrum sequitur, ra­ <lb/> tio. Quare
-						ut istum jam sermonem concludamus ali­ <lb/> quando, cernis certe cum sint
-						metra pene innumera­ <lb/> bilia, versum tamen esse non posse, nisi duobus
-						mem­ <lb/> bris sibimet concinnatis, aut totidem semipedibus, sed <lb/> non
-						conversibilibus terminatis, ut est, <hi rend="italic">Mæcenas atavis</hi>
-						<lb/> edite <hi rend="italic">regibus;</hi> aut dispari numero etiam
-						semipedum, <lb/> sed tamen aliqua æqualitate conjunctis, ut sunt qua­ <lb/>
-						tuor el tres, aut quinque ct tres, vel quinquc et sc­ <lb/> ptem, aut sex et
-						septem, ant octo et septem, vel se­ <lb/> plem et novem. A pleno cnim pede
-						trochaicus, ut est, <lb/>
+						<lb/>polius ipsa nos, quam uterque nostrum sequitur, ra­<lb/>tio. Quare
+						ut istum jam sermonem concludamus ali­<lb/>quando, cernis certe cum sint
+						metra pene innumera­<lb/>bilia, versum tamen esse non posse, nisi duobus
+						mem­<lb/>bris sibimet concinnatis, aut totidem semipedibus, sed<lb/>non
+						conversibilibus terminatis, ut est, <hi rend="italic">Maecenas atavis</hi>
+						<lb/>edite <hi rend="italic">regibus;</hi> aut dispari numero etiam
+						semipedum,<lb/>sed tamen aliqua aequalitate conjunctis, ut sunt qua­<lb/>
+						tuor el tres, aut quinque ct tres, vel quinquc et sc­<lb/>ptem, aut sex et
+						septem, ant octo et septem, vel se­<lb/>plem et novem. A pleno cnim pede
+						trochaicus, ut est,<lb/>
 						<hi rend="italic">Optimus beatus ille qui procul negotio;</hi> et a non
-						pleno <lb/> potest versus exordiri, ut est, Vir <hi rend="italic">optimus
-							beatus ille <lb/> qui procul negotio</hi> : terminari aulem nisi non
-						pleno <lb/> prorsus non potest. Scd isti non pleni pedes, sive in­ <lb/>
-						tegros semipedes habeant, sicuti est iste quem nunc <lb/> posui; sive minus
-						quam dimidium pedem, sicut in illo <lb/> choriambico duae ultimas breves,
-						Macerias <hi rend="italic">atavis edite <lb/> regibus;</hi> sive plus quam
-						dimidium, ut in ejus capite <lb/> dux primae longæ, aut in fine alterius
-						choriambici <lb/> bacchius, cujus exemplum est, <hi rend="italic">Te domus
-							Evandri</hi> *, te <lb/>
+						pleno<lb/>potest versus exordiri, ut est, Vir <hi rend="italic">optimus
+							beatus ille<lb/>qui procul negotio</hi> : terminari aulem nisi non
+						pleno<lb/>prorsus non potest. Scd isti non pleni pedes, sive in­<lb/>
+						tegros semipedes habeant, sicuti est iste quem nunc<lb/>posui; sive minus
+						quam dimidium pedem, sicut in illo<lb/>choriambico duae ultimas breves,
+						Macerias <hi rend="italic">atavis edite<lb/>regibus;</hi> sive plus quam
+						dimidium, ut in ejus capite<lb/>dux primae longae, aut in fine alterius
+						choriambici<lb/>bacchius, cujus exemplum est, <hi rend="italic">Te domus
+							Evandri</hi> *, te<lb/>
 						<hi rend="italic">sedes celsa Latini (a).</hi> Omnes ergo isti non pleni
-						pedes <lb/> semipedes nuncupantur. <note type="footnote">
+						pedes<lb/>semipedes nuncupantur. <note type="footnote">
 							<hi rend="italic">I Te domus Evandrea,</hi> juxta Er. <hi rend="italic"
 								>Evandria,</hi> juxta Lov. </note>
 						<note type="footnote">
 							<hi rend="italic">(a)</hi> Hunc versum TerentianUs refert inter I
 							halecios. </note>
 					</p>
-					</div><div type="textpart" subtype="dialog"><p>28. Janvero non solum talia poemata versibus Hunt, <lb/> ut in his unum gcnus
-						teneatur, qualia Epicorum poe­ <lb/> tarum sunt, vcl etiam Comicorum; sed
-						illos quoqne <lb/> ambitus quos <foreign xml:lang="grc">περιόδους</foreign>
-						Graeci vocant, non tantum iliis <lb/> metris quæ lege versuum non tenentur,
-						Lyrici poctæ <lb/> faciunt, sed etiam versibus. Nam iI!e Flacci, <lb/>
-						<lb/> Nox erat, et carlo fulgebat lana sereno <lb/> Inter minora sidera. <lb/>
-						<hi rend="italic">(Horat. Epod. ode</hi> 15; ) <lb/> bimembris ambitus es!,
-						et versibus constans. Qui duo <lb/> versus sibimet convenire non possunt,
-						nis! uterque ad <lb/> senorum temporum rcferatur pedes. Nam modus he­ <lb/>
-						roicus cum modo iambico vcl trochaico non concinit, <lb/> quia illi pedes ad
-						tantumdem, hi ad duplum partiun­ <lb/> tur. Fiunt ergo ambitus aut omnibus
-						metris non cum <lb/> versibus, ut il!i sunt de quibus in supcriori sermone
-						<lb/> disputatum cst, cum de ipsis metris agercmus; aut <lb/> tantum
-						versibus, ut ii de qubus nunc dictum est ; <lb/> aut ut ctversibus, et aliis
-						metris temperentur \ quale <lb/> illud cst: <lb/> Diffugere nives, redeunt
-						jam gramina aun; is, <lb/> Arborihusquc comae. <lb/>
+					</div><div type="textpart" subtype="dialog"><p>28. Janvero non solum talia poemata versibus Hunt,<lb/>ut in his unum gcnus
+						teneatur, qualia Epicorum poe­<lb/>tarum sunt, vcl etiam Comicorum; sed
+						illos quoqne<lb/>ambitus quos <foreign xml:lang="grc">περιόδους</foreign>
+						Graeci vocant, non tantum iliis<lb/>metris quae lege versuum non tenentur,
+						Lyrici poctae<lb/>faciunt, sed etiam versibus. Nam iI!e Flacci,<lb/>
+						<lb/>Nox erat, et carlo fulgebat lana sereno<lb/>Inter minora sidera.<lb/>
+						<hi rend="italic">(Horat. Epod. ode</hi> 15; )<lb/>bimembris ambitus es!,
+						et versibus constans. Qui duo<lb/>versus sibimet convenire non possunt,
+						nis! uterque ad<lb/>senorum temporum rcferatur pedes. Nam modus he­<lb/>
+						roicus cum modo iambico vcl trochaico non concinit,<lb/>quia illi pedes ad
+						tantumdem, hi ad duplum partiun­<lb/>tur. Fiunt ergo ambitus aut omnibus
+						metris non cum<lb/>versibus, ut il!i sunt de quibus in supcriori sermone
+						<lb/>disputatum cst, cum de ipsis metris agercmus; aut<lb/>tantum
+						versibus, ut ii de qubus nunc dictum est ;<lb/>aut ut ctversibus, et aliis
+						metris temperentur \ quale<lb/>illud cst:<lb/>Diffugere nives, redeunt
+						jam gramina aun; is,<lb/>Arborihusquc comae.<lb/>
 						<hi rend="italic">(Id. tib.</hi> 4 <hi rend="italic">carminum, ode 7.)</hi>
-						<lb/> Quo autem ordine lorentur vel versus cum aliis me­ <lb/> tris, vel
-						majora membra cum minoribus, nihil inter­ <lb/> est ad aurium voluptatem,
-						dummodo non brevior <lb/> quam bimembris, non amplior quam quadrimembris
-						<lb/> sit ambitus. Scd jam si nihil habes quod contradicas, <lb/> finis sit
-						hujus disputationis, ut deinceps quod ad hanc <lb/> partem musicæ attinet
-						quæ in numeris temporum est, <lb/> ab his vestigiis ejus sensibilibus, ad
-						ipsa cubilia, ubi <lb/> ab omni corpore aliena est, quanta valemus
-						sagacitate <lb/> veniamus. <note type="footnote">4 Sic Ms. A: <hi
+						<lb/>Quo autem ordine lorentur vel versus cum aliis me­<lb/>tris, vel
+						majora membra cum minoribus, nihil inter­<lb/>est ad aurium voluptatem,
+						dummodo non brevior<lb/>quam bimembris, non amplior quam quadrimembris
+						<lb/>sit ambitus. Scd jam si nihil habes quod contradicas,<lb/>finis sit
+						hujus disputationis, ut deinceps quod ad hanc<lb/>partem musicae attinet
+						quae in numeris temporum est,<lb/>ab his vestigiis ejus sensibilibus, ad
+						ipsa cubilia, ubi<lb/>ab omni corpore aliena est, quanta valemus
+						sagacitate<lb/>veniamus. <note type="footnote">4 Sic Ms. A: <hi
 								rend="italic">fut et l'ernbu, et aliis metns temperantur.</hi> II.
 						</note></p>
 				</div><div type="textpart" subtype="book">
@@ -4721,54 +4721,54 @@
 								scripti sint, quove consilio.</hi>
 						</title>
 					</ab>
-					<div type="textpart" subtype="dialog"><p>1. M. Satis din pene1 atque adeo plane pueriliter <lb/> per quinque libros in
-						vestigiis numerorum ad moras <lb/> temporum pertinentium monli sumus:quam
-						nostram <lb/> nugacitatem apud benevolos homines facile fortassis <lb/>
-						excuset officiosus labor; quem non ob aliud suscipien­ <lb/> dum putavimus,
-						nisi ut adolescentes, vel cujuslibet <lb/> ætatis homines, quos bono ingenio
-						donavit Deus, non <lb/> præpropere, sed quibusdam gradibus a sensibus car­
-						<lb/> nis atque a carnalibus litteris, quibus eos non hærere <lb/> difficile
-						est, duce ratione avellerentur, atque um Dco <lb/> et Domino rerum omnium,
-						qui humanis mentibus <lb/> nulla natura interposita præsidet, incommutabilis
-						ve­ <lb/> ritaiis amore adhærescerent. Illos igitur libros qui <note
+					<div type="textpart" subtype="dialog"><p>1. M. Satis din pene1 atque adeo plane pueriliter<lb/>per quinque libros in
+						vestigiis numerorum ad moras<lb/>temporum pertinentium monli sumus:quam
+						nostram<lb/>nugacitatem apud benevolos homines facile fortassis<lb/>
+						excuset officiosus labor; quem non ob aliud suscipien­<lb/>dum putavimus,
+						nisi ut adolescentes, vel cujuslibet<lb/>aetatis homines, quos bono ingenio
+						donavit Deus, non<lb/>praepropere, sed quibusdam gradibus a sensibus car­
+						<lb/>nis atque a carnalibus litteris, quibus eos non haerere<lb/>difficile
+						est, duce ratione avellerentur, atque um Dco<lb/>et Domino rerum omnium,
+						qui humanis mentibus<lb/>nulla natura interposita praesidet, incommutabilis
+						ve­<lb/>ritaiis amore adhaerescerent. Illos igitur libros qui <note
 							type="footnote"> ' <hi rend="italic">satis diu penes te,</hi> juxta Er.
 							ven. et MS A. M. </note>
-						<lb/> leget, inveniet nos cum grammaticis et pocticis ani <lb/> mis, non
-						habitandi electione, sed itinerandi necessi­ <lb/> tate versatos. Ad hunc
-						autcm librum cum vcnerit, si, <lb/> ut spero et supplex deprecor, Deus et
-						Dominus noster <lb/> propositum meum voluntatemque gubernaverit, et co <lb/>
-						quo est intenta perduxerit, intelliget non vilis posses­ <lb/> sionis esse
-						vilem viam, per quam nunc cum imbecil­ <lb/> lioribus, nec nos ipsi admodum
-						fortes ambulare ma­ <lb/> luimus, quam minus pennatos per liberiores auras
-						<lb/> præcipitare. Ita nos, quantum arbitror, ant nibil ant <lb/> non
-						inultum peccasse judicabit, si tamen de numero <lb/> spiritualium virorum
-						iste fuerit. Nam turba caetera de <lb/> scholis linguarum tumultuantium, et
-						ad plaudentiuin <lb/> strepitum vulgari levitate latantium, si Curte
-						irruerit <lb/> in has liucras, aut contemnet omnes, aut illos quin­ <lb/>
+						<lb/>leget, inveniet nos cum grammaticis et pocticis ani<lb/>mis, non
+						habitandi electione, sed itinerandi necessi­<lb/>tate versatos. Ad hunc
+						autcm librum cum vcnerit, si,<lb/>ut spero et supplex deprecor, Deus et
+						Dominus noster<lb/>propositum meum voluntatemque gubernaverit, et co<lb/>
+						quo est intenta perduxerit, intelliget non vilis posses­<lb/>sionis esse
+						vilem viam, per quam nunc cum imbecil­<lb/>lioribus, nec nos ipsi admodum
+						fortes ambulare ma­<lb/>luimus, quam minus pennatos per liberiores auras
+						<lb/>praecipitare. Ita nos, quantum arbitror, ant nibil ant<lb/>non
+						inultum peccasse judicabit, si tamen de numero<lb/>spiritualium virorum
+						iste fuerit. Nam turba caetera de<lb/>scholis linguarum tumultuantium, et
+						ad plaudentiuin<lb/>strepitum vulgari levitate latantium, si Curte
+						irruerit<lb/>in has liucras, aut contemnet omnes, aut illos quin­<lb/>
 						que libros sufficere sibi arbitrabitur : istum vero in <note type="footnote"
 							> PATROI.. XXXII. </note>
 						<note type="footnote">
 							<hi rend="italic">(Trente-sept J</hi>
 						</note>
 						<lb/>
-						<pb n="1163"/> quo fructus illorum est, vel abjiciet quasi non neces­ <lb/>
-						sarum, vel differet quasi post necefsarium. Reliquos <lb/> vero qui ad ista
-						intelligenda eruditi non sunt, si sa­ <lb/> cramentis Christianæ puritatis
-						imbuti1, in unum et <lb/> verum Deum summa charitate nitentes, cuncta pueri­
-						<lb/> lia transvolaverunt, fraterne admoneo ne ad ista de­ <lb/> scendant,
-						et cum hie laborare corperint, de tarditate <lb/> sua conquerantur,
-						ignorantes itinera difficilia et mo­ <lb/> lesta pedibus suis, volando se
-						posse ctiam ignorata <lb/> transire. Si autem ii legunt qui et infirmis aut
-						inexer­ <lb/> citatis gressibus hac ambulare non possont, et nullas <lb/>
-						pietatis alas habent, quibus ista neglecta .prætervo­ <lb/> lent, non se
-						inserant inconvenienti ncgolio; sed præ­ <lb/> ceptis saluberrimæ
-						religionis, et nido fidei Christianae <lb/> pennas nutriant, quibus subveti
-						laborem ac pulvc­ <lb/> rem hujus itineris evadant, magis ipsius patri.c
-						quam <lb/> ,'tarum flexuosarum amore flagrantes. liis enim hæc <lb/> scripta
-						sunt, qui litteris sæcularibus dediti, magnis <lb/> implicantur erroribus,
-						ct bona ingenia in nugis ron­ <lb/> terunt, nescientes quid ibi delectet.
-						Quod si animad­ <lb/> verterent, viderent qua effugerent illa retia, et
-						quisnam <lb/> esset beatissimæ securitatis locus.</p>
+						<pb n="1163"/> quo fructus illorum est, vel abjiciet quasi non neces­<lb/>
+						sarum, vel differet quasi post necefsarium. Reliquos<lb/>vero qui ad ista
+						intelligenda eruditi non sunt, si sa­<lb/>cramentis Christianae puritatis
+						imbuti1, in unum et<lb/>verum Deum summa charitate nitentes, cuncta pueri­
+						<lb/>lia transvolaverunt, fraterne admoneo ne ad ista de­<lb/>scendant,
+						et cum hie laborare corperint, de tarditate<lb/>sua conquerantur,
+						ignorantes itinera difficilia et mo­<lb/>lesta pedibus suis, volando se
+						posse ctiam ignorata<lb/>transire. Si autem ii legunt qui et infirmis aut
+						inexer­<lb/>citatis gressibus hac ambulare non possont, et nullas<lb/>
+						pietatis alas habent, quibus ista neglecta .praetervo­<lb/>lent, non se
+						inserant inconvenienti ncgolio; sed prae­<lb/>ceptis saluberrimae
+						religionis, et nido fidei Christianae<lb/>pennas nutriant, quibus subveti
+						laborem ac pulvc­<lb/>rem hujus itineris evadant, magis ipsius patri.c
+						quam<lb/>,'tarum flexuosarum amore flagrantes. liis enim haec<lb/>scripta
+						sunt, qui litteris saecularibus dediti, magnis<lb/>implicantur erroribus,
+						ct bona ingenia in nugis ron­<lb/>terunt, nescientes quid ibi delectet.
+						Quod si animad­<lb/>verterent, viderent qua effugerent illa retia, et
+						quisnam<lb/>esset beatissimae securitatis locus.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT II. — Sonorum numeri <hi rend="italic">quotuplicis,
 								generis, et an quodque eorum genus sine alio esse possit. Primum
@@ -4776,73 +4776,73 @@
 								audientis.</hi>
 						</title>
 					</ab>
-					<div type="textpart" subtype="dialog"><p>2. <hi rend="italic">M.</hi> Quamobrem tu rum quo mihi nunc ratio est, <lb/>
-						familiaris meus, ut a corporcis ad incorporea trans­ <lb/> camus, responde,
-						si videtur, cum istum versum pro­ <lb/> nuntiamus, <hi rend="italic">Deus
-							creator omnium,</hi> istos quatuor iambos <lb/> quibus constat, et
-						tempora duodecim ubinam esse <lb/> arbitreris, id est, in sono tantum qui
-						auditur, an <lb/> etiam in sensu audicntis qui ad aures pcriinet, an in
-						<lb/> actu etiam pronuntiantis, an quia notus versus est, <lb/> in mcmoria
-						quoque nostra hos numcros esse faten­ <lb/> dum est ? <hi rend="italic"
-							>D.</hi> In his omnibus puto. <hi rend="italic">M.</hi> Nusquamne <lb/>
+					<div type="textpart" subtype="dialog"><p>2. <hi rend="italic">M.</hi> Quamobrem tu rum quo mihi nunc ratio est,<lb/>
+						familiaris meus, ut a corporcis ad incorporea trans­<lb/>camus, responde,
+						si videtur, cum istum versum pro­<lb/>nuntiamus, <hi rend="italic">Deus
+							creator omnium,</hi> istos quatuor iambos<lb/>quibus constat, et
+						tempora duodecim ubinam esse<lb/>arbitreris, id est, in sono tantum qui
+						auditur, an<lb/>etiam in sensu audicntis qui ad aures pcriinet, an in
+						<lb/>actu etiam pronuntiantis, an quia notus versus est,<lb/>in mcmoria
+						quoque nostra hos numcros esse faten­<lb/>dum est ? <hi rend="italic"
+							>D.</hi> In his omnibus puto. <hi rend="italic">M.</hi> Nusquamne<lb/>
 						amplius ? <hi rend="italic">D.</hi> Quid aliud restet non video, nisi forte
-						<lb/> interior et superior aliqua vis sit I unde ista proce­ <lb/> dunt. 3/.
-						Non ego quaero quid suspicandum sit: <lb/> quare si hæc quatuor genera ita
-						tibi apparent, ut nul­ <lb/> lum aliud videas quod æque manifestum sit,
-						discer­ <lb/> namus ea , si placet, ab invicem , et videamus utrum <lb/>
-						singula esse sine invicem possint. Nam credo non te <lb/> csse negaturum
-						fieri posse, ut in aliquo loco aliquis <lb/> sonus existat hujuscemodi
-						morulis et dimensionibus <lb/> verberans aerem vel stillicidio vel aliquo
-						alio pulsu <lb/> corporum, ubi nullus adsit auditor. Quod cum fit, <lb/> num
-						præter illud primum geuus, cum ipse sonus hos <lb/> numcros habet, ullum
+						<lb/>interior et superior aliqua vis sit I unde ista proce­<lb/>dunt. 3/.
+						Non ego quaero quid suspicandum sit:<lb/>quare si haec quatuor genera ita
+						tibi apparent, ut nul­<lb/>lum aliud videas quod aeque manifestum sit,
+						discer­<lb/>namus ea , si placet, ab invicem , et videamus utrum<lb/>
+						singula esse sine invicem possint. Nam credo non te<lb/>csse negaturum
+						fieri posse, ut in aliquo loco aliquis<lb/>sonus existat hujuscemodi
+						morulis et dimensionibus<lb/>verberans aerem vel stillicidio vel aliquo
+						alio pulsu<lb/>corporum, ubi nullus adsit auditor. Quod cum fit,<lb/>num
+						praeter illud primum geuus, cum ipse sonus hos<lb/>numcros habet, ullum
 						horum quatuor rcperitur ? <hi rend="italic">D.</hi>
-						<lb/> Nullum aliud video.</p>
+						<lb/>Nullum aliud video.</p>
 					</div><div type="textpart" subtype="dialog"><p>3. <hi rend="italic">M.</hi> Quid iste alter, qui est in sensu audientis ?
-						<lb/> potestne esse si nihil sonct? Non enim quæro utrum <lb/> habeant illae
-						aures vim percipiendi si quidquam so­ <lb/> nuerit, qua utique non carent si
-						desit sonus: non <lb/> onim et cum silentium est, nihil a surdis differunt;
-						<lb/> sed quæro utrum ipsos numeros habeant, etiamsi nihil <note
+						<lb/>potestne esse si nihil sonct? Non enim quaero utrum<lb/>habeant illae
+						aures vim percipiendi si quidquam so­<lb/>nuerit, qua utique non carent si
+						desit sonus: non<lb/>onim et cum silentium est, nihil a surdis differunt;
+						<lb/>sed quaero utrum ipsos numeros habeant, etiamsi nihil <note
 							type="footnote">1 Er. et LOV., <hi rend="italic">veritatis imbutf;</hi>
-							at Mss. habent cum Am., <lb/>
+							at Mss. habent cum Am.,<lb/>
 							<hi rend="italic">puritatis.</hi>
 						</note><note type="footnote"> ' <hi rend="italic">ut.</hi> juxta 111. A. M. </note>
-						<lb/> sonet. Siquidem aliud est habere numeros, aliud <lb/> posse sentire
-						numerosum sonum. Nam et si sentien­ <lb/> tem corporis locum digito tangas,
-						quotieslibet tangi­ <lb/> tur, toties sentitur tactu ille numerus : et cum
-						senti­ <lb/> tur, non eo caret sentiens : sed utrum insit etiam tan­ <lb/>
-						gente nullo, non sensus ille , sed numerus, similiter <lb/> quæritur. <hi
-							rend="italic">D.</hi> Non facile dixerim, carere sensum nu­ <lb/> meris
-						talibus in se constitutis, etiam antequam aliquid <lb/> sonet: non enim
-						aliter aut corum mulceretur concin­ <lb/> nitale, aut absurditate
-						offenderetur. Idipsum ergo <lb/> quidquid est, quo aut annuimus aut
-						abhorremus, nou <lb/> ratione sed natura, cum aliquid sonat, ipsius sensus
-						<lb/> numcrum voco. Non enim tunc fit in auribus mei;, <lb/> cum sonum
-						audio, hæc vis approbandi et improbandi. <lb/> Aures quippe non aliter bonis
-						sonis quam nolis pa­ <lb/> tent. <hi rend="italic">M.</hi> Vide potius ne
-						ista duo sint minime confun­ <lb/> denda. Nam si versus quilibet modo
-						correptius, modo <lb/> productius pronuntietur, spatium temporis non idem
-						<lb/> teneat necesse est, quamvis eadem pedum ratione <lb/> servata. Ut ergo
-						ipso suo gcnere aures mulceat, illa <lb/> vis facit qua concinna
-						adsciscimus, et absurda re­ <lb/> spuimus. Ut autem breviore tempore
-						sentiatur cum <lb/> celerius, quam cum tardius promitur, non interest <lb/>
-						aliquid nisi quamdiu aures tangantur sono. Affectio <lb/> ergo hæc aurium
-						cum tanguntur sono, nullo modo <lb/> talis est ac si non tangantur. Ut cnim
-						differt audire <lb/> ab eo quod est non audire, ita differt hanc vocem au­
-						<lb/> dire ab eo quod est alteram audire. hæc igitur affectio <lb/> nee
-						ultra porrigitur, nec infra cohibetur; quoniam <lb/> est mensura ejus soni
-						qui facit eam. Altera est ergo <lb/> in ianibo, altera in tribracho;
-						productior in produ­ <lb/> ctiore iambo, correptior in correpliore ; nulla
-						in si­ <lb/> lentio. Quæ si numerosa voce fit, ctiam ipsa nume­ <lb/> rosa
-						sit necesse est. Neque esse potest, nisi cum <lb/> adest effector ejus sonus
-						: similis est enim vestigio in <lb/> aqua impresso, quod neque ante formatur
-						quam cor­ <lb/> pus impresseris, neque remanet cum detraxeris. Na­ <lb/>
-						turalis vero illa vis quasi judiciaria, quai auribus <lb/> adest, non
-						desinit esse in silentio, nec nobis eam <lb/> sonus infert, sed ab ea
-						potius, sive probandus, sive <lb/> improbandus excipitur. Quare ista duo,
-						nisi fallor, <lb/> distinguenda sunt; et fatendum numeros, qui sunt in <lb/>
-						ipsa passione aurium, cum aliquid auditur , sono in­ <lb/> ferri, auferri
-						silentio. Ex quo colligitur numeros qui <lb/> sunt in ipso sono, posse esse
-						sine istis qui sunt in eo <lb/> quod est audire. cum hi siue illis esse non
+						<lb/>sonet. Siquidem aliud est habere numeros, aliud<lb/>posse sentire
+						numerosum sonum. Nam et si sentien­<lb/>tem corporis locum digito tangas,
+						quotieslibet tangi­<lb/>tur, toties sentitur tactu ille numerus : et cum
+						senti­<lb/>tur, non eo caret sentiens : sed utrum insit etiam tan­<lb/>
+						gente nullo, non sensus ille , sed numerus, similiter<lb/>quaeritur. <hi
+							rend="italic">D.</hi> Non facile dixerim, carere sensum nu­<lb/>meris
+						talibus in se constitutis, etiam antequam aliquid<lb/>sonet: non enim
+						aliter aut corum mulceretur concin­<lb/>nitale, aut absurditate
+						offenderetur. Idipsum ergo<lb/>quidquid est, quo aut annuimus aut
+						abhorremus, nou<lb/>ratione sed natura, cum aliquid sonat, ipsius sensus
+						<lb/>numcrum voco. Non enim tunc fit in auribus mei;,<lb/>cum sonum
+						audio, haec vis approbandi et improbandi.<lb/>Aures quippe non aliter bonis
+						sonis quam nolis pa­<lb/>tent. <hi rend="italic">M.</hi> Vide potius ne
+						ista duo sint minime confun­<lb/>denda. Nam si versus quilibet modo
+						correptius, modo<lb/>productius pronuntietur, spatium temporis non idem
+						<lb/>teneat necesse est, quamvis eadem pedum ratione<lb/>servata. Ut ergo
+						ipso suo gcnere aures mulceat, illa<lb/>vis facit qua concinna
+						adsciscimus, et absurda re­<lb/>spuimus. Ut autem breviore tempore
+						sentiatur cum<lb/>celerius, quam cum tardius promitur, non interest<lb/>
+						aliquid nisi quamdiu aures tangantur sono. Affectio<lb/>ergo haec aurium
+						cum tanguntur sono, nullo modo<lb/>talis est ac si non tangantur. Ut cnim
+						differt audire<lb/>ab eo quod est non audire, ita differt hanc vocem au­
+						<lb/>dire ab eo quod est alteram audire. haec igitur affectio<lb/>nee
+						ultra porrigitur, nec infra cohibetur; quoniam<lb/>est mensura ejus soni
+						qui facit eam. Altera est ergo<lb/>in ianibo, altera in tribracho;
+						productior in produ­<lb/>ctiore iambo, correptior in correpliore ; nulla
+						in si­<lb/>lentio. Quae si numerosa voce fit, ctiam ipsa nume­<lb/>rosa
+						sit necesse est. Neque esse potest, nisi cum<lb/>adest effector ejus sonus
+						: similis est enim vestigio in<lb/>aqua impresso, quod neque ante formatur
+						quam cor­<lb/>pus impresseris, neque remanet cum detraxeris. Na­<lb/>
+						turalis vero illa vis quasi judiciaria, quai auribus<lb/>adest, non
+						desinit esse in silentio, nec nobis eam<lb/>sonus infert, sed ab ea
+						potius, sive probandus, sive<lb/>improbandus excipitur. Quare ista duo,
+						nisi fallor,<lb/>distinguenda sunt; et fatendum numeros, qui sunt in<lb/>
+						ipsa passione aurium, cum aliquid auditur , sono in­<lb/>ferri, auferri
+						silentio. Ex quo colligitur numeros qui<lb/>sunt in ipso sono, posse esse
+						sine istis qui sunt in eo<lb/>quod est audire. cum hi siue illis esse non
 						possint.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT III. — Tertium <hi rend="italic">genus
@@ -4851,325 +4851,325 @@
 						</title>
 					</ab>
 					</div><div type="textpart" subtype="dialog"><p>4. <hi rend="italic">D.</hi> Assentior. <hi rend="italic">M.</hi> Atlende
-						igitur hoc tertium <lb/> gcnus, quod est in ipso usu 1et operatione pronun­
-						<lb/> tiantis; et vide utrum possint esse hi numeri sine <lb/> illis qui
-						sunt in memoria. Nam et taciti apud nosmet­ <lb/> ipsos possumus aliquos
-						numeros cogitando peragere <lb/> ca mora temporis, qua etiam voce
-						pcragerentur. Illos <lb/> in quadam operatione animi esse manifestum cst,
-						<lb/> quae quoniam nullum edit sonum, nihilque passionis <lb/> infert
+						igitur hoc tertium<lb/>gcnus, quod est in ipso usu 1et operatione pronun­
+						<lb/>tiantis; et vide utrum possint esse hi numeri sine<lb/>illis qui
+						sunt in memoria. Nam et taciti apud nosmet­<lb/>ipsos possumus aliquos
+						numeros cogitando peragere<lb/>ca mora temporis, qua etiam voce
+						pcragerentur. Illos<lb/>in quadam operatione animi esse manifestum cst,
+						<lb/>quae quoniam nullum edit sonum, nihilque passionis<lb/>infert
 						auribus, ostendit hoc genus sinc illis duobus <note type="footnote"> I
 							lrisu, juxta Ms. A. II. </note>
 						<lb/>
-						<pb n="1165"/> esse posse, quorum unum in sono est, alterum in an. <lb/>
-						diente, quando audit. Sed utrum existerct, nisi ad­ <lb/> juvante memoria,
-						quærimus. Quanquam si anima hos <lb/> numeros agit, quos in venarum pulsu
-						invenimus, <lb/> soluta quæstio est : nam et in operatione hos esse <lb/>
-						manifestum est, et nihil ad eos adjuvamur memoria. <lb/> Quod si de his
-						incertum est, utrum operantis animae <lb/> sint; de istis certe quos
-						reciproco spiritu agimus, <lb/> nulli dubium est, quin et temporum
-						intervallis numeri <lb/> sint, ei cos sic anima opcrelur, ut etiam voluntate
-						<lb/> adhibita multis modis variari queant: nec tamen ut <lb/> agantur, ulla
-						opus cst memoria. <hi rend="italic">D.</hi> Videtur mihi hoc <lb/> genus
-						sine tribus cæteris esse posse. Quamvis enim <lb/> pro temperatione corporum
-						varios venarum pulsus, <lb/> et respirationis intervalla fieri non ambigam ;
-						tamen <lb/> operante anima fieri, negare quis audeat ? Qui cursus <lb/> et
-						si pro diversitale corporum aliis celerior est, aliis <lb/> tardior; nisi
-						tamen adsit anima quæ id agat, nullus <lb/> est. Jf. Conidera igitur et
-						quartum genus, eorum <lb/> scilicet numerorum qui sunt in memoria : nam si
-						eos <lb/> rccordatione depromimus, et cum in alias cogitationes <lb/>
-						deferimur, bos rursum relinquimus velut in suis se­ <lb/> cretis reconditos,
-						non, opinor, occultum est cos esse <lb/> posse sinc cæteris. <hi
-							rend="italic">D.</hi> Non dubito eos esse sine cxte­ <lb/> ris ; sed
-						tamen nisi auditi, vel cogitati, non manda­ <lb/> rentur memoriæ : et idco
-						quanquam illis desinen­ <lb/> tibus maneant, iisdem tamen præcedentibus
-						impri­ <lb/> muntur.</p>
+						<pb n="1165"/> esse posse, quorum unum in sono est, alterum in an.<lb/>
+						diente, quando audit. Sed utrum existerct, nisi ad­<lb/>juvante memoria,
+						quaerimus. Quanquam si anima hos<lb/>numeros agit, quos in venarum pulsu
+						invenimus,<lb/>soluta quaestio est : nam et in operatione hos esse<lb/>
+						manifestum est, et nihil ad eos adjuvamur memoria.<lb/>Quod si de his
+						incertum est, utrum operantis animae<lb/>sint; de istis certe quos
+						reciproco spiritu agimus,<lb/>nulli dubium est, quin et temporum
+						intervallis numeri<lb/>sint, ei cos sic anima opcrelur, ut etiam voluntate
+						<lb/>adhibita multis modis variari queant: nec tamen ut<lb/>agantur, ulla
+						opus cst memoria. <hi rend="italic">D.</hi> Videtur mihi hoc<lb/>genus
+						sine tribus caeteris esse posse. Quamvis enim<lb/>pro temperatione corporum
+						varios venarum pulsus,<lb/>et respirationis intervalla fieri non ambigam ;
+						tamen<lb/>operante anima fieri, negare quis audeat ? Qui cursus<lb/>et
+						si pro diversitale corporum aliis celerior est, aliis<lb/>tardior; nisi
+						tamen adsit anima quae id agat, nullus<lb/>est. Jf. Conidera igitur et
+						quartum genus, eorum<lb/>scilicet numerorum qui sunt in memoria : nam si
+						eos<lb/>rccordatione depromimus, et cum in alias cogitationes<lb/>
+						deferimur, bos rursum relinquimus velut in suis se­<lb/>cretis reconditos,
+						non, opinor, occultum est cos esse<lb/>posse sinc caeteris. <hi
+							rend="italic">D.</hi> Non dubito eos esse sine cxte­<lb/>ris ; sed
+						tamen nisi auditi, vel cogitati, non manda­<lb/>rentur memoriae : et idco
+						quanquam illis desinen­<lb/>tibus maneant, iisdem tamen praecedentibus
+						impri­<lb/>muntur.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT IV. — Quintum <hi rend="italic">genus numerorum in
 								ipso na­</hi> turali <hi rend="italic">judicio sentiendi. Ex quinque
 								recensitis nume­ rorum generibus quodnam antecellat.</hi>
 						</title>
 					</ab>
-					</div><div type="textpart" subtype="dialog"><p>5. <hi rend="italic">M.</hi> Non resisto tibi, ct vellem jam quaerere, <lb/>
-						quod tandem horum quatuor generum praestantissi­ <lb/> nium judices : nisi
-						arbitrarer dum illa tractamus, <lb/> nescio unde apparuisse nobis quintum
-						genus, quod <lb/> est in ipso naturali judicio sentiendi, cum delectamur
-						<lb/> parilitale numerorum, vel cum in eis peccatur, offen­ <lb/> dimur. Non
-						enim contemno quod tibi visum cst, sinc <lb/> quibusdam numeris in co
-						latentibus , hoc sensum <lb/> nostrum nullo modo agere potuisse. An forte ad
-						<lb/> istorum quatuor aliquod genus hanc tantam vim per­ <lb/> tinere
-						arbitraris ? <hi rend="italic">D.</hi> Ego vero ab illis omnibus hoc <lb/>
-						gcnus distinguendum puto. S'quidem aliud est sonare, <lb/> quod corpori
-						tribuitur, aliud audire, quod in corpore <lb/> auima de sonis palilor, aliud
-						operari numeros vel <lb/> productius vel correptius, aliud ista memimsse,
-						aliud <lb/> de his omnibus vel annuendo vel abhorrendo quasi <lb/> quodam
+					</div><div type="textpart" subtype="dialog"><p>5. <hi rend="italic">M.</hi> Non resisto tibi, ct vellem jam quaerere,<lb/>
+						quod tandem horum quatuor generum praestantissi­<lb/>nium judices : nisi
+						arbitrarer dum illa tractamus,<lb/>nescio unde apparuisse nobis quintum
+						genus, quod<lb/>est in ipso naturali judicio sentiendi, cum delectamur
+						<lb/>parilitale numerorum, vel cum in eis peccatur, offen­<lb/>dimur. Non
+						enim contemno quod tibi visum cst, sinc<lb/>quibusdam numeris in co
+						latentibus , hoc sensum<lb/>nostrum nullo modo agere potuisse. An forte ad
+						<lb/>istorum quatuor aliquod genus hanc tantam vim per­<lb/>tinere
+						arbitraris ? <hi rend="italic">D.</hi> Ego vero ab illis omnibus hoc<lb/>
+						gcnus distinguendum puto. S'quidem aliud est sonare,<lb/>quod corpori
+						tribuitur, aliud audire, quod in corpore<lb/>auima de sonis palilor, aliud
+						operari numeros vel<lb/>productius vel correptius, aliud ista memimsse,
+						aliud<lb/>de his omnibus vel annuendo vel abhorrendo quasi<lb/>quodam
 						naturali jure ferre sententiam.</p>
-					</div><div type="textpart" subtype="dialog"><p>6. <hi rend="italic">M.</hi> Age, nunc dic mihi quinque horum quod <lb/>
+					</div><div type="textpart" subtype="dialog"><p>6. <hi rend="italic">M.</hi> Age, nunc dic mihi quinque horum quod<lb/>
 						maxime excellat. <hi rend="italic">D.</hi> Hoc quintum puto. <hi
-							rend="italic">M.</hi> Recte <lb/> putas: non enim de illis posset, nisi
-						excelleret, judi­ <lb/> care. Sed rursus quæro, caeterorum quatuor quod
-						<lb/> maxime probes. <hi rend="italic">D.</hi> Illud profecto quod est in
-						memo­ <lb/> ria ; quia video ibi diaturniores esse numeros, quam <lb/> cum
-						sonant, vel cum audiantur, vel cum aguntur. <lb/> M. Præponis ergo factos
-						facientibus: nam istos qni <lb/> sunt in memoria, ab illis aliis imprimi
-						paulo ante <lb/> dixisti. <hi rend="italic">D.</hi> Nollem pranponere : sed
-						rursus quomodo <lb/> non præponam diuturniora minus diuturnis, non v i-
-						<lb/> deo. <hi rend="italic">II.</hi> Non te istuc movcat. Non enim sicut
-						æterna <lb/> temporalibus, ita ea quæ diutius abolentur, iis quæ <lb/>
-						breviore tempore transeunt, præfereda sunt. Quia <lb/> et sanitas unius dici
-						profecto cst melior, qnam mul­ <lb/> torum dierum imbecilitas.Et si optanda
-						optandis <lb/> comparemus, melior est unius dici lectio, quam plu­ <lb/>
-						rium scriptio, si cadem res uno dic legatur, quæ <lb/> pluribus scribitur.
-						Ita numeri qui sunt in memoria, <lb/> etsi diutius manent quam illi a quibus
-						imprimuntur, <lb/> non cos tamen anteponere oportet cis quos agimus, <lb/>
-						non in corpore, sed in anima : ulriquc enim præter­ <lb/> eunt, alii
-						cessatione, alii oblivione. Sed illi quos <lb/> operamur, etiam nondum
-						cessantibus nobis succes­ <lb/> sione sequentium videntur auferri, dum primi
-						secnn­ <lb/> dis, et secundi tertiis, atque ita dcinc ps priorcs po­ <lb/>
-						sterioribus prætereundo concedunt locum, donce <lb/> ultimos perimat ipsa
-						cessatio. Oblivione vero plures <lb/> simul numeri, quamvis paulatim,
-						absterguntur : nam <lb/> nec ipsi aliquandiu manent integri. Quod enim post
-						<lb/> annum, verbi gratia, in memoria non invenitur, etiam <lb/> post unum
-						diem jam minus est: sed non sentitur ista <lb/> diminutio : non tamcn falso
-						ex eo conjicitur, quia non <lb/> utique pridie quam compleatur annus repente
-						totum <lb/> evolat: unde inteligi datur, ab illo tempore quo in­ <lb/> hæret
-						memoriæne, incipere labi. Hinc est illud quod <lb/> plerumque dicimus,
-						Tenuiter memini, cum aliquid <lb/> post tempus recordando repetimus,
-						antequam plane <lb/> totum excidat. Quapropter utrumque hoc numerorum <lb/>
-						genus mortale est. Ycrumtamcn facientes factis jure <lb/> anteponuntur. <hi
+							rend="italic">M.</hi> Recte<lb/>putas: non enim de illis posset, nisi
+						excelleret, judi­<lb/>care. Sed rursus quaero, caeterorum quatuor quod
+						<lb/>maxime probes. <hi rend="italic">D.</hi> Illud profecto quod est in
+						memo­<lb/>ria ; quia video ibi diaturniores esse numeros, quam<lb/>cum
+						sonant, vel cum audiantur, vel cum aguntur.<lb/>M. Praeponis ergo factos
+						facientibus: nam istos qni<lb/>sunt in memoria, ab illis aliis imprimi
+						paulo ante<lb/>dixisti. <hi rend="italic">D.</hi> Nollem pranponere : sed
+						rursus quomodo<lb/>non praeponam diuturniora minus diuturnis, non v i-
+						<lb/>deo. <hi rend="italic">II.</hi> Non te istuc movcat. Non enim sicut
+						aeterna<lb/>temporalibus, ita ea quae diutius abolentur, iis quae<lb/>
+						breviore tempore transeunt, praefereda sunt. Quia<lb/>et sanitas unius dici
+						profecto cst melior, qnam mul­<lb/>torum dierum imbecilitas.Et si optanda
+						optandis<lb/>comparemus, melior est unius dici lectio, quam plu­<lb/>
+						rium scriptio, si cadem res uno dic legatur, quae<lb/>pluribus scribitur.
+						Ita numeri qui sunt in memoria,<lb/>etsi diutius manent quam illi a quibus
+						imprimuntur,<lb/>non cos tamen anteponere oportet cis quos agimus,<lb/>
+						non in corpore, sed in anima : ulriquc enim praeter­<lb/>eunt, alii
+						cessatione, alii oblivione. Sed illi quos<lb/>operamur, etiam nondum
+						cessantibus nobis succes­<lb/>sione sequentium videntur auferri, dum primi
+						secnn­<lb/>dis, et secundi tertiis, atque ita dcinc ps priorcs po­<lb/>
+						sterioribus praetereundo concedunt locum, donce<lb/>ultimos perimat ipsa
+						cessatio. Oblivione vero plures<lb/>simul numeri, quamvis paulatim,
+						absterguntur : nam<lb/>nec ipsi aliquandiu manent integri. Quod enim post
+						<lb/>annum, verbi gratia, in memoria non invenitur, etiam<lb/>post unum
+						diem jam minus est: sed non sentitur ista<lb/>diminutio : non tamcn falso
+						ex eo conjicitur, quia non<lb/>utique pridie quam compleatur annus repente
+						totum<lb/>evolat: unde inteligi datur, ab illo tempore quo in­<lb/>haeret
+						memoriaene, incipere labi. Hinc est illud quod<lb/>plerumque dicimus,
+						Tenuiter memini, cum aliquid<lb/>post tempus recordando repetimus,
+						antequam plane<lb/>totum excidat. Quapropter utrumque hoc numerorum<lb/>
+						genus mortale est. Ycrumtamcn facientes factis jure<lb/>anteponuntur. <hi
 							rend="italic">D.</hi> Accipio, et probo.</p>
-					</div><div type="textpart" subtype="dialog"><p>7. M. Jam ergo tria rcliqua intucre, et eorum quo­ <lb/> que quod sit optimum
-						et cæteris præferendum, edis­ <lb/> sere. <hi rend="italic">D.</hi> Non est
-						hoc facile. Nam ex illa regula qua <lb/> factis facicntes oportet anteferre,
-						cogor sonautibus <lb/> numeris palmam dare : hos enim scntimus audientes.
-						<lb/> ct cum hos sentimus, bos patimur. Ili ergo faciunt <lb/> eos qui sunt
-						in aurium passione cnm audimus : hi au­ <lb/> tem rursus quos sentiendo
-						habemus, faciunt alios in <lb/> memoria, quibus a se factis recte
-						præferuntur. Sed <lb/> hic quia et sentire et meminisse animæ est, non mo­
-						<lb/> veor, si aliquid quod in anima fit, alicui quod item in <lb/> ca fit
-						anteponam. Illud me conturbat, quomodo so­ <lb/> nantes numeri, qui certe
-						corporei sunt, vel quoquo <lb/> modo in corpore, magis laudandi sint quam
-						illi, qui. <lb/> cum sentimus, in anima esse rcperiuntur. Sed rursus <lb/>
-						conturbat quomodo non magis laudandi sint, cum hi <lb/> faciant, illi ab his
-						Gant. <hi rend="italic">M.</hi> Mirarc potius qnod facere <lb/> aliquid in
-						anima corpus potest. Hoc emm fortasse <lb/> non posset, si non peccato primo
-						corpus iHud quod <lb/> nulla molestia et summa facilitate animabat et guber­
-						<lb/> nabat, in deterius commutatum, et corruptioni subja­ <lb/> cerei et
-						morti: quod tamen habet sui generis pulchri­ <lb/> tudinem, ct eo ipso
-						dignitatem animæ satis commea. <lb/> dat, cujus nec plaga, nee morbus siDe
-						honore alicujus <lb/> decoris meruit esse. Quam plagam summa Dei Sapien­
-						<lb/> lia, mirabili et ineffabili sacramento dignata est assu­ <lb/> mere,
-						cum hominem sine peccato, non sine peccatoris <lb/> conditione suscepit. Nam
-						ct nasci humanitns, et pall <lb/> ci muri voluit. Nihil horuin merito, sed
+					</div><div type="textpart" subtype="dialog"><p>7. M. Jam ergo tria rcliqua intucre, et eorum quo­<lb/>que quod sit optimum
+						et caeteris praeferendum, edis­<lb/>sere. <hi rend="italic">D.</hi> Non est
+						hoc facile. Nam ex illa regula qua<lb/>factis facicntes oportet anteferre,
+						cogor sonautibus<lb/>numeris palmam dare : hos enim scntimus audientes.
+						<lb/>ct cum hos sentimus, bos patimur. Ili ergo faciunt<lb/>eos qui sunt
+						in aurium passione cnm audimus : hi au­<lb/>tem rursus quos sentiendo
+						habemus, faciunt alios in<lb/>memoria, quibus a se factis recte
+						praeferuntur. Sed<lb/>hic quia et sentire et meminisse animae est, non mo­
+						<lb/>veor, si aliquid quod in anima fit, alicui quod item in<lb/>ca fit
+						anteponam. Illud me conturbat, quomodo so­<lb/>nantes numeri, qui certe
+						corporei sunt, vel quoquo<lb/>modo in corpore, magis laudandi sint quam
+						illi, qui.<lb/>cum sentimus, in anima esse rcperiuntur. Sed rursus<lb/>
+						conturbat quomodo non magis laudandi sint, cum hi<lb/>faciant, illi ab his
+						Gant. <hi rend="italic">M.</hi> Mirarc potius qnod facere<lb/>aliquid in
+						anima corpus potest. Hoc emm fortasse<lb/>non posset, si non peccato primo
+						corpus iHud quod<lb/>nulla molestia et summa facilitate animabat et guber­
+						<lb/>nabat, in deterius commutatum, et corruptioni subja­<lb/>cerei et
+						morti: quod tamen habet sui generis pulchri­<lb/>tudinem, ct eo ipso
+						dignitatem animae satis commea.<lb/>dat, cujus nec plaga, nee morbus siDe
+						honore alicujus<lb/>decoris meruit esse. Quam plagam summa Dei Sapien­
+						<lb/>lia, mirabili et ineffabili sacramento dignata est assu­<lb/>mere,
+						cum hominem sine peccato, non sine peccatoris<lb/>conditione suscepit. Nam
+						ct nasci humanitns, et pall<lb/>ci muri voluit. Nihil horuin merito, sed
 						excellentissi­ <pb n="1167"/>
-						<unclear/><lb/> i;i.i honitate; ut nos caveremus magis superbiam, qua <lb/>
-						dignissime in ista <unclear>cecnfimus</unclear>, quam contumelias quas <lb/>
-						indignus excepit; et animo æquo mortem debitam sol­ <lb/> vercmus, si
-						propter nos potuit etiam indebitam susti­ <lb/> nere; et quidquid secretius
-						atque purgatius in tali <lb/> sacramento a sanctis et melioribus intelligi
-						potest. <lb/> Ergo :ruinam in care mortali operantem, passionem <lb/>
-						corporum sentire non mirum est. Nec quia ipsa est <lb/> corpore melior,
-						melius putandum est omne quod in <lb/> ea fil, qnam omne quod lit iri
-						corpore. Credo enim <lb/> tibi ,Meri verum falso esse præponendum. D. Quis
-						<lb/> dubitaverit? <hi rend="italic">M.</hi> Num vero est arbor, quam
-						videmus <lb/> in somnis? <hi rend="italic">D.</hi> Nullo modo. <hi
-							rend="italic">M.</hi> At ejus forma inaaima <lb/> fit, hujus autem, quam
-						nuuc videmus, in corpore <lb/> facta cst. Quare cnm ct verum falso, et anima
-						corpore <lb/> melior sit, verum in cerpore melius est quam falsum <lb/> in
-						anima. Sed ut hoc in quantum vcrum, non in quan­ <lb/> tum in corpore fit,
-						melius est; ita illud in quantum fal­ <lb/> sum, non in quanluln in anima
-						fit, fortasse est dete­ <lb/> rius. Nisi quid habes ad hæc. <hi
-							rend="italic">D.</hi> N.hil cquidem. <hi rend="italic">M.</hi> Au­ <lb/>
-						di aHud quod sit, ut puto, vicinius quam melius1. Neque <lb/> enimnegabis,
-						quod dccet esse melius, quam id quod <lb/> non decet. <hi rend="italic"
-							>D.</hi> imo fatcor. M. At in qua veste decens <lb/> cst mulier, in
-						cadem virum indecentem esse posse, quis <lb/> ambigat? <hi rend="italic"
-							>D.</hi> Et hoc manifestum est. M. Quid si ergo <lb/> forma ista
-						numerorum decet in sonis, qui allabuutur <lb/> auribus, et dedecet in anima,
-						curO cos sentiendo ac <lb/> patiendo habet, num magnopere mirandum esL?
-						<lb/> D. Non opinor. M. Quid ergo dubitamus sonantes no­ <lb/> meros atque
-						corporeos præponere iis qui ab ipsis <lb/> fiunt, quamvis in anima fiant,
-						qunc corpore est me­ <lb/> lior? quia numeros numeris, efficientes factisnon
-						<lb/> corpus animæ præponimus. Corpora enim tanto me­ <lb/> liora sunt,
-						quanto numerosiora talibus uumeris. Anima <lb/> vero istis quæ per corpus
-						accipit, carendo fit melior, <lb/> cum sese avertit a carnalibus sensibus,
-						et divinis sa­ <lb/> pientiæ numeris reformatur (a). Ita quippe in Scripta­
-						<lb/> ris sanctis dicitur : <hi rend="italic">Circumivi ego, ut scirem et
-							conside­ <lb/> rarem et qu</hi>æ<hi rend="italic">rerem sapientiam et
-							numerum (Ercle.</hi> VII, <lb/> 26). Quod nu'lo modo arbitrandum est de
-						his nume­ <lb/> ris dictum, quibus etiam flagitiosa theatra personant: <lb/>
-						sed de illis, credo, quos non a corpore accipit anima, <lb/> scd acceptos a
-						sununo Dco ipsa potius imprimit cor­ <lb/> pori. Quod quale sit, non hoc
+						<unclear/><lb/>i;i.i honitate; ut nos caveremus magis superbiam, qua<lb/>
+						dignissime in ista <unclear>cecnfimus</unclear>, quam contumelias quas<lb/>
+						indignus excepit; et animo aequo mortem debitam sol­<lb/>vercmus, si
+						propter nos potuit etiam indebitam susti­<lb/>nere; et quidquid secretius
+						atque purgatius in tali<lb/>sacramento a sanctis et melioribus intelligi
+						potest.<lb/>Ergo :ruinam in care mortali operantem, passionem<lb/>
+						corporum sentire non mirum est. Nec quia ipsa est<lb/>corpore melior,
+						melius putandum est omne quod in<lb/>ea fil, qnam omne quod lit iri
+						corpore. Credo enim<lb/>tibi ,Meri verum falso esse praeponendum. D. Quis
+						<lb/>dubitaverit? <hi rend="italic">M.</hi> Num vero est arbor, quam
+						videmus<lb/>in somnis? <hi rend="italic">D.</hi> Nullo modo. <hi
+							rend="italic">M.</hi> At ejus forma inaaima<lb/>fit, hujus autem, quam
+						nuuc videmus, in corpore<lb/>facta cst. Quare cnm ct verum falso, et anima
+						corpore<lb/>melior sit, verum in cerpore melius est quam falsum<lb/>in
+						anima. Sed ut hoc in quantum vcrum, non in quan­<lb/>tum in corpore fit,
+						melius est; ita illud in quantum fal­<lb/>sum, non in quanluln in anima
+						fit, fortasse est dete­<lb/>rius. Nisi quid habes ad haec. <hi
+							rend="italic">D.</hi> N.hil cquidem. <hi rend="italic">M.</hi> Au­<lb/>
+						di aHud quod sit, ut puto, vicinius quam melius1. Neque<lb/>enimnegabis,
+						quod dccet esse melius, quam id quod<lb/>non decet. <hi rend="italic"
+							>D.</hi> imo fatcor. M. At in qua veste decens<lb/>cst mulier, in
+						cadem virum indecentem esse posse, quis<lb/>ambigat? <hi rend="italic"
+							>D.</hi> Et hoc manifestum est. M. Quid si ergo<lb/>forma ista
+						numerorum decet in sonis, qui allabuutur<lb/>auribus, et dedecet in anima,
+						curO cos sentiendo ac<lb/>patiendo habet, num magnopere mirandum esL?
+						<lb/>D. Non opinor. M. Quid ergo dubitamus sonantes no­<lb/>meros atque
+						corporeos praeponere iis qui ab ipsis<lb/>fiunt, quamvis in anima fiant,
+						qunc corpore est me­<lb/>lior? quia numeros numeris, efficientes factisnon
+						<lb/>corpus animae praeponimus. Corpora enim tanto me­<lb/>liora sunt,
+						quanto numerosiora talibus uumeris. Anima<lb/>vero istis quae per corpus
+						accipit, carendo fit melior,<lb/>cum sese avertit a carnalibus sensibus,
+						et divinis sa­<lb/>pientiae numeris reformatur (a). Ita quippe in Scripta­
+						<lb/>ris sanctis dicitur : <hi rend="italic">Circumivi ego, ut scirem et
+							conside­<lb/>rarem et qu</hi>ae<hi rend="italic">rerem sapientiam et
+							numerum (Ercle.</hi> VII,<lb/>26). Quod nu'lo modo arbitrandum est de
+						his nume­<lb/>ris dictum, quibus etiam flagitiosa theatra personant:<lb/>
+						sed de illis, credo, quos non a corpore accipit anima,<lb/>scd acceptos a
+						sununo Dco ipsa potius imprimit cor­<lb/>pori. Quod quale sit, non hoc
 						loco est considerandum.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT V. — <hi rend="italic">Anima an a corpore patiatur,
 								et quomodo sentiat.</hi>
 						</title>
 					</ab>
-					</div><div type="textpart" subtype="dialog"><p>8. Verumtamen ne illud occurrat, arboris vitam <lb/> meliorem esse quam
-						nostram, quoniam non accipit <lb/> sentiendo a corpore numeros (nullus-enim
-						ei sensus <lb/> est) ; diligenter considerandum est utrum revera nihil <lb/>
-						sil aliud quod dicitur audire, nisi aliquid a corpore in <lb/> anima fieri.
-						Sed perabsurdum est fabricatori corpori <lb/> materiam quoquo modo animam
-						subdere. Nunqnam <lb/> enim anima est corpore dclerior; et omnis materia
-						<lb/> fabricatore deterior. Nullo modo igitur anima fa- <note
+					</div><div type="textpart" subtype="dialog"><p>8. Verumtamen ne illud occurrat, arboris vitam<lb/>meliorem esse quam
+						nostram, quoniam non accipit<lb/>sentiendo a corpore numeros (nullus-enim
+						ei sensus<lb/>est) ; diligenter considerandum est utrum revera nihil<lb/>
+						sil aliud quod dicitur audire, nisi aliquid a corpore in<lb/>anima fieri.
+						Sed perabsurdum est fabricatori corpori<lb/>materiam quoquo modo animam
+						subdere. Nunqnam<lb/>enim anima est corpore dclerior; et omnis materia
+						<lb/>fabricatore deterior. Nullo modo igitur anima fa- <note
 							type="footnote">1 Editi : <hi rend="italic">ft ptUo vtcinius. yeqite
-								eniin negabis;</hi> omisso <lb/> quan nteGas, quod ex MSS.
+								eniin negabis;</hi> omisso<lb/>quan nteGas, quod ex MSS.
 							restituimus. </note><note type="footnote"> * Juxta Ms. A : <hi
 								rend="italic">At facienics fact s.</hi> M. </note>
-						<lb/> bricatori corpori est subjecta materies. Essa au­ <lb/> tem, si
-						aliquos in ea numeros corpus operaretur. <lb/> Non ergo, cum audimus, fiunt
-						in anima numeri ab iia <lb/> quos in sotiis cognoscimus. An aliquid renuis ?
-						D. Quid <lb/> est ergo quod in audiente contingit? <hi rend="italic">M.</hi>
-						Quidquid i!. <lb/> lud sit quod fortasse invenire aut explicare non pos­
-						<lb/> sumus, num ad hoc valebit, ut animam corpore me­ <lb/> liorem esse
-						dubitemus ? Aut cum hoc fatemur, pote. <lb/> rimusne operanli corpori et
-						numeros imponenti cam <lb/> subdere; ut illud sit fabricans, haec autem
-						materies <lb/> de qua et in qua numerosum aliquid fabricetur ? Quod <lb/> si
-						credimus, deteriorem iilam credamus neccsse est. <lb/> Quo quid miserius ,
-						quid detestabilius credi potest? <lb/> Quæ cum ita sint, conabor equidem 4,
-						quantum Deus <lb/> adjuvare dignabitur, quidnam ibi lateat conjectare at­
-						<lb/> que disserere. Sed si hoc propter utriusque aut alte. <lb/> rius
-						nostrum infirmitatem minus pro voluntate suc­ <lb/> cesserit, vel nos ipsi
-						alias sercniores id investigabimus, <lb/> vel intelligentioribus
-						investiganda deferemus, vel aequo <lb/> animo latere patiemur: non tamen
-						ideo ista certiora <lb/> de manibus debemus amittere. <hi rend="italic"
-							>D.</hi> Tenebo istud in­ <lb/> concussum si potero, et tamen latebram
-						istam non <lb/> esse impenetrabilem nobis velim.</p>
+						<lb/>bricatori corpori est subjecta materies. Essa au­<lb/>tem, si
+						aliquos in ea numeros corpus operaretur.<lb/>Non ergo, cum audimus, fiunt
+						in anima numeri ab iia<lb/>quos in sotiis cognoscimus. An aliquid renuis ?
+						D. Quid<lb/>est ergo quod in audiente contingit? <hi rend="italic">M.</hi>
+						Quidquid i!.<lb/>lud sit quod fortasse invenire aut explicare non pos­
+						<lb/>sumus, num ad hoc valebit, ut animam corpore me­<lb/>liorem esse
+						dubitemus ? Aut cum hoc fatemur, pote.<lb/>rimusne operanli corpori et
+						numeros imponenti cam<lb/>subdere; ut illud sit fabricans, haec autem
+						materies<lb/>de qua et in qua numerosum aliquid fabricetur ? Quod<lb/>si
+						credimus, deteriorem iilam credamus neccsse est.<lb/>Quo quid miserius ,
+						quid detestabilius credi potest?<lb/>Quae cum ita sint, conabor equidem 4,
+						quantum Deus<lb/>adjuvare dignabitur, quidnam ibi lateat conjectare at­
+						<lb/>que disserere. Sed si hoc propter utriusque aut alte.<lb/>rius
+						nostrum infirmitatem minus pro voluntate suc­<lb/>cesserit, vel nos ipsi
+						alias sercniores id investigabimus,<lb/>vel intelligentioribus
+						investiganda deferemus, vel aequo<lb/>animo latere patiemur: non tamen
+						ideo ista certiora<lb/>de manibus debemus amittere. <hi rend="italic"
+							>D.</hi> Tenebo istud in­<lb/>concussum si potero, et tamen latebram
+						istam non<lb/>esse impenetrabilem nobis velim.</p>
 					</div><div type="textpart" subtype="dialog"><p>9. <hi rend="italic">M.</hi> Cito dicam quid sentio : tu vero aut sequere,
-						<lb/> aut etiam præcede, si valebis, ubi me cunctari et hæ­ <lb/> sitare
-						animadverteris. Ego enim ab anima boc corpus <lb/> animari non puto, nisi
-						intentione facientis. Nec ab <lb/> isto quidquam illam pati arbitror, sed
-						facere de illo et <lb/> in illo tanquam subjecto divinitus dominationi suae
-						: <lb/> aliquando tamen cum facilitate, aliquando cam difO­ <lb/> cultate
-						operari, quanto pro ejus meritis magis minua­ <lb/> ve illi cedit natura
-						corporea. Corporalia ergo quæcum­ <lb/> que huic corpori ingeruntur aut
-						objiciuntur exlriuse­ <lb/> cus, non in anima, sed in ipso corpore aliquid
-						faciunt, <lb/> quoJ operi ejus aut adversetur, aut congruat. Ideo­ <lb/> que
-						cum rcnitilur adversanti, et materiam sibi sub­ <lb/> jectam in operis sui
-						vias difficulier impingit, fit at­ <lb/> tcutior ex difficultate in
-						actionem; quæ difficultas <lb/> propter attentionem, eum eam non latet,
-						sentire di­ <lb/> citur, et hoc vocatur dolor aut labor. Cum autem con­
-						<lb/> gruit quod infertur, aut adjacet, facile totum id vel <lb/> ex eo
-						quantum opus est, in sui operis itinera traducit. <lb/> Et ista ejus actio
-						qua suum corpus convenienti ex­ <lb/> trinsecus corpori adjungit, quoniam
-						propter quiddam . <lb/> adventitium attentius agitur, non latet; sed propter
-						<lb/> convenientiam, cum voluptate sentitur. Atcum desunt <lb/> ca quibus
-						corporis detrimenta reficiat, egestas conse­ <lb/> quitur; et hac actionis
-						difficultate cuin fit attentior, <lb/> et talis ejus operatio non cam latet,
-						fames aut sitis, <lb/> aut tale aliquid appellatur. Cum aulcm supersuut in­
-						<lb/> gesta, et ex eoram onere nascitur difficultas operandi, <lb/> neque
-						hoc sine attentione fit; et cum talis actio nun <lb/> latet, cruditas
-						sentitur : attente etiam operatur cum <lb/> ejicit superfluum, si leniicr,
-						cum voluptate; si aspere, <lb/> cum dolore. Morbidam quoque perturbationem
-						cor­ <lb/> puris attente agit, succurrere appetens labenti atque <lb/>
-						diffluenti; et hac actione non latente morbos et ægro­ <lb/> tationes
+						<lb/>aut etiam praecede, si valebis, ubi me cunctari et hae­<lb/>sitare
+						animadverteris. Ego enim ab anima boc corpus<lb/>animari non puto, nisi
+						intentione facientis. Nec ab<lb/>isto quidquam illam pati arbitror, sed
+						facere de illo et<lb/>in illo tanquam subjecto divinitus dominationi suae
+						:<lb/>aliquando tamen cum facilitate, aliquando cam difO­<lb/>cultate
+						operari, quanto pro ejus meritis magis minua­<lb/>ve illi cedit natura
+						corporea. Corporalia ergo quaecum­<lb/>que huic corpori ingeruntur aut
+						objiciuntur exlriuse­<lb/>cus, non in anima, sed in ipso corpore aliquid
+						faciunt,<lb/>quoJ operi ejus aut adversetur, aut congruat. Ideo­<lb/>que
+						cum rcnitilur adversanti, et materiam sibi sub­<lb/>jectam in operis sui
+						vias difficulier impingit, fit at­<lb/>tcutior ex difficultate in
+						actionem; quae difficultas<lb/>propter attentionem, eum eam non latet,
+						sentire di­<lb/>citur, et hoc vocatur dolor aut labor. Cum autem con­
+						<lb/>gruit quod infertur, aut adjacet, facile totum id vel<lb/>ex eo
+						quantum opus est, in sui operis itinera traducit.<lb/>Et ista ejus actio
+						qua suum corpus convenienti ex­<lb/>trinsecus corpori adjungit, quoniam
+						propter quiddam .<lb/>adventitium attentius agitur, non latet; sed propter
+						<lb/>convenientiam, cum voluptate sentitur. Atcum desunt<lb/>ca quibus
+						corporis detrimenta reficiat, egestas conse­<lb/>quitur; et hac actionis
+						difficultate cuin fit attentior,<lb/>et talis ejus operatio non cam latet,
+						fames aut sitis,<lb/>aut tale aliquid appellatur. Cum aulcm supersuut in­
+						<lb/>gesta, et ex eoram onere nascitur difficultas operandi,<lb/>neque
+						hoc sine attentione fit; et cum talis actio nun<lb/>latet, cruditas
+						sentitur : attente etiam operatur cum<lb/>ejicit superfluum, si leniicr,
+						cum voluptate; si aspere,<lb/>cum dolore. Morbidam quoque perturbationem
+						cor­<lb/>puris attente agit, succurrere appetens labenti atque<lb/>
+						diffluenti; et hac actione non latente morbos et aegro­<lb/>tationes
 						sentire dicitur. <note type="footnote"> 1 Juxta Ms. A, <hi rend="italic"
 								>conabor</hi> etiam. M. </note>
 						<pb n="1169"/>
 					</p>
-					</div><div type="textpart" subtype="dialog"><p>10. Et ne longum faciam, videtur mibranima cum <lb/> sentit in corpore, non
-						ab illo aliquid pati, sed in ejus <lb/> passionibus attentius agere, et has
-						actiones sive faci­ <lb/> les propter convenientiam, sive difficiles propter
-						in­ <lb/> convenientiam, non eam latere : et hoc totum est <lb/> quod
-						sentire dicitur. Sed iste sensus, qui etiam dum <lb/> nihil sentimus, inest
-						tamen, instrumentum est corpo­ <lb/> ris , quod ea temperatione agitur ab
-						anima , ut In co <lb/> sit ad passiones corporis cum attentione agendas pa­
-						<lb/> ratior, similia similibus ut adjungat, repellatque quod <lb/> noxium
-						est. Agit porro, ut opinor, luminosum aliquid <lb/> in oculis, aerium
-						serenissimum et mobilissimum in <lb/> auribus, caliginosum in naribus, in
-						ore humidum, in <lb/> tactu terrenum et quasi lutulentum. Sed sive hac sive
-						<lb/> alia disiributione ista conjiciantur; agit hæc anima <lb/> eum quiete
-						,. si ea quae insunt in unitate vuletudmis, <lb/> quasi familiari quadam
-						consensione cesserunt'. Cum <lb/> autem adhibentur ea quae nonnulla, ut ita
-						dicam, al­ <lb/> teritate corpus afficiunt; exserit attentiores actiones,
-						<lb/> suis quibusque locis atque instrumentis accommoda­ <lb/> tas : tunc
-						videre, vel audire, vel olfacere, vel gustare, <lb/> vel tangendo sentire
-						dicitur; quibus actionibus con­ <lb/> grua libenter associat, et moleste
-						obsistit incon­ <lb/> gruis. Has operationes passionibus corporis puto ani­
-						<lb/> mam exhibere cutn sentit, non easdem passiones <lb/> recipere.</p>
-					</div><div type="textpart" subtype="dialog"><p>11. Quapropter cum de sonorum numeris in præ­ <lb/> sentia quæratur, et
-						sensus aurium vocetur in dubium, <lb/> non oportet per cætera diutius
-						evagari. Referamus <lb/> itaquc nos ad id de quo agitur, et videamus utrum
-						<lb/> sonus in auribus aliquid faciat. An tu id negabis! <lb/> 0. Nihil
-						minus. <hi rend="italic">M.</hi> Quid? easdem aures animatum <lb/> membrum
+					</div><div type="textpart" subtype="dialog"><p>10. Et ne longum faciam, videtur mibranima cum<lb/>sentit in corpore, non
+						ab illo aliquid pati, sed in ejus<lb/>passionibus attentius agere, et has
+						actiones sive faci­<lb/>les propter convenientiam, sive difficiles propter
+						in­<lb/>convenientiam, non eam latere : et hoc totum est<lb/>quod
+						sentire dicitur. Sed iste sensus, qui etiam dum<lb/>nihil sentimus, inest
+						tamen, instrumentum est corpo­<lb/>ris , quod ea temperatione agitur ab
+						anima , ut In co<lb/>sit ad passiones corporis cum attentione agendas pa­
+						<lb/>ratior, similia similibus ut adjungat, repellatque quod<lb/>noxium
+						est. Agit porro, ut opinor, luminosum aliquid<lb/>in oculis, aerium
+						serenissimum et mobilissimum in<lb/>auribus, caliginosum in naribus, in
+						ore humidum, in<lb/>tactu terrenum et quasi lutulentum. Sed sive hac sive
+						<lb/>alia disiributione ista conjiciantur; agit haec anima<lb/>eum quiete
+						,. si ea quae insunt in unitate vuletudmis,<lb/>quasi familiari quadam
+						consensione cesserunt'. Cum<lb/>autem adhibentur ea quae nonnulla, ut ita
+						dicam, al­<lb/>teritate corpus afficiunt; exserit attentiores actiones,
+						<lb/>suis quibusque locis atque instrumentis accommoda­<lb/>tas : tunc
+						videre, vel audire, vel olfacere, vel gustare,<lb/>vel tangendo sentire
+						dicitur; quibus actionibus con­<lb/>grua libenter associat, et moleste
+						obsistit incon­<lb/>gruis. Has operationes passionibus corporis puto ani­
+						<lb/>mam exhibere cutn sentit, non easdem passiones<lb/>recipere.</p>
+					</div><div type="textpart" subtype="dialog"><p>11. Quapropter cum de sonorum numeris in prae­<lb/>sentia quaeratur, et
+						sensus aurium vocetur in dubium,<lb/>non oportet per caetera diutius
+						evagari. Referamus<lb/>itaquc nos ad id de quo agitur, et videamus utrum
+						<lb/>sonus in auribus aliquid faciat. An tu id negabis!<lb/>0. Nihil
+						minus. <hi rend="italic">M.</hi> Quid? easdem aures animatum<lb/>membrum
 						esse nonne concedis? <hi rend="italic">D.</hi> Concedo. <hi rend="italic"
-							>M.</hi> Cum <lb/> ergo id quod in eo membro simile est aeri, moveatur
-						<lb/> aere percusso ; animam illam quæ ante istum sonum <lb/> vitali motu in
-						silentio corpus aurium vegetabat, num <lb/> putamus aut cessare posse ab
-						opere movendi quod <lb/> animat, aut eodem modo movere commotum extrin­
-						<lb/> secus aerem auris suæ , quo movebat antequam ille <lb/> illaberetur
+							>M.</hi> Cum<lb/>ergo id quod in eo membro simile est aeri, moveatur
+						<lb/>aere percusso ; animam illam quae ante istum sonum<lb/>vitali motu in
+						silentio corpus aurium vegetabat, num<lb/>putamus aut cessare posse ab
+						opere movendi quod<lb/>animat, aut eodem modo movere commotum extrin­
+						<lb/>secus aerem auris suae , quo movebat antequam ille<lb/>illaberetur
 						sonus? <hi rend="italic">D.</hi> Non videtur nisi aliter. <hi rend="italic"
-							>M.</hi> noc <lb/> ergo aliter movere 2, nonne fatendum est facere esse,
-						<lb/> non pati? <hi rend="italic">D.</hi> Ita est. M. Non igllur absurde
-						eredimus <lb/> motus suns animam, vel actiones, vel operationes, vel <lb/>
-						si quo alio nomine commodius significari possunt, non <lb/> latere cum
+							>M.</hi> noc<lb/>ergo aliter movere 2, nonne fatendum est facere esse,
+						<lb/>non pati? <hi rend="italic">D.</hi> Ita est. M. Non igllur absurde
+						eredimus<lb/>motus suns animam, vel actiones, vel operationes, vel<lb/>
+						si quo alio nomine commodius significari possunt, non<lb/>latere cum
 						sentit.</p>
-					</div><div type="textpart" subtype="dialog"><p>12. Hae autem operationes, vel præcedentibus cor­ <lb/> porum passionibus
-						adhibentur; ut sust cum illae ocn­ <lb/> lorum nostrorum lucem formae
-						interpellant, aut in <lb/> aures influit sonus, aut naribus exhalationes,
-						pal'ato <lb/> sapores, caetero corpori qualibet solida et corpulenta <lb/>
-						admoventur extrinsecus, vel in ipso corpore de loco <lb/> in loeuro migrat
-						aliqnid aive transit, vel totum ipsum <lb/> corpus suo alienove pondere
-						movetur: hac sunt opera­ <lb/> tiones quas adhibet anima præcedentibus
-						passionibus <lb/> corporis; quæ delectant eam associantem, offendunt <lb/>
+					</div><div type="textpart" subtype="dialog"><p>12. Hae autem operationes, vel praecedentibus cor­<lb/>porum passionibus
+						adhibentur; ut sust cum illae ocn­<lb/>lorum nostrorum lucem formae
+						interpellant, aut in<lb/>aures influit sonus, aut naribus exhalationes,
+						pal'ato<lb/>sapores, caetero corpori qualibet solida et corpulenta<lb/>
+						admoventur extrinsecus, vel in ipso corpore de loco<lb/>in loeuro migrat
+						aliqnid aive transit, vel totum ipsum<lb/>corpus suo alienove pondere
+						movetur: hac sunt opera­<lb/>tiones quas adhibet anima praecedentibus
+						passionibus<lb/>corporis; quae delectant eam associantem, offendunt<lb/>
 						resistentem. Cum autem ab eisdem suis operationi­ <note type="footnote">'
-							Sic Mss. omnes praeter vaticanum, qui cum Am. et Cr. <lb/> habet, <hi
-								rend="italic">coh</hi>æ<hi rend="italic">serint.</hi> At tov., <hi
+							Sic Mss. omnes praeter vaticanum, qui cum Am. et Cr.<lb/>habet, <hi
+								rend="italic">coh</hi>ae<hi rend="italic">serint.</hi> At tov., <hi
 								rend="italic">concesserint.</hi>
 						</note><note type="footnote"> I In editis : <hi rend="italic">A&lt;w!
 								videlwr mihi aliler. M. noc ergo getwt</hi>
-							<lb/> Itiliter <hi rend="italic">movcre.</hi> At in melioribus Mss
+							<lb/>Itiliter <hi rend="italic">movcre.</hi> At in melioribus Mss
 							lectio nostra cxhilctur. x </note>
-						<lb/> bus aliquid patitur , a seipsa patitur, non a corpore; <lb/> sed plane
-						cum se accommodat corpori: ct ideo apud <lb/> scipsam minus est, qnia corpus
-						semper minus quam <lb/> ipsa est.</p>
-					</div><div type="textpart" subtype="dialog"><p>13. Conversa ergo a Domino suo ad servum suum, <lb/> necessario deficit -
-						conversa item a servo suo ad Do <lb/> minum suum, nccessario proficit , et
-						præbet cidem <lb/> seno facillimam vitam, ct propterea minime opero­ <lb/>
-						sam et negotiosam , ad quam propter summam quio­ <lb/> tem nulla
-						detorqueatur attentio ; sicut est alfeclio <lb/> corporis quae sanitas
-						dicitur : nulla quippe attentiono <lb/> nostra opus habet, non quia nihil
-						tunc agit anima in <lb/> corpore, sed quia nihil facilius agit. Nam in
-						omnibus <lb/> operibus nostris tanto quidquam attentius, quanto <lb/>
-						difficilius operamur. Hæc autem sanitas tunc firmis­ <lb/> sima erit atque
-						certissima , cum pristinæ stabilitati, <lb/> certo suo tempore atque ordinc,
-						hoc corpus fucrit <lb/> restitutum (a), quæ resurrectio ejus antequam
-						plenis­ <lb/> sime intelligatur, salubriter creditur. Oportet enim <lb/>
-						animam et regi a superiore, et regere inferiorem. <lb/> Superior illa solus
-						Deus cst, inferius illa solum cor­ <lb/> pus, si ad omnem et totam : nininm
-						intendas. Ut ergo <lb/> tota esse sine Domino , sic excellere sine servo non
-						<lb/> potest. Ut autem Dominus ejus magis est quam ipsa, <lb/> ita servus
-						minus. Quare intenta in Dominum intelligit <lb/> aeterna ejus, et magis est,
-						magisque est etiam ipse <lb/> servus in suo genere per illam. Neglecto autcm
-						Do­ <lb/> mino intenta in servum carnali qua ducitur concu­ <lb/> piscentia
-						1, sentit motus suos quos illi cxhibct, et. <lb/> minus est : nec tamen
-						tantum niinus, quantum ipso <lb/> servus, etiam cum maxime cst in natura
-						propria. Hæc <lb/> antem delicto dominæ multo minus est quam crat, <lb/> cum
+						<lb/>bus aliquid patitur , a seipsa patitur, non a corpore;<lb/>sed plane
+						cum se accommodat corpori: ct ideo apud<lb/>scipsam minus est, qnia corpus
+						semper minus quam<lb/>ipsa est.</p>
+					</div><div type="textpart" subtype="dialog"><p>13. Conversa ergo a Domino suo ad servum suum,<lb/>necessario deficit -
+						conversa item a servo suo ad Do<lb/>minum suum, nccessario proficit , et
+						praebet cidem<lb/>seno facillimam vitam, ct propterea minime opero­<lb/>
+						sam et negotiosam , ad quam propter summam quio­<lb/>tem nulla
+						detorqueatur attentio ; sicut est alfeclio<lb/>corporis quae sanitas
+						dicitur : nulla quippe attentiono<lb/>nostra opus habet, non quia nihil
+						tunc agit anima in<lb/>corpore, sed quia nihil facilius agit. Nam in
+						omnibus<lb/>operibus nostris tanto quidquam attentius, quanto<lb/>
+						difficilius operamur. Haec autem sanitas tunc firmis­<lb/>sima erit atque
+						certissima , cum pristinae stabilitati,<lb/>certo suo tempore atque ordinc,
+						hoc corpus fucrit<lb/>restitutum (a), quae resurrectio ejus antequam
+						plenis­<lb/>sime intelligatur, salubriter creditur. Oportet enim<lb/>
+						animam et regi a superiore, et regere inferiorem.<lb/>Superior illa solus
+						Deus cst, inferius illa solum cor­<lb/>pus, si ad omnem et totam : nininm
+						intendas. Ut ergo<lb/>tota esse sine Domino , sic excellere sine servo non
+						<lb/>potest. Ut autem Dominus ejus magis est quam ipsa,<lb/>ita servus
+						minus. Quare intenta in Dominum intelligit<lb/>aeterna ejus, et magis est,
+						magisque est etiam ipse<lb/>servus in suo genere per illam. Neglecto autcm
+						Do­<lb/>mino intenta in servum carnali qua ducitur concu­<lb/>piscentia
+						1, sentit motus suos quos illi cxhibct, et.<lb/>minus est : nec tamen
+						tantum niinus, quantum ipso<lb/>servus, etiam cum maxime cst in natura
+						propria. Haec<lb/>antem delicto dominae multo minus est quam crat,<lb/>cum
 						illa ante delictum magis esset *.</p>
-					</div><div type="textpart" subtype="dialog"><p>14. Quocirca mortali jam et fragili, cum magna <lb/> difficultate atque
-						attentione dominatur. Hinc illi error <lb/> incurrit, ut voluptatem
-						corporis, quia ejus attention; <lb/> cedit materies, pluris sestimct quam
-						ipsam sanitatem, <lb/> cui attentione nulla opus est. Nec mirum, si aerumnis
-						<lb/> implicatur, præponens curam securitati. Convertenti <lb/> se antem ad
-						Dominum, major cura oritur, ne averta­ <lb/> lur; donec carnalium negotiorum
-						requiescat impetus, <lb/> effrenatus consuctudinc diuturna, et tumultuosis
-						rc­ <lb/> cordationibus conversioni ejus sese inserens : ita se­ <lb/> datis
-						motibus suis quibus in exteriora provehebatur, <lb/> agit otium intrinsecus
-						libcruln, quod significatur sab­ <lb/> bato; sic cognoscit solum Dcum esse
-						Dominum suum, <lb/> cui uni summa libertate servitur. Non autem illos <lb/>
-						carnales motus, ut cum libct exserit, ita etiam cum <lb/> libet exstinguit.
-						Non enim sicut peccatum in ejas 1 o- <lb/> testate est, ita etiam poena
-						peccati. Magna quippe res <lb/> cst ipsa anima, nec ad opprimendus lascivos
-						molis <lb/> suO! idonea sibi remanet. Valentior emm peccat, et <lb/> post
-						peccatum divina lege facta imbecillior, minus <lb/> potens est auferre quod
+					</div><div type="textpart" subtype="dialog"><p>14. Quocirca mortali jam et fragili, cum magna<lb/>difficultate atque
+						attentione dominatur. Hinc illi error<lb/>incurrit, ut voluptatem
+						corporis, quia ejus attention;<lb/>cedit materies, pluris sestimct quam
+						ipsam sanitatem,<lb/>cui attentione nulla opus est. Nec mirum, si aerumnis
+						<lb/>implicatur, praeponens curam securitati. Convertenti<lb/>se antem ad
+						Dominum, major cura oritur, ne averta­<lb/>lur; donec carnalium negotiorum
+						requiescat impetus,<lb/>effrenatus consuctudinc diuturna, et tumultuosis
+						rc­<lb/>cordationibus conversioni ejus sese inserens : ita se­<lb/>datis
+						motibus suis quibus in exteriora provehebatur,<lb/>agit otium intrinsecus
+						libcruln, quod significatur sab­<lb/>bato; sic cognoscit solum Dcum esse
+						Dominum suum,<lb/>cui uni summa libertate servitur. Non autem illos<lb/>
+						carnales motus, ut cum libct exserit, ita etiam cum<lb/>libet exstinguit.
+						Non enim sicut peccatum in ejas 1 o<lb/>testate est, ita etiam poena
+						peccati. Magna quippe res<lb/>cst ipsa anima, nec ad opprimendus lascivos
+						molis<lb/>suO! idonea sibi remanet. Valentior emm peccat, et<lb/>post
+						peccatum divina lege facta imbecillior, minus<lb/>potens est auferre quod
 						lecit. <hi rend="italic">Infelix ego homo, quis</hi>
 						<note type="footnote">1 Er. hahet, <hi rend="italic">carnaletn;</hi> lov.,
 								<hi rend="italic">cartwlis:</hi> Am., <hi rend="italic"
-								>carnali,</hi> quo­ <lb/> modo etiam octo Mss. supra Vaticanuui, qui
-							unus sic prose­ <lb/> quitur : <hi rend="italic">carnali qua ducitur
-								concupucetdia. [camali qtios di­ <lb/> Citur concupiscentia.]</hi>
+								>carnali,</hi> quo­<lb/>modo etiam octo Mss. supra Vaticanuui, qui
+							unus sic prose­<lb/>quitur : <hi rend="italic">carnali qua ducitur
+								concupucetdia. [camali qtios di­<lb/>Citur concupiscentia.]</hi>
 						</note><note type="footnote"> I Sic legc;odu;n videtur juitaMss.At Am .£, et
-							Lov. Ita- <lb/> bent: <hi rend="italic">cum ille ante delictum nicgis
+							Lov. Ita<lb/>bent: <hi rend="italic">cum ille ante delictum nicgis
 								esset.</hi>
 						</note>
 						<note type="footnote">
@@ -5177,64 +5177,64 @@
 						<lb/>
 						<pb n="1171"/>
 						<hi rend="italic">me liberabil de corpore mortis hujus ? Gratia Dei per
-							<lb/> Jesum</hi> CAntum <hi rend="italic">Dominum nostrum (Hom.</hi>
-						VII, 24, 25). <lb/> Motus igitur animæ servans impetum suum, et non­ <lb/>
-						dum exstinctus, in memoria esse dicitur : et cnm in <lb/> alind intenditur
-						animus, quasi non inest animo pristi­ <lb/> nus motus, et revera minor fit,
-						nisi antequam interci­ <lb/> dat, quadam similium vicinitate renovetur.</p>
-					</div><div type="textpart" subtype="dialog"><p>15. Sed velim scire, utrum te adversus ista nihil <lb/> moveat. <hi
-							rend="italic">D.</hi> Probabiliter mihi dicere videris, nec au­ <lb/>
+							<lb/>Jesum</hi> CAntum <hi rend="italic">Dominum nostrum (Hom.</hi>
+						VII, 24, 25).<lb/>Motus igitur animae servans impetum suum, et non­<lb/>
+						dum exstinctus, in memoria esse dicitur : et cnm in<lb/>alind intenditur
+						animus, quasi non inest animo pristi­<lb/>nus motus, et revera minor fit,
+						nisi antequam interci­<lb/>dat, quadam similium vicinitate renovetur.</p>
+					</div><div type="textpart" subtype="dialog"><p>15. Sed velim scire, utrum te adversus ista nihil<lb/>moveat. <hi
+							rend="italic">D.</hi> Probabiliter mihi dicere videris, nec au­<lb/>
 						sim resistere. <hi rend="italic">M.</hi> Cum igitur ipsum sentire movere
-						<lb/> sit corpus adversus illum motum qui in eo factus est, <lb/> nonne
-						existimas ideo nos non sentire cum ossa et <lb/> ungues et capilli secantur,
-						non quia ista in nobis <lb/> omnino non vivunt, non enim aliter aut
-						continerentur <lb/> aut nutrirentur aut crescerent, aut etiam vim suam <lb/>
-						in serenda prole monstrarent; sed quia minus libero <lb/> acre penetrantur,
-						mobili scilicet elemento, quam ut <lb/> motus ibi possit ab anima fleri tam
-						celer, quam est ille <lb/> adversus quem fit cum sentire dicitur. Talis
-						quaedam <lb/> vita cum in arboribus atque stirpibus cæteris esse in­ <lb/>
-						telligatur, nullo modo eam non solum nostro quæ ra­ <lb/> tione etiam
-						præpollet, sed ne ipsi quidem belluinæ <lb/> decet præponere. Aliud est enim
-						summa stoliditatc, <lb/> aliud summa sanitate corporis nihil sentirc. Nam in
-						<lb/> altero instrumenta desunt, quae adversus passiones <lb/> corporis
-						moveantur, in altero ipsae passiones.D. Probo <lb/> et assentior.</p>
+						<lb/>sit corpus adversus illum motum qui in eo factus est,<lb/>nonne
+						existimas ideo nos non sentire cum ossa et<lb/>ungues et capilli secantur,
+						non quia ista in nobis<lb/>omnino non vivunt, non enim aliter aut
+						continerentur<lb/>aut nutrirentur aut crescerent, aut etiam vim suam<lb/>
+						in serenda prole monstrarent; sed quia minus libero<lb/>acre penetrantur,
+						mobili scilicet elemento, quam ut<lb/>motus ibi possit ab anima fleri tam
+						celer, quam est ille<lb/>adversus quem fit cum sentire dicitur. Talis
+						quaedam<lb/>vita cum in arboribus atque stirpibus caeteris esse in­<lb/>
+						telligatur, nullo modo eam non solum nostro quae ra­<lb/>tione etiam
+						praepollet, sed ne ipsi quidem belluinae<lb/>decet praeponere. Aliud est enim
+						summa stoliditatc,<lb/>aliud summa sanitate corporis nihil sentirc. Nam in
+						<lb/>altero instrumenta desunt, quae adversus passiones<lb/>corporis
+						moveantur, in altero ipsae passiones.D. Probo<lb/>et assentior.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT VI. — <hi rend="italic">Inter genera numerorum ordo,
 								et eorum nomina.</hi>
 						</title>
 					</ab>
-					</div><div type="textpart" subtype="dialog"><p>16. M. Redi ergo mecum ad propositum, atque <lb/> responde de tribus illis
-						generibus numerorum, quo­ <lb/> rum alterum in memoria est, alterum in
-						sentiendo, <lb/> alterum in sono, quodnam tibi videatur excellere. <lb/>
-						<hi rend="italic">D.</hi> Sonum duobus illis postpono quæ in anima sunt
-						<lb/> ct vivunt quodammodo : ped horum duorum quod <lb/> præstantius
-						judicem, incertus sum, nisi forte quo­ <lb/> niam illos qui sunt in actione,
-						non ob aliud præpo­ <lb/> nendos iis qui sunt in memoria dixeramus, nisi
-						quod- <lb/> illi facientes sunt, isti ab bis facti; eadem ratione istos
-						<lb/> etiam qui dum audimus insunt in anima, oportet iis <lb/> anteponere
-						qui ab iisdem in memoria fiunt, sicuti et <lb/> dudum mibi videbatur. M. Non
-						puto absurdam re­ <lb/> sponsionem tuam : sed quoniam disputatum est, bos
-						<lb/> etiam qui sunt in sentiendo numeros operationes esse <lb/> animae;
-						quomodo eos ab illis discernis, quos in actu <lb/> esse animadvertimus ,
-						etiam cum in silentio non re­ <lb/> cordans agit aliquid anima per
-						temporalia spatia nu­ <lb/> merosum' ? an quod illi sunt moventis sese animæ
-						ad <lb/> corpus suum, hi vero in audiendo moventis sese <lb/> animæ adyersus
-						passiones corporis sui ? <hi rend="italic">D.</hi> Accipio <lb/> istam
-						differentiam. M. Quid? in sententia manen­ <lb/> dumne arbitraris, ut
-						præstantiores illi judicentur qui <lb/> sunt ad corpus, quam illi qui sunt
-						adversus passiones <lb/> corporis? <hi rend="italic">D.</hi> Liberiores mihi
-						videntur illi qui sunt in <lb/> silentio, quam ii qui non solum ad corpus,
-						sed ad pas­ <lb/> siones etiam corporis exseruntur. <hi rend="italic"
-							>M.</hi> Distincta a nobis, <lb/> et quibusdam memorum gradibus ordinata
+					</div><div type="textpart" subtype="dialog"><p>16. M. Redi ergo mecum ad propositum, atque<lb/>responde de tribus illis
+						generibus numerorum, quo­<lb/>rum alterum in memoria est, alterum in
+						sentiendo,<lb/>alterum in sono, quodnam tibi videatur excellere.<lb/>
+						<hi rend="italic">D.</hi> Sonum duobus illis postpono quae in anima sunt
+						<lb/>ct vivunt quodammodo : ped horum duorum quod<lb/>praestantius
+						judicem, incertus sum, nisi forte quo­<lb/>niam illos qui sunt in actione,
+						non ob aliud praepo­<lb/>nendos iis qui sunt in memoria dixeramus, nisi
+						quod<lb/>illi facientes sunt, isti ab bis facti; eadem ratione istos
+						<lb/>etiam qui dum audimus insunt in anima, oportet iis<lb/>anteponere
+						qui ab iisdem in memoria fiunt, sicuti et<lb/>dudum mibi videbatur. M. Non
+						puto absurdam re­<lb/>sponsionem tuam : sed quoniam disputatum est, bos
+						<lb/>etiam qui sunt in sentiendo numeros operationes esse<lb/>animae;
+						quomodo eos ab illis discernis, quos in actu<lb/>esse animadvertimus ,
+						etiam cum in silentio non re­<lb/>cordans agit aliquid anima per
+						temporalia spatia nu­<lb/>merosum' ? an quod illi sunt moventis sese animae
+						ad<lb/>corpus suum, hi vero in audiendo moventis sese<lb/>animae adyersus
+						passiones corporis sui ? <hi rend="italic">D.</hi> Accipio<lb/>istam
+						differentiam. M. Quid? in sententia manen­<lb/>dumne arbitraris, ut
+						praestantiores illi judicentur qui<lb/>sunt ad corpus, quam illi qui sunt
+						adversus passiones<lb/>corporis? <hi rend="italic">D.</hi> Liberiores mihi
+						videntur illi qui sunt in<lb/>silentio, quam ii qui non solum ad corpus,
+						sed ad pas­<lb/>siones etiam corporis exseruntur. <hi rend="italic"
+							>M.</hi> Distincta a nobis,<lb/>et quibusdam memorum gradibus ordinata
 						video quin­ <note type="footnote"> * Editi: <hi rend="italic">rer kmporalti
-								spatia</hi> numerorum. Reposuimusuu­ <lb/>
+								spatia</hi> numerorum. Reposuimusuu­<lb/>
 							<hi rend="italic">rnerosvm,</hi> ex auctoritate sex manuscrit torum. </note>
-						<lb/> que genera numerorum, quibus, si placet, imponamus <lb/> congrua
-						vocabula, ne in reliquo sermone pluribus <lb/> verbis quam rebus uti necesse
-						sit. <hi rend="italic">D.</hi> Placet vero. <lb/>
+						<lb/>que genera numerorum, quibus, si placet, imponamus<lb/>congrua
+						vocabula, ne in reliquo sermone pluribus<lb/>verbis quam rebus uti necesse
+						sit. <hi rend="italic">D.</hi> Placet vero.<lb/>
 						<hi rend="italic">II.</hi> Vocentur ergo primi judiciales, secundi
-						progresso­ <lb/> res, tertii occursores, quarti recordabiles, quinti &amp;o­
-						<lb/> nantes. <hi rend="italic">D.</hi> Teneo, et his nominibus utar
+						progresso­<lb/>res, tertii occursores, quarti recordabiles, quinti &amp;o­
+						<lb/>nantes. <hi rend="italic">D.</hi> Teneo, et his nominibus utar
 						libentius.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT VII. — <hi rend="italic">Numeri judiciales an</hi>
@@ -5242,356 +5242,356 @@
 						</title>
 					</ab>
 					</div><div type="textpart" subtype="dialog"><p>17. <hi rend="italic">M.</hi> Attende igitur de nceps, et dic mihi, qui­
-						<lb/> nam istorum immortales tibi videantur, an omnes suis <lb/> temporibus
-						labi atque occidere existimes. <hi rend="italic">D.</hi> Judicia­ <lb/> les
-						solos immortales puto; exteros video vel transire <lb/> cum fiunt, vel de
-						memoria oblivione deleri. M. Tam <lb/> certus es de istorum immortalitate,
-						quam de interitu <lb/> cæterorum; an diligentius, utrum vere hi immortales
-						<lb/> sint, oportet quærere? <hi rend="italic">D.</hi> Quæramus sane. M. Dic
-						<lb/> ergo, cum aliquanto correptius sive productius, dum <lb/> serviam
-						temporum legi qua simplo ad duplum pedes <lb/> conveniunt, versum pronuntio,
-						num offendo ulla <lb/> fraude judicium sensus tui? <hi rend="italic">D.</hi>
-						Non omnino. <hi rend="italic">iI.</hi> Quid? <lb/> sanus ille qui
-						correptioribus et quasi fugacioribus syl­ <lb/> labis editur, num potest
-						plus temporis occupare quam <lb/> sonat? D. Qui potest? M. Judiciales ergo
-						illi numcri <lb/> si vinculo temporis in tanto spatio tenerentur, quanto
-						<lb/> isti sonantes digesti suut; Fossentne ad eorum sonan­ <lb/> tium qui
-						paulo productius eadem iambica lege fundun­ <lb/> tur, aspirare judicium ?
-							<hi rend="italic">D.</hi> Nullo modo. M. Igitur <lb/> apparet bos mora
-						temporum, qni judicando præsi­ <lb/> dent, non teneri. <hi rend="italic"
+						<lb/>nam istorum immortales tibi videantur, an omnes suis<lb/>temporibus
+						labi atque occidere existimes. <hi rend="italic">D.</hi> Judicia­<lb/>les
+						solos immortales puto; exteros video vel transire<lb/>cum fiunt, vel de
+						memoria oblivione deleri. M. Tam<lb/>certus es de istorum immortalitate,
+						quam de interitu<lb/>caeterorum; an diligentius, utrum vere hi immortales
+						<lb/>sint, oportet quaerere? <hi rend="italic">D.</hi> Quaeramus sane. M. Dic
+						<lb/>ergo, cum aliquanto correptius sive productius, dum<lb/>serviam
+						temporum legi qua simplo ad duplum pedes<lb/>conveniunt, versum pronuntio,
+						num offendo ulla<lb/>fraude judicium sensus tui? <hi rend="italic">D.</hi>
+						Non omnino. <hi rend="italic">iI.</hi> Quid?<lb/>sanus ille qui
+						correptioribus et quasi fugacioribus syl­<lb/>labis editur, num potest
+						plus temporis occupare quam<lb/>sonat? D. Qui potest? M. Judiciales ergo
+						illi numcri<lb/>si vinculo temporis in tanto spatio tenerentur, quanto
+						<lb/>isti sonantes digesti suut; Fossentne ad eorum sonan­<lb/>tium qui
+						paulo productius eadem iambica lege fundun­<lb/>tur, aspirare judicium ?
+							<hi rend="italic">D.</hi> Nullo modo. M. Igitur<lb/>apparet bos mora
+						temporum, qni judicando praesi­<lb/>dent, non teneri. <hi rend="italic"
 							>D.</hi> Prorsus apparet.</p>
 					</div><div type="textpart" subtype="dialog"><p>18. <hi rend="italic">II.</hi> Recte annuis. Sed si nulla tenerentur, quan­
-						<lb/> tolibet productius, legitimis intervallis iambicos pro­ <lb/> ferrem
-						sonos, nihilominus ad judicandum adhibcren­ <lb/> tur: nunc vero si ederem
-						unam syllabam quanta mora <lb/> peraguntur (ne multum dicam) tres passus
-						incedentis, <lb/> et aliam duplo, atque ita deinceps tam longos iambos <lb/>
-						ordinarem; simpli et dupli lex illa nihilosecius serva­ <lb/> retur: nec
-						tamen naturale illud judicium his dimen­ <lb/> sionibus approbandis adhibere
-						possemus. An tibi non <lb/> videtur ? <hi rend="italic">D.</hi> Negare non
-						pogsum ita videri: nam mea <lb/> quidem sententia res in aperto est. M.
-						Tenentur ergo <lb/> et hi judiciales nonnullis finibus temporalium spatio­
-						<lb/> rum, quos in judicando excedere nequeunt , et quid­ <lb/> quid excedit
-						haec spatia, non assequuntur ut judicent : <lb/> atque ita si tenentur,
-						quomodo sint immortales non <lb/> video. D. Nec ego video quid respondeam.
-						Sed quan- <lb/> quam de immortalitate horum jam minus praesumam, <lb/> non
-						tamen quo pacto hinc mortales convincantur in­ <lb/> telligo. Fieri enim
-						potest, ut quantacumque spatia <lb/> judicare possunt, semper id possint,
-						quoniam non <lb/> sicut caetcros, aut oblivione aboleri possum diceret <lb/>
-						aut tamdiu esse vel in tantum extendi, quamdiu sonus <lb/> appellitur et in
-						quantum extenduntur occursores illi, <lb/> aut quamdiu aguntur vel quantum
-						producuntur quos <lb/> progressores vocavimus; nam utrique cum ipso tem­
-						<lb/> pore operationis suae transeunt: hi autem judiciales , <lb/> utrum et
-						in anima nescio, in ipsa certe hominis <lb/> natura manent, judicaturi de
-						oblatis, quanquam a <lb/> certa brevitate usque ad certam longitudincm va-
-						<lb/> riertur, approbando in his numerosa, et perturbata <lb/> damnando.</p>
+						<lb/>tolibet productius, legitimis intervallis iambicos pro­<lb/>ferrem
+						sonos, nihilominus ad judicandum adhibcren­<lb/>tur: nunc vero si ederem
+						unam syllabam quanta mora<lb/>peraguntur (ne multum dicam) tres passus
+						incedentis,<lb/>et aliam duplo, atque ita deinceps tam longos iambos<lb/>
+						ordinarem; simpli et dupli lex illa nihilosecius serva­<lb/>retur: nec
+						tamen naturale illud judicium his dimen­<lb/>sionibus approbandis adhibere
+						possemus. An tibi non<lb/>videtur ? <hi rend="italic">D.</hi> Negare non
+						pogsum ita videri: nam mea<lb/>quidem sententia res in aperto est. M.
+						Tenentur ergo<lb/>et hi judiciales nonnullis finibus temporalium spatio­
+						<lb/>rum, quos in judicando excedere nequeunt , et quid­<lb/>quid excedit
+						haec spatia, non assequuntur ut judicent :<lb/>atque ita si tenentur,
+						quomodo sint immortales non<lb/>video. D. Nec ego video quid respondeam.
+						Sed quan<lb/>quam de immortalitate horum jam minus praesumam,<lb/>non
+						tamen quo pacto hinc mortales convincantur in­<lb/>telligo. Fieri enim
+						potest, ut quantacumque spatia<lb/>judicare possunt, semper id possint,
+						quoniam non<lb/>sicut caetcros, aut oblivione aboleri possum diceret<lb/>
+						aut tamdiu esse vel in tantum extendi, quamdiu sonus<lb/>appellitur et in
+						quantum extenduntur occursores illi,<lb/>aut quamdiu aguntur vel quantum
+						producuntur quos<lb/>progressores vocavimus; nam utrique cum ipso tem­
+						<lb/>pore operationis suae transeunt: hi autem judiciales ,<lb/>utrum et
+						in anima nescio, in ipsa certe hominis<lb/>natura manent, judicaturi de
+						oblatis, quanquam a<lb/>certa brevitate usque ad certam longitudincm va-
+						<lb/>riertur, approbando in his numerosa, et perturbata<lb/>damnando.</p>
 					<pb n="1173"/>
 
-					</div><div type="textpart" subtype="dialog"><p>19. II. Saltem illud concedis, alios homines citius <lb/> offendi
-						claudicantibus numeris, alios tardius, et pIe­ <lb/> rosque nonnisi ex
-						comparatione integrorum judicare <lb/> vitiosos, cum et illos congruos et
-						illos incongruos au­ <lb/> dierint. D. Concedo. 3/. Unde tandem hanc
-						differen­ <lb/> tiam putas existere. nisi aut natura, aut exercitatione,
-						<lb/> aut utroquc? D. Sic arbitror. M. Quæro igitur utrum <lb/> possit
-						aliquis aliquando productiora intervalla judi­ <lb/> carc ct approbare, Quæ
-						alius non possit. <hi rend="italic">D.</hi> Credo <lb/> esse posse. M. Quid?
-						ille qui non potest, si sc excr­ <lb/> ceat congruenter, nec adeo tardus
-						sit, nonne poterit? <lb/>
+					</div><div type="textpart" subtype="dialog"><p>19. II. Saltem illud concedis, alios homines citius<lb/>offendi
+						claudicantibus numeris, alios tardius, et pIe­<lb/>rosque nonnisi ex
+						comparatione integrorum judicare<lb/>vitiosos, cum et illos congruos et
+						illos incongruos au­<lb/>dierint. D. Concedo. 3/. Unde tandem hanc
+						differen­<lb/>tiam putas existere. nisi aut natura, aut exercitatione,
+						<lb/>aut utroquc? D. Sic arbitror. M. Quaero igitur utrum<lb/>possit
+						aliquis aliquando productiora intervalla judi­<lb/>carc ct approbare, Quae
+						alius non possit. <hi rend="italic">D.</hi> Credo<lb/>esse posse. M. Quid?
+						ille qui non potest, si sc excr­<lb/>ceat congruenter, nec adeo tardus
+						sit, nonne poterit?<lb/>
 						<hi rend="italic">D.</hi> Poterit vero. M. Num in tantum possunt isti pro­
-						<lb/> ficere ad productiora judicanda, ut horarum, vel dic­ <lb/> rum, vcl
-						etiam mensium annorumve dupla et simpla <lb/> spatia, cum saltem somno
-						interpediantur *, sensu illa <lb/> judiciaria possint possint comprehendere,
-						et tanquam illos <lb/> inmbos motionis nutibus approbare? <hi rend="italic"
-							>D.</hi> Non possunt. <lb/> M. Quid ita non possunt, nisi quia unicuique
-						animanti <lb/> in genere proprio, proportione universitatis, sensus <lb/>
-						locorum temporumque tributus est; ut quomodo cor­ <lb/> pus ejus proportione
-						universi corporis tatum cst, <lb/> cujus pars est, et actas ejus proportione
-						universi sae­ <lb/> culi tanta est, cujus pars est; ita sensus ejus actioni
-						<lb/> ejus congruat, quam proportione agit universi tolus, <lb/> cujus hæc
-						pars est? Sic habendo omnia magnus cst <lb/> hic mundus, qui sæpe in
-						Scripturis divinis coeli ct <lb/> terrænomine nuncupatur, cujus omnes partes
-						si pro­ <lb/> portione minuantur, tantus est; et si proporLionc aih <lb/>
-						Beantur, nihilominus tantus est : quia nihil in spatiis <lb/> locorum et
-						temporum per seipsum magnum est, sed. <lb/> ad aliquid brevius; et nihil
-						rursus in his per seipsum <lb/> breve est, sed ad aliquid majus. Quapropter
-						si hu­ <lb/> manae naturae ad carnalis vitæ actiones talis sensus <lb/>
-						tributus est, quo majora temporum spatia judicare <lb/> non possit, quam,
-						intervalla postulant ad talis vitæ <lb/> uum pertinentia; quoniam talis
-						hominis natura mor­ <lb/> talis est, etiam talem sensum mortalem puto. Non
-						<lb/> enimtrustra consuetudo quasi secunda, et quasi af­ <lb/> fabricata
-						natura dicitur. Videmus autem velut quos­ <lb/> dam sensus novos in
-						judicandis cujuscemodi rebus <lb/> corporcis consuetudine affectos, alia
-						consuetudine de­ <lb/> perire.</p>
+						<lb/>ficere ad productiora judicanda, ut horarum, vel dic­<lb/>rum, vcl
+						etiam mensium annorumve dupla et simpla<lb/>spatia, cum saltem somno
+						interpediantur *, sensu illa<lb/>judiciaria possint possint comprehendere,
+						et tanquam illos<lb/>inmbos motionis nutibus approbare? <hi rend="italic"
+							>D.</hi> Non possunt.<lb/>M. Quid ita non possunt, nisi quia unicuique
+						animanti<lb/>in genere proprio, proportione universitatis, sensus<lb/>
+						locorum temporumque tributus est; ut quomodo cor­<lb/>pus ejus proportione
+						universi corporis tatum cst,<lb/>cujus pars est, et actas ejus proportione
+						universi sae­<lb/>culi tanta est, cujus pars est; ita sensus ejus actioni
+						<lb/>ejus congruat, quam proportione agit universi tolus,<lb/>cujus haec
+						pars est? Sic habendo omnia magnus cst<lb/>hic mundus, qui saepe in
+						Scripturis divinis coeli ct<lb/>terraenomine nuncupatur, cujus omnes partes
+						si pro­<lb/>portione minuantur, tantus est; et si proporLionc aih<lb/>
+						Beantur, nihilominus tantus est : quia nihil in spatiis<lb/>locorum et
+						temporum per seipsum magnum est, sed.<lb/>ad aliquid brevius; et nihil
+						rursus in his per seipsum<lb/>breve est, sed ad aliquid majus. Quapropter
+						si hu­<lb/>manae naturae ad carnalis vitae actiones talis sensus<lb/>
+						tributus est, quo majora temporum spatia judicare<lb/>non possit, quam,
+						intervalla postulant ad talis vitae<lb/>uum pertinentia; quoniam talis
+						hominis natura mor­<lb/>talis est, etiam talem sensum mortalem puto. Non
+						<lb/>enimtrustra consuetudo quasi secunda, et quasi af­<lb/>fabricata
+						natura dicitur. Videmus autem velut quos­<lb/>dam sensus novos in
+						judicandis cujuscemodi rebus<lb/>corporcis consuetudine affectos, alia
+						consuetudine de­<lb/>perire.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
-						<title type="sub">CAPUT VIII. — <hi rend="italic">Numeri cæteri judicialium
+						<title type="sub">CAPUT VIII. — <hi rend="italic">Numeri caeteri judicialium
 								examini subjiciuntur.</hi>
 						</title>
 					</ab>
-					</div><div type="textpart" subtype="dialog"><p>20. Sed quoquo modo se habeant hi numcri judi­ <lb/> ciales, eo certe
-						præstant quod dubitamus, vel difficile <lb/> pervestigamus utrum mortales
-						sint. De cæteris autem <lb/> quatuor gcneribus nec quicstio est quin
-						mortales sint; <lb/> quorum etsi quosdam non comprehendunt, quia ultra <lb/>
-						ipsorum jura porrecti sunt, genera tamen ipsa suo <lb/> examini vindicant.
-						Nam et illi progressores cum ali­ <lb/> quam in corpore numerosam
-						operationem appetunt, <lb/> latente istorum judicialium nutu modificantur.
-						Quod <lb/> enim nos vel ambulantes ab imparibus passibus, vel <lb/>
-						percutientes ab imparibus intervallis plagarum, vel <lb/> edentes vel
-						bibentes ab imparibus malarum motibus, <lb/> scaluentes denique ab imparibus
+					</div><div type="textpart" subtype="dialog"><p>20. Sed quoquo modo se habeant hi numcri judi­<lb/>ciales, eo certe
+						praestant quod dubitamus, vel difficile<lb/>pervestigamus utrum mortales
+						sint. De caeteris autem<lb/>quatuor gcneribus nec quicstio est quin
+						mortales sint;<lb/>quorum etsi quosdam non comprehendunt, quia ultra<lb/>
+						ipsorum jura porrecti sunt, genera tamen ipsa suo<lb/>examini vindicant.
+						Nam et illi progressores cum ali­<lb/>quam in corpore numerosam
+						operationem appetunt,<lb/>latente istorum judicialium nutu modificantur.
+						Quod<lb/>enim nos vel ambulantes ab imparibus passibus, vel<lb/>
+						percutientes ab imparibus intervallis plagarum, vel<lb/>edentes vel
+						bibentes ab imparibus malarum motibus,<lb/>scaluentes denique ab imparibus
 						unguium ductibus ; <note type="footnote"> Edili: <hi rend="italic">somno non
-								impediantur.</hi> At Mss. absque negatio­ <lb/> ne, <hi
+								impediantur.</hi> At Mss. absque negatio­<lb/>ne, <hi
 								rend="italic">sommo interpediantur.</hi>
 						</note>
-						<lb/> et ne per multas alias operationes percurram, quod <lb/> nos in
-						qualibet attentione agendi aliquid pcr corporis <lb/> membra ab imparibus
-						motibus refrenat et cohibet, et <lb/> quamdam parilitatem tacite imperat;
-						idipsum cst ju­ <lb/> dicialc nescio qnid, quod conditerem animalis insinuat
-						<lb/> Dcum : quem certe decet credere auctorem omnis con­ <lb/> venieutiæ
+						<lb/>et ne per multas alias operationes percurram, quod<lb/>nos in
+						qualibet attentione agendi aliquid pcr corporis<lb/>membra ab imparibus
+						motibus refrenat et cohibet, et<lb/>quamdam parilitatem tacite imperat;
+						idipsum cst ju­<lb/>dicialc nescio qnid, quod conditerem animalis insinuat
+						<lb/>Dcum : quem certe decet credere auctorem omnis con­<lb/>venieutiae
 						atque concordiae.</p>
-					</div><div type="textpart" subtype="dialog"><p>21. Et illi occursores numeri, qui certe non pro sue <lb/> nutu, sed pro
-						passionibus corporis aguntur, in quan <lb/> tum corum intervalla potest
-						memoria custodire, in <lb/> tantum his judicialibus judicandi offeruntur
-						atqne ju­ <lb/> dicantur. Numerus namque iste qui intervallis tempo­ <lb/>
-						rum constat, nisi adjuvemur in co memoria, judicari <lb/> a nobis nullo
-						pacto potest. Quamlibet cuim brevis syl­ <lb/> laba, cum et incipiat, et
-						desinat, alio tempore initium <lb/> ejus, et alio finis sonat. Tenditur crgo
-						ct ipsa quantu­ <lb/> locumquc temporis intevallo, et ab initio SilO per
-						<lb/> medium suum tendit ad fincm. Ita ratio invenit tam <lb/> localia quam
-						temporalia spatia infinitam divisionem <lb/> recipere; et idcirco nullius
-						syllabæ cum initie finis <lb/> auditur. In audicnda itaque vel brevissima
-						syllaba, <lb/> nisi memoria nos adjuvet, ut eo momento temporis <lb/> quo
-						jam non initium, sed fiuis syllabæ sonat, maneat <lb/> ille motus in animo,
-						qui factus est cnm initium ipsum <lb/> sonuit; nibil nos audisse po ssumus
-						dIcere. Hinc est <lb/> illud quod plerumque alia cogitationc occupati, cornm
-						<lb/> loquentes non nobis videmur audisse: non qnia occur­ <lb/> sores illos
-						numcros non agit tunc anima, cum sine du­ <lb/> bio sonus ad aures
-						perveniat, et illa in passione cor­ <lb/> poris sui cessare non possit, nec
-						possit nisi aliter <lb/> moveri quam si illa non fieret; sed quia intentione
-						iri <lb/> aliud subinde exstinguitur motionis impetus, qui si <lb/> maneret,
-						in memoria utique maneret, ut nos ct inve­ <lb/> niremus et sentiremus
-						audisse. Quod si de una syllaba <lb/> brevi minus sequitur mens tardior quod
-						invenit ratio, <lb/> de duabus certe nemo dubitat, quin eas simul nulla
-						<lb/> anima possit audire. Non enim sonat secunda, nisi <lb/> prima
-						destiterit: quod autem simul sonarc non potest, <lb/> simul audiri qui
-						potest? Ut igitur nos ad capicnda <lb/> spatia locorum diffusio radiorum
-						juvat, qui e brevibus <lb/> p apulis in aperta emicant, ct adeo sunt nostri
-						corpn. <lb/> ris, ut quanquam in procul positis rebus quas vi­ <lb/> demus,
-						a nostra anima vegetentur; ut ergo eorum <lb/> effusione adjuvamur 1 ad
-						capienda spatia locorum : ita <lb/> memoria, quod quasi lumen est
-						temporalium spatio­ <lb/> rum, quantum in suo genere quodammodo extrudi po­
-						<lb/> test, tantum eorumdem spatiorum capit. Cum autem <lb/> diutius aures
-						pulsat sonus nullis distinctus articulis I <lb/> et ab aliquo tandem finc
-						conjunctus alter duplo, aut <lb/> etiam tanto editur spatio; attentione in
-						succedentem <lb/> perpetuo sonum motus ille animi, qui atlentione ad <lb/>
-						præteritum et elapsum sonum cum transibat est fa­ <lb/> ctus, reprimitur, id
-						cst non ita remanet, in memoria. <lb/> Quapropter judiciales illi numeri,
-						qui numcros in in­ <lb/> tervallis temporum sitos, exceptis progressoribus
-						<lb/> quibus etiam ipsum progressum modificant, judicare <lb/> non possunt
+					</div><div type="textpart" subtype="dialog"><p>21. Et illi occursores numeri, qui certe non pro sue<lb/>nutu, sed pro
+						passionibus corporis aguntur, in quan<lb/>tum corum intervalla potest
+						memoria custodire, in<lb/>tantum his judicialibus judicandi offeruntur
+						atqne ju­<lb/>dicantur. Numerus namque iste qui intervallis tempo­<lb/>
+						rum constat, nisi adjuvemur in co memoria, judicari<lb/>a nobis nullo
+						pacto potest. Quamlibet cuim brevis syl­<lb/>laba, cum et incipiat, et
+						desinat, alio tempore initium<lb/>ejus, et alio finis sonat. Tenditur crgo
+						ct ipsa quantu­<lb/>locumquc temporis intevallo, et ab initio SilO per
+						<lb/>medium suum tendit ad fincm. Ita ratio invenit tam<lb/>localia quam
+						temporalia spatia infinitam divisionem<lb/>recipere; et idcirco nullius
+						syllabae cum initie finis<lb/>auditur. In audicnda itaque vel brevissima
+						syllaba,<lb/>nisi memoria nos adjuvet, ut eo momento temporis<lb/>quo
+						jam non initium, sed fiuis syllabae sonat, maneat<lb/>ille motus in animo,
+						qui factus est cnm initium ipsum<lb/>sonuit; nibil nos audisse po ssumus
+						dIcere. Hinc est<lb/>illud quod plerumque alia cogitationc occupati, cornm
+						<lb/>loquentes non nobis videmur audisse: non qnia occur­<lb/>sores illos
+						numcros non agit tunc anima, cum sine du­<lb/>bio sonus ad aures
+						perveniat, et illa in passione cor­<lb/>poris sui cessare non possit, nec
+						possit nisi aliter<lb/>moveri quam si illa non fieret; sed quia intentione
+						iri<lb/>aliud subinde exstinguitur motionis impetus, qui si<lb/>maneret,
+						in memoria utique maneret, ut nos ct inve­<lb/>niremus et sentiremus
+						audisse. Quod si de una syllaba<lb/>brevi minus sequitur mens tardior quod
+						invenit ratio,<lb/>de duabus certe nemo dubitat, quin eas simul nulla
+						<lb/>anima possit audire. Non enim sonat secunda, nisi<lb/>prima
+						destiterit: quod autem simul sonarc non potest,<lb/>simul audiri qui
+						potest? Ut igitur nos ad capicnda<lb/>spatia locorum diffusio radiorum
+						juvat, qui e brevibus<lb/>p apulis in aperta emicant, ct adeo sunt nostri
+						corpn.<lb/>ris, ut quanquam in procul positis rebus quas vi­<lb/>demus,
+						a nostra anima vegetentur; ut ergo eorum<lb/>effusione adjuvamur 1 ad
+						capienda spatia locorum : ita<lb/>memoria, quod quasi lumen est
+						temporalium spatio­<lb/>rum, quantum in suo genere quodammodo extrudi po­
+						<lb/>test, tantum eorumdem spatiorum capit. Cum autem<lb/>diutius aures
+						pulsat sonus nullis distinctus articulis I<lb/>et ab aliquo tandem finc
+						conjunctus alter duplo, aut<lb/>etiam tanto editur spatio; attentione in
+						succedentem<lb/>perpetuo sonum motus ille animi, qui atlentione ad<lb/>
+						praeteritum et elapsum sonum cum transibat est fa­<lb/>ctus, reprimitur, id
+						cst non ita remanet, in memoria.<lb/>Quapropter judiciales illi numeri,
+						qui numcros in in­<lb/>tervallis temporum sitos, exceptis progressoribus
+						<lb/>quibus etiam ipsum progressum modificant, judicare<lb/>non possunt
 						nisi quos eis tanquam ministra memoria <note type="footnote"> 1 sic in Mss.
-							At in editis legitur: il <hi rend="italic">ergo effusione Lucis <lb/>
+							At in editis legitur: il <hi rend="italic">ergo effusione Lucis<lb/>
 								adjuvamur.</hi>
 						</note>
 						<lb/>
-						<pb n="1175"/> obtulerit; nonne ipsi existiimandi sunt pcr certum <lb/>
-						spatium temporis tendi?Sed interest quibus tempo.. <lb/> rum spatiis vel
-						excidat nobis, vcl meminerimus quod <lb/> judicant. Siquidem nee in ipsis
-						corporum formis quai <lb/> ad oculos pertinent , possumus rotunda vel
-						quadra, <lb/> vel quæcumque alia solida et determinata judicare, et <lb/>
-						omnino sentire, nisi ea ob oculos versemus 1 : cun. <lb/> autem alia pars
-						aspicitur, si exciderit quod est aspe­ <lb/> ctum in alia , frustratur
-						omnimo judicantis intentio, <lb/> quia et h c aliqua mora temporis fit; cui
-						variatæ <lb/> opus est invigilare mmeoriam.</p>
-					</div><div type="textpart" subtype="dialog"><p>22. Record abiles vcro numeros multo evidentius <lb/> cst, quod eadem ipsa
-						offerente memoria, judicamus <lb/> his judicialibus. Nam sl occursores,
-						quantum ab ea <lb/> ofreruntur, tantum judicantur; multo magis ii, ad <lb/>
-						quos tanquam repositos post alias intentiones revoca­ <lb/> mur
-						recordatione, in ipsa memoria vivereinveniuntur. <lb/> Quid enim aliud
-						agimus cum revocamus nos in me­ <lb/> moriam , nisi quodammodo quod
-						reposuimus quxri­ <lb/> mus? Rccurrit autem in cogitationem occasione si­
-						<lb/> milium motus animi non exstinctus, et hxc est quæ <lb/> dicitur
-						recordatio. Sic agimus numeros, vel in sola <lb/> cogitatione, vel etiam in
-						membrorum motu, quos <lb/> jam egimus aliquando. Indc autem scimus non
-						venisse, <lb/> sed redisse illos in cogitationem, quia cum memorie <lb/>
-						mandarentur, cum difficullato repetebantur, et indi­ <lb/> gebamus aliqua
-						præmonstratione ut sequeremur: qua <lb/> difficultate dempta, cum sese ipsi
-						accommodate vo- <lb/> Juntali offerunt, consequenter temporibus atque ordine
-						<lb/> suo, tam facile ut qui vehementius inhæserunt, etiam <lb/> aliunde
-						cogitantibus nobis, jam quasi proprio nutu <lb/> pcragantur, non cos utique
-						novos esse sentimus. Est <lb/> etiam aliud unde nos sentire arbitror
-						præsentem mo­ <lb/> tum animi aliquando jam fuisse, quod est recogno­ <lb/>
-						scere, dum recentes motus rjus actionis in qua sumus <lb/> cum rccordamur,
-						qni certe vivaciores sunt, cum rc­ <lb/> cordabilibus jam sedatioribus
-						quodam interiore lu­ <lb/> mine comparamus : et talis agnitio, recognitio
-						cst ct <lb/> rccordalio. Judicantur ergo et recordabiles nnmeri <lb/> ab Ira
-						judicialibus, nunquam soli, sed adjunctis acti­ <lb/> vis, aut occursoribus,
-						aut utrisque, qui cos tanquam <lb/> e latebris suis in manifestum producant,
-						et quasi re­ <lb/> dintegratos qui jam abolebantur, rursum recordan­ <lb/>
-						tur. Ita cum occursores in tantum judicentur, in quan­ <lb/> tum cos memoria
-						judicantibus admoverit, possunt <lb/> vicissim et recordabiles qui sunt in
-						memoria occur­ <lb/> soribus eos exhibentibus judicari : ut hoc intersit,
-						<lb/> quod occursores ut judicentur, quasi recentia corum <lb/> fugientium
-						vestigia offert memoria; recordabiles au­ <lb/> tem quando eos andicndo
-						judicamus, quasi cadem <lb/> veestigia occursoribus transeuntibus
-						revirescunt. Jam <lb/> porro de sonantibus numeris quid opus est dicere,
-						<lb/> cum in occursoribus judicentur, si audiantur? Si vero <lb/> thi sonant
-						uhi non audiuntur, quis dubitet eos a nohis <lb/> non posse judicari? Sane
-						ut in sonis per instrumen­ <lb/> tum aurium, ita in saltationibus cæterisque
-						visibilibus <lb/> motibus, quod ad temporales numeros allinct, eadcm <note
+						<pb n="1175"/> obtulerit; nonne ipsi existiimandi sunt pcr certum<lb/>
+						spatium temporis tendi?Sed interest quibus tempo..<lb/>rum spatiis vel
+						excidat nobis, vcl meminerimus quod<lb/>judicant. Siquidem nee in ipsis
+						corporum formis quai<lb/>ad oculos pertinent , possumus rotunda vel
+						quadra,<lb/>vel quaecumque alia solida et determinata judicare, et<lb/>
+						omnino sentire, nisi ea ob oculos versemus 1 : cun.<lb/>autem alia pars
+						aspicitur, si exciderit quod est aspe­<lb/>ctum in alia , frustratur
+						omnimo judicantis intentio,<lb/>quia et h c aliqua mora temporis fit; cui
+						variatae<lb/>opus est invigilare mmeoriam.</p>
+					</div><div type="textpart" subtype="dialog"><p>22. Record abiles vcro numeros multo evidentius<lb/>cst, quod eadem ipsa
+						offerente memoria, judicamus<lb/>his judicialibus. Nam sl occursores,
+						quantum ab ea<lb/>ofreruntur, tantum judicantur; multo magis ii, ad<lb/>
+						quos tanquam repositos post alias intentiones revoca­<lb/>mur
+						recordatione, in ipsa memoria vivereinveniuntur.<lb/>Quid enim aliud
+						agimus cum revocamus nos in me­<lb/>moriam , nisi quodammodo quod
+						reposuimus quxri­<lb/>mus? Rccurrit autem in cogitationem occasione si­
+						<lb/>milium motus animi non exstinctus, et hxc est quae<lb/>dicitur
+						recordatio. Sic agimus numeros, vel in sola<lb/>cogitatione, vel etiam in
+						membrorum motu, quos<lb/>jam egimus aliquando. Indc autem scimus non
+						venisse,<lb/>sed redisse illos in cogitationem, quia cum memorie<lb/>
+						mandarentur, cum difficullato repetebantur, et indi­<lb/>gebamus aliqua
+						praemonstratione ut sequeremur: qua<lb/>difficultate dempta, cum sese ipsi
+						accommodate vo<lb/>Juntali offerunt, consequenter temporibus atque ordine
+						<lb/>suo, tam facile ut qui vehementius inhaeserunt, etiam<lb/>aliunde
+						cogitantibus nobis, jam quasi proprio nutu<lb/>pcragantur, non cos utique
+						novos esse sentimus. Est<lb/>etiam aliud unde nos sentire arbitror
+						praesentem mo­<lb/>tum animi aliquando jam fuisse, quod est recogno­<lb/>
+						scere, dum recentes motus rjus actionis in qua sumus<lb/>cum rccordamur,
+						qni certe vivaciores sunt, cum rc­<lb/>cordabilibus jam sedatioribus
+						quodam interiore lu­<lb/>mine comparamus : et talis agnitio, recognitio
+						cst ct<lb/>rccordalio. Judicantur ergo et recordabiles nnmeri<lb/>ab Ira
+						judicialibus, nunquam soli, sed adjunctis acti­<lb/>vis, aut occursoribus,
+						aut utrisque, qui cos tanquam<lb/>e latebris suis in manifestum producant,
+						et quasi re­<lb/>dintegratos qui jam abolebantur, rursum recordan­<lb/>
+						tur. Ita cum occursores in tantum judicentur, in quan­<lb/>tum cos memoria
+						judicantibus admoverit, possunt<lb/>vicissim et recordabiles qui sunt in
+						memoria occur­<lb/>soribus eos exhibentibus judicari : ut hoc intersit,
+						<lb/>quod occursores ut judicentur, quasi recentia corum<lb/>fugientium
+						vestigia offert memoria; recordabiles au­<lb/>tem quando eos andicndo
+						judicamus, quasi cadem<lb/>veestigia occursoribus transeuntibus
+						revirescunt. Jam<lb/>porro de sonantibus numeris quid opus est dicere,
+						<lb/>cum in occursoribus judicentur, si audiantur? Si vero<lb/>thi sonant
+						uhi non audiuntur, quis dubitet eos a nohis<lb/>non posse judicari? Sane
+						ut in sonis per instrumen­<lb/>tum aurium, ita in saltationibus caeterisque
+						visibilibus<lb/>motibus, quod ad temporales numeros allinct, eadcm <note
 							type="footnote"> ' Ann. Er. et !.ov.: <hi rend="italic">rossemusnii
 								ex</hi> obliqiio <hi rend="italic">oculo* ver­</hi>
-							<lb/> mremuo. sed concinnior « st Mss. leclio quam amplectimur. </note>
-						<lb/> adjuvante memoria iisdem numeris judicialibus diju. <lb/> dicamus.</p>
+							<lb/>mremuo. sed concinnior « st Mss. leclio quam amplectimur. </note>
+						<lb/>adjuvante memoria iisdem numeris judicialibus diju.<lb/>dicamus.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT IX. — <hi rend="italic">Numeri alii in</hi> anima
 								<hi rend="italic">illis</hi> judidalibus <hi rend="italic"
-								>præcellentes.</hi>
+								>praecellentes.</hi>
 						</title>
 					</ab>
-					</div><div type="textpart" subtype="dialog"><p>23. Hæc cum ita sint, conemur, si possumus, istos <lb/> numcros judiciales
-						transcendere, et quæramus utrum <lb/> sint superiores. In his enim quanquam
-						spatia tempo­ <lb/> rum jam minime videamus, non tamen adhibentur, <lb/>
-						nisi ad ea judicanda quæ in spatio temporis fiunt; net <lb/> ipsa quidem
-						omnia, sed quæ possunt articulari memo­ <lb/> riter. Nisi quid habes forte
-						quod contra haec velis di­ <lb/> cere. D. Movet me plurimum istorum
-						judicialium vis <lb/> atque potentia : ipsi enim mihi videntur esse ad quos
-						<lb/> omnium sensuum ministeria referuntur. Itaque his <lb/> excellentius
-						utrum quidquam in numeris inveniri <lb/> possit, ignoro. M. Nihil deperit
-						quod diligcutius quae­ <lb/> rimus. Aut enim inveniemus superiores in anima
-						ha­ <lb/> mana, aut hos in ea summos esse firmabimus, si ta­ <lb/> men illud
-						cJarueril, nullos in ea esse præstantiores. <lb/> Aliud est enim non esse,
-						aliud non posse inveniri, <lb/> sive ab ullo homine. sive a nobis. Sed ego
-						puto cum <lb/> ille a nobis propositus versus canitur, <hi rend="italic"
-							>Deus creator<lb/> omnium;</hi> nos eum et occursoribus illis numcris
-						an­ <lb/> dire, et recordabilibus recognoscere, et progressori­ <lb/> bus
-						pronuntiare, et his judicialibus dcleclari, et nescio <lb/> quibus aliis
-						æstimare, et de ista delectatione quæ <lb/> quasi sententia est judicialium
-						istorum, aliam secun­ <lb/> dum hos latentiores certiorem ferre sententiam
-						I. An <lb/> tibi unum atque idem videtur delectari sensu, et <lb/> æstimare
-						ratione? <hi rend="italic">D.</hi> Diversa esse fateor. Sed primo <lb/> ipso
-						moveor vocabulo, cur non potius isti vocentur <lb/> judiciales quibus inest
-						ratio, quam isti quibus inest <lb/> delectatio. Deinde vereor ne nihil sit
-						aliud æstimatio <lb/> isLi rationis, quam eorum de seipsis quædam diligcn­
-						<lb/> tior judicatio : ut non alii sint numeri in delectatione, <lb/> ani in
-						ratione; sed uni atque iidem alias judicent de <lb/> iis quae aguntur in
-						corpore, cum eos, ut supra de­ <lb/> monstratum est , offert memoria; alias
-						de seipsis re­ <lb/> motius a corpore atquc sincerius.</p>
-					</div><div type="textpart" subtype="dialog"><p>24. <hi rend="italic">M.</hi> De vocabulis quidcm nihil satagas; res in <lb/>
-						potestate cst : placito cnim, non natura imponuntur. <lb/> Quod autem eosdem
-						csse arbitraris, nec duo genera <lb/> numerorum hæc vis accipere; illud, ni
-						fallor, te ra­ <lb/> pit, quod eadem anima utrumque agit. Sed animad­ <lb/>
-						vertere te opus est, et in progressoribus camdem ani­ <lb/> mam corpus
-						movere vel ad corpus moveri; et in oc­ <lb/> cursoribus hanc eamdera
-						passionibus ejus ire obviam ; <lb/> et in recordabilibus istam ipsam, donce
-						quodammodo <lb/> detumescant, ipsis quasi fluctuare motionibus. Nus <lb/>
-						crgo in istis generibus numerandis et distinguendis <lb/> unius naturæ, id
-						est, anima; motuss affectiones que <lb/> dispicimus. Quare si ut aliud cst
-						ad ca qu:ccorpus pa­ <lb/> titur moveri, quod fit in sentiondo; aliud movere
-						<lb/> se ad corpus, quod fit in opcrando; aliud quod cx his <lb/> motibus in
-						anima factum cst continere, qnod cst mc­ <lb/> minisse; ita est aliud
+					</div><div type="textpart" subtype="dialog"><p>23. Haec cum ita sint, conemur, si possumus, istos<lb/>numcros judiciales
+						transcendere, et quaeramus utrum<lb/>sint superiores. In his enim quanquam
+						spatia tempo­<lb/>rum jam minime videamus, non tamen adhibentur,<lb/>
+						nisi ad ea judicanda quae in spatio temporis fiunt; net<lb/>ipsa quidem
+						omnia, sed quae possunt articulari memo­<lb/>riter. Nisi quid habes forte
+						quod contra haec velis di­<lb/>cere. D. Movet me plurimum istorum
+						judicialium vis<lb/>atque potentia : ipsi enim mihi videntur esse ad quos
+						<lb/>omnium sensuum ministeria referuntur. Itaque his<lb/>excellentius
+						utrum quidquam in numeris inveniri<lb/>possit, ignoro. M. Nihil deperit
+						quod diligcutius quae­<lb/>rimus. Aut enim inveniemus superiores in anima
+						ha­<lb/>mana, aut hos in ea summos esse firmabimus, si ta­<lb/>men illud
+						cJarueril, nullos in ea esse praestantiores.<lb/>Aliud est enim non esse,
+						aliud non posse inveniri,<lb/>sive ab ullo homine. sive a nobis. Sed ego
+						puto cum<lb/>ille a nobis propositus versus canitur, <hi rend="italic"
+							>Deus creator<lb/>omnium;</hi> nos eum et occursoribus illis numcris
+						an­<lb/>dire, et recordabilibus recognoscere, et progressori­<lb/>bus
+						pronuntiare, et his judicialibus dcleclari, et nescio<lb/>quibus aliis
+						aestimare, et de ista delectatione quae<lb/>quasi sententia est judicialium
+						istorum, aliam secun­<lb/>dum hos latentiores certiorem ferre sententiam
+						I. An<lb/>tibi unum atque idem videtur delectari sensu, et<lb/>aestimare
+						ratione? <hi rend="italic">D.</hi> Diversa esse fateor. Sed primo<lb/>ipso
+						moveor vocabulo, cur non potius isti vocentur<lb/>judiciales quibus inest
+						ratio, quam isti quibus inest<lb/>delectatio. Deinde vereor ne nihil sit
+						aliud aestimatio<lb/>isLi rationis, quam eorum de seipsis quaedam diligcn­
+						<lb/>tior judicatio : ut non alii sint numeri in delectatione,<lb/>ani in
+						ratione; sed uni atque iidem alias judicent de<lb/>iis quae aguntur in
+						corpore, cum eos, ut supra de­<lb/>monstratum est , offert memoria; alias
+						de seipsis re­<lb/>motius a corpore atquc sincerius.</p>
+					</div><div type="textpart" subtype="dialog"><p>24. <hi rend="italic">M.</hi> De vocabulis quidcm nihil satagas; res in<lb/>
+						potestate cst : placito cnim, non natura imponuntur.<lb/>Quod autem eosdem
+						csse arbitraris, nec duo genera<lb/>numerorum haec vis accipere; illud, ni
+						fallor, te ra­<lb/>pit, quod eadem anima utrumque agit. Sed animad­<lb/>
+						vertere te opus est, et in progressoribus camdem ani­<lb/>mam corpus
+						movere vel ad corpus moveri; et in oc­<lb/>cursoribus hanc eamdera
+						passionibus ejus ire obviam ;<lb/>et in recordabilibus istam ipsam, donce
+						quodammodo<lb/>detumescant, ipsis quasi fluctuare motionibus. Nus<lb/>
+						crgo in istis generibus numerandis et distinguendis<lb/>unius naturae, id
+						est, anima; motuss affectiones que<lb/>dispicimus. Quare si ut aliud cst
+						ad ca qu:ccorpus pa­<lb/>titur moveri, quod fit in sentiondo; aliud movere
+						<lb/>se ad corpus, quod fit in opcrando; aliud quod cx his<lb/>motibus in
+						anima factum cst continere, qnod cst mc­<lb/>minisse; ita est aliud
 						annucrc, vel rcnucre his moti- <note type="footnote"> I Editi: <hi
-								rend="italic">Aliatn secundum hos latmtiorem, sed cettiorein <lb/>
+								rend="italic">Aliatn secundum hos latmtiorem, sed cettiorein<lb/>
 								ferre sentenlium.Mss.: secundum hos latentiores.</hi> Suj-i
-							de,filii-- <lb/>
+							de,filii<lb/>
 							<hi rend="italic">meros</hi>
 						</note>
 						<lb/>
-						<pb n="1177"/> bus, aut cum priniilus exseruntur, aut cum rccorda­ <lb/>
-						tione resuscitantur, quod fit in delectatione conve­ <lb/> nientiæ, et
-						offensione absurditatis talium motionum <lb/> sive affectiouum; et aliud est
-						æstimare utrum recte <lb/> an serus ista delectent, quod fit ratiocinando :
-						necesse <lb/> est fateamur ita haec esse duo genera, ut illa sunt tria.
-						<lb/> Et si recte nobis visum est, nist quibusdam numeris <lb/> esset ipse
-						delectationis sensus imbutus, nullo modo <lb/> cum potuisse annuere paribus
-						intervallis, et pertur­ <lb/> baLa respuere: recte etiam videri potest
-						ratio, quæ <lb/> nuic delectationi superimponitur, nullo modo sine <lb/>
-						quibusdam numeris vivocioribus, de numeris quos in­ <lb/> fra se habet posse
-						judicare. Quæ si vera sunt, apparet <lb/> inventa esse in anima quinque
-						genera numerorum, <lb/> quibus cum addideris corporales illos quos sonantes
-						<lb/> vocavimus, sex genera numerorum disposita et ordi­ <lb/> nata
-						cognosces. Jam nunc, si placet, illi qui nobis <lb/> subrepserant ad
-						principatum obtinendum, sensuales <lb/> nominentur, et judicialium nomen,
-						qnoninm cst lio­ <lb/> noratius, hi accipiant qui excellentiores comperti
-						<lb/> sunt: quanquam et sonantium nomen mutandum pu­ <lb/> tem, quoniam si
-						corporales vocentur, manifestius si­ <lb/> gnificabunt etiam illos qui sunt
-						in saltatione, et in <lb/> caetero motu visibili. Si tamen ea quae dicta
-						sunt pro­ <lb/> bas. D. Probo sane : nam et vera et manifesta mihi <lb/>
-						vid' ntur. Horum etiam emendationem vocabulorum <lb/> libenter accipio.</p>
+						<pb n="1177"/> bus, aut cum priniilus exseruntur, aut cum rccorda­<lb/>
+						tione resuscitantur, quod fit in delectatione conve­<lb/>nientiae, et
+						offensione absurditatis talium motionum<lb/>sive affectiouum; et aliud est
+						aestimare utrum recte<lb/>an serus ista delectent, quod fit ratiocinando :
+						necesse<lb/>est fateamur ita haec esse duo genera, ut illa sunt tria.
+						<lb/>Et si recte nobis visum est, nist quibusdam numeris<lb/>esset ipse
+						delectationis sensus imbutus, nullo modo<lb/>cum potuisse annuere paribus
+						intervallis, et pertur­<lb/>baLa respuere: recte etiam videri potest
+						ratio, quae<lb/>nuic delectationi superimponitur, nullo modo sine<lb/>
+						quibusdam numeris vivocioribus, de numeris quos in­<lb/>fra se habet posse
+						judicare. Quae si vera sunt, apparet<lb/>inventa esse in anima quinque
+						genera numerorum,<lb/>quibus cum addideris corporales illos quos sonantes
+						<lb/>vocavimus, sex genera numerorum disposita et ordi­<lb/>nata
+						cognosces. Jam nunc, si placet, illi qui nobis<lb/>subrepserant ad
+						principatum obtinendum, sensuales<lb/>nominentur, et judicialium nomen,
+						qnoninm cst lio­<lb/>noratius, hi accipiant qui excellentiores comperti
+						<lb/>sunt: quanquam et sonantium nomen mutandum pu­<lb/>tem, quoniam si
+						corporales vocentur, manifestius si­<lb/>gnificabunt etiam illos qui sunt
+						in saltatione, et in<lb/>caetero motu visibili. Si tamen ea quae dicta
+						sunt pro­<lb/>bas. D. Probo sane : nam et vera et manifesta mihi<lb/>
+						vid' ntur. Horum etiam emendationem vocabulorum<lb/>libenter accipio.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT X. — <hi rend="italic">Rationis vis in perspiciendis
 								quce ad Musicam pertinent,</hi> uli <hi rend="italic">nthil aliud
-								quam</hi> æqualitas <hi rend="italic">delectat.</hi>
+								quam</hi> aequalitas <hi rend="italic">delectat.</hi>
 						</title>
 					</ab>
-					</div><div type="textpart" subtype="dialog"><p>25. <hi rend="italic">M.</hi> Age, nunc aspice in vim potentiamque ra­ <lb/>
-						tionis, quantum ex operibus ejus aspicere possumus. <lb/> Ipsa enim, ut id
-						potissimum dicam quod ad hujus <lb/> operis susceptionem attinet, primo quid
-						sit ipsa bona <lb/> modulatio consideravit, ct eam in quodam motu Ii...
-						<lb/> bcro, ct ad suoe pulchritudinis finem converso esse <lb/> perspexit.
-						Deinde vidit in molibus corporum aliud <lb/> esse quod brevitate ct
-						productione temporis variarc­ <lb/> tur, in quantum magis esset minusve
-						diuturnum, aliud <lb/> localium spatiorum percussione1 in quibusdam gia­
-						<lb/> dibus celcritalis et tarditatis : qua divisione faCIa, n- <lb/> lud
-						quod in temporis mora esset, modestis intervallis, <lb/> et humano sensui
-						accommodatis articulatim varios <lb/> efficeret numcros, eorumque genera et
-						ordinem usque <lb/> ad modulos versuum persecuta est. Postremo attendit
-						<lb/> quid in his moderandis, operandis, sentiendis, reti­ <lb/> nendis
-						ageret anima cujus caput ipsa esset: hosque <lb/> omnes animales numeros a
-						corporalibus separavit: <lb/> seque ipsam hæc omnia ncquc animadvertere,
-						neque <lb/> distinguere, ncque recte numerare sine quibusdam <lb/> suis
-						numeris potuisse cognovit, eosque cæteris in­ <lb/> ferioris ordinis
-						judiciaria quadam æstimatione præ­ <lb/> posuit.</p>
-					</div><div type="textpart" subtype="dialog"><p>26. Et nunc cum ipsa sua delectatione, quæ 3 in <lb/> temporum momenta
+					</div><div type="textpart" subtype="dialog"><p>25. <hi rend="italic">M.</hi> Age, nunc aspice in vim potentiamque ra­<lb/>
+						tionis, quantum ex operibus ejus aspicere possumus.<lb/>Ipsa enim, ut id
+						potissimum dicam quod ad hujus<lb/>operis susceptionem attinet, primo quid
+						sit ipsa bona<lb/>modulatio consideravit, ct eam in quodam motu Ii...
+						<lb/>bcro, ct ad suoe pulchritudinis finem converso esse<lb/>perspexit.
+						Deinde vidit in molibus corporum aliud<lb/>esse quod brevitate ct
+						productione temporis variarc­<lb/>tur, in quantum magis esset minusve
+						diuturnum, aliud<lb/>localium spatiorum percussione1 in quibusdam gia­
+						<lb/>dibus celcritalis et tarditatis : qua divisione faCIa, n<lb/>lud
+						quod in temporis mora esset, modestis intervallis,<lb/>et humano sensui
+						accommodatis articulatim varios<lb/>efficeret numcros, eorumque genera et
+						ordinem usque<lb/>ad modulos versuum persecuta est. Postremo attendit
+						<lb/>quid in his moderandis, operandis, sentiendis, reti­<lb/>nendis
+						ageret anima cujus caput ipsa esset: hosque<lb/>omnes animales numeros a
+						corporalibus separavit:<lb/>seque ipsam haec omnia ncquc animadvertere,
+						neque<lb/>distinguere, ncque recte numerare sine quibusdam<lb/>suis
+						numeris potuisse cognovit, eosque caeteris in­<lb/>ferioris ordinis
+						judiciaria quadam aestimatione prae­<lb/>posuit.</p>
+					</div><div type="textpart" subtype="dialog"><p>26. Et nunc cum ipsa sua delectatione, quae 3 in<lb/>temporum momenta
 						perpendit, et talibus numeris <note type="footnote"> 4 septem Mss., <hi
 								rend="italic">percussionem.</hi> ' </note><note type="footnote"> I
 							Ita plerique Mss., cnm Am. At Lov.habet: <hi rend="italic">In hts
 								moae­</hi>
-							<lb/> randis, <hi rend="italic">sentiendis, relinendis, delectandis
+							<lb/>randis, <hi rend="italic">sentiendis, relinendis, delectandis
 								agerEt anima.</hi>
 						</note><note type="footnote"> I Duo Mss., <hi rend="italic">qnam.</hi> Alii
-							tres, <hi rend="italic">qua.</hi> Paulo post, alter e victo­ <lb/> nnis
+							tres, <hi rend="italic">qua.</hi> Paulo post, alter e victo­<lb/>nnis
 							codicibui: <hi rend="italic">Propendet, tfillbw numeris.</hi>
 						</note>
-						<lb/> modificandis nutus suos exhibet, sic agit; quid est <lb/> quod in
-						sensibili numerositate diligimus? Num aliud <lb/> praeter parilitatem
-						quamdam et aequaliter dimensa in­ <lb/> . tervalla? An ille pyrrhichius pes
-						sive spondeus, sive <lb/> anapaestus, sive dactylus, siveprocelensmaticus,
-						sivo <lb/> dispondeus nos aliter delectaret ; nisi partem suam <lb/> parti
-						alteri æquali divisione conferret? Quid vero <lb/> iambus, trochaRus,
-						tribrachus pulchritudinis habent, <lb/> nisi quod minore sua parte majorcm
-						suam partem in <lb/> tantas dnas aequaliter dividunt? Jani porro sex tem­
-						<lb/> porum pedes, num I aliunde blandius sonant atque <lb/> festivius, nisi
-						quod utraque lege partiuntur; scilicet <lb/> aut in duas æquales partes
-						terna tempora possidentes, <lb/> ant in unam simplam ex æqualibus partem 2,
-						et alte­ <lb/> ram duplam, id est, ut major habeat bis minorem, ct <lb/> eo
-						modo ab illa dividatur acqualiter, duobus tempori­ <lb/> bus quatuor tempora
-						in bina demetiente ac secante? <lb/> Quid illi quinnm soptenumque temporum
-						pedes? unde <lb/> solutae orationi, quam versibus videntur aptiores, nisi
-						<lb/> quod eorum pars minor in partos æquales majorem <lb/> non dividit? Et
-						hi tamen ipsi unde admittuntur in sui <lb/> generis ordine ad temporum
-						numerositatem, nisi quia <lb/> et in quinque temporibus tantas duas
-						particulas habet <lb/> pars minor, quantas major tres; et in septem tantas
-						<lb/> tres minor, quantas major quatuor? Ita in omnibus <lb/> pedibus nulla
-						pars minima est alicujus dimcn ionis <lb/> articulo notata, cui nou cæteræ
-						quanta possunt æqua­ <lb/> liiatc consentiant.</p>
-					</div><div type="textpart" subtype="dialog"><p>27. Age, in conjunctis pcdibus sive libera perpe­ <lb/> tuitate porrigatur
-						ista conjunctio, sicut in rhythmis; <lb/> sive ab aliquo certo fine
-						rcvocetur, sicut in metris; <lb/> sive eliam in duo membra quadam lege
-						sibimct con­ <lb/> gruentia tribuatur, sicut in versibus; qua tandem nlia
-						<lb/> re, nisi æqualitate pcs pedi amicus est? Unde molossi, <lb/> et
-						ionicorum syllaba media quæ longa est, non se­ <lb/> ctione, sed nutu I ipso
-						pronuntiantis atque plaudentis <lb/> in duo paria momenta distribui potest;
-						tit cHam ad <lb/> tcma tempora pes totus convenint, quando cæteris <lb/> qui
-						codem modo dividuntur, adjungitur; cur nisi <lb/> æqualitatis jure
-						dominante, quod scilicet aequalis (st <lb/> lateribus * suis, quæ binorum
-						temporum sunt, cum <lb/> et ipsa sit duum temporum? Cur idem fieri in amphi­
-						<lb/> bracho non potest, quando cæteris quatuor temporum <lb/> adjungitur,
-						nisi quia tanta ibi non invenitur aequalitas <lb/> duplo medio, lateribus
-						simplis? Cur in silentiorum in­ <lb/> tervallis nulla fraude sensus
-						offenditur, nisi qnia ei­ <lb/> dcm juri æqualitatis, etiamsi non sono,
-						spatio tamen <lb/> temporis quod dcbetnr, cxsolvitur? Cur sequente si­ <lb/>
-						lentio etiam brevis syllaba pro longa accipitur, non <lb/> in tituto, sed
-						ipso naturali examinc quod auribus <lb/> præsidet; nisi quia in spatio
-						temporis longiore sonuin <lb/> coarctare in angustias eadem illa æqualitatis
-						lege pro­ <lb/> hibemur? Itaque syllabam ultra duo tempora produ­ <lb/>
-						cere, ut etiam sono impleatur quod silentio impleri <lb/> potest, admittit
+						<lb/>modificandis nutus suos exhibet, sic agit; quid est<lb/>quod in
+						sensibili numerositate diligimus? Num aliud<lb/>praeter parilitatem
+						quamdam et aequaliter dimensa in­<lb/>. tervalla? An ille pyrrhichius pes
+						sive spondeus, sive<lb/>anapaestus, sive dactylus, siveprocelensmaticus,
+						sivo<lb/>dispondeus nos aliter delectaret ; nisi partem suam<lb/>parti
+						alteri aequali divisione conferret? Quid vero<lb/>iambus, trochaRus,
+						tribrachus pulchritudinis habent,<lb/>nisi quod minore sua parte majorcm
+						suam partem in<lb/>tantas dnas aequaliter dividunt? Jani porro sex tem­
+						<lb/>porum pedes, num I aliunde blandius sonant atque<lb/>festivius, nisi
+						quod utraque lege partiuntur; scilicet<lb/>aut in duas aequales partes
+						terna tempora possidentes,<lb/>ant in unam simplam ex aequalibus partem 2,
+						et alte­<lb/>ram duplam, id est, ut major habeat bis minorem, ct<lb/>eo
+						modo ab illa dividatur acqualiter, duobus tempori­<lb/>bus quatuor tempora
+						in bina demetiente ac secante?<lb/>Quid illi quinnm soptenumque temporum
+						pedes? unde<lb/>solutae orationi, quam versibus videntur aptiores, nisi
+						<lb/>quod eorum pars minor in partos aequales majorem<lb/>non dividit? Et
+						hi tamen ipsi unde admittuntur in sui<lb/>generis ordine ad temporum
+						numerositatem, nisi quia<lb/>et in quinque temporibus tantas duas
+						particulas habet<lb/>pars minor, quantas major tres; et in septem tantas
+						<lb/>tres minor, quantas major quatuor? Ita in omnibus<lb/>pedibus nulla
+						pars minima est alicujus dimcn ionis<lb/>articulo notata, cui nou caeterae
+						quanta possunt aequa­<lb/>liiatc consentiant.</p>
+					</div><div type="textpart" subtype="dialog"><p>27. Age, in conjunctis pcdibus sive libera perpe­<lb/>tuitate porrigatur
+						ista conjunctio, sicut in rhythmis;<lb/>sive ab aliquo certo fine
+						rcvocetur, sicut in metris;<lb/>sive eliam in duo membra quadam lege
+						sibimct con­<lb/>gruentia tribuatur, sicut in versibus; qua tandem nlia
+						<lb/>re, nisi aequalitate pcs pedi amicus est? Unde molossi,<lb/>et
+						ionicorum syllaba media quae longa est, non se­<lb/>ctione, sed nutu I ipso
+						pronuntiantis atque plaudentis<lb/>in duo paria momenta distribui potest;
+						tit cHam ad<lb/>tcma tempora pes totus convenint, quando caeteris<lb/>qui
+						codem modo dividuntur, adjungitur; cur nisi<lb/>aequalitatis jure
+						dominante, quod scilicet aequalis (st<lb/>lateribus * suis, quae binorum
+						temporum sunt, cum<lb/>et ipsa sit duum temporum? Cur idem fieri in amphi­
+						<lb/>bracho non potest, quando caeteris quatuor temporum<lb/>adjungitur,
+						nisi quia tanta ibi non invenitur aequalitas<lb/>duplo medio, lateribus
+						simplis? Cur in silentiorum in­<lb/>tervallis nulla fraude sensus
+						offenditur, nisi qnia ei­<lb/>dcm juri aequalitatis, etiamsi non sono,
+						spatio tamen<lb/>temporis quod dcbetnr, cxsolvitur? Cur sequente si­<lb/>
+						lentio etiam brevis syllaba pro longa accipitur, non<lb/>in tituto, sed
+						ipso naturali examinc quod auribus<lb/>praesidet; nisi quia in spatio
+						temporis longiore sonuin<lb/>coarctare in angustias eadem illa aequalitatis
+						lege pro­<lb/>hibemur? Itaque syllabam ultra duo tempora produ­<lb/>
+						cere, ut etiam sono impleatur quod silentio impleri<lb/>potest, admittit
 						natura audiendi et tacendi5: ut autem <note type="footnote"> 1 Ms. A sic:
 								<hi rend="italic">Non aliunde blandius sonant atque festitius.</hi>
 							M. </note><note type="footnote"> 1 Duodecim Mss., <hi rend="italic">ex
@@ -5599,820 +5599,820 @@
 						</note><note type="footnote"> a Ila in Mss. At in prius editis, <hi
 								rend="italic">motu.</hi> — Sic etiamMf. A. M. </note><note
 							type="footnote"> * An. Er. et l.os.ycrqualibus laleribus. St*J clarius
-							aliqwot <lb/> Mss., <hi rend="italic">æqualis est;</hi> scilicet, pes
+							aliqwot<lb/>Mss., <hi rend="italic">aequalis est;</hi> scilicet, pes
 							tum tnofoSSIIS, lum ionicus. </note><note type="footnote"> IS In
 							plerisque Mss., <hi rend="italic">audiendi et canendi.</hi> Et mox ill
 							editia </note>
 						<lb/>
-						<pb n="1179"/> minos quam duo tempora occupet syllaba, dum restat <lb/>
-						spatium tacitis nutibus, quædam fraus aequalitatis <lb/> est, quia minus
-						quam in duobus esse æqualitas non <lb/> potest. Jam vero in ipsa aequalitate
-						membrorum qua <lb/> variantur illi ambitus, quos Graeci <foreign
-							xml:lang="grc">περιὸδους</foreign> vocant, <lb/> versusque figurantur,
-						quomodo ad eamdem aequali­ <lb/> tatem secretius reditur; nisi ut in ambitu
-						brevius <lb/> membrum majori aequalibus pedibus ad plausum con­ <lb/>
-						veniat, et in versu occultiore consideratione nume. <lb/> rorum, ea quas
-						inæqualia membra junguntur, vim <lb/> aequalitatis habere inveniantur?</p>
-					</div><div type="textpart" subtype="dialog"><p>28. Quaerit ergo ratio, et carnalem animae de­ <lb/> lectationem, quae
-						judiciales partes sibi vindicabat, <lb/> interrogat, cum eam in spatiorum
-						temporalium nu­ <lb/> meri aequalitas mulceat, utrum duae syllaba breves
-						<lb/> quascuinque audierit vere sint æquales; an fieri pos­ <lb/> sit, ut
-						una earum edatur productius , non usque ad <lb/> longæ syllabæ modum, sed
-						infra quantumlibet, quo <lb/> tamen excedat sociam suam. Nnm negari potest,
-						fieri <lb/> posse, cum hæc delectatio ista non sentiat, et in­ <lb/>
-						æqualibus velut æqualibus gaudeat? quo errore et in­ <lb/> arqualitate quid
-						turpius? Ex quo admonelnur ab his <lb/> avertere gaudium, quae imitantur
-						a'qualitatem , et <lb/> utrum impleant, comprebendere non possumus: imo
-						<lb/> quod non impleant fortasse comprehendimus; et <lb/> tamen in quantum
-						imitantur, pulchra esse in suo ge­ <lb/> nere et ordine suo, negare non
+						<pb n="1179"/> minos quam duo tempora occupet syllaba, dum restat<lb/>
+						spatium tacitis nutibus, quaedam fraus aequalitatis<lb/>est, quia minus
+						quam in duobus esse aequalitas non<lb/>potest. Jam vero in ipsa aequalitate
+						membrorum qua<lb/>variantur illi ambitus, quos Graeci <foreign
+							xml:lang="grc">περιὸδους</foreign> vocant,<lb/>versusque figurantur,
+						quomodo ad eamdem aequali­<lb/>tatem secretius reditur; nisi ut in ambitu
+						brevius<lb/>membrum majori aequalibus pedibus ad plausum con­<lb/>
+						veniat, et in versu occultiore consideratione nume.<lb/>rorum, ea quas
+						inaequalia membra junguntur, vim<lb/>aequalitatis habere inveniantur?</p>
+					</div><div type="textpart" subtype="dialog"><p>28. Quaerit ergo ratio, et carnalem animae de­<lb/>lectationem, quae
+						judiciales partes sibi vindicabat,<lb/>interrogat, cum eam in spatiorum
+						temporalium nu­<lb/>meri aequalitas mulceat, utrum duae syllaba breves
+						<lb/>quascuinque audierit vere sint aequales; an fieri pos­<lb/>sit, ut
+						una earum edatur productius , non usque ad<lb/>longae syllabae modum, sed
+						infra quantumlibet, quo<lb/>tamen excedat sociam suam. Nnm negari potest,
+						fieri<lb/>posse, cum haec delectatio ista non sentiat, et in­<lb/>
+						aequalibus velut aequalibus gaudeat? quo errore et in­<lb/>arqualitate quid
+						turpius? Ex quo admonelnur ab his<lb/>avertere gaudium, quae imitantur
+						a'qualitatem , et<lb/>utrum impleant, comprebendere non possumus: imo
+						<lb/>quod non impleant fortasse comprehendimus; et<lb/>tamen in quantum
+						imitantur, pulchra esse in suo ge­<lb/>nere et ordine suo, negare non
 						possumus.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT XI. — Inferioribus <hi rend="italic">non offendi,
 								solis</hi> superio­ <hi rend="italic">ribus numeris delectari</hi>
 							conveni. <hi rend="italic">Differentia</hi> phanta- <hi rend="italic"
-								>siæ et phantasmatis.</hi>
+								>siae et phantasmatis.</hi>
 						</title>
 					</ab>
-					</div><div type="textpart" subtype="dialog"><p>29. Non ergo invideamus inferioribus quam nos <lb/> sumus, nosque ipsos inter
-						iila quæ infra nos sunt <lb/> et illa quae supra nos sunt, ita Deo et Domino
-						nostro <lb/> opitulante ordinemus, ut inferioribus non offendamur, <lb/>
-						solis autem superioribus delectemur. Delectatio quippe <lb/> quasi pondus
-						est animae. Delectatio ergo ordiuat ani­ <lb/> mam. <hi rend="italic">Ubi
-							enim erit thesaurus tuus, ibi erit et cor</hi> tuum <lb/>
+					</div><div type="textpart" subtype="dialog"><p>29. Non ergo invideamus inferioribus quam nos<lb/>sumus, nosque ipsos inter
+						iila quae infra nos sunt<lb/>et illa quae supra nos sunt, ita Deo et Domino
+						nostro<lb/>opitulante ordinemus, ut inferioribus non offendamur,<lb/>
+						solis autem superioribus delectemur. Delectatio quippe<lb/>quasi pondus
+						est animae. Delectatio ergo ordiuat ani­<lb/>mam. <hi rend="italic">Ubi
+							enim erit thesaurus tuus, ibi erit et cor</hi> tuum<lb/>
 						<hi rend="italic">(Matth.</hi> vi, 21): ubi delectatio , ibi thesaurus: ubi
-						<lb/> autem cor, ibi beatitudo aut miseria. Quae vcro supe­ <lb/> riora
-						sunt, nisi illa in quibus summa, inconcussa, <lb/> incommutabilis, æterna
-						manet æqualitas? Ubi nul­ <lb/> lum est tempus, quia nulla mutabilitas est;
-						et unde <lb/> tempora fabricantur et ordinantur et modificantur <lb/>
-						æternitatem imitantia , dum cœli conversio ad idem <lb/> redit1, et cœlestia
-						corpora ad idem revocat, diebus­ <lb/> que et mensinus et annis ct lusiris,
-						cæterisque side­ <lb/> rum orbibus, legibus æqualitatis et unitatis et ordi­
-						<lb/> nationis obtemperat. Ita coelestibus terrena subjecta, <lb/> orbes
-						temporum. suorum numerosa successione quasi <lb/> carmini universitatis
+						<lb/>autem cor, ibi beatitudo aut miseria. Quae vcro supe­<lb/>riora
+						sunt, nisi illa in quibus summa, inconcussa,<lb/>incommutabilis, aeterna
+						manet aequalitas? Ubi nul­<lb/>lum est tempus, quia nulla mutabilitas est;
+						et unde<lb/>tempora fabricantur et ordinantur et modificantur<lb/>
+						aeternitatem imitantia , dum cœli conversio ad idem<lb/>redit1, et cœlestia
+						corpora ad idem revocat, diebus­<lb/>que et mensinus et annis ct lusiris,
+						caeterisque side­<lb/>rum orbibus, legibus aequalitatis et unitatis et ordi­
+						<lb/>nationis obtemperat. Ita coelestibus terrena subjecta,<lb/>orbes
+						temporum. suorum numerosa successione quasi<lb/>carmini universitatis
 						associant.</p>
-					</div><div type="textpart" subtype="dialog"><p>30. In quibus multa nobis videntur inordinata et <lb/> perturbata, quia eorum
-						ordini pro nostris meritis <lb/> assuti sumus', nescientes quid de nobis
-						divina pro­ <lb/> videntia pulchrum gerat. Quoniam si quls, verbi <lb/>
-						gratia, in amplissimarum pulcherrimarumque ædium <lb/> uno aliquo angulo
-						tanquam statua collocetur, pul. <lb/> cbritudincm illius fabricæ sentire non
-						poterit, cyro <lb/> et ipse pars erit. Nec universi exercitus ordinem mi­
-						<lb/> lus in acie valet intueri. Et in quolibet poemate si <lb/> quanto
-						spatio syllabae sonant, tanto viverent atque <lb/> sentirent. nullo modo
-						illa numerositas et contexti <lb/> operis pulchritudo cis placeret , quam
-						tutam perspi- <lb/> cere atque approbare non possent, cum de ipsis sin­
-						<lb/> gulis prætereuntibus fabricata esset atque perfecta. <lb/> Ita
-						peccantem hominem ordinavit Deus turpem, non <lb/> turpiter. Turpis enim
-						factus cst voluntate, univcr­ <lb/> sum amittendo quod Dei præceptis
-						obtemperans pos­ <lb/> sidebat, et ordinatus in parte est, ut qui legem
-						agere <lb/> noluit, a lege agatur. Quidquid autem legitime, uti- <lb/> que
-						juste ; et quidquid juste, non utique turpiter agi- ; <lb/> tur : quia et in
-						malis operibus nostris Dei opera bona <lb/> sunt. Homo namque in quantum
-						homo est, aliquod <lb/> bonum est; adulterium autem in quantum adulte­ <lb/>
-						rium est, malum opus est: plerumque autem de adul- <lb/> tcrio nascitur
-						bomo, de malo scilicet hominis opere <lb/> bonum opus Dei.</p>
-					</div><div type="textpart" subtype="dialog"><p>31. Quamobrem ut nos ad propositum, prop'er <lb/> quod hanc sunt dicta,
-						referamus, hi numeri rationis <lb/> pulchritudine praeminent, a quibus si
-						prorsus absciu­ <lb/> dcremur, cum inclinamur ad corpus, progressores <lb/>
-						numeros sensuales non modificarent: qui rursus mo­ <lb/> vendis corporibus
-						agunt sensibiles temporum pul­ <lb/> chritudines: atque ita sonantibus obvii
-						etiam occur­ <lb/> sores numeri fabricantur; quos omnes impetus suus <lb/>
-						eadem anima excipiens, quasi multiplicat in seipsa, <lb/> et recordabiles
-						facit: quae vis ejus memoria dicitur, <lb/> magnum quoddam adjutorium in
-						hujus vitæ negotio­ <lb/> sissimis actibus.</p>
-					</div><div type="textpart" subtype="dialog"><p>32. Haec igitur memoria quæcumque de motibus <lb/> animi tenet, qui adversus
-						passiones corporis acti <lb/> sunt, <foreign xml:lang="grc"
-							>ϕαντασιἑαι</foreign> græce vocantur; nee invenio quid eas <lb/> latine
-						malim vocare : quas pro cognitis habere atque <lb/> pro perceptis opinabilis
-						vita est 1, constituta in ipso <lb/> erroris introitu. Sed cam sibi isti
-						motus occursant, et <lb/> tanquam diversis et repugnantibus intentionis
-						flati­ <lb/> bus æstuant, alios ex aliis motus pariunt; non jam <lb/> eos
-						qui tenentur ex occursionibus passionum corporis <lb/> impressi de sensibus,
-						similes tamen tanquam imagi­ <lb/> num imagines, quæ phantasmata dici
-							<unclear>placuit</unclear> Alitcr <lb/> enim cogito patrem meum quem
-						sæpe vidi, aliter <lb/> arum quem nunquam vidi. Horum pilu.um phantasia
-						<lb/> est. alterum phantasma. Illud in memoria invenio, <lb/> hoc in eo motu
-						animi, qui ex iis ortus est quos habet <lb/> memoria. Quomodo autem oriantur
-						hæc, et invenire <lb/> et explicare difficile est. Arbitror tamen, quod si
-						nun­ <lb/> qnam humana corpora vidissem, nullo modo ea pos­ <lb/> sem
+					</div><div type="textpart" subtype="dialog"><p>30. In quibus multa nobis videntur inordinata et<lb/>perturbata, quia eorum
+						ordini pro nostris meritis<lb/>assuti sumus', nescientes quid de nobis
+						divina pro­<lb/>videntia pulchrum gerat. Quoniam si quls, verbi<lb/>
+						gratia, in amplissimarum pulcherrimarumque aedium<lb/>uno aliquo angulo
+						tanquam statua collocetur, pul.<lb/>cbritudincm illius fabricae sentire non
+						poterit, cyro<lb/>et ipse pars erit. Nec universi exercitus ordinem mi­
+						<lb/>lus in acie valet intueri. Et in quolibet poemate si<lb/>quanto
+						spatio syllabae sonant, tanto viverent atque<lb/>sentirent. nullo modo
+						illa numerositas et contexti<lb/>operis pulchritudo cis placeret , quam
+						tutam perspi<lb/>cere atque approbare non possent, cum de ipsis sin­
+						<lb/>gulis praetereuntibus fabricata esset atque perfecta.<lb/>Ita
+						peccantem hominem ordinavit Deus turpem, non<lb/>turpiter. Turpis enim
+						factus cst voluntate, univcr­<lb/>sum amittendo quod Dei praeceptis
+						obtemperans pos­<lb/>sidebat, et ordinatus in parte est, ut qui legem
+						agere<lb/>noluit, a lege agatur. Quidquid autem legitime, uti<lb/>que
+						juste ; et quidquid juste, non utique turpiter agi- ;<lb/>tur : quia et in
+						malis operibus nostris Dei opera bona<lb/>sunt. Homo namque in quantum
+						homo est, aliquod<lb/>bonum est; adulterium autem in quantum adulte­<lb/>
+						rium est, malum opus est: plerumque autem de adul<lb/>tcrio nascitur
+						bomo, de malo scilicet hominis opere<lb/>bonum opus Dei.</p>
+					</div><div type="textpart" subtype="dialog"><p>31. Quamobrem ut nos ad propositum, prop'er<lb/>quod hanc sunt dicta,
+						referamus, hi numeri rationis<lb/>pulchritudine praeminent, a quibus si
+						prorsus absciu­<lb/>dcremur, cum inclinamur ad corpus, progressores<lb/>
+						numeros sensuales non modificarent: qui rursus mo­<lb/>vendis corporibus
+						agunt sensibiles temporum pul­<lb/>chritudines: atque ita sonantibus obvii
+						etiam occur­<lb/>sores numeri fabricantur; quos omnes impetus suus<lb/>
+						eadem anima excipiens, quasi multiplicat in seipsa,<lb/>et recordabiles
+						facit: quae vis ejus memoria dicitur,<lb/>magnum quoddam adjutorium in
+						hujus vitae negotio­<lb/>sissimis actibus.</p>
+					</div><div type="textpart" subtype="dialog"><p>32. Haec igitur memoria quaecumque de motibus<lb/>animi tenet, qui adversus
+						passiones corporis acti<lb/>sunt, <foreign xml:lang="grc"
+							>ϕαντασιἑαι</foreign> graece vocantur; nee invenio quid eas<lb/>latine
+						malim vocare : quas pro cognitis habere atque<lb/>pro perceptis opinabilis
+						vita est 1, constituta in ipso<lb/>erroris introitu. Sed cam sibi isti
+						motus occursant, et<lb/>tanquam diversis et repugnantibus intentionis
+						flati­<lb/>bus aestuant, alios ex aliis motus pariunt; non jam<lb/>eos
+						qui tenentur ex occursionibus passionum corporis<lb/>impressi de sensibus,
+						similes tamen tanquam imagi­<lb/>num imagines, quae phantasmata dici
+							<unclear>placuit</unclear> Alitcr<lb/>enim cogito patrem meum quem
+						saepe vidi, aliter<lb/>arum quem nunquam vidi. Horum pilu.um phantasia
+						<lb/>est. alterum phantasma. Illud in memoria invenio,<lb/>hoc in eo motu
+						animi, qui ex iis ortus est quos habet<lb/>memoria. Quomodo autem oriantur
+						haec, et invenire<lb/>et explicare difficile est. Arbitror tamen, quod si
+						nun­<lb/>qnam humana corpora vidissem, nullo modo ea pos­<lb/>sem
 						visibili specie cogitando figurare. Quod autem ex <note type="footnote">
 							<hi rend="italic">legitur, spatium taciturnitatis;</hi> ubi substituimus
 							ex Mss., ta- citis nulibus.</note>
 						<note type="footnote"> 1 Am. Er. ad et plores » ad <hi rend="italic"
-								>diem</hi> redit. Et infra iidem ha­ <lb/>
+								>diem</hi> redit. Et infra iidem ha­<lb/>
 							<hi rend="italic">bent Mss., ad diem</hi> revocat. Paulo , ost in editis
-							legitur, side­ <lb/>
+							legitur, side­<lb/>
 							<hi rend="italic">rum ordinibus</hi> legibusque. At in mss., <hi
 								rend="italic">siderum orbibus, legi- busque.</hi>
 						</note><note type="footnote"> 2 Libri scripti et excuni ferunt, <hi
-								rend="italic">asarceti sumut.</hi> sed incun­ <lb/> ctanter
+								rend="italic">asarceti sumut.</hi> sed incun­<lb/>ctanter
 							legendum, <hi rend="italic">assuti sumus,</hi> ut in corbeiensi codice
-							le- <lb/> gebatur antequam passus esxet secundam manum, quæ in- <lb/>
-							serta vocali fecit usuetf. vide librum de vera Relirione <lb/> cap. 22,
-							n. 43, ubi rem eamdem inculcans Augustinus, «Sæ­ <lb/> culorum, ail,
+							le<lb/>gebatur antequam passus esxet secundam manum, quae in<lb/>
+							serta vocali fecit usuetf. vide librum de vera Relirione<lb/>cap. 22,
+							n. 43, ubi rem eamdem inculcans Augustinus, «Sae­<lb/>culorum, ail,
 							partes damnatione facti sumus.» </note><note type="footnote">1 Plurimum
-							hic variant libri Et Er, quidem editio Loo,habet, <lb/> pro certis
+							hic variant libri Et Er, quidem editio Loo,habet,<lb/>pro certis
 							opinatis visa est. At Am. Er. et aliquot Mss., opina- bilis vita est.
 							Alii., Mss., opinabilis via est. Quidam demum opi- nans , vel opinatius. </note>
 						<lb/>
-						<pb n="1181"/> eo quod vidi facio, memoria facio: et lamen aliud <lb/> est
-						in memoria invenire phantasiam, aliud de memo­ <lb/> ria facere phantasma.
-						Quæ omnia vis animæ potest. <lb/> Sed vera eliam phantasmata habere pro
-						cognitis, <lb/> summus error est. Quanquam sit in utroque genere <lb/> quod
-						nos non absurde scire dicamus, id est, sensisse <lb/> nos lalia, vel
-						imaginari nos talia. Patrem denique me <lb/> babuisse et avum, non temere
-						possum dicere : ipsos <lb/> autem esse quos animus meus in phantasia vel in
-						<lb/> phantasmate tenet, dementissime dixerim. Sequun­ <lb/> tur autem
-						nonnulli phantasmata sua tam præcipites, <lb/> ut nulla sit alia materies
-						omnium falsarum opinio­ <lb/> num, quam habere phantasias vel phantasmata
-						pro <lb/> cognitis, quæ cognoscuntur per sensam Quare his <lb/> potissimum
-						resistamus, nee eis ita mentem accommo­ <lb/> demus, ut dum in his est
-						cogitatio, intelligentia ea <lb/> cerni arbitremur.</p>
-					</div><div type="textpart" subtype="dialog"><p>33. Cur autem si hujusmodi numeri qni nunt in <lb/> anima rebus temporalibus
-						dedita, habent sui generis <lb/> pulchritudinem , quamvis cam transcundo
-						actitent, <lb/> invideat huic pulchritudini divina providentia, quæ <lb/> de
-						nostra poenali mortalitate formatur, quam justis­ <lb/> sima Dei lege
-						meruimus : in qua tamen nos non ita <lb/> deseruit, ut non valeamus
-						recurrere, et a carnalium <lb/> sensuum delectatione, misericordia ejus
-						maium por­ <lb/> rigente , revocari. Talis enim delectatio vehementer <lb/>
-						Infigit memoriae quod trahit a lubricis sensibus. Haec <lb/> autem animae
-						consuetudo facta cum carne, propter <lb/> carnalem affectionem, in
-						Scripturis divinis caro no­ <lb/> minatur. Hæc menti obluctatur, cum jam
-						dici potest <lb/> apostolicum illud: <hi rend="italic">Mente</hi> servio <hi
-							rend="italic">legi Dei, carne autem<lb/> legi peccati (Rom.</hi> VII,
-						25). Sed in spiritualia mente <lb/> suspensa atque ibi fixa et manente,
-						etiam hujus con­ <lb/> suetudinis impetus frangiiur, et paulatim repressus
-						<lb/> exstinguitur. Major euim erat cum sequeremur; uon <lb/> tamen omnino
-						nullus, sed certe minor est cum eum <lb/> refrenamus, atque ita certis
-						regressibus ab omni <lb/> lasciviente motu , in quo defectus essentiae est
-						animae, <lb/> delectatione in rationis nnmeros restituta ad Deum <lb/> tota
-						vita nostra convertitur, dans corpori nnmeros <lb/> sanitatis, non accipiens
-						inde heliliam; quod cor­ <lb/> rupto exteriore homine, et ejus in melius
-						commuta­ <lb/> tione continget.</p>
+						<pb n="1181"/> eo quod vidi facio, memoria facio: et lamen aliud<lb/>est
+						in memoria invenire phantasiam, aliud de memo­<lb/>ria facere phantasma.
+						Quae omnia vis animae potest.<lb/>Sed vera eliam phantasmata habere pro
+						cognitis,<lb/>summus error est. Quanquam sit in utroque genere<lb/>quod
+						nos non absurde scire dicamus, id est, sensisse<lb/>nos lalia, vel
+						imaginari nos talia. Patrem denique me<lb/>babuisse et avum, non temere
+						possum dicere : ipsos<lb/>autem esse quos animus meus in phantasia vel in
+						<lb/>phantasmate tenet, dementissime dixerim. Sequun­<lb/>tur autem
+						nonnulli phantasmata sua tam praecipites,<lb/>ut nulla sit alia materies
+						omnium falsarum opinio­<lb/>num, quam habere phantasias vel phantasmata
+						pro<lb/>cognitis, quae cognoscuntur per sensam Quare his<lb/>potissimum
+						resistamus, nee eis ita mentem accommo­<lb/>demus, ut dum in his est
+						cogitatio, intelligentia ea<lb/>cerni arbitremur.</p>
+					</div><div type="textpart" subtype="dialog"><p>33. Cur autem si hujusmodi numeri qni nunt in<lb/>anima rebus temporalibus
+						dedita, habent sui generis<lb/>pulchritudinem , quamvis cam transcundo
+						actitent,<lb/>invideat huic pulchritudini divina providentia, quae<lb/>de
+						nostra poenali mortalitate formatur, quam justis­<lb/>sima Dei lege
+						meruimus : in qua tamen nos non ita<lb/>deseruit, ut non valeamus
+						recurrere, et a carnalium<lb/>sensuum delectatione, misericordia ejus
+						maium por­<lb/>rigente , revocari. Talis enim delectatio vehementer<lb/>
+						Infigit memoriae quod trahit a lubricis sensibus. Haec<lb/>autem animae
+						consuetudo facta cum carne, propter<lb/>carnalem affectionem, in
+						Scripturis divinis caro no­<lb/>minatur. Haec menti obluctatur, cum jam
+						dici potest<lb/>apostolicum illud: <hi rend="italic">Mente</hi> servio <hi
+							rend="italic">legi Dei, carne autem<lb/>legi peccati (Rom.</hi> VII,
+						25). Sed in spiritualia mente<lb/>suspensa atque ibi fixa et manente,
+						etiam hujus con­<lb/>suetudinis impetus frangiiur, et paulatim repressus
+						<lb/>exstinguitur. Major euim erat cum sequeremur; uon<lb/>tamen omnino
+						nullus, sed certe minor est cum eum<lb/>refrenamus, atque ita certis
+						regressibus ab omni<lb/>lasciviente motu , in quo defectus essentiae est
+						animae,<lb/>delectatione in rationis nnmeros restituta ad Deum<lb/>tota
+						vita nostra convertitur, dans corpori nnmeros<lb/>sanitatis, non accipiens
+						inde heliliam; quod cor­<lb/>rupto exteriore homine, et ejus in melius
+						commuta­<lb/>tione continget.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT XII. — <hi rend="italic">De</hi> numeris <hi
-								rend="italic">spiritualibus et æternis.</hi>
+								rend="italic">spiritualibus et aeternis.</hi>
 						</title>
 					</ab>
-					</div><div type="textpart" subtype="dialog"><p>34. Excipit autem memoria non solum carnales <lb/> motus animi, de quibus
-						numeris supra jam diximus; <lb/> tcd etiam spirituales, de quibus breviter
-						dicam. Quo <lb/> enim simpliciores sunt, eo verborum minus, sed plu­ <lb/>
-						rimum serena' mentis desiderant. i£qualitatem illam <lb/> quam in
-						sensibilibus numeris non reperiebamus cer­ <lb/> tam et manentem, sed tamen
-						adumbratam et præter­ <lb/> euntem agnoscebamus, nusquam profecto appeteret
-						<lb/> animus nisi alicubi nota esset: hoc autem alicubi non <lb/> in spatiis
-						locorum et temporum ; nam illa tument, et <lb/> ista prætereunt. Ubi ergo
+					</div><div type="textpart" subtype="dialog"><p>34. Excipit autem memoria non solum carnales<lb/>motus animi, de quibus
+						numeris supra jam diximus;<lb/>tcd etiam spirituales, de quibus breviter
+						dicam. Quo<lb/>enim simpliciores sunt, eo verborum minus, sed plu­<lb/>
+						rimum serena' mentis desiderant. i£qualitatem illam<lb/>quam in
+						sensibilibus numeris non reperiebamus cer­<lb/>tam et manentem, sed tamen
+						adumbratam et praeter­<lb/>euntem agnoscebamus, nusquam profecto appeteret
+						<lb/>animus nisi alicubi nota esset: hoc autem alicubi non<lb/>in spatiis
+						locorum et temporum ; nam illa tument, et<lb/>ista praetereunt. Ubi ergo
 						censes, responde, quaeso, <note type="footnote">a A ( Icrisque Mss. absunt
-							isthaec verba : <hi rend="italic">Qiuim</hi> habere <lb/>
-							<hi rend="italic">rhuntawis rei phantasmata pro cognitis, quæ
+							isthaec verba : <hi rend="italic">Qiuim</hi> habere<lb/>
+							<hi rend="italic">rhuntawis rei phantasmata pro cognitis, quae
 								coqnoscutUur</hi>
-							<lb/> ver settsum. </note>
-						<lb/> si potes. Non enim in corporum formis putas, quas. <lb/> liquido
-						examine æquales nunquam dicere audebis; <lb/> aut in temporum intervallis,
-						in quibus similiter <lb/> utruni sit aliquid aliquanto quam oportet
-						productius <lb/> vel correptius quod sensum fugiat, ignoramus. Illam <lb/>
-						quippe æqualitatem quaero ubi esse arbitreris, quam <lb/> intuentes cupimus
-						æqualia esse quaedam corpora vcl <lb/> corporum motus, et diligentius
-						considerantes eis <lb/> fidere non audemus. <hi rend="italic">D.</hi> Ibi
-						puto quod est corpori­ <lb/> bus excellentius; sed utrum in ipsa anima, an
-						edam <lb/> supra animam nescio.</p>
-					</div><div type="textpart" subtype="dialog"><p>35. <hi rend="italic">M.</hi> Si ergo quaeramus artem istam rhythmicam <lb/>
-						vel metricam, qua utuntur qui versus faciunt, putasne <lb/> habere aliquos
-						numeros, secundum quos fabricant <lb/> versus? <hi rend="italic">D.</hi>
-						Nihil aliud possum existimare. <hi rend="italic">M.</hi> Qui­ <lb/> cumque
-						isti sunt numeri, praeterire tibi videntur cum <lb/> versibus, an manere?
-							<hi rend="italic">D.</hi> Manere sane. M. Cousen­ <lb/> ticndum est
-						ergo, ab aliquibus manentibus numeris <lb/> prætereuntes aliquos fabricari?
-							<hi rend="italic">D.</hi> Cogit me ratio con­ <lb/> sentire. <hi
-							rend="italic">M.</hi> Quid? hanc artem num aliud putas quam <lb/>
+							<lb/>ver settsum. </note>
+						<lb/>si potes. Non enim in corporum formis putas, quas.<lb/>liquido
+						examine aequales nunquam dicere audebis;<lb/>aut in temporum intervallis,
+						in quibus similiter<lb/>utruni sit aliquid aliquanto quam oportet
+						productius<lb/>vel correptius quod sensum fugiat, ignoramus. Illam<lb/>
+						quippe aequalitatem quaero ubi esse arbitreris, quam<lb/>intuentes cupimus
+						aequalia esse quaedam corpora vcl<lb/>corporum motus, et diligentius
+						considerantes eis<lb/>fidere non audemus. <hi rend="italic">D.</hi> Ibi
+						puto quod est corpori­<lb/>bus excellentius; sed utrum in ipsa anima, an
+						edam<lb/>supra animam nescio.</p>
+					</div><div type="textpart" subtype="dialog"><p>35. <hi rend="italic">M.</hi> Si ergo quaeramus artem istam rhythmicam<lb/>
+						vel metricam, qua utuntur qui versus faciunt, putasne<lb/>habere aliquos
+						numeros, secundum quos fabricant<lb/>versus? <hi rend="italic">D.</hi>
+						Nihil aliud possum existimare. <hi rend="italic">M.</hi> Qui­<lb/>cumque
+						isti sunt numeri, praeterire tibi videntur cum<lb/>versibus, an manere?
+							<hi rend="italic">D.</hi> Manere sane. M. Cousen­<lb/>ticndum est
+						ergo, ab aliquibus manentibus numeris<lb/>praetereuntes aliquos fabricari?
+							<hi rend="italic">D.</hi> Cogit me ratio con­<lb/>sentire. <hi
+							rend="italic">M.</hi> Quid? hanc artem num aliud putas quam<lb/>
 						affectionem quamdam esse animi artificis? <hi rend="italic">D.</hi> Ita
-						<lb/> credo. <hi rend="italic">M.</hi> Credisne hanc affectionem etiam esse
-						in eo, <lb/> qui hujus artis imperitus cst? <hi rend="italic">D.</hi> Nullo
+						<lb/>credo. <hi rend="italic">M.</hi> Credisne hanc affectionem etiam esse
+						in eo,<lb/>qui hujus artis imperitus cst? <hi rend="italic">D.</hi> Nullo
 						modo. <hi rend="italic">M.</hi>
-						<lb/> Quid? in illo qui oblitus csl eam? D. Nec in illo qui­ <lb/> dem, quia
-						ct ipse imperitus est, etiamsi fuit peritus <lb/> aliquando. <hi
-							rend="italic">M.</hi> Quid? si eum quisquam interrogando <lb/>
-						commemoret? remigrare ad eum putas illos numeros <lb/> ab eo ipso qui
-						interrogat; an illum intrinsecus apud <lb/> mentem suam movere se ad
-						aliquid, unde sibi quod <lb/> amiserat redhibeatur? <hi rend="italic"
-							>D.</hi> Apud semetipsum puto id <lb/> agere. <hi rend="italic">M.</hi>
-						Num eliam quæ corripiatur syllaba, quævo <lb/> producatur si penitus
-						excidit, commoneri eum inter­ <lb/> rogando arbitraris; cum hominum prisco
-						placito et <lb/> consuetudine, aliis minor, aliis major mora syllabis <lb/>
-						data sit? Nam profecto si natura vel disciplina id <lb/> fixum esset ac
-						stabile, non recentioris temporis docti <lb/> homines nonnullas produxissent
-						quas corripuerunt <lb/> antiqui, vel corripuissent quas produxerunt. D. Puto
-						<lb/> et hoc posse, quoniam quantumvis quidque excidat, <lb/> potest
-						interrogatione commemorante rcdire in memo­ <lb/> riam. <hi rend="italic"
-							>M.</hi> Mirum si opinaris, quovis interrogante posse <lb/> te recordari
-						quid ante annum coenavcris. <hi rend="italic">D.</hi> Fateor <lb/> me non
-						posse, nec illum jam existimo de syllabis <lb/> posse, quarum spatia penitns
-						oblitus est, interrogando <lb/> admoneri. M. Cur ita, nisi quia in hoc
-						nomine quod <lb/>
+						<lb/>Quid? in illo qui oblitus csl eam? D. Nec in illo qui­<lb/>dem, quia
+						ct ipse imperitus est, etiamsi fuit peritus<lb/>aliquando. <hi
+							rend="italic">M.</hi> Quid? si eum quisquam interrogando<lb/>
+						commemoret? remigrare ad eum putas illos numeros<lb/>ab eo ipso qui
+						interrogat; an illum intrinsecus apud<lb/>mentem suam movere se ad
+						aliquid, unde sibi quod<lb/>amiserat redhibeatur? <hi rend="italic"
+							>D.</hi> Apud semetipsum puto id<lb/>agere. <hi rend="italic">M.</hi>
+						Num eliam quae corripiatur syllaba, quaevo<lb/>producatur si penitus
+						excidit, commoneri eum inter­<lb/>rogando arbitraris; cum hominum prisco
+						placito et<lb/>consuetudine, aliis minor, aliis major mora syllabis<lb/>
+						data sit? Nam profecto si natura vel disciplina id<lb/>fixum esset ac
+						stabile, non recentioris temporis docti<lb/>homines nonnullas produxissent
+						quas corripuerunt<lb/>antiqui, vel corripuissent quas produxerunt. D. Puto
+						<lb/>et hoc posse, quoniam quantumvis quidque excidat,<lb/>potest
+						interrogatione commemorante rcdire in memo­<lb/>riam. <hi rend="italic"
+							>M.</hi> Mirum si opinaris, quovis interrogante posse<lb/>te recordari
+						quid ante annum coenavcris. <hi rend="italic">D.</hi> Fateor<lb/>me non
+						posse, nec illum jam existimo de syllabis<lb/>posse, quarum spatia penitns
+						oblitus est, interrogando<lb/>admoneri. M. Cur ita, nisi quia in hoc
+						nomine quod<lb/>
 						<hi rend="italic">Italia</hi> dicitur, prima syllaba pro voluntate quorum­
-						<lb/> dam hominum corripiebatur, ct nunc pro aliorum vo­ <lb/> luntate
-						producitur? Ut autem unum et dno non sint <lb/> tria, et ut duo uni non
-						duplo respondeant, nullus <lb/> mortuorum potuit, nullus vivorum potest,
-						nullus po­ <lb/> sterorum poterit facere. <hi rend="italic">D.</hi> Nihil
+						<lb/>dam hominum corripiebatur, ct nunc pro aliorum vo­<lb/>luntate
+						producitur? Ut autem unum et dno non sint<lb/>tria, et ut duo uni non
+						duplo respondeant, nullus<lb/>mortuorum potuit, nullus vivorum potest,
+						nullus po­<lb/>sterorum poterit facere. <hi rend="italic">D.</hi> Nihil
 						manifestius. <hi rend="italic">M.</hi>
-						<lb/> Quid si ergo isto modo quo de uno et de duobus <lb/> apertissime
-						quævimus, cætera omnia , qua; ad illos <lb/> numeros pertinent et ille
-						interrogetur, qui non obli­ <lb/> viscendo, sed quia nunqnam didicit,
-						imperitus est ? <lb/> nonne eum censes similiter hanc artem exceptis syl­
-						<lb/> labis posse cognoscere? <hi rend="italic">D.</hi> Quis dubitaverit?
-							<hi rend="italic">M.</hi> Quo <lb/> igitur se etiam istum moturum putas,
-						nt menti <lb/> ejus imprimantur hi numeri, et iilam faciant affectio­ <lb/>
-						<pb n="1183"/> nero quae ars dicitur? an huic saltem ille interrogator <lb/>
-						eos dabit? <hi rend="italic">D.</hi> Eo modo etiam istum arbitror apud <lb/>
-						semetipsum agere, ut ea quæ interrogantur, vera <lb/> esse intelligat atque
+						<lb/>Quid si ergo isto modo quo de uno et de duobus<lb/>apertissime
+						quaevimus, caetera omnia , qua; ad illos<lb/>numeros pertinent et ille
+						interrogetur, qui non obli­<lb/>viscendo, sed quia nunqnam didicit,
+						imperitus est ?<lb/>nonne eum censes similiter hanc artem exceptis syl­
+						<lb/>labis posse cognoscere? <hi rend="italic">D.</hi> Quis dubitaverit?
+							<hi rend="italic">M.</hi> Quo<lb/>igitur se etiam istum moturum putas,
+						nt menti<lb/>ejus imprimantur hi numeri, et iilam faciant affectio­<lb/>
+						<pb n="1183"/> nero quae ars dicitur? an huic saltem ille interrogator<lb/>
+						eos dabit? <hi rend="italic">D.</hi> Eo modo etiam istum arbitror apud<lb/>
+						semetipsum agere, ut ea quae interrogantur, vera<lb/>esse intelligat atque
 						respondeat..</p>
-					</div><div type="textpart" subtype="dialog"><p>36. <hi rend="italic">M.</hi> Age, nunc dic mihi utrum hi numeri de <lb/>
-						quihus sic quæritur, commutabiles esse tibi videan­ <lb/> tur. <hi
-							rend="italic">D.</hi> Nullo modo. 31. Ergo aeternos esse non negas. <lb/>
+					</div><div type="textpart" subtype="dialog"><p>36. <hi rend="italic">M.</hi> Age, nunc dic mihi utrum hi numeri de<lb/>
+						quihus sic quaeritur, commutabiles esse tibi videan­<lb/>tur. <hi
+							rend="italic">D.</hi> Nullo modo. 31. Ergo aeternos esse non negas.<lb/>
 						<hi rend="italic">D.</hi> Imo fateor. <hi rend="italic">M.</hi> Quid ? metus
-						ille non suberit, ne ali­ <lb/> qua nos in eis inaequalitas fallat1 ? <hi
-							rend="italic">D.</hi> Nihil me omnino <lb/> est de istorum aequalitate
-						securius. <hi rend="italic">II.</hi> Unde ergo cre­ <lb/> dendum est animae
-						tribui quod æternum est et incom­ <lb/> mutabile, nisi ab uno æterno et
-						incommutabili Deo? <lb/>
+						ille non suberit, ne ali­<lb/>qua nos in eis inaequalitas fallat1 ? <hi
+							rend="italic">D.</hi> Nihil me omnino<lb/>est de istorum aequalitate
+						securius. <hi rend="italic">II.</hi> Unde ergo cre­<lb/>dendum est animae
+						tribui quod aeternum est et incom­<lb/>mutabile, nisi ab uno aeterno et
+						incommutabili Deo?<lb/>
 						<hi rend="italic">D.</hi> Non video quid aliud credi eporteat. M. Quid tan­
-						<lb/> dem ? illud nonne manifestum est, eum qui alio in­ <lb/> terrogante
-						sese intus ad Deum movet, ut verum <lb/> incommutabile intelligat; nisi
-						eumdem motum suum <lb/> memoria teneat, non posse ad intuendum illud ve­
-						<lb/> rum, nullo extrinsecus admonente revocari ? <hi rend="italic">D.</hi>
-						Ma­ <lb/> nifestum est.</p>
+						<lb/>dem ? illud nonne manifestum est, eum qui alio in­<lb/>terrogante
+						sese intus ad Deum movet, ut verum<lb/>incommutabile intelligat; nisi
+						eumdem motum suum<lb/>memoria teneat, non posse ad intuendum illud ve­
+						<lb/>rum, nullo extrinsecus admonente revocari ? <hi rend="italic">D.</hi>
+						Ma­<lb/>nifestum est.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT XIII. — <hi rend="italic">Anumus unde fit ut a
 								veritate incom­ mutabili avertatur.</hi>
 						</title>
 					</ab>
-					</div><div type="textpart" subtype="dialog"><p>37. M. Quaero ergo quonam iste ab hujuscemodi <lb/> rerum contemplatione
-						discedat, ut illum ad cam ne. <lb/> cesse sit memoria revocari. An forte in
-						aliud intentus <lb/> animus tali reditu indigere putandus est? <hi
-							rend="italic">D.</hi> Sic exi­ <lb/> stimo. M. Videamus, si placet, quid
-						tantum illud sit <lb/> quo possit intendi, ut ab incommutabilis et summæ
-						<lb/> , æqualitatis contemplatione avertatur. Nam tribus ge­ <lb/> neribus
-						amplius nihil video. Aut enim ad aliquid par <lb/> atque ad ejusmodi aliud
-						se intendit animus, cum hinc <lb/> avertitur, aut ad superius, aut ad
-						inferius. <hi rend="italic">D.</hi> De cic­ <lb/> teris duobus quærendum est
-						: nan quid sit supcrius <lb/> æterna æqualitate non video <hi rend="italic"
-							>M.</hi> Videsne illud, obse­ <lb/> cro, quidnam ei par esse possit,
-						quod tamen aliud <lb/> sit? <hi rend="italic">D.</hi> Ne id quidem video. M.
-						Restat ergo ut quæ­ <lb/> ramus, quid sit inferius. Sed nonne tibi prius
-						ipsa <lb/> anima occurrit, quai certa aequalitatcm illam incommu­ <lb/>
-						tabilem esse confitetur, se autcm agnoscit mutari co <lb/> ipso quod alias
-						hanc, alias aliud intuetur; ct hoc modo <lb/> aliud atque aliud sequens
-						varietatem temporis opera­ <lb/> tur, qunc in a ternis et incommutahilibus
+					</div><div type="textpart" subtype="dialog"><p>37. M. Quaero ergo quonam iste ab hujuscemodi<lb/>rerum contemplatione
+						discedat, ut illum ad cam ne.<lb/>cesse sit memoria revocari. An forte in
+						aliud intentus<lb/>animus tali reditu indigere putandus est? <hi
+							rend="italic">D.</hi> Sic exi­<lb/>stimo. M. Videamus, si placet, quid
+						tantum illud sit<lb/>quo possit intendi, ut ab incommutabilis et summae
+						<lb/>, aequalitatis contemplatione avertatur. Nam tribus ge­<lb/>neribus
+						amplius nihil video. Aut enim ad aliquid par<lb/>atque ad ejusmodi aliud
+						se intendit animus, cum hinc<lb/>avertitur, aut ad superius, aut ad
+						inferius. <hi rend="italic">D.</hi> De cic­<lb/>teris duobus quaerendum est
+						: nan quid sit supcrius<lb/>aeterna aequalitate non video <hi rend="italic"
+							>M.</hi> Videsne illud, obse­<lb/>cro, quidnam ei par esse possit,
+						quod tamen aliud<lb/>sit? <hi rend="italic">D.</hi> Ne id quidem video. M.
+						Restat ergo ut quae­<lb/>ramus, quid sit inferius. Sed nonne tibi prius
+						ipsa<lb/>anima occurrit, quai certa aequalitatcm illam incommu­<lb/>
+						tabilem esse confitetur, se autcm agnoscit mutari co<lb/>ipso quod alias
+						hanc, alias aliud intuetur; ct hoc modo<lb/>aliud atque aliud sequens
+						varietatem temporis opera­<lb/>tur, qunc in a ternis et incommutahilibus
 						nulla est? <hi rend="italic">D.</hi>
-						<lb/> Assontior. <hi rend="italic">M.</hi> Hxc igitur affectio animæ vel
-						motus, <lb/> quo intelligit aeterna, et his inferiora esse temporalia. <lb/>
-						etiam in seipsa; et hæc appetenda potius quæ supe­ <lb/> nora sunt, quam
-						illa quæ inferiora sunt novit: nonne <lb/> tibi prudentia videtur? <hi
+						<lb/>Assontior. <hi rend="italic">M.</hi> Hxc igitur affectio animae vel
+						motus,<lb/>quo intelligit aeterna, et his inferiora esse temporalia.<lb/>
+						etiam in seipsa; et haec appetenda potius quae supe­<lb/>nora sunt, quam
+						illa quae inferiora sunt novit: nonne<lb/>tibi prudentia videtur? <hi
 							rend="italic">D.</hi> Nihil aliud videtur.</p>
-					</div><div type="textpart" subtype="dialog"><p>38. M. Quid illud? num minus considcrandum pu­ <lb/> tas quod nondum in ea
-						simul est a ternis inhærere, <lb/> cum jam in ca sit nosse his esse
-						inhærendun}? I. Imo <lb/> maxime ut id consideremus peto, et unde accidat
-						scire <lb/> cupio. <hi rend="italic">M.</hi> Facile id videbis, si
-						animadverteris quibus <lb/> rebus maxime animum soleamus intendere, et ma­
-						<lb/> gnam curam exhibere : nam eas opinor esse quas <lb/> multum amamus :
-						an tu alias opinaris? <hi rend="italic">D.</hi> Nullas <lb/> equidem alias.
-							<hi rend="italic">M.</hi> Dic, oro te, num possumus amare <lb/> nisi
-						pulchra? Nam etsi quidam videntur amare dcfur­ <lb/> mia, quos vulgo Græci
+					</div><div type="textpart" subtype="dialog"><p>38. M. Quid illud? num minus considcrandum pu­<lb/>tas quod nondum in ea
+						simul est a ternis inhaerere,<lb/>cum jam in ca sit nosse his esse
+						inhaerendun}? I. Imo<lb/>maxime ut id consideremus peto, et unde accidat
+						scire<lb/>cupio. <hi rend="italic">M.</hi> Facile id videbis, si
+						animadverteris quibus<lb/>rebus maxime animum soleamus intendere, et ma­
+						<lb/>gnam curam exhibere : nam eas opinor esse quas<lb/>multum amamus :
+						an tu alias opinaris? <hi rend="italic">D.</hi> Nullas<lb/>equidem alias.
+							<hi rend="italic">M.</hi> Dic, oro te, num possumus amare<lb/>nisi
+						pulchra? Nam etsi quidam videntur amare dcfur­<lb/>mia, quos vulgo Graeci
 							<foreign xml:lang="grc">σαπροϕίλους</foreign> vocant, interest <note
-							type="footnote">11.0'. : <hi rend="italic">-"os in ci-, æqualitas</hi>
+							type="footnote">11.0'. : <hi rend="italic">-"os in ci-, aequalitas</hi>
 							fallet. Sex Mss., <hi rend="italic">inatqualilns.</hi>
 						</note>
-						<lb/> tamen quanto minus pulchra sint quam Hia qua; p!u- <lb/> ribus
-						placent. Nam ea neminem amare manifestum <lb/> est; quorum fceditate sensus
-						oflenditur. <hi rend="italic">D.</hi> Ita est, at <lb/> dicis. M. Hæc igitur
-						pulchra numero placent, in quo <lb/> jam ostendimus aequalitatem appeti. Non
-						enim boc <lb/> tantum in ea pulchritudine quae ad aures pertinet , <lb/>
-						atque in motu corporum est, invenitur, sed in ipsis <lb/> etiam visibilibus
-						formis, in quibus jam usitatius dici­ <lb/> tur pulchritudo. An aliud quam
-						aequalitatem numero­ <lb/> sam esse arbitraris, cum paria paribus bimi
-						membra <lb/> respondent: quæ autem singula sunt, medium locum <lb/> tenent,
-						ut ad ea de utraque parte paria intervalla <lb/> serventur? <hi
+						<lb/>tamen quanto minus pulchra sint quam Hia qua; p!u<lb/>ribus
+						placent. Nam ea neminem amare manifestum<lb/>est; quorum fceditate sensus
+						oflenditur. <hi rend="italic">D.</hi> Ita est, at<lb/>dicis. M. Haec igitur
+						pulchra numero placent, in quo<lb/>jam ostendimus aequalitatem appeti. Non
+						enim boc<lb/>tantum in ea pulchritudine quae ad aures pertinet ,<lb/>
+						atque in motu corporum est, invenitur, sed in ipsis<lb/>etiam visibilibus
+						formis, in quibus jam usitatius dici­<lb/>tur pulchritudo. An aliud quam
+						aequalitatem numero­<lb/>sam esse arbitraris, cum paria paribus bimi
+						membra<lb/>respondent: quae autem singula sunt, medium locum<lb/>tenent,
+						ut ad ea de utraque parte paria intervalla<lb/>serventur? <hi
 							rend="italic">D.</hi> Non aliter puto. <hi rend="italic">M.</hi> Quid in
-						ipsa luce <lb/> visibili quae omnium colorum habet principatum, nam <lb/> et
-						color nos delectat in corporum formis; quid ergo <lb/> aliud in luce et
-						coloribus, nisi quod nostris oculis <lb/> c ngruit, appetimus? Etenim a
-						nimio fulgore aversa­ <lb/> mur, et nimis obscura nolumus cernere, sicut
-						etiam <lb/> in sonis et a nimium sonantibus abhorremus, et quasi <lb/>
-						susurranua non amamus. Quod non in temporum in­ <lb/> tervallis est, sed in
-						ipso sono, qui quasi lux est talium <lb/> numerorum, cui sic est contrarium
-						silentium, ut co­ <lb/> loribus tenebrae. In his ergo cum appetimus conve­
-						<lb/> nientia pro naturæ nostrae modo, et inconvenientia <lb/> respuimus,
-						quoe aliis tamen animalibus convenire sen. <lb/> Limus, nonne bic etiam
-						quodam aequalitatis jure læ­ <lb/> tamur, cum occultioribus modis paria
-						paribus tributa <lb/> esse cognoscimus? Hoc in odoribus et in saporibus,
-						<lb/> et in tangendi sensu animadvertere licet, quæ longum <lb/> est
-						enucleatius persequi, sed explorare facillimum: <lb/> nihil enim est horum
-						sensibilium, quod nobis non <lb/> æqualitate aut similitudine placeat. Ubi
-						autem æqua­ <lb/> litas aut similitudo, ibi numerositas; nibil est quippe
-						<lb/> tam aequale aut simile quam unum et unum : nisi quid <lb/> habes ad
-						hæc. <hi rend="italic">D.</hi> Omnino assentior.</p>
-					</div><div type="textpart" subtype="dialog"><p>39. M. Quid ? superior illa tractatio nonne persuasit <lb/> nobis agere hanc
-						animam in corporibus, non a corpo­ <lb/> ribus pati? <hi rend="italic"
-							>D.</hi> Persuasit sane. M. Amor igitur agendi <lb/> adversus
-						succedentes passiones corporis sui, avertit <lb/> animam a contemplatione
-						aeternorum, sensibilis vo­ <lb/> luptatis cura ejus avocans intentionem :'
-						hoc autem <lb/> agit occursoribus numeris. Avertit etiam amor de <lb/>
-						corporibus operandi, et inquietam facil: hoc autem <lb/> agit progressoribus
-						numeris. Avertunt phantasiæ at­ <lb/> que phantasmata : et hæc agit
-						recordabilibus numeris. <lb/> Avertit denique amor vanissimae cognitionis
-						talium <lb/> rerum : et hoc agit sensualibus numeris, quibus in­ <lb/> sunt
-						quasi regulæ quaedam artis imitatione gaudentes: <lb/> et ex his curiositas
-						nascitur ipso curae nomine inimica <lb/> securitati, et vanitate impos
+						ipsa luce<lb/>visibili quae omnium colorum habet principatum, nam<lb/>et
+						color nos delectat in corporum formis; quid ergo<lb/>aliud in luce et
+						coloribus, nisi quod nostris oculis<lb/>c ngruit, appetimus? Etenim a
+						nimio fulgore aversa­<lb/>mur, et nimis obscura nolumus cernere, sicut
+						etiam<lb/>in sonis et a nimium sonantibus abhorremus, et quasi<lb/>
+						susurranua non amamus. Quod non in temporum in­<lb/>tervallis est, sed in
+						ipso sono, qui quasi lux est talium<lb/>numerorum, cui sic est contrarium
+						silentium, ut co­<lb/>loribus tenebrae. In his ergo cum appetimus conve­
+						<lb/>nientia pro naturae nostrae modo, et inconvenientia<lb/>respuimus,
+						quoe aliis tamen animalibus convenire sen.<lb/>Limus, nonne bic etiam
+						quodam aequalitatis jure lae­<lb/>tamur, cum occultioribus modis paria
+						paribus tributa<lb/>esse cognoscimus? Hoc in odoribus et in saporibus,
+						<lb/>et in tangendi sensu animadvertere licet, quae longum<lb/>est
+						enucleatius persequi, sed explorare facillimum:<lb/>nihil enim est horum
+						sensibilium, quod nobis non<lb/>aequalitate aut similitudine placeat. Ubi
+						autem aequa­<lb/>litas aut similitudo, ibi numerositas; nibil est quippe
+						<lb/>tam aequale aut simile quam unum et unum : nisi quid<lb/>habes ad
+						haec. <hi rend="italic">D.</hi> Omnino assentior.</p>
+					</div><div type="textpart" subtype="dialog"><p>39. M. Quid ? superior illa tractatio nonne persuasit<lb/>nobis agere hanc
+						animam in corporibus, non a corpo­<lb/>ribus pati? <hi rend="italic"
+							>D.</hi> Persuasit sane. M. Amor igitur agendi<lb/>adversus
+						succedentes passiones corporis sui, avertit<lb/>animam a contemplatione
+						aeternorum, sensibilis vo­<lb/>luptatis cura ejus avocans intentionem :'
+						hoc autem<lb/>agit occursoribus numeris. Avertit etiam amor de<lb/>
+						corporibus operandi, et inquietam facil: hoc autem<lb/>agit progressoribus
+						numeris. Avertunt phantasiae at­<lb/>que phantasmata : et haec agit
+						recordabilibus numeris.<lb/>Avertit denique amor vanissimae cognitionis
+						talium<lb/>rerum : et hoc agit sensualibus numeris, quibus in­<lb/>sunt
+						quasi regulae quaedam artis imitatione gaudentes:<lb/>et ex his curiositas
+						nascitur ipso curae nomine inimica<lb/>securitati, et vanitate impos
 						veritatis1.</p>
-					</div><div type="textpart" subtype="dialog"><p>40. Generalis vero amor actionis, quae avertit a <lb/> vero, a superbia
-						proficiscitur, quo vitio Deum imitari; <lb/> qunm Deo servire anima maluit.
-						Recte itaque scri­ <lb/> ptum est in sanctis Libris : <hi rend="italic"
-							>Initium superbiæ</hi> homini <lb/>
+					</div><div type="textpart" subtype="dialog"><p>40. Generalis vero amor actionis, quae avertit a<lb/>vero, a superbia
+						proficiscitur, quo vitio Deum imitari;<lb/>qunm Deo servire anima maluit.
+						Recte itaque scri­<lb/>ptum est in sanctis Libris : <hi rend="italic"
+							>Initium superbiae</hi> homini<lb/>
 						<hi rend="italic">apostatare a Deo;</hi> et, <hi rend="italic">Initium</hi>
-						omnis <hi rend="italic">percati</hi> superbiæ. <lb/> Non potuit autem melius
-						demonstrari quid sit super­ <lb/> bia, quam in eo quod ibi dictum est : <hi
+						omnis <hi rend="italic">percati</hi> superbiae.<lb/>Non potuit autem melius
+						demonstrari quid sit super­<lb/>bia, quam in eo quod ibi dictum est : <hi
 							rend="italic">Quid</hi> superbit <note type="footnote">1 sic meliores
 							Mss. At Am. et Er. baheDt: <hi rend="italic">Et smritatit</hi> iiept
-							<lb/> vc <hi rend="italic">it Ii q'e.</hi> L&lt;w,: <hi rend="italic"
+							<lb/>vc <hi rend="italic">it Ii q'e.</hi> L&lt;w,: <hi rend="italic"
 								>1.t iunilus</hi> oppoiiti arrit:&lt;ti. </note>
 						<lb/>
 						<pb n="1185"/>
 						<hi rend="italic">terra et cinis, quoniam</hi> iii vita sua <hi
 							rend="italic">projectt</hi> intima <hi rend="italic">sua?<lb/>
-							(Eccli.</hi> x, 14,45, 9,10.) Caim enim anima per seipsam <lb/> nihil
-						sit; non enim aliter esset commutabilis, et pale­ <lb/> retur defectum ab
-						essentia : cum ergo ipsa per se <lb/> nihil sit, quidquid autem illi esse
-						est, a Deo sit; in <lb/> ordine suo manens, ipsius Oei prærsentia vcgetalur
-						in <lb/> mente atque conscientia. itaque hoc bonum habet <lb/> intimum.
-						Quare superbia intumescere, hoc illi est in <lb/> extmna progredi, et ut ita
-						dicam, inanescerc, quod est <lb/> minus minusque esse. Progredi autcm in
-						extima, quid <lb/> est aliud quam intima projiccre; id est, longe a se fa­
-						<lb/> cere Deum, non locorum spatio, scd mentis affectu?</p>
-					</div><div type="textpart" subtype="dialog"><p>41. Islc autem animæ appetitus est sub se habere <lb/> alias animas; non
-						pecorum, quas divino jure con­ <lb/> cessum est, sed rationales, id est,
-						proximas suas, et <lb/> sub cadem lege socias atque consortes. De bis autem
-						<lb/> appetit operari anima superba , et tanto excellentior <lb/> vidotur
-						hæc actio qunm illa de corporibus, quanto <lb/> aaima omnis omni corpore est
-						melior. Sed operari de <lb/> animis rationalibus, non por corpus, sed. per
-						seipsum, <lb/> solus Deus potest. Peccatorum tamen condilione fit, <lb/> ut
-						permittantur anima? de animis aliquid agere , si­ <lb/> gnificando eas
-						moventes per alterutra corpora, vel <lb/> naturalibus signis, sicut est
-						vultus vel nutus, vel pla­ <lb/> citis, sicut sunt verba. Nam et jubentes et
-						suadentes <lb/> signis agunt, et si quid est aliud preter jussionem et <lb/>
-						suasionem, quo animæ de animis vel cum animis a'i- <lb/> quid agunt. Jure
-						autem secutum est, ut quæ superbia <lb/> c Heris excellere cupierunt, nec
-						suis partibus atque <lb/> corporibus sine difficultate et doloribus
-						imperent, par­ <lb/> titi stultæ in se, partim mortalibus membris aggra­
-						<lb/> vatæ. Et his igitur numcris et motibus quibus animæ <lb/> ad animas
-						agunt, honores laudesque appetendo aver­ <lb/> tuntur a perspectione purae
-						illius et sincerae veritatis. <lb/> Solus enim honorat Deus animam beatam
-						faciens in <lb/> occulto coram se juste et pie viventem.</p>
-					</div><div type="textpart" subtype="dialog"><p>42. Motus igitur quos exserit anima de inhærenti­ <lb/> bus sibi, et subditis
-						animis, progressoribus illis sunt <lb/> similes; agit enim tanquam de
-						corpore suo. Illi autem <lb/> motus quos exserit, aggregare sibi aliquas vel
-						subdere <lb/> cupicns, in occursorum numero deputantur. Agit <lb/> enim
-						tanquam in sensibus id moliens, ut unum secum <lb/> Nat, quod velut
-						extrinsecus admovetur, et quod non <lb/> p-test repellatur. Et hos utrosque
-						motus excipit me­ <lb/> moria, et recordabiles facit, simili modo in
-						phantasiis <lb/> ct phantasmatibus actionum talium tumultuosissimc <lb/>
-						exæstuans. Nec illi tanquam examinatores numeri <lb/> desunt, qui sentiant
-						quid in his actibus commode sive <lb/> incommode moveatur, quos itcm
-						sensuales appellare <lb/> non pigeat, quia sensibilia signa sunt quibus hoc
-						modo <lb/> animae ad animas agunt. His tol et tantis intentioni­ <lb/> bus
-						anima implicata , quid mirum, si a contempla­ <lb/> tione veritatis
-						avertitur ? Et quantum quidem ab his <lb/> respirat videt illam ; sed quia
-						nondum eas evicit, in <lb/> illa manere non sinitur. Ex quo lit ut non simul
-						ha­ <lb/> beat anima nosse in quibus consistendum sit, et posse <lb/>
-						consistere: sed numquid tu forte adversus hæc? <hi rend="italic">D.</hi> Ni­
-						<lb/> hil est qnod contradicerc audcam.</p>
+							(Eccli.</hi> x, 14,45, 9,10.) Caim enim anima per seipsam<lb/>nihil
+						sit; non enim aliter esset commutabilis, et pale­<lb/>retur defectum ab
+						essentia : cum ergo ipsa per se<lb/>nihil sit, quidquid autem illi esse
+						est, a Deo sit; in<lb/>ordine suo manens, ipsius Oei praersentia vcgetalur
+						in<lb/>mente atque conscientia. itaque hoc bonum habet<lb/>intimum.
+						Quare superbia intumescere, hoc illi est in<lb/>extmna progredi, et ut ita
+						dicam, inanescerc, quod est<lb/>minus minusque esse. Progredi autcm in
+						extima, quid<lb/>est aliud quam intima projiccre; id est, longe a se fa­
+						<lb/>cere Deum, non locorum spatio, scd mentis affectu?</p>
+					</div><div type="textpart" subtype="dialog"><p>41. Islc autem animae appetitus est sub se habere<lb/>alias animas; non
+						pecorum, quas divino jure con­<lb/>cessum est, sed rationales, id est,
+						proximas suas, et<lb/>sub cadem lege socias atque consortes. De bis autem
+						<lb/>appetit operari anima superba , et tanto excellentior<lb/>vidotur
+						haec actio qunm illa de corporibus, quanto<lb/>aaima omnis omni corpore est
+						melior. Sed operari de<lb/>animis rationalibus, non por corpus, sed. per
+						seipsum,<lb/>solus Deus potest. Peccatorum tamen condilione fit,<lb/>ut
+						permittantur anima? de animis aliquid agere , si­<lb/>gnificando eas
+						moventes per alterutra corpora, vel<lb/>naturalibus signis, sicut est
+						vultus vel nutus, vel pla­<lb/>citis, sicut sunt verba. Nam et jubentes et
+						suadentes<lb/>signis agunt, et si quid est aliud preter jussionem et<lb/>
+						suasionem, quo animae de animis vel cum animis a'i<lb/>quid agunt. Jure
+						autem secutum est, ut quae superbia<lb/>c Heris excellere cupierunt, nec
+						suis partibus atque<lb/>corporibus sine difficultate et doloribus
+						imperent, par­<lb/>titi stultae in se, partim mortalibus membris aggra­
+						<lb/>vatae. Et his igitur numcris et motibus quibus animae<lb/>ad animas
+						agunt, honores laudesque appetendo aver­<lb/>tuntur a perspectione purae
+						illius et sincerae veritatis.<lb/>Solus enim honorat Deus animam beatam
+						faciens in<lb/>occulto coram se juste et pie viventem.</p>
+					</div><div type="textpart" subtype="dialog"><p>42. Motus igitur quos exserit anima de inhaerenti­<lb/>bus sibi, et subditis
+						animis, progressoribus illis sunt<lb/>similes; agit enim tanquam de
+						corpore suo. Illi autem<lb/>motus quos exserit, aggregare sibi aliquas vel
+						subdere<lb/>cupicns, in occursorum numero deputantur. Agit<lb/>enim
+						tanquam in sensibus id moliens, ut unum secum<lb/>Nat, quod velut
+						extrinsecus admovetur, et quod non<lb/>p-test repellatur. Et hos utrosque
+						motus excipit me­<lb/>moria, et recordabiles facit, simili modo in
+						phantasiis<lb/>ct phantasmatibus actionum talium tumultuosissimc<lb/>
+						exaestuans. Nec illi tanquam examinatores numeri<lb/>desunt, qui sentiant
+						quid in his actibus commode sive<lb/>incommode moveatur, quos itcm
+						sensuales appellare<lb/>non pigeat, quia sensibilia signa sunt quibus hoc
+						modo<lb/>animae ad animas agunt. His tol et tantis intentioni­<lb/>bus
+						anima implicata , quid mirum, si a contempla­<lb/>tione veritatis
+						avertitur ? Et quantum quidem ab his<lb/>respirat videt illam ; sed quia
+						nondum eas evicit, in<lb/>illa manere non sinitur. Ex quo lit ut non simul
+						ha­<lb/>beat anima nosse in quibus consistendum sit, et posse<lb/>
+						consistere: sed numquid tu forte adversus haec? <hi rend="italic">D.</hi> Ni­
+						<lb/>hil est qnod contradicerc audcam.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT XIV. <hi rend="italic">- Ad Dei</hi> amorem <hi
 								rend="italic">provocatur anima</hi> a <hi rend="italic">numerorum et
 								ordinis ratione quam in rebus diligit.</hi>
 						</title>
 					</ab>
-					</div><div type="textpart" subtype="dialog"><p>43. M. Quid ergo restat? An ut, quoniam sicut po­ <lb/> tuimus inquinationem
-						et aggravationem animae con­ <lb/> sideravimus, videamus quænam illi actio
-						divinitus <lb/> imperetur, qua purgata atque exonerata revolet ad <lb/>
-						quietem, et intret in gaudium Domini sui?D. Ita fiat. <lb/>
+					</div><div type="textpart" subtype="dialog"><p>43. M. Quid ergo restat? An ut, quoniam sicut po­<lb/>tuimus inquinationem
+						et aggravationem animae con­<lb/>sideravimus, videamus quaenam illi actio
+						divinitus<lb/>imperetur, qua purgata atque exonerata revolet ad<lb/>
+						quietem, et intret in gaudium Domini sui?D. Ita fiat.<lb/>
 						<hi rend="italic">M.</hi> Quid me putas hinc diutius dobere dicere, cum di­
-						<lb/> vinc Scripturæ tot voluminibus et tanta auctoritate <lb/> et
-						sanctitate præditis, nihil nobiscum aliud agant, nisi <lb/> ut diligamus
-						Deum et Dominum nostrum ex toto <lb/> corde, ex tota anima, et ex tota
-						mentc; et diligamus <lb/> proximum nostrum tanquam nosmetipsos? Ad hunc
-						<lb/> igitur finem si omnes illos humanæ actionis motus, <lb/> numerosque
-						referamus, sine dubitatione mundalri­ <lb/> mur. An aliud existimas? <hi
-							rend="italic">D.</hi> Nihil equidem aliud. Sed <lb/> quam hoc auditu
-						breve est, tam factu difficile atque <lb/> arduum.</p>
+						<lb/>vinc Scripturae tot voluminibus et tanta auctoritate<lb/>et
+						sanctitate praeditis, nihil nobiscum aliud agant, nisi<lb/>ut diligamus
+						Deum et Dominum nostrum ex toto<lb/>corde, ex tota anima, et ex tota
+						mentc; et diligamus<lb/>proximum nostrum tanquam nosmetipsos? Ad hunc
+						<lb/>igitur finem si omnes illos humanae actionis motus,<lb/>numerosque
+						referamus, sine dubitatione mundalri­<lb/>mur. An aliud existimas? <hi
+							rend="italic">D.</hi> Nihil equidem aliud. Sed<lb/>quam hoc auditu
+						breve est, tam factu difficile atque<lb/>arduum.</p>
 					</div><div type="textpart" subtype="dialog"><p>44. <hi rend="italic">M.</hi> Quid ergo facile est ? an amare colores, et
-						<lb/> voces, et placentas, et rosas, et corpora leniter mol­ <lb/> lia ?
-						hæccine amare facile est animæ, in quibus nihil <lb/> nisi æqualitatem ac
-						similitudinem appetit, et paulo <lb/> diligentius considerans, vix ejus
-						extremam umbram <lb/> vestigiumque cognoscit; et Deum amare difficile est,
-						<lb/> quem in quantum potest, adhuc saucia et sordida eo­ <lb/> gitans,
-						nihil in eo inaequale, nihil sui dissimile, nihil <lb/> disclusum locis,
-						nihil variatum tempore suspicatur ? <lb/> An exstruere moles ædificiorum, et
-						hujuscemodi ope­ <lb/> ribus delectat extendi, in quibus si numeri placeut
-						<lb/> ( non enim aliud invenio) quid in his æquale ac si­ <lb/> mile dicitur
-						quod non derideat ratio disciplinae ? <lb/> Quod si ita est, cur ab illa
-						verissima æqualitatis arce <lb/> ad ista delabitur, et ruinis suis terrenas
-						machinas <lb/> erigit? Non hoc promissum est ab illo qui fallere <lb/>
+						<lb/>voces, et placentas, et rosas, et corpora leniter mol­<lb/>lia ?
+						haeccine amare facile est animae, in quibus nihil<lb/>nisi aequalitatem ac
+						similitudinem appetit, et paulo<lb/>diligentius considerans, vix ejus
+						extremam umbram<lb/>vestigiumque cognoscit; et Deum amare difficile est,
+						<lb/>quem in quantum potest, adhuc saucia et sordida eo­<lb/>gitans,
+						nihil in eo inaequale, nihil sui dissimile, nihil<lb/>disclusum locis,
+						nihil variatum tempore suspicatur ?<lb/>An exstruere moles aedificiorum, et
+						hujuscemodi ope­<lb/>ribus delectat extendi, in quibus si numeri placeut
+						<lb/>( non enim aliud invenio) quid in his aequale ac si­<lb/>mile dicitur
+						quod non derideat ratio disciplinae ?<lb/>Quod si ita est, cur ab illa
+						verissima aequalitatis arce<lb/>ad ista delabitur, et ruinis suis terrenas
+						machinas<lb/>erigit? Non hoc promissum est ab illo qui fallere<lb/>
 						ignorat. <hi rend="italic">Jugum enim</hi> meum, inquit, <hi rend="italic"
-							>lere est (Matth.</hi> XI, <lb/> 50). Laboriosior est hujus mundi amor:
-						Quod enim <lb/> in illo anima quærit, constantiam scilicet aeternitatem­
-						<lb/> que, non invenit: quoniam rerum transitu completur <lb/> infima
-						pulchritudo, et quod in illa imitatur constap­ <lb/> tiam, a summo Deo per
-						animam trajicitur : quoniam <lb/> prior est species tantummodo tempore
-						commutabilis, <lb/> quam ea quae et tempore et locis (a). Sicut itaque <lb/>
-						præceptum est animis a Domino quid diligant, ita per <lb/> Joannem apostolum
-						quid non diligant. <hi rend="italic">Nolite,</hi> inquit, <lb/>
+							>lere est (Matth.</hi> XI,<lb/>50). Laboriosior est hujus mundi amor:
+						Quod enim<lb/>in illo anima quaerit, constantiam scilicet aeternitatem­
+						<lb/>que, non invenit: quoniam rerum transitu completur<lb/>infima
+						pulchritudo, et quod in illa imitatur constap­<lb/>tiam, a summo Deo per
+						animam trajicitur : quoniam<lb/>prior est species tantummodo tempore
+						commutabilis,<lb/>quam ea quae et tempore et locis (a). Sicut itaque<lb/>
+						praeceptum est animis a Domino quid diligant, ita per<lb/>Joannem apostolum
+						quid non diligant. <hi rend="italic">Nolite,</hi> inquit,<lb/>
 						<hi rend="italic">diligere</hi> mundum : <hi rend="italic">quia omnia</hi>
-						quæ in <hi rend="italic">mundo</hi> sunt, con­ <lb/>
+						quae in <hi rend="italic">mundo</hi> sunt, con­<lb/>
 						<hi rend="italic">cupiscentia carnis est, et concupiscentia oculorum,
-							et<lb/> ambitio sœculi</hi> (I <hi rend="italic">Joan.</hi> II, 15,
+							et<lb/>ambitio sœculi</hi> (I <hi rend="italic">Joan.</hi> II, 15,
 						16).</p>
-					</div><div type="textpart" subtype="dialog"><p>45. Sed qualis tibi humo vidctur, qui omnes illos <lb/> numeros qui sunt de
-						corpore, et adversus passiones <lb/> corporis, et qui ex bis memoria
-						continentur, non ad <lb/> carnalem voluptatem, sed ad salutem tautum
-						corporis <lb/> refert: omnesque illos qui de adjunctis animis ope­ <lb/>
-						rantur, vel qui ad adjungendas exseruntur, ct qui ex <lb/> bis inhaerent
-						memor'ire, non ad superbam excelleu­ <lb/> tiam suam, sed ad ipsarum
+					</div><div type="textpart" subtype="dialog"><p>45. Sed qualis tibi humo vidctur, qui omnes illos<lb/>numeros qui sunt de
+						corpore, et adversus passiones<lb/>corporis, et qui ex bis memoria
+						continentur, non ad<lb/>carnalem voluptatem, sed ad salutem tautum
+						corporis<lb/>refert: omnesque illos qui de adjunctis animis ope­<lb/>
+						rantur, vel qui ad adjungendas exseruntur, ct qui ex<lb/>bis inhaerent
+						memor'ire, non ad superbam excelleu­<lb/>tiam suam, sed ad ipsarum
 						animarum utilitalrm re- <note type="footnote">1 Er. et Lov.: In <hi
-								rend="italic">aiibus quid nisi numeri placent? AWi eram <lb/>
+								rend="italic">aiibus quid nisi numeri placent? AWi eram<lb/>
 								aliud</hi> invenio <hi rend="italic">quoa</hi> iti <hi rend="italic"
-								>his wquale ac swule dia.tl..r</hi> Elcci- <lb/> rous leCLionelD
+								>his wquale ac swule dia.tl..r</hi> Elcci<lb/>rous leCLionelD
 							nianusciuptoruin. </note>
 						<note type="footnote"> (a) vid. Retract, lib. 1, cap. U, a. 4. </note>
 						<lb/>
-						<pb n="1187"/> digit: illis etiam qui in utroque goncre quasi mode­ <lb/>
-						ratores exploratoresque cæterorum transcuntium in <lb/> sensu praesident,
-						non ad superfluam vel perniciosam <lb/> curiositatem, sed ad necessariam
-						probationem vel im­ <lb/> probationem utitur : nonne et istos omnes numeros
-						<lb/> agit, et nullis eorum laqueis implicatur? Quandoqui­ <lb/> dem et,
-						salutem corporis ut non impediatur eligit, et <lb/> omnes eas actiones ad
-						utilitatem proximi revocat, <lb/> quem propter communis juris naturale
-						vinculum tan­ <lb/> quam seipsum diligere jussus est. <hi rend="italic"
-							>D.</hi> Magnum quem­ <lb/> dam virum et vere humanissimum
+						<pb n="1187"/> digit: illis etiam qui in utroque goncre quasi mode­<lb/>
+						ratores exploratoresque caeterorum transcuntium in<lb/>sensu praesident,
+						non ad superfluam vel perniciosam<lb/>curiositatem, sed ad necessariam
+						probationem vel im­<lb/>probationem utitur : nonne et istos omnes numeros
+						<lb/>agit, et nullis eorum laqueis implicatur? Quandoqui­<lb/>dem et,
+						salutem corporis ut non impediatur eligit, et<lb/>omnes eas actiones ad
+						utilitatem proximi revocat,<lb/>quem propter communis juris naturale
+						vinculum tan­<lb/>quam seipsum diligere jussus est. <hi rend="italic"
+							>D.</hi> Magnum quem­<lb/>dam virum et vere humanissimum
 						praedicas.</p>
-					</div><div type="textpart" subtype="dialog"><p>46. M. Non igitur numeri qui sunt infra rationem <lb/> et in suo genere
-						pulchri sunt, sed amor inferioris pul­ <lb/> chritudinis animam polluit :
-						quæ cum in illa non <lb/> modo æqualitatem , de qua pro suscepto opere salis
-						<lb/> dictum est, sed etiam ordinem diligat, amisit ipsa or­ <lb/> dinem .
-						suum; nec tamen excessit ordinem rerum, <lb/> quandoquidem ibi est, et ita
-						est, ubi esse, et quo­ <lb/> modo esse tales, ordinatissimam est. Aliud enim
-						est <lb/> tenere ordinem, aliud ordine teneri. Tenet ordinem, <lb/> seipsa
-						tota diligens quod supra se est, id est Deum, <lb/> socias autem animas
-						tanquam scipsam. Hac quippe <lb/> dilectionis virtute inferiora ordinal, nee
-						ab inferiori­ <lb/> bus sordidatur I. Quod autem illam sordidat, non <lb/>
-						est malum, quia etiam corpus crcatura Dei cst, et <lb/> apecie sua quamvis
-						infima decoratur, sed præ animæ <lb/> dignitate contemnitur; sicuti anri
-						dignitas, etiam pur­ <lb/> gaLissimi argenti commixtione sordescit.
-						Quapropter <lb/> quicumque do nostra quoque poenali I mortalitate <lb/>
-						numeri facti sunt, non eos abdicemus a fabricatione <lb/> divinae
-						providentiæ, cum sint in genere Suo pulchri. <lb/> Neque amemus eos, ut
-						qUasi perfruendo talibus beati <lb/> efficiamur. His etenim, quoniam
-						temporales sunt, tan­ <lb/> quam tabula in fluctibus, neque abjiciendo quasi
-						one­ <lb/> rosos, ncque amplectendo quasi fuudalos, sed bene <lb/> utendo
-						carebimus. A dilectione autcm proximi tanta <lb/> quanta præcipitur,
-						certissimus gradus fit nobis, ut in­ <lb/> hæreamus Deo, et non teneamur
-						tantum ordinatione <lb/> illius, sed nostrUm eliam ordinem inconcussum cer­
-						<lb/> tumque teneamus.</p>
-					</div><div type="textpart" subtype="dialog"><p>47. An fortasse ordinem non diligit anima illis etiam <lb/> numeris
-						sensualibus attestantibus? Unde crgo primus <lb/> pes est pyrrhichius,
-						secundus iambus, tertius tro­ <lb/> chæus, et deinceps cæteri ? Sed jure hoc
-						dixeris ratio­ <lb/> nem potius seculam esse, non sensum. Quid itaque, <lb/>
-						illud nonne sensualibus numeris dandum est, quod <lb/> cum tantum temporis
-						occupent, verbi gratia, octo <lb/> longæ syllabæ, quantum sexdecim breves,
-						in codem <lb/> tamen spatio breves longis potius misceri exspectant? <lb/>
-						De quo sensu cum ratio judicat, et ei proceleumatici <lb/> pedes esse
-						æquales spondcis pedibus renuntiantur, <lb/> nihil aliud hic valere invenit,
-						quam ordinationis po­ <lb/> tentiam, quia nec longæ syllabæ nisi brevium
-						compa­ <lb/> ratione longæ sunt, nec breves rursum breves sunt <lb/> nisi
+					</div><div type="textpart" subtype="dialog"><p>46. M. Non igitur numeri qui sunt infra rationem<lb/>et in suo genere
+						pulchri sunt, sed amor inferioris pul­<lb/>chritudinis animam polluit :
+						quae cum in illa non<lb/>modo aequalitatem , de qua pro suscepto opere salis
+						<lb/>dictum est, sed etiam ordinem diligat, amisit ipsa or­<lb/>dinem .
+						suum; nec tamen excessit ordinem rerum,<lb/>quandoquidem ibi est, et ita
+						est, ubi esse, et quo­<lb/>modo esse tales, ordinatissimam est. Aliud enim
+						est<lb/>tenere ordinem, aliud ordine teneri. Tenet ordinem,<lb/>seipsa
+						tota diligens quod supra se est, id est Deum,<lb/>socias autem animas
+						tanquam scipsam. Hac quippe<lb/>dilectionis virtute inferiora ordinal, nee
+						ab inferiori­<lb/>bus sordidatur I. Quod autem illam sordidat, non<lb/>
+						est malum, quia etiam corpus crcatura Dei cst, et<lb/>apecie sua quamvis
+						infima decoratur, sed prae animae<lb/>dignitate contemnitur; sicuti anri
+						dignitas, etiam pur­<lb/>gaLissimi argenti commixtione sordescit.
+						Quapropter<lb/>quicumque do nostra quoque poenali I mortalitate<lb/>
+						numeri facti sunt, non eos abdicemus a fabricatione<lb/>divinae
+						providentiae, cum sint in genere Suo pulchri.<lb/>Neque amemus eos, ut
+						qUasi perfruendo talibus beati<lb/>efficiamur. His etenim, quoniam
+						temporales sunt, tan­<lb/>quam tabula in fluctibus, neque abjiciendo quasi
+						one­<lb/>rosos, ncque amplectendo quasi fuudalos, sed bene<lb/>utendo
+						carebimus. A dilectione autcm proximi tanta<lb/>quanta praecipitur,
+						certissimus gradus fit nobis, ut in­<lb/>haereamus Deo, et non teneamur
+						tantum ordinatione<lb/>illius, sed nostrUm eliam ordinem inconcussum cer­
+						<lb/>tumque teneamus.</p>
+					</div><div type="textpart" subtype="dialog"><p>47. An fortasse ordinem non diligit anima illis etiam<lb/>numeris
+						sensualibus attestantibus? Unde crgo primus<lb/>pes est pyrrhichius,
+						secundus iambus, tertius tro­<lb/>chaeus, et deinceps caeteri ? Sed jure hoc
+						dixeris ratio­<lb/>nem potius seculam esse, non sensum. Quid itaque,<lb/>
+						illud nonne sensualibus numeris dandum est, quod<lb/>cum tantum temporis
+						occupent, verbi gratia, octo<lb/>longae syllabae, quantum sexdecim breves,
+						in codem<lb/>tamen spatio breves longis potius misceri exspectant?<lb/>
+						De quo sensu cum ratio judicat, et ei proceleumatici<lb/>pedes esse
+						aequales spondcis pedibus renuntiantur,<lb/>nihil aliud hic valere invenit,
+						quam ordinationis po­<lb/>tentiam, quia nec longae syllabae nisi brevium
+						compa­<lb/>ratione longae sunt, nec breves rursum breves sunt<lb/>nisi
 						comparatione longarum : ideoque iambieus ver- <note type="footnote"> J Ita
 							Mss. undecim. At Am. Er. et Lov. habent, <hi rend="italic"
 								>ordinatur</hi>
 						</note><note type="footnote"> U)v., parili morta<foreign xml:lang="grc"
-								>ι̇ι̇</foreign>tate. Sed melius Ain. et hr. cium. MSS.! <lb/>
-							<hi rend="italic">'urmatur.uli</hi> supra, n. 53: Quæ <hi rend="italic"
-								>de wstro pællali mortalitate</hi>
+								>ι̇ι̇</foreign>tate. Sed melius Ain. et hr. cium. MSS.!<lb/>
+							<hi rend="italic">'urmatur.uli</hi> supra, n. 53: Quae <hi rend="italic"
+								>de wstro paellali mortalitate</hi>
 						</note>
-						<lb/> sus quamlibet productius pronuntiatus, non amissi <lb/> , regula
-						simpli et dupli, nec nomen amittit: at ille ver­ <lb/> sus qui pyrrbichiis
-						pedibus constat, paulatim addita <lb/> pronuntiandi mora, fit repente
-						spondiacus, si noa <lb/> grammaticam, sed musicam consulas. At vero si da­
-						<lb/> ctylicus aut annpaesticus sit, quoniam longæ mixtarum <lb/> brevium
-						comparatione sentiuntur, qualibet mora pro. <lb/> nuntietur, servat nomen
-						suum. Quid additamenta so- <lb/> mipedum non eadem lege in capite qua in
-						fine scr­ <lb/> vanda, nec omnia quamvis ad eumdem plausum <lb/> coaptentur,
-						adhibenda? quid duamm aliquando bre­ <lb/> vium potius, quam unius longæ in
-						fine positio? nonne <lb/> ipso sensu modificantur? Nec in his æqualitatis
-						nu­ <lb/> merus, cui nibil deperit, sive illud sive aliud sit, sed <lb/>
-						ordinis vinculum reperitur. Longum est percurrere <lb/> caetera ad eamdem
-						vim pertinentia in numeris tempo­ <lb/> rum. Sed nempe etiam formas
-						visibiles sensus ipse <lb/> aspernatur, aut pronas contra quam decet, aut
-						capite <lb/> deorsum, et similia, in quibus non inaequalitas, ma­ <lb/>
-						nente partium parilitate, sed perversitas improbatur. <lb/> Postremo in
-						omnibus sensibus et operibus nostris, <lb/> cum insolita pleraque, et ob hoe
-						injueuDda quibusdam <lb/> gradibus appetitui nostro conciliamus, et ea primo
-						<lb/> tolerabiliter, deinde libenter accipimus; nonne ordine <lb/>
-						conteximus voluptatem, et nisi priora mediis, et me­ <lb/> dia postremis
+						<lb/>sus quamlibet productius pronuntiatus, non amissi<lb/>, regula
+						simpli et dupli, nec nomen amittit: at ille ver­<lb/>sus qui pyrrbichiis
+						pedibus constat, paulatim addita<lb/>pronuntiandi mora, fit repente
+						spondiacus, si noa<lb/>grammaticam, sed musicam consulas. At vero si da­
+						<lb/>ctylicus aut annpaesticus sit, quoniam longae mixtarum<lb/>brevium
+						comparatione sentiuntur, qualibet mora pro.<lb/>nuntietur, servat nomen
+						suum. Quid additamenta so<lb/>mipedum non eadem lege in capite qua in
+						fine scr­<lb/>vanda, nec omnia quamvis ad eumdem plausum<lb/>coaptentur,
+						adhibenda? quid duamm aliquando bre­<lb/>vium potius, quam unius longae in
+						fine positio? nonne<lb/>ipso sensu modificantur? Nec in his aequalitatis
+						nu­<lb/>merus, cui nibil deperit, sive illud sive aliud sit, sed<lb/>
+						ordinis vinculum reperitur. Longum est percurrere<lb/>caetera ad eamdem
+						vim pertinentia in numeris tempo­<lb/>rum. Sed nempe etiam formas
+						visibiles sensus ipse<lb/>aspernatur, aut pronas contra quam decet, aut
+						capite<lb/>deorsum, et similia, in quibus non inaequalitas, ma­<lb/>
+						nente partium parilitate, sed perversitas improbatur.<lb/>Postremo in
+						omnibus sensibus et operibus nostris,<lb/>cum insolita pleraque, et ob hoe
+						injueuDda quibusdam<lb/>gradibus appetitui nostro conciliamus, et ea primo
+						<lb/>tolerabiliter, deinde libenter accipimus; nonne ordine<lb/>
+						conteximus voluptatem, et nisi priora mediis, et me­<lb/>dia postremis
 						concorditer nexa sint, abhorremus?</p>
-					</div><div type="textpart" subtype="dialog"><p>48. Quamobrem neque in voluptate carnali, neque <lb/> in bonoribus et
-						laudibus hominum , neque in eurum <lb/> exploratione quae forinsecus corpus
-						attingunt, nostra <lb/> gaudia collocemus, habentes in intimo Deum, ubi cer­
-						<lb/> tum est et incommutabile omne quod amamus. Ita fit, <lb/> ut et cum
-						adsunt haec temporalia, non lamen eis im­ <lb/> plicemur, et sine sensu
-						doloris quae extra corpus sunt, <lb/> absint: ipsum autem corpus, aut nullo,
-						ant non gravi <lb/> sensu doloris adimatur, et reformandum naturæ suæ <lb/>
-						morte reddatur. Attentio namque animæ ad corporis <lb/> partem inquieta
-						negotia contrahit, et universali lege <lb/> neglecta privati cujusdam operis
-						amor, quod ipsum <lb/> tamcn ab universitate quam Deus regit non potest
-						<lb/> alicnari. Itaque subditur legibus qui non amat lcges.</p>
+					</div><div type="textpart" subtype="dialog"><p>48. Quamobrem neque in voluptate carnali, neque<lb/>in bonoribus et
+						laudibus hominum , neque in eurum<lb/>exploratione quae forinsecus corpus
+						attingunt, nostra<lb/>gaudia collocemus, habentes in intimo Deum, ubi cer­
+						<lb/>tum est et incommutabile omne quod amamus. Ita fit,<lb/>ut et cum
+						adsunt haec temporalia, non lamen eis im­<lb/>plicemur, et sine sensu
+						doloris quae extra corpus sunt,<lb/>absint: ipsum autem corpus, aut nullo,
+						ant non gravi<lb/>sensu doloris adimatur, et reformandum naturae suae<lb/>
+						morte reddatur. Attentio namque animae ad corporis<lb/>partem inquieta
+						negotia contrahit, et universali lege<lb/>neglecta privati cujusdam operis
+						amor, quod ipsum<lb/>tamcn ab universitate quam Deus regit non potest
+						<lb/>alicnari. Itaque subditur legibus qui non amat lcges.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT XV. — <hi rend="italic">Corporales numeros
 								postresurrectionem aget anima quiete. Virtutes quatuor quibus
 								hic</hi> anima <hi rend="italic">perficitur.</hi>
 						</title>
 					</ab>
-					</div><div type="textpart" subtype="dialog"><p>49. Sed si de rebus incorporeis et eodem modo se <lb/> semper habeutibus,
-						plerumque attemissime cogitan­ <lb/> tes, si quos forte illo tempore agimus
-						numeros tem­ <lb/> porales iu quolibet corporis motu, facili sanc atque
-						<lb/> usitatissimo, sivc deambulantes, sive psalleates, pro.-­ <lb/> sus
-						nobis ignorantibus transeunt, quamvis nobis non <lb/> agentibus nulli
-						essent: si denique in ipsis nostris <lb/> inanibus phaatasmatibus cum
-						occupati sums, simili­ <lb/> tcr isia prætereunt agentibus nec sentientibus
-						nobis, <lb/> quanto magis quantoque constantius, <hi rend="italic">cum
-							corruptibile <lb/> hoc induerit incorrupiionem, et mortale hoc induerit
-							<lb/> immortalitatem</hi> (I <hi rend="italic">Cor.</hi> XV, 53), id
-						est, ut hoc ideut <lb/> planius eloquar, cum Deus vivificaverit mortatia
-						cor-. <lb/> pora nostra , sicut Apostolus dicit, <hi rend="italic">propter
-							spiritum <lb/> manentem</hi> in <hi rend="italic">nobis (Rom.</hi> VIII,
+					</div><div type="textpart" subtype="dialog"><p>49. Sed si de rebus incorporeis et eodem modo se<lb/>semper habeutibus,
+						plerumque attemissime cogitan­<lb/>tes, si quos forte illo tempore agimus
+						numeros tem­<lb/>porales iu quolibet corporis motu, facili sanc atque
+						<lb/>usitatissimo, sivc deambulantes, sive psalleates, pro.-­<lb/>sus
+						nobis ignorantibus transeunt, quamvis nobis non<lb/>agentibus nulli
+						essent: si denique in ipsis nostris<lb/>inanibus phaatasmatibus cum
+						occupati sums, simili­<lb/>tcr isia praetereunt agentibus nec sentientibus
+						nobis,<lb/>quanto magis quantoque constantius, <hi rend="italic">cum
+							corruptibile<lb/>hoc induerit incorrupiionem, et mortale hoc induerit
+							<lb/>immortalitatem</hi> (I <hi rend="italic">Cor.</hi> XV, 53), id
+						est, ut hoc ideut<lb/>planius eloquar, cum Deus vivificaverit mortatia
+						cor-.<lb/>pora nostra , sicut Apostolus dicit, <hi rend="italic">propter
+							spiritum<lb/>manentem</hi> in <hi rend="italic">nobis (Rom.</hi> VIII,
 						11): quanto ergo tunc <note type="footnote"> I I fitur in [lluribus Mss.,
 								<hi rend="italic">in</hi> temporis <hi rend="italic">partem.</hi>
 						</note>
 						<lb/>
-						<pb n="1189"/> magis in unum Dcum et perspicuam intenti veritatem, <lb/> ut
+						<pb n="1189"/> magis in unum Dcum et perspicuam intenti veritatem,<lb/>ut
 						dictum est, <hi rend="italic">facie ad faciem,</hi> numeros quibus agimus
-						<lb/> corpora, nulla inquietudine sentiemus, et gaudebimus? <lb/> Nisi forte
-						eredendum est, animam cum de iis quæ <lb/> per ipsam bona suut, gaudere
-						possit, de iis ex quibus <lb/> ipsa bona est, non posse gaudere.</p>
-					</div><div type="textpart" subtype="dialog"><p>50. Sed hæc actio qua sese anima, opitulante Deo <lb/> ct Domino suo, ab
-						amore inferioris pulchritudinis <lb/> extrahit, debellans atque interficiens
-						adversus se <lb/> militantem consuetudinem suam, ea victoria trium­ <lb/>
-						phatura ill semetipsa de potestatibus aeris hujus, qui­ <lb/> bus
-						invidentibus et præpedire cupientibus, cvolat ad <lb/> suam stabilitatem et
-						firmamentum Dcum ; nonne tibi <lb/> videtur ea csse virtus quæ temperantia
+						<lb/>corpora, nulla inquietudine sentiemus, et gaudebimus?<lb/>Nisi forte
+						eredendum est, animam cum de iis quae<lb/>per ipsam bona suut, gaudere
+						possit, de iis ex quibus<lb/>ipsa bona est, non posse gaudere.</p>
+					</div><div type="textpart" subtype="dialog"><p>50. Sed haec actio qua sese anima, opitulante Deo<lb/>ct Domino suo, ab
+						amore inferioris pulchritudinis<lb/>extrahit, debellans atque interficiens
+						adversus se<lb/>militantem consuetudinem suam, ea victoria trium­<lb/>
+						phatura ill semetipsa de potestatibus aeris hujus, qui­<lb/>bus
+						invidentibus et praepedire cupientibus, cvolat ad<lb/>suam stabilitatem et
+						firmamentum Dcum ; nonne tibi<lb/>videtur ea csse virtus quae temperantia
 						dicitur? <hi rend="italic">D.</hi>
-						<lb/> Agnosco ct intelligo. Jf. Quid porro? cum in boc <lb/> itinere
-						prolicit, jam æterna gaudia præsentientem ac <lb/> pene prehendentem, num
-						amissiorerum temporalium, <lb/> aut mors ulla deterret jam valentem dicere
-						inferiori­ <lb/> bus sociis : <hi rend="italic">Bonum est mihi</hi>
+						<lb/>Agnosco ct intelligo. Jf. Quid porro? cum in boc<lb/>itinere
+						prolicit, jam aeterna gaudia praesentientem ac<lb/>pene prehendentem, num
+						amissiorerum temporalium,<lb/>aut mors ulla deterret jam valentem dicere
+						inferiori­<lb/>bus sociis : <hi rend="italic">Bonum est mihi</hi>
 						dissolvi, <hi rend="italic">et esse cum Christo:</hi>
-						<lb/> manere <hi rend="italic">autem in carne, necessarium propter</hi> vos
-							<hi rend="italic">? (Phi­ <lb/> lipp.</hi> i, i3, 24.) <hi rend="italic"
-							>D.</hi> Sic existimo. <hi rend="italic">M</hi> At ista cjus <lb/>
-						affectio qua nullas adversitates mortemve formidat, <lb/> quid aliud quam
-						fortitudo dicenda est? <hi rend="italic">D.</hi> Et' hoc <lb/> agnosco. <hi
-							rend="italic">M.</hi> Jamvero ipsa ejus ordinatio qua nulli <lb/> servit
-						nisi uni Dco, nulli coæquari nisi purissimis <lb/> animis, nulli dominari
-						appetit nisi naturæ bestiali at­ <lb/> que corporeæ, quæ tandem virtus tibi
-						esse videtur? <lb/>
+						<lb/>manere <hi rend="italic">autem in carne, necessarium propter</hi> vos
+							<hi rend="italic">? (Phi­<lb/>lipp.</hi> i, i3, 24.) <hi rend="italic"
+							>D.</hi> Sic existimo. <hi rend="italic">M</hi> At ista cjus<lb/>
+						affectio qua nullas adversitates mortemve formidat,<lb/>quid aliud quam
+						fortitudo dicenda est? <hi rend="italic">D.</hi> Et' hoc<lb/>agnosco. <hi
+							rend="italic">M.</hi> Jamvero ipsa ejus ordinatio qua nulli<lb/>servit
+						nisi uni Dco, nulli coaequari nisi purissimis<lb/>animis, nulli dominari
+						appetit nisi naturae bestiali at­<lb/>que corporeae, quae tandem virtus tibi
+						esse videtur?<lb/>
 						<hi rend="italic">D.</hi> Quis non intelligat hanc esse justitiam? <hi
-							rend="italic">M.</hi> Recte <lb/> intelligis.</p>
+							rend="italic">M.</hi> Recte<lb/>intelligis.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT XVI. — <hi rend="italic">De quatuor virtutibus an et
 								quomodo sint</hi> in <hi rend="italic">beatis.</hi>
 						</title>
 					</ab>
-					</div><div type="textpart" subtype="dialog"><p>51. Sed illud jam quæro, cum prudentiam superius <lb/>
+					</div><div type="textpart" subtype="dialog"><p>51. Sed illud jam quaero, cum prudentiam superius<lb/>
 						<hi rend="italic">(a)</hi> cam esse constiterit inter nos, qua intelligit
-						anima <lb/> ubi ci consistendum sit, quo sese attollit per tempe­ <lb/>
-						rantiam, id est, conversionem amoris in Deum, quae <lb/> charitas dicitur,
-						ct aversionem ab hoc sæculo, quam <lb/> etiam fortitudo et justitia
-						comitantur; utrum existi­ <lb/> mes cum ad suæ dilectionis et conatus
-						fructum per­ <lb/> fecta sanctific atione pervenerit, perfecta etiam vivifi­
-						<lb/> catione illa corporis sui, et deletis de memoria phan­ <lb/> tasmatum
-						turbis, apud Deum ipsum solo Deo vivere <lb/> cæperit, cum impletum fuerit,
-						quod divinitus nobis <lb/> hoc modo proinittitur : <hi rend="italic"
+						anima<lb/>ubi ci consistendum sit, quo sese attollit per tempe­<lb/>
+						rantiam, id est, conversionem amoris in Deum, quae<lb/>charitas dicitur,
+						ct aversionem ab hoc saeculo, quam<lb/>etiam fortitudo et justitia
+						comitantur; utrum existi­<lb/>mes cum ad suae dilectionis et conatus
+						fructum per­<lb/>fecta sanctific atione pervenerit, perfecta etiam vivifi­
+						<lb/>catione illa corporis sui, et deletis de memoria phan­<lb/>tasmatum
+						turbis, apud Deum ipsum solo Deo vivere<lb/>caeperit, cum impletum fuerit,
+						quod divinitus nobis<lb/>hoc modo proinittitur : <hi rend="italic"
 							>Dilectissimi, nunc</hi> filii <hi rend="italic">Dei</hi>
-						<lb/> sumus, <hi rend="italic">ei nondum apparuit quid erimus. Scimus
+						<lb/>sumus, <hi rend="italic">ei nondum apparuit quid erimus. Scimus
 							quia</hi>
-						<lb/> cum <hi rend="italic">apparuerit, similes illi</hi> erimus, quoniam
-						videbimus <lb/> eum <hi rend="italic">sicuti cst</hi> ( I <hi rend="italic"
-							>Joan.</hi> III, 2) : quæro ergo, utrum <lb/> existimes has ibi virtutes
-						quas commemoravimus, <lb/> cuam tunc iuturas. D. Non vidco, cum adversa
-						prae­ <lb/> terierint, quibus obluctalur, quomodo aut prudentia <lb/> ibi
-						esse possit, quæ non eligit quid sequatur nisi in <lb/> adversis ; aut
-						temperantia , quæ amorem non avertit <lb/> nisi ab adversis; aut fortitudo,
-						quæ non tolcrat nisi <lb/> adversa ; aut justitia, quae non appetit æquari
-						beatis­ <lb/> simis animis, et inferiori naturæ dominari, nisi in <lb/>
-						adversis, id cst, nondum assecuta idipsum quod <lb/> appeut.</p>
-					</div><div type="textpart" subtype="dialog"><p><hi rend="italic">52. M.</hi> Non usquequaque absurda est responsio <lb/>
+						<lb/>cum <hi rend="italic">apparuerit, similes illi</hi> erimus, quoniam
+						videbimus<lb/>eum <hi rend="italic">sicuti cst</hi> ( I <hi rend="italic"
+							>Joan.</hi> III, 2) : quaero ergo, utrum<lb/>existimes has ibi virtutes
+						quas commemoravimus,<lb/>cuam tunc iuturas. D. Non vidco, cum adversa
+						prae­<lb/>terierint, quibus obluctalur, quomodo aut prudentia<lb/>ibi
+						esse possit, quae non eligit quid sequatur nisi in<lb/>adversis ; aut
+						temperantia , quae amorem non avertit<lb/>nisi ab adversis; aut fortitudo,
+						quae non tolcrat nisi<lb/>adversa ; aut justitia, quae non appetit aequari
+						beatis­<lb/>simis animis, et inferiori naturae dominari, nisi in<lb/>
+						adversis, id cst, nondum assecuta idipsum quod<lb/>appeut.</p>
+					</div><div type="textpart" subtype="dialog"><p><hi rend="italic">52. M.</hi> Non usquequaque absurda est responsio<lb/>
 						tua; et quibusdam doctis visum hoc esse, non nego. <note type="footnote">
 							(a) tal" 55,37. </note>
-						<lb/> Sed ego consulens Libros, quos nulla antecellit aueto­ <lb/> mas, ita
-						invenio dictum esse : <hi rend="italic">Gustate et videte, quo­<lb/> niam
-							suavis est Dominus (Psal.</hi> XXXIII, 9). Quod aposto­ <lb/> lus etiam
-						Petrus sic interposuit : Si <hi rend="italic">tamen gustastis, <lb/> quomam
-							suavis eat Dominus (IPetr.</hi> n, 3). Hoc esse <lb/> arbitror quod
-						agitur in his virtutibus quæ ipsa con­ <lb/> versione animam purgant. Non
-						enim amor tempora­ <lb/> lium rerum expugnaretur, nisi aliqua suavitate
-						aeter­ <lb/> narum. Ubi autem ventum fuerit ad illud quod canitur: <lb/>
+						<lb/>Sed ego consulens Libros, quos nulla antecellit aueto­<lb/>mas, ita
+						invenio dictum esse : <hi rend="italic">Gustate et videte, quo­<lb/>niam
+							suavis est Dominus (Psal.</hi> XXXIII, 9). Quod aposto­<lb/>lus etiam
+						Petrus sic interposuit : Si <hi rend="italic">tamen gustastis,<lb/>quomam
+							suavis eat Dominus (IPetr.</hi> n, 3). Hoc esse<lb/>arbitror quod
+						agitur in his virtutibus quae ipsa con­<lb/>versione animam purgant. Non
+						enim amor tempora­<lb/>lium rerum expugnaretur, nisi aliqua suavitate
+						aeter­<lb/>narum. Ubi autem ventum fuerit ad illud quod canitur:<lb/>
 						<hi rend="italic">bilii autem hominum sub tegmine alarum</hi> tuarum <hi
-							rend="italic">spera­ <lb/> bunt; inebriabuntur ab ubertate domus</hi>
-						tuae, <hi rend="italic">et torrente <lb/> voluptatis tuas potabis eos;
-							quoniam apud te eat fons <lb/> vitæ</hi> : non jam gustatu suavem fore
-						Dominum dicit; <lb/> sed vides quae inundatio et affluentia praedicetur fon­
-						<lb/> tis acterni; quam etiam ebrietas quaedam consequitur: <lb/> quo nomine
-						mihi videtur mirabiliter signilicari oblivio <lb/> illa sæcularium vanitatum
-						atque phantasmatum. Con­ <lb/> texit deinde caetera, et dicit : <hi
-							rend="italic">In</hi> lumine <hi rend="italic">tuo videbimus<lb/> lumen.
-							Praetende misericordiam tuam scientibus te. In, <lb/> lumine,</hi>
-						scilicet in Christo accipiendum, qui Sapicntia <lb/> Dei est, ct lumen
-						totics appellatur. Ubi ergo dicitur, <lb/> V idebimus, et, <hi rend="italic"
-							>scientibus te ,</hi> negari non potest futu­ <lb/> ram ibi esse
-						.prudentiam. An videri verum bonum <lb/> animæ etsciri potest, ubi nulla
-						prudentia est? <hi rend="italic">D.</hi> Jam <lb/> intelligo.</p>
-					</div><div type="textpart" subtype="dialog"><p>53. M. Quid ? recti corde possunt esse sine justitia ? <lb/>
+							rend="italic">spera­<lb/>bunt; inebriabuntur ab ubertate domus</hi>
+						tuae, <hi rend="italic">et torrente<lb/>voluptatis tuas potabis eos;
+							quoniam apud te eat fons<lb/>vitae</hi> : non jam gustatu suavem fore
+						Dominum dicit;<lb/>sed vides quae inundatio et affluentia praedicetur fon­
+						<lb/>tis acterni; quam etiam ebrietas quaedam consequitur:<lb/>quo nomine
+						mihi videtur mirabiliter signilicari oblivio<lb/>illa saecularium vanitatum
+						atque phantasmatum. Con­<lb/>texit deinde caetera, et dicit : <hi
+							rend="italic">In</hi> lumine <hi rend="italic">tuo videbimus<lb/>lumen.
+							Praetende misericordiam tuam scientibus te. In,<lb/>lumine,</hi>
+						scilicet in Christo accipiendum, qui Sapicntia<lb/>Dei est, ct lumen
+						totics appellatur. Ubi ergo dicitur,<lb/>V idebimus, et, <hi rend="italic"
+							>scientibus te ,</hi> negari non potest futu­<lb/>ram ibi esse
+						.prudentiam. An videri verum bonum<lb/>animae etsciri potest, ubi nulla
+						prudentia est? <hi rend="italic">D.</hi> Jam<lb/>intelligo.</p>
+					</div><div type="textpart" subtype="dialog"><p>53. M. Quid ? recti corde possunt esse sine justitia ?<lb/>
 						<hi rend="italic">D.</hi> Recognosco isto nomine crebrius significari justi­
-						<lb/> tiam. <hi rend="italic">M.</hi> Quid ergo admonet aliud propheta idcm
-						<lb/> consequenter, cum canit : <hi rend="italic">Et justitiam tuam iia qui
-							<lb/> recto sunt corde? D.</hi> Manifestum est. M. Age deinceps, <lb/>
-						recordare, si placet, satis nos superius tractasse, <lb/> superbia labi
-						animam ad actiones quasdam potestatis <lb/> suae , et universali lege
-						neglecta in agenda quædam <lb/> privata cecidisse, quod dicitur apostatare a
-						Deo. <lb/>
+						<lb/>tiam. <hi rend="italic">M.</hi> Quid ergo admonet aliud propheta idcm
+						<lb/>consequenter, cum canit : <hi rend="italic">Et justitiam tuam iia qui
+							<lb/>recto sunt corde? D.</hi> Manifestum est. M. Age deinceps,<lb/>
+						recordare, si placet, satis nos superius tractasse,<lb/>superbia labi
+						animam ad actiones quasdam potestatis<lb/>suae , et universali lege
+						neglecta in agenda quaedam<lb/>privata cecidisse, quod dicitur apostatare a
+						Deo.<lb/>
 						<hi rend="italic">D.</hi> Memini vero. <hi rend="italic">M.</hi> Cum ergo id
-						agit ne ulterius id <lb/> delectet aliquando , nonne tibi videtur amorem
-						suum <lb/> ligere in Deo, et ab omni inquinamento temperatis­ <lb/> sime et
-						castissime et securissime vivere? <hi rend="italic">D.</hi> Videtur <lb/>
+						agit ne ulterius id<lb/>delectet aliquando , nonne tibi videtur amorem
+						suum<lb/>ligere in Deo, et ab omni inquinamento temperatis­<lb/>sime et
+						castissime et securissime vivere? <hi rend="italic">D.</hi> Videtur<lb/>
 						sane. <hi rend="italic">M.</hi> Vide etiam quemadmodum id quoque adjun­
-						<lb/> gat propheta, dicens : <hi rend="italic">Non veniat mihi pes
-							supeibiæ.</hi>
-						<lb/> Pedem enim appellans discessum ipsum lapsumve <lb/> significat, a quo
-						anima temperando, inhæreus Deo <lb/> vivit in æternum. <hi rend="italic"
+						<lb/>gat propheta, dicens : <hi rend="italic">Non veniat mihi pes
+							supeibiae.</hi>
+						<lb/>Pedem enim appellans discessum ipsum lapsumve<lb/>significat, a quo
+						anima temperando, inhaereus Deo<lb/>vivit in aeternum. <hi rend="italic"
 							>D.</hi> Accipio et sequor.</p>
 					</div><div type="textpart" subtype="dialog"><p>54. <hi rend="italic">N.</hi> Restat igitur fortitudo. Sed ut temperantia
-						<lb/> contra lapsum qui est in libera voluntate ; sic forti­ <lb/> tudo
-						contra vim valet, qua etiam cogi quis potest, <lb/> si minus fortis sit ad
-						ea quibus evertatur, et miserri­ <lb/> mus jaceat. Hæc autem vis decenter in
-						Scripturis <lb/> manus nomine significari solet. Qui porro hanc vim, <lb/>
-						nisi peccatores conantur inferre 9 Quod tunc per id­ <lb/> ipsum 1
-						communitur anima, et custoditur firmamento <lb/> Dei, ut hoc illi nullo modo
-						undecumque possit acci­ <lb/> dere ; potentiam quamdam stabilem, et, ut ita
-						dicam, <lb/> impassibilem gerit, quæ, nisi quid libi displicet, recte <lb/>
-						fortitudo nominatur, ct cam dici arbitror cum adjun­ <lb/> gitur: <hi
+						<lb/>contra lapsum qui est in libera voluntate ; sic forti­<lb/>tudo
+						contra vim valet, qua etiam cogi quis potest,<lb/>si minus fortis sit ad
+						ea quibus evertatur, et miserri­<lb/>mus jaceat. Haec autem vis decenter in
+						Scripturis<lb/>manus nomine significari solet. Qui porro hanc vim,<lb/>
+						nisi peccatores conantur inferre 9 Quod tunc per id­<lb/>ipsum 1
+						communitur anima, et custoditur firmamento<lb/>Dei, ut hoc illi nullo modo
+						undecumque possit acci­<lb/>dere ; potentiam quamdam stabilem, et, ut ita
+						dicam,<lb/>impassibilem gerit, quae, nisi quid libi displicet, recte<lb/>
+						fortitudo nominatur, ct cam dici arbitror cum adjun­<lb/>gitur: <hi
 							rend="italic">Neque manus peccatorum dimoveat</hi> me <hi rend="italic"
 							>(Psal.</hi>
 						<note type="footnote"> 1 Ita editiones et melioris potae Mas. POrro in
-							editis non­ <lb/> nullis habetur: <hi rend="italic">Quod autem contra
-								id</hi> ipsum torunaumu, <lb/>
+							editis non­<lb/>nullis habetur: <hi rend="italic">Quod autem contra
+								id</hi> ipsum torunaumu,<lb/>
 							<hi rend="italic">anvna.</hi>
 						</note>
 						<lb/>
 						<pb n="1191"/> XXXV, 8 - 12).</p>
-					</div><div type="textpart" subtype="dialog"><p>55. Sed sive hoc sive aliud in his verbis intelligen­ <lb/> dum sii, tu
-						negabis in illa perfectione ac beatitate <lb/> animam constitutam , et
-						conspicere veritatem, et im­ <lb/> maculatam manere , et nihil molestiae
-						pati posse, et <lb/> uni Dio subdi, caeteris vero supereminere naturis ? <lb/>
+					</div><div type="textpart" subtype="dialog"><p>55. Sed sive hoc sive aliud in his verbis intelligen­<lb/>dum sii, tu
+						negabis in illa perfectione ac beatitate<lb/>animam constitutam , et
+						conspicere veritatem, et im­<lb/>maculatam manere , et nihil molestiae
+						pati posse, et<lb/>uni Dio subdi, caeteris vero supereminere naturis ?<lb/>
 						<hi rend="italic">D.</hi> Imo aliter eam perfectissimam et beatissimam esse
-						<lb/> posse non video. M. Haec ergo contemplatio, sanctifi­ <lb/> catio,
-						impassibilitas, ordinatio ejus, aut illæ suut <lb/> quatuor virtutes
-						perfectæ atque consummatae; aut ne <lb/> da nominibus cum res conveniant,
-						frustra laboremus, <lb/> pro istis virtuLibus, quibus constituta in
-						laboribus <lb/> utitur anima, tales quædam potentiæ in æterna ei vita <lb/>
-						sporandæ suut.</p>
+						<lb/>posse non video. M. Haec ergo contemplatio, sanctifi­<lb/>catio,
+						impassibilitas, ordinatio ejus, aut illae suut<lb/>quatuor virtutes
+						perfectae atque consummatae; aut ne<lb/>da nominibus cum res conveniant,
+						frustra laboremus,<lb/>pro istis virtuLibus, quibus constituta in
+						laboribus<lb/>utitur anima, tales quaedam potentiae in aeterna ei vita<lb/>
+						sporandae suut.</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT XVII. — <hi rend="italic">Quod peccatrix anima
 								numeros agat, et</hi> numeris <hi rend="italic">agatur. Conclusio
 								operit.</hi>
 						</title>
 					</ab>
-					</div><div type="textpart" subtype="dialog"><p>56. Nos tantum meminerimus, quod ad susceptam <lb/> praesentem disputationem
-						maxime pertinet, id agi per <lb/> providentiam Dei, per quam cuncta creavit
-						et regit, <lb/> ut etiam peccatrix et aerumnosa anima numeris aga­ <lb/>
-						tur, et numeros agat psque ad infimam carnis corru­ <lb/> ptionem : qui
-						certe numeri minus minusque pulchri <lb/> esse possunt, penitus vero carere
-						pulchritudine non <lb/> possunt. Deus autem summe bonus, et summe justus,
-						<lb/> nulli invidet pulchritudini, quae sive damnatione <lb/> animae, sive
-						regressione, sive permansione fabricator. <lb/> Numerus autem et ab uno
-						incipit, et æqualitate ac si­ <lb/> militudine pulcher est, et ordine
-						copulatur. Quamob­ <lb/> rem quisquis fatetur nullam esse naturam, quae non
-						<lb/> ut sit quidquid est, appetat unitatem, suique similis <lb/> in quantum
-						potest esse conetur v atque ordinem pro­ <lb/> prium vei locis vel
-						temporibus, val in corpore 1 quo­ <lb/> dam libramento salutem suam teneat :
-						debet fateri <lb/> ab uno principio per æqualem illi ac similem speciem
-						<lb/> divitiis bonitatis ejus , qua inter se unum et de uno <lb/> unum
-						charissima I, ut ita dicam, charitate junguntur, <lb/> omnia facta esse
-						atque condita quaecumque sunt, in <lb/> quantumcumque sunt.</p>
+					</div><div type="textpart" subtype="dialog"><p>56. Nos tantum meminerimus, quod ad susceptam<lb/>praesentem disputationem
+						maxime pertinet, id agi per<lb/>providentiam Dei, per quam cuncta creavit
+						et regit,<lb/>ut etiam peccatrix et aerumnosa anima numeris aga­<lb/>
+						tur, et numeros agat psque ad infimam carnis corru­<lb/>ptionem : qui
+						certe numeri minus minusque pulchri<lb/>esse possunt, penitus vero carere
+						pulchritudine non<lb/>possunt. Deus autem summe bonus, et summe justus,
+						<lb/>nulli invidet pulchritudini, quae sive damnatione<lb/>animae, sive
+						regressione, sive permansione fabricator.<lb/>Numerus autem et ab uno
+						incipit, et aequalitate ac si­<lb/>militudine pulcher est, et ordine
+						copulatur. Quamob­<lb/>rem quisquis fatetur nullam esse naturam, quae non
+						<lb/>ut sit quidquid est, appetat unitatem, suique similis<lb/>in quantum
+						potest esse conetur v atque ordinem pro­<lb/>prium vei locis vel
+						temporibus, val in corpore 1 quo­<lb/>dam libramento salutem suam teneat :
+						debet fateri<lb/>ab uno principio per aequalem illi ac similem speciem
+						<lb/>divitiis bonitatis ejus , qua inter se unum et de uno<lb/>unum
+						charissima I, ut ita dicam, charitate junguntur,<lb/>omnia facta esse
+						atque condita quaecumque sunt, in<lb/>quantumcumque sunt.</p>
 					</div><div type="textpart" subtype="dialog"><p>57. Quare ille versus a nobis propositus, <hi rend="italic">Deus crea­</hi>
-						<lb/> tor <hi rend="italic">omnium,</hi> non solum auribus sono numeroso,
-						sed <lb/> multo magis est animæ sententiae sanitate et veritate <lb/>
-						gratissimus. Nisi forte movet te tarditas eorum, ut <lb/> mitius loquar, qui
-						negant de nihilo fieri posse aliquid, <lb/> cum id omnipotens Deus fecisse
-						dicatur. An vero fa­ <lb/> ber potest rationabilibus numeris qui sunt in
-						arte <lb/> ejus, sensuales numeros qui sunt in consuetudine <lb/> ejus
-						operari; et sensualibus numeris progressores <lb/> illos quibus membra in
-						operando movet, ad quos jam <lb/> intervalla temporum pertinent, et bis
-						rursus formas <lb/> visibiles de ligno fabricari, locorum intervallis nume­
-						<lb/> rosas: et rerum natura Dei nutibus serviens, ipsum <lb/> lignum de
+						<lb/>tor <hi rend="italic">omnium,</hi> non solum auribus sono numeroso,
+						sed<lb/>multo magis est animae sententiae sanitate et veritate<lb/>
+						gratissimus. Nisi forte movet te tarditas eorum, ut<lb/>mitius loquar, qui
+						negant de nihilo fieri posse aliquid,<lb/>cum id omnipotens Deus fecisse
+						dicatur. An vero fa­<lb/>ber potest rationabilibus numeris qui sunt in
+						arte<lb/>ejus, sensuales numeros qui sunt in consuetudine<lb/>ejus
+						operari; et sensualibus numeris progressores<lb/>illos quibus membra in
+						operando movet, ad quos jam<lb/>intervalla temporum pertinent, et bis
+						rursus formas<lb/>visibiles de ligno fabricari, locorum intervallis nume­
+						<lb/>rosas: et rerum natura Dei nutibus serviens, ipsum<lb/>lignum de
 						terra et caeteris elementis facere non po­ <note type="footnote">'Er. et
-							Lov., incorporeo <hi rend="italic">quodam libramento.</hi> Aliquot Mss., <lb/>
+							Lov., incorporeo <hi rend="italic">quodam libramento.</hi> Aliquot Mss.,<lb/>
 							<hi rend="italic">In corporeo quodam.</hi> At Am. et codices plerique
-							veteres <lb/> praeferunt, in <hi rend="italic">corpore quodam :</hi>
+							veteres<lb/>praeferunt, in <hi rend="italic">corpore quodam :</hi>
 							quod magis probamus. </note><note type="footnote"> s Insignior iste de
-							Trinitate locus in editionibus Er et <lb/> toy. necnon in recentioribus
-							aliquot Mss. ita corrupte legi­ <lb/> tui- : <hi rend="italic">Qua</hi>
+							Trinitate locus in editionibus Er et<lb/>toy. necnon in recentioribus
+							aliquot Mss. ita corrupte legi­<lb/>tui- : <hi rend="italic">Qua</hi>
 							inter <hi rend="italic">se unum ei duo chamsima, vt itu dicanl.</hi>
-							<lb/> ID editione autem Am.: <hi rend="italic">Qua inter se tmum et de
-								11110 mum<lb/> chansma : et</hi> tU <hi rend="italic">ita
-								dicam.</hi> Red<unclear>integravimus</unclear> totum ad Ii­ <lb/>
+							<lb/>ID editione autem Am.: <hi rend="italic">Qua inter se tmum et de
+								11110 mum<lb/>chansma : et</hi> tU <hi rend="italic">ita
+								dicam.</hi> Red<unclear>integravimus</unclear> totum ad Ii­<lb/>
 							proa Toleres optimae notae. </note>
-						<lb/> test; et ipsa extrema non poterat de nullo 1 ? imo et <lb/> urboris
-						locales numeros, temporales numeri antece­ <lb/> dant necesse est. Nullum
-						est enim stirpium genus <lb/> quod non certis pro suo semine dimensionibus
-						tem­ <lb/> porum et coalescat, et germinet, et in auras cmicet, <lb/> et
-						folia explicet, ct roborctur, et sive fructum , sive <lb/> ipsius ligni
-						occultissimis numeris vim rursus seminis <lb/> referat : quanto magis
-						animalium corpora, in quibus <lb/> intervalla membrorum numerosam
-						parilitatem multo <lb/> magis aspectibus offerunt? An ista de elementis
-						fieri <lb/> possunt, et ipsa elementa non potuerunt fieri de nihi­ <lb/> lo?
-						Quasi vcro quidquam sit in eis vilius et abjectius <lb/> quam terra est. Quæ
-						primo generalem speciem cor­ <lb/> pcris hahet, in qua unitas quandam et
-						numeri et ordo <lb/> esse convincitur. Namque ab aliqua impertili nota *
-						<lb/> in longitudinem necesse est porrigatur quælibet ejus <lb/> quantumvis
-						parva particula, tertiam latitudinem su­ <lb/> mat, ct quartam altitudinem
-						qua corpus impletur. <lb/> Unde ergo iste a primo usque ad quartum
-						progressionis <lb/> modus? Unde et æqualitas quoque partium, quae in <lb/>
-						longitudine et latitudine et altitudine reperitur? Unde <lb/>
-						corrationalitas quædam (ita euim malui analogiam vo­ <lb/> care), ut quam
-						rationem habet longitudo ad imperti- <lb/> lem notam, eamdem latitudo ad
-						longitudinem, et ad <lb/> latitudinem babeat altitudo? Unde, quaeso, ista,
-						nisi <lb/> ab illo summo atque æterno principatu numerorum <lb/> et
-						similitudinis et æqualitatis et ordinis veniunt? <lb/> Atqui hæc si terrae
-						ademeris, nihil erit. Quocirca <lb/> omnipotens Deus terram fecit, et de
-						nihilo terra facta <lb/> est.</p>
-					</div><div type="textpart" subtype="dialog"><p>. 58. Quid porro? ipsa species qua item a cæteris ele­ <lb/> mentis terra
-						discernitur, nonne et unum aliquid quan­ <lb/> tum accepit ostentat, et
-						nulla pars ejus a toio est dis­ <lb/> similis, et earumdem partium
-						connexione atque con­ <lb/> cordia suo genere saluberrimam sedem infimam
-						tenet? <lb/> Cui superfunditur aquarum natura, nitens et ipsa ad <lb/>
-						unitatem, speciosior et perlucidior propter majorem <lb/> similitudinem
-						partium, et custodiens locum ordinis <lb/> ct salutis suæ. Quid de aeris
-						natura dicam, multo fa­ <lb/> ciliore complexu ad Hnitatem nitente, et tanto
-						specio­ <lb/> siore aquis, quam illæ terris sunt, tantoque superiore <lb/>
-						ad salutem •? Quid de cœli supremo ambitu, quo <lb/> tota universitas
-						visibilium corporum terminatur, et <lb/> summa in hoc genere species, ac
-						saluberrima loci <lb/> excellentia? Ista certe omnia quae carnalis sensus
-						mi­ <lb/> nisterio numeramus, ct quæcumque in cis sunt, locales <lb/>
-						numeros qui videntur esse in aliquo statu, nisi præce­ <lb/> dentibus
-						intimis et in silentio temporalibus numeris <lb/> qui sunt in motu, nec
-						accipere illos possunt, ner ha­ <lb/> bere. Illos itidem temporum
-						intervallis agiles praece­ <lb/>
+						<lb/>test; et ipsa extrema non poterat de nullo 1 ? imo et<lb/>urboris
+						locales numeros, temporales numeri antece­<lb/>dant necesse est. Nullum
+						est enim stirpium genus<lb/>quod non certis pro suo semine dimensionibus
+						tem­<lb/>porum et coalescat, et germinet, et in auras cmicet,<lb/>et
+						folia explicet, ct roborctur, et sive fructum , sive<lb/>ipsius ligni
+						occultissimis numeris vim rursus seminis<lb/>referat : quanto magis
+						animalium corpora, in quibus<lb/>intervalla membrorum numerosam
+						parilitatem multo<lb/>magis aspectibus offerunt? An ista de elementis
+						fieri<lb/>possunt, et ipsa elementa non potuerunt fieri de nihi­<lb/>lo?
+						Quasi vcro quidquam sit in eis vilius et abjectius<lb/>quam terra est. Quae
+						primo generalem speciem cor­<lb/>pcris hahet, in qua unitas quandam et
+						numeri et ordo<lb/>esse convincitur. Namque ab aliqua impertili nota *
+						<lb/>in longitudinem necesse est porrigatur quaelibet ejus<lb/>quantumvis
+						parva particula, tertiam latitudinem su­<lb/>mat, ct quartam altitudinem
+						qua corpus impletur.<lb/>Unde ergo iste a primo usque ad quartum
+						progressionis<lb/>modus? Unde et aequalitas quoque partium, quae in<lb/>
+						longitudine et latitudine et altitudine reperitur? Unde<lb/>
+						corrationalitas quaedam (ita euim malui analogiam vo­<lb/>care), ut quam
+						rationem habet longitudo ad imperti<lb/>lem notam, eamdem latitudo ad
+						longitudinem, et ad<lb/>latitudinem babeat altitudo? Unde, quaeso, ista,
+						nisi<lb/>ab illo summo atque aeterno principatu numerorum<lb/>et
+						similitudinis et aequalitatis et ordinis veniunt?<lb/>Atqui haec si terrae
+						ademeris, nihil erit. Quocirca<lb/>omnipotens Deus terram fecit, et de
+						nihilo terra facta<lb/>est.</p>
+					</div><div type="textpart" subtype="dialog"><p>. 58. Quid porro? ipsa species qua item a caeteris ele­<lb/>mentis terra
+						discernitur, nonne et unum aliquid quan­<lb/>tum accepit ostentat, et
+						nulla pars ejus a toio est dis­<lb/>similis, et earumdem partium
+						connexione atque con­<lb/>cordia suo genere saluberrimam sedem infimam
+						tenet?<lb/>Cui superfunditur aquarum natura, nitens et ipsa ad<lb/>
+						unitatem, speciosior et perlucidior propter majorem<lb/>similitudinem
+						partium, et custodiens locum ordinis<lb/>ct salutis suae. Quid de aeris
+						natura dicam, multo fa­<lb/>ciliore complexu ad Hnitatem nitente, et tanto
+						specio­<lb/>siore aquis, quam illae terris sunt, tantoque superiore<lb/>
+						ad salutem •? Quid de cœli supremo ambitu, quo<lb/>tota universitas
+						visibilium corporum terminatur, et<lb/>summa in hoc genere species, ac
+						saluberrima loci<lb/>excellentia? Ista certe omnia quae carnalis sensus
+						mi­<lb/>nisterio numeramus, ct quaecumque in cis sunt, locales<lb/>
+						numeros qui videntur esse in aliquo statu, nisi praece­<lb/>dentibus
+						intimis et in silentio temporalibus numeris<lb/>qui sunt in motu, nec
+						accipere illos possunt, ner ha­<lb/>bere. Illos itidem temporum
+						intervallis agiles praece­<lb/>
 						<hi rend="italic">j</hi>
 						<note type="footnote">1 Exfungenda videretur particula negans, nisi exstaret
-							in <lb/> »'ss. a quihus tamen cum absint sequentia verba, scilicet, <lb/>
+							in<lb/>»'ss. a quihus tamen cum absint sequentia verba, scilicet,<lb/>
 							<hi rend="italic">et ipsa extrema non poterat de nullo,</hi> fatemur non
-							tantam <lb/> lis fidem esse tribuendam hoc loco, qui iibrai-ioruni
-							lanso4 <lb/> vitialas sit. </note><note type="footnote"> * Lov., <hi
+							tantam<lb/>lis fidem esse tribuendam hoc loco, qui iibrai-ioruni
+							lanso4<lb/>vitialas sit. </note><note type="footnote"> * Lov., <hi
 								rend="italic">imparUi</hi> notajEi rursum inferius, <hi
-								rend="italic">inaparilml no. <lb/> Lrni.</hi> sed melus Am. et Er.
-							cum aliquot Mss., <hi rend="italic">intperlili</hi> et im­ <lb/> pertitu
+								rend="italic">inaparilml no.<lb/>Lrni.</hi> sed melus Am. et Er.
+							cum aliquot Mss., <hi rend="italic">intperlili</hi> et im­<lb/>pertitu
 								<hi rend="italic">m :</hi> nam hic nomine notae intelligitur
-							PUUclUUl seu si­ <lb/> gnum unde linea ducitur; quod in libro de
-							Qua.llitate Ani­ <lb/> ina?, cap. ii, n. i8, sicdefinitur : tKota sine
+							PUUclUUl seu si­<lb/>gnum unde linea ducitur; quod in libro de
+							Qua.llitate Ani­<lb/>ina?, cap. ii, n. i8, sicdefinitur : tKota sine
 							lartibus.* </note><note type="footnote">a Lov.: <hi rend="italic">Et
-								tanto speciosiore, quanto speciostores aquæ stmi</hi>
-							<lb/> terris, <hi rend="italic">fI1umlOque ad superiorem salutem altior
+								tanto speciosiore, quanto speciostores aquae stmi</hi>
+							<lb/>terris, <hi rend="italic">fI1umlOque ad superiorem salutem altior
 								terra nititur.</hi>
 						</note>
 						<lb/>
-						<pb n="1193"/> dit et modificat vitalis motus, serviens Domino rerum <lb/>
-						omnium, nun temporalia habens digesta intervalla <lb/> numerorum suorum, sed
-						tempora ministrante poten­ <lb/> tia; supra quam rationales et
-						intellectuales numeri <lb/> beatarum animarum atque sanctarum, legem ipsam
-						<lb/> Dei, sinc qua folium de arbore non cadit, et cui nostri <lb/> capilli
-						numerati sunt, nulla interposita natura exci­ <lb/> pientes, usque ad
-						terrena et inferna jura transmit­ <lb/> tunt (a).</p>
+						<pb n="1193"/> dit et modificat vitalis motus, serviens Domino rerum<lb/>
+						omnium, nun temporalia habens digesta intervalla<lb/>numerorum suorum, sed
+						tempora ministrante poten­<lb/>tia; supra quam rationales et
+						intellectuales numeri<lb/>beatarum animarum atque sanctarum, legem ipsam
+						<lb/>Dei, sinc qua folium de arbore non cadit, et cui nostri<lb/>capilli
+						numerati sunt, nulla interposita natura exci­<lb/>pientes, usque ad
+						terrena et inferna jura transmit­<lb/>tunt (a).</p>
 					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CONCLUSIO OPERIS.</title>
 					</ab>
-					</div><div type="textpart" subtype="dialog"><p>59. Quæ potui et sicut potui de tantis tantillus te­ <lb/> cuin contuli.
-						Sermonem autem hunc nostrum manda­ <lb/> tum litteris si qui legunt, sciant
-						multo infirmioribus <lb/> hæc esse scripta, quam sunt illi qui unius summi
+					</div><div type="textpart" subtype="dialog"><p>59. Quae potui et sicut potui de tantis tantillus te­<lb/>cuin contuli.
+						Sermonem autem hunc nostrum manda­<lb/>tum litteris si qui legunt, sciant
+						multo infirmioribus<lb/>haec esse scripta, quam sunt illi qui unius summi
 						De! <note type="footnote"> . <hi rend="italic">(a)</hi> vid. Retract. lib.
 							i, cap. i, n. 4. </note>
-						<lb/> consubstantialem et incommutabilem Trinitatcm, cit <lb/> quo omnia,
-						per quem omnia, in quo omnia duorum Tc­ <lb/> stamentorum auctoritatem
-						seculi venerantur et colunt <lb/> eam credendo, sperando et diligendo.
-							<unclear>Hi</unclear> enim non scin - <lb/> tillantibus humanis
-						ratiocinationibus, sed validissimo <lb/> et flagrantissimo charitatis igne
-						purgantur. Nos autem <lb/> dum negligendos esse non existimamus quos
-						hæretici <lb/> rationis et scientiæ fallaci pollicitatione decipiunt; <lb/>
-						tardius incedimus, consideratione ipsarum viarum , <lb/> qnam sancti viri
-						qui cas volando nop dignantur at­ <lb/> tendere. Quod tamen faccre non
-						auderemus, nisi mill. <lb/> tos pios Ecclesiæ catholicæ matris optimæ
-						filios, qqi <lb/> pucrilibus studiis loquendi ac disserendi facultatem <lb/>
-						quantum satis est consecuti essent, eadcm refellen- <lb/> dorum hæreticorum
+						<lb/>consubstantialem et incommutabilem Trinitatcm, cit<lb/>quo omnia,
+						per quem omnia, in quo omnia duorum Tc­<lb/>stamentorum auctoritatem
+						seculi venerantur et colunt<lb/>eam credendo, sperando et diligendo.
+							<unclear>Hi</unclear> enim non scin<lb/>tillantibus humanis
+						ratiocinationibus, sed validissimo<lb/>et flagrantissimo charitatis igne
+						purgantur. Nos autem<lb/>dum negligendos esse non existimamus quos
+						haeretici<lb/>rationis et scientiae fallaci pollicitatione decipiunt;<lb/>
+						tardius incedimus, consideratione ipsarum viarum ,<lb/>qnam sancti viri
+						qui cas volando nop dignantur at­<lb/>tendere. Quod tamen faccre non
+						auderemus, nisi mill.<lb/>tos pios Ecclesiae catholicae matris optimae
+						filios, qqi<lb/>pucrilibus studiis loquendi ac disserendi facultatem<lb/>
+						quantum satis est consecuti essent, eadcm refellen<lb/>dorum haereticorum
 						necessitate fecisse videremus.</p></div>
 				</div>
 			</div>

--- a/data/stoa0040/stoa008/stoa0040.stoa008.opp-lat1.xml
+++ b/data/stoa0040/stoa008/stoa0040.stoa008.opp-lat1.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://www.stoa.org/epidoc/schema/latest/tei-epidoc.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
-  <teiHeader>
-    <fileDesc>
+	<teiHeader>
+		<fileDesc>
 			<titleStmt>
 				<title>Patrologiae Cursus Completus. Series Latina (PL)</title>
 				<sponsor>University of Leipzig</sponsor>
@@ -30,8 +30,9 @@
 				<authority>University of Leipzig</authority>
 				<idno type="filename">PL32.xml</idno>
 				<availability>
-					<licence target="https://creativecommons.org/licenses/by-sa/4.0/">Available under a
-						Creative Commons Attribution-ShareAlike 4.0 International License</licence>
+					<licence target="https://creativecommons.org/licenses/by-sa/4.0/">Available
+						under a Creative Commons Attribution-ShareAlike 4.0 International
+						License</licence>
 				</availability>
 				<date>2014</date>
 				<publisher>University of Leipzig</publisher>
@@ -47,14 +48,16 @@
 									<name xml:lang="fr">Jacques Paul Migne</name>
 								</persName>
 							</editor>
-							<author ref="http://data.perseus.org/catalog/urn:cts:latinLit:stoa0040">Augustinus</author>
+							<author ref="http://data.perseus.org/catalog/urn:cts:latinLit:stoa0040"
+								>Augustinus</author>
 							<title>Soliloquiorum Libri Duo</title>
 							<title>De Immortalitate Animae</title>
 							<title>De Quantitate Animae</title>
 							<title>De Musica Libri Sex</title>
 							<title>De Magistro</title>
 							<title>De Libero Arbitrio</title>
-							<title>De Moribus Ecclesiae Catholicae et de Moribus Manichaeorum</title>
+							<title>De Moribus Ecclesiae Catholicae et de Moribus
+								Manichaeorum</title>
 							<title>Regula ad Servos Dei</title>
 							<title>De Grammatica. Admonitio [Auctore Maurino]</title>
 							<title>De Grammatica</title>
@@ -80,12 +83,14 @@
 
 		</fileDesc>
 		<encodingDesc>
-			<p>The following text is encoded in accordance with EpiDoc standards and with the CTS/CITE
-				Architecture.</p>
-		  <refsDecl n="CTS">
-        <cRefPattern n="no citable units founds" matchPattern="(.+)" replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"/>
-      </refsDecl>
-    </encodingDesc>
+			<p>The following text is encoded in accordance with EpiDoc standards and with the
+				CTS/CITE Architecture.</p>
+			<refsDecl n="CTS">
+				<cRefPattern n="no citable units founds" matchPattern="(.+)"
+					replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"
+				/>
+			</refsDecl>
+		</encodingDesc>
 
 		<profileDesc>
 			<langUsage>
@@ -94,14 +99,14 @@
 		</profileDesc>
 
 	</teiHeader>
-  <text>
-    <body><div type="edition" n="urn:cts:latinLit:stoa0040.stoa008.opp-lat1">
-					<head>
-						<title type="main">S. AURELII AUGUSTINI HIPPONENSIS EPISCOPI DE MUSICA LIBRI SEX
-							(a).</title>
-					</head>
-					<div type="textpart" subtype="chapter">
-						<ab>
+	<text>
+		<body>
+			<div type="edition" n="urn:cts:latinLit:stoa0040.stoa008.opp-lat1">
+				<head>
+					<title type="main">S. AURELII AUGUSTINI HIPPONENSIS EPISCOPI DE MUSICA LIBRI SEX
+						(a).</title>
+				</head>
+					<ab>
 						<title type="sub">
 							<hi rend="italic">LIBER PRIMUS.</hi>
 						</title>
@@ -111,5074 +116,6291 @@
 							considerationem pertinent, motuum numcrosorum spocics ac proportio
 							explicantur.</title>
 					</ab>
+				<div type="textpart" subtype="chapter" n="1">
 					<ab>
-						<title type="sub">CAPUT PRIMUM.— <hi rend="italic">Sonorum certas dimensiones</hi>
-							obser­ <hi rend="italic">vare non ad grammaticam</hi> spectat, <hi rend="italic">sed
-								ad musicam.</hi>
+						<title type="sub"><hi rend="italic">Sonorum certas
+								dimensiones</hi> obser­ <hi rend="italic">vare non ad
+								grammaticam</hi> spectat, <hi rend="italic">sed ad musicam.</hi>
 						</title>
 					</ab>
-					<p>i. MAGISTER : <hi rend="italic">Modus,</hi> qui pes est? DISCIPULUS 1 : <lb/>
-						Pyrrhichius. <hi rend="italic">M.</hi> Quot temporum est? <hi rend="italic">D.</hi>
-						Duum. <lb/>
-						<hi rend="italic">II. Bonus,</hi> qui pes est ? D. Idem qui ct modus. <hi rend="italic">M.</hi> Hoc <lb/> est ergo <hi rend="italic">modus,</hi> quod <hi rend="italic">bonus. D.</hi> Non. 3/. Cur ergo <lb/> idem? <hi rend="italic">D.</hi> Quia idem iti
-						sono, in significatione aliud. <lb/>
-						<hi rend="italic">M.</hi> Concedis ergo cumdem sonum esse cum dici.mus, <note type="footnote"> ADMONITIO PP. BENEDICTINORUM. </note><note type="footnote"> ,mendis i
-							ropc innumeris expuvgati sunt (Libri deMusica) ad Mss. Corbeiensem 01 tinae notæ,
-							Arnulfensem, Albinensem, <lb/> victorinum, regium, vaticanum ; ad lectiones ex
-							Helgicis quatuor per Lovanienses collectas; et ad editiones Am. Fr. ct Lov. <lb/>
-							Præterea libri quinque priores ad alium victorinum et ad Navarricum Mss. collati sunt;
-							sextus demum liber ad alium <lb/> Navar. et alium Victor. ad unum majoris conventus
-							Augustinianoium Paris. ctad Benignianum. </note><note type="footnote"><hi rend="italic">comparavimus præterea eas omnes editiones initio</hi> Retractationum
-							et Confessionum <hi rend="italic">memoratas , necnon duos Regiæ<lb/> Bibliothecæ</hi>
-							Mss., numeris A, 7200, <hi rend="italic">et</hi> H, 7231 <hi rend="italic">designatos,
-								ac operis Augustiniani quamdam epitomen ex</hi> ipis <hi rend="italic">potissimum
-								<lb/> Augustini</hi> verbis concinnatam, <hi rend="italic">quam ngelus Maius in
-								pervetusto codice B</hi><hi rend="italic">ibliothecæ</hi> V<hi rend="italic">aticanæ
-								reperit ediditque Romæ,<lb/> anno</hi> 1828, in tomo 5, parte 3, i ag. 116-134,
-							novie collectionis s:riptorum veterum e vaticanis Cdd. ex; ressæ. M.</note>
-						<note type="footnote"> s in a; ite operis, apud Albinensem Mss. habctur : <hi rend="italic">Inci­<lb/> frit dwtogoritm</hi> augustini <hi rend="italic">et
-								Licentii de Musica liber primus.</hi>
-							<lb/> Titulum persinulem j'rn'ferun!. Regius codex et Victorini <lb/> (w' ty v.ss.
-							autem Corb. Aruulf. et aliis tlcrisque, uilerlo <lb/> cutores Au;:,uSlinns' ct
-							Licentius ex nomine designantur |er <lb/> t&lt;;Lmn &lt; | ns , ubicumque in uilis
-							nolie anix.e sunt Vagistri <lb/> ac Discipuli. </note>
+					<div type="textpart" subtype="dialog" n="1"><p>1. MAGISTER : <hi rend="italic">Modus,</hi> qui pes est? DISCIPULUS 1 : <lb/>
+						Pyrrhichius. <hi rend="italic">M.</hi> Quot temporum est? <hi rend="italic"
+							>D.</hi> Duum. <lb/>
+						<hi rend="italic">II. Bonus,</hi> qui pes est ? D. Idem qui ct modus. <hi
+							rend="italic">M.</hi> Hoc <lb/> est ergo <hi rend="italic">modus,</hi>
+						quod <hi rend="italic">bonus. D.</hi> Non. 3/. Cur ergo <lb/> idem? <hi
+							rend="italic">D.</hi> Quia idem iti sono, in significatione aliud. <lb/>
+						<hi rend="italic">M.</hi> Concedis ergo cumdem sonum esse cum dici.mus,
+							<note type="footnote"> ADMONITIO PP. BENEDICTINORUM. </note><note
+							type="footnote"> ,mendis i ropc innumeris expuvgati sunt (Libri
+							deMusica) ad Mss. Corbeiensem 01 tinae notæ, Arnulfensem, Albinensem,
+							<lb/> victorinum, regium, vaticanum ; ad lectiones ex Helgicis quatuor
+							per Lovanienses collectas; et ad editiones Am. Fr. ct Lov. <lb/>
+							Præterea libri quinque priores ad alium victorinum et ad Navarricum Mss.
+							collati sunt; sextus demum liber ad alium <lb/> Navar. et alium Victor.
+							ad unum majoris conventus Augustinianoium Paris. ctad Benignianum.
+							</note><note type="footnote"><hi rend="italic">comparavimus præterea eas
+								omnes editiones initio</hi> Retractationum et Confessionum <hi
+								rend="italic">memoratas , necnon duos Regiæ<lb/> Bibliothecæ</hi>
+							Mss., numeris A, 7200, <hi rend="italic">et</hi> H, 7231 <hi
+								rend="italic">designatos, ac operis Augustiniani quamdam epitomen
+								ex</hi> ipis <hi rend="italic">potissimum <lb/> Augustini</hi>
+							verbis concinnatam, <hi rend="italic">quam ngelus Maius in pervetusto
+								codice B</hi><hi rend="italic">ibliothecæ</hi> V<hi rend="italic"
+								>aticanæ reperit ediditque Romæ,<lb/> anno</hi> 1828, in tomo 5,
+							parte 3, i ag. 116-134, novie collectionis s:riptorum veterum e
+							vaticanis Cdd. ex; ressæ. M.</note>
+						<note type="footnote"> s in a; ite operis, apud Albinensem Mss. habctur :
+								<hi rend="italic">Inci­<lb/> frit dwtogoritm</hi> augustini <hi
+								rend="italic">et Licentii de Musica liber primus.</hi>
+							<lb/> Titulum persinulem j'rn'ferun!. Regius codex et Victorini <lb/>
+							(w' ty v.ss. autem Corb. Aruulf. et aliis tlcrisque, uilerlo <lb/>
+							cutores Au;:,uSlinns' ct Licentius ex nomine designantur |er <lb/>
+							t&lt;;Lmn &lt; | ns , ubicumque in uilis nolie anix.e sunt Vagistri
+							<lb/> ac Discipuli. </note>
 						<note type="footnote">
-							<hi rend="italic">(a)</hi> Inclinati an. Christi oo7, perfecti circiter au. 3SQ. </note>
+							<hi rend="italic">(a)</hi> Inclinati an. Christi oo7, perfecti circiter
+							au. 3SQ. </note>
 						<lb/>
 						<pb n="1083"/>
-						<hi rend="italic">modus,</hi> et, bonus. D. Litterarum sono ista video dis­ <lb/>
-						crepare, cætera autem paria csse. <hi rend="italic">M.</hi> Quid? cum enun­ <lb/>
-						tiamus, <hi rend="italic">pone</hi> verbum, ct <hi rend="italic">pone</hi> adverbium;
-						præter id <lb/> Quod significatio diversa est, nihil libi vidclur sonus <lb/> dustare?
-							<hi rend="italic">D.</hi> Distat omnino. <hi rend="italic">M.</hi> Unde distat, cum et
-						<lb/> iisdem temporibus utrumque, ct iisdem litteris con­ <lb/> stet? D. Eo distat 1
-						quod in diversis locis habent acu­ <lb/> mcn. <hi rend="italic">Al.</hi> Cujus tandem
-						artis cst ista dignoscere? <hi rend="italic">D.</hi> A <lb/> grammaticis hæc audire
-						soleo, ct ibi ea didici ; sed <lb/> utrumc hoc ejusdem a.-tis sit proprium, an aliunde
-						<lb/> usurpatum , nescio. <hi rend="italic">M.</hi> Post ista videbimus : nunc <lb/>
-						illud quæro, utrum si tympanum vel chordam bis per­ <lb/> cuterem tam raptim et
-						velociter quam cum enuntia­ <lb/> mus <hi rend="italic">modus,</hi> aut <hi rend="italic">bonus;</hi> agnosceres et tibi eadcm <lb/> tempora casu , an non. D.
-						Agnoscerem. M. Vocarcs <lb/> largo pedem pyrrhicliinm. <hi rend="italic">D.</hi>
-						Vocarem. <hi rend="italic">M.</hi> Nomen <lb/> hujus pedis a quo, nisi a grammatico,
-						didicisti ? <hi rend="italic">D.</hi>
-						<lb/> Fatcor. <hi rend="italic">M.</hi> Ergo de omnibus hujusmodi sonis gram­ <lb/>
-						maticus judicabit; an per teipsum istos pulsus didi­ <lb/> cisti, sed nomen quod
-						imponeres, a grammatico au­ <lb/> dieras? <hi rend="italic">D.</hi> Ita est. <hi rend="italic">M.</hi> Et ausus es nomen quod te <lb/> grammatica docuit, transferre ad
-						cam rem, quam non <lb/> pertiuere ad grammaticam confiteris? <hi rend="italic">D.</hi>
-						Video non <lb/> ob aliud pcdi nomen impositum, quam propter tem­ <lb/> porum
-						dimensionem; quam ubicumque cognovero, eo <lb/> transferrc illud vocabulum cur non
-						audeo? Sed clsi <lb/> alia vocabula sunt imponenda, cum ejusdem dimen­ <lb/> sionis soni
-						sunt, sed ad grammaticos tamen non per­ <lb/> tinent; quid milii est de nominibus
-						laborare, cum res <lb/> aperta sit? <hi rend="italic">31.</hi> Nee ego id volo : sed
-						tamen cum vi­ <lb/> deas innumcrahilia genera sonorum, in quibus certae <lb/>
-						dimensiones observari possunt, qu:e genera fatemur <lb/> grammaticæ disciplinænon case
-						tribuenda ; nonne <lb/> censes case aliam aliquam disciplinam, quæ quidquid <lb/> in
-						hujusmodi sit vocibus numerosum artificiosumque, <lb/> contineat? <hi rend="italic">D.</hi> Probahilc mihi videtur. <hi rend="italic">M.</hi> Qaod cjus <lb/> esse nomen
-						existimas? Nam opinor n &gt;n libi nevum <lb/> esse omnipotentiam quamdam canendi Musis
-						solcre <lb/> concedi. Hac est, nisi fallor, illa quæ Musica nomina­ <lb/> tur. <hi rend="italic">D.</hi> Ei cgo hanc esse existimo.</p>
-					<ab>
-						<title type="sub">CAPUT II. — <hi rend="italic">Musica quid sit. Modulari quid sit.</hi>
+						<hi rend="italic">modus,</hi> et, bonus. D. Litterarum sono ista video dis­
+						<lb/> crepare, cætera autem paria csse. <hi rend="italic">M.</hi> Quid? cum
+						enun­ <lb/> tiamus, <hi rend="italic">pone</hi> verbum, ct <hi rend="italic"
+							>pone</hi> adverbium; præter id <lb/> Quod significatio diversa est,
+						nihil libi vidclur sonus <lb/> dustare? <hi rend="italic">D.</hi> Distat
+						omnino. <hi rend="italic">M.</hi> Unde distat, cum et <lb/> iisdem
+						temporibus utrumque, ct iisdem litteris con­ <lb/> stet? D. Eo distat 1 quod
+						in diversis locis habent acu­ <lb/> mcn. <hi rend="italic">Al.</hi> Cujus
+						tandem artis cst ista dignoscere? <hi rend="italic">D.</hi> A <lb/>
+						grammaticis hæc audire soleo, ct ibi ea didici ; sed <lb/> utrumc hoc
+						ejusdem a.-tis sit proprium, an aliunde <lb/> usurpatum , nescio. <hi
+							rend="italic">M.</hi> Post ista videbimus : nunc <lb/> illud quæro,
+						utrum si tympanum vel chordam bis per­ <lb/> cuterem tam raptim et velociter
+						quam cum enuntia­ <lb/> mus <hi rend="italic">modus,</hi> aut <hi
+							rend="italic">bonus;</hi> agnosceres et tibi eadcm <lb/> tempora casu ,
+						an non. D. Agnoscerem. M. Vocarcs <lb/> largo pedem pyrrhicliinm. <hi
+							rend="italic">D.</hi> Vocarem. <hi rend="italic">M.</hi> Nomen <lb/>
+						hujus pedis a quo, nisi a grammatico, didicisti ? <hi rend="italic">D.</hi>
+						<lb/> Fatcor. <hi rend="italic">M.</hi> Ergo de omnibus hujusmodi sonis
+						gram­ <lb/> maticus judicabit; an per teipsum istos pulsus didi­ <lb/>
+						cisti, sed nomen quod imponeres, a grammatico au­ <lb/> dieras? <hi
+							rend="italic">D.</hi> Ita est. <hi rend="italic">M.</hi> Et ausus es
+						nomen quod te <lb/> grammatica docuit, transferre ad cam rem, quam non <lb/>
+						pertiuere ad grammaticam confiteris? <hi rend="italic">D.</hi> Video non
+						<lb/> ob aliud pcdi nomen impositum, quam propter tem­ <lb/> porum
+						dimensionem; quam ubicumque cognovero, eo <lb/> transferrc illud vocabulum
+						cur non audeo? Sed clsi <lb/> alia vocabula sunt imponenda, cum ejusdem
+						dimen­ <lb/> sionis soni sunt, sed ad grammaticos tamen non per­ <lb/>
+						tinent; quid milii est de nominibus laborare, cum res <lb/> aperta sit? <hi
+							rend="italic">31.</hi> Nee ego id volo : sed tamen cum vi­ <lb/> deas
+						innumcrahilia genera sonorum, in quibus certae <lb/> dimensiones observari
+						possunt, qu:e genera fatemur <lb/> grammaticæ disciplinænon case tribuenda ;
+						nonne <lb/> censes case aliam aliquam disciplinam, quæ quidquid <lb/> in
+						hujusmodi sit vocibus numerosum artificiosumque, <lb/> contineat? <hi
+							rend="italic">D.</hi> Probahilc mihi videtur. <hi rend="italic">M.</hi>
+						Qaod cjus <lb/> esse nomen existimas? Nam opinor n &gt;n libi nevum <lb/>
+						esse omnipotentiam quamdam canendi Musis solcre <lb/> concedi. Hac est, nisi
+						fallor, illa quæ Musica nomina­ <lb/> tur. <hi rend="italic">D.</hi> Ei cgo
+						hanc esse existimo.</p>
+					</div>
+				</div>
+					<div type="textpart" subtype="chapter" n="2"><ab>
+						<title type="sub"><hi rend="italic">Musica quid sit. Modulari
+								quid sit.</hi>
 						</title>
 					</ab>
-					<p>2. <hi rend="italic">M.</hi> Sed jam placcl nobis dc nomine minine la­ <lb/> borare :
-						modo inquiramus, si videtur, quam diligcn­ <lb/> tissime possumus , omnem hujus
-						quæcumque cst <lb/> disciplinæ vim atque rationem. <hi rend="italic">D.</hi> Inquiramus
-						sanc : <lb/> nam boc lotuin quidquid csl, mulium nosse desidero. <lb/>
-						<hi rend="italic">M.</hi> Dclini ergo musicam. <hi rend="italic">D.</hi> Non audeo. <hi rend="italic">M.</hi> Potes <lb/> saltem definitionem meam probarc? <hi rend="italic">D.</hi> Experibor, <lb/> si dixeris. <hi rend="italic">Al.</hi> Musica , cst scientia
-						bene modulandi. <lb/> An tibi non videtur? <hi rend="italic">D.</hi> Videretur frtasse,
-						si mihi <lb/> liqueret quid sit ipsa modulatio. <hi rend="italic">M.</hi> Numquidnam hoc
-						<lb/> verbum quod modulari dicitur, aut nunquam audisti, <lb/> aut uspiam nisi in eo
-						quod ad cantandum saltandumve <lb/> pertineret? <hi rend="italic">D.</hi> Ita cst quidem
-						: sed quia video modu­ <lb/> lari a modo esse dictum, cum in omnibus bene factis <lb/>
-						modus servandua sit, ei multa etiam in canendo ac <lb/> saltando quamvis delectent,
-						vilissima sint; volo plc­ <lb/> nissime accipere quid prorsus sii ipsa modulatio, quo
-							<note type="footnote">
-							<hi rend="italic">1 Itistant,</hi> juxta r.d. Vs. A ct edd. rr. !u.'!. M. </note>
-						<lb/> uno pene verbo tantæ disciplinæ dcfinitio continetur. <lb/> Nan enim tale aliquid
-						hic discendum est, quale qui­ <lb/> libet cantorcs histrionesque novcrunt. <hi rend="italic">M.</hi> Illud supe­ <lb/> rus, quod in omnibus etiam præter musicam
-						faetis <lb/> inodus servandus est, et tamcn in musica modulatio <lb/> dicitur, non te
-						moveat; nisi forte ignoras dictionem <lb/> oratoris proprie nominari. <hi rend="italic">D.</hi> Non ignoro : sed quor­ <lb/> sum istuc? <hi rend="italic">M.</hi> Quia et
-						puer tuus quamlibct impolitis­ <lb/> simus et rusticissimus, cum vcl uno verbo
-						interroganti <lb/> tibi respondet, fateris cum aliquid dicere? <hi rend="italic">D.</hi>
-						Fateor. <lb/>
-						<hi rend="italic">M.</hi> Ergo et ille orator est? D. Non. M. Non igitur dictio­ <lb/>
-						ne usus cst cum aliquid dixerit, quamvis dictioncm a <lb/> dicendo dictam esse fateamur.
-							<hi rend="italic">D.</hi> Concedo : sed et hoc <lb/> quo pertineat requiro. <hi rend="italic">M.</hi> Ad id scilicet ut intelligas <lb/> modulationem posse ad solam
-						musicam pertinere, <lb/> quamvis nudus unde flexum verbum est, possit etiam <lb/> in
-						aliis rebus esse: quemadmodum dictio proprie tribui­ <lb/> tur oratoribus, quamvis dicat
-						aliquid omnis qui loqui­ <lb/> tur, et a discendo dictio nominata sit. <hi rend="italic">D.</hi> Jam intelligo,</p>
-					<p>3. M. Illud ergo quod abs te postea dictum est, multa <lb/> esse in canendo et saltando
-						vilia, in quibus si modula­ <lb/> tionis nomen accipimus, pene divina ista disciplina
-						<lb/> vilescit; cautissime omninoabs te animadversumest. <lb/> Itaque discutiamus primum
-						quid sit modulari, deinde <lb/> quid sit bene modulari : non enim frustra est defini-
-						<lb/> Hon! additum. Postremo etiam quod ibi scientia po­ <lb/> sita est, non est
-						contemnendum : nam bis tribus, nisi <lb/> fallor, definitio illa perfecta cst. <hi rend="italic">D.</hi> Ila fiat. <hi rend="italic">M.</hi> Igitur <lb/> quoniam fatemur
-						modulationem a modo csse nomina­ <lb/> tam; numquidnam tibi videtur metuendum ne ant
-						<lb/> excedatur modus, aut non impleatur nisi in rebus <lb/> quæ motu aliquo fiunt? aut
-						si nihil moveatur, possu­ <lb/> mus formidare ne præter modum aliquid fiat? D. Nullo
-						<lb/> pacto. <hi rend="italic">M.</hi> Ergo modulatio non incongrue dicitur mo­ <lb/>
-						vendi quædam peritia, vel certe qua fit ut bene ali­ <lb/> quid moveatur. Non cnim
-						possumus dicere bene mo­ <lb/> veri aliquid, si modum non servat. <hi rend="italic">D.</hi> Non possumus <lb/> quidcm : sed necesse crit rursus istam modulationem <lb/>
-						in omnibus bene factis intelligere. Nihil quippe nisi <lb/> bene movendo, bene fieri
-						video. M. Quid si forte ista <lb/> omnia per musicam fiant, quamvis modulationis no­
-						<lb/> meu in cujuscemodi I organis magis tritum sit, nec <lb/> immerito? Nam credo
-						videri libi aliud esse tornatum <lb/> aliquid ligneum, vel argenteum, vel cujusce
-						matcriae; <lb/> aliud autcm ipsum motum artificis, cum illa tornan­ <lb/> tar. <hi rend="italic">D.</hi> Assentior multum differre. <hi rend="italic">M.</hi> Numquidnam
-						<lb/> ergo ipse motus propter se appetitur, et non propter <lb/> id quod vult esse
-						toruatum ? <hi rend="italic">D.</hi> Manifestum est. M. <lb/> Quid ? si membra non ob
-						aliud moveret, nisi ut pulchre <lb/> ac decore moverentur, cum facere aliud nisi
-						saltarcdi­ <lb/> cercmus ? <hi rend="italic">D.</hi> Ita videtur. <hi rend="italic">M.</hi> Quando ergo censes ali­ <lb/> quam rcm præstare et quasi dominari? cum
-						propter se­ <lb/> ipsam, an cum propter aliud appelitur? <hi rend="italic">D.</hi> Quis
-						negai <lb/> cum propter scipsam? <hi rend="italic">M.</hi> Repete nunc illud supertus
-						<lb/> quod de modulatione diximus : nam ita cam posuera­ <lb/> mus, quasi quamdam
-						movendi esse pcriliam. ct vide <lb/> uhi magis habere sedem debeat hoc nomen: in eo motu
-						<lb/> qui velut liber cst, id cst propter se ipse appetitur et <note type="footnote"> *
-							sic &gt;:s. B; at Ms. a, hujuscam (ti. Fdd. <hi rend="italic">ejuscemodi.</hi> M. </note>
+					<div type="textpart" subtype="dialog" n="2"><p>2. <hi rend="italic">M.</hi> Sed jam placcl nobis dc nomine minine la­ <lb/>
+						borare : modo inquiramus, si videtur, quam diligcn­ <lb/> tissime possumus ,
+						omnem hujus quæcumque cst <lb/> disciplinæ vim atque rationem. <hi
+							rend="italic">D.</hi> Inquiramus sanc : <lb/> nam boc lotuin quidquid
+						csl, mulium nosse desidero. <lb/>
+						<hi rend="italic">M.</hi> Dclini ergo musicam. <hi rend="italic">D.</hi> Non
+						audeo. <hi rend="italic">M.</hi> Potes <lb/> saltem definitionem meam
+						probarc? <hi rend="italic">D.</hi> Experibor, <lb/> si dixeris. <hi
+							rend="italic">Al.</hi> Musica , cst scientia bene modulandi. <lb/> An
+						tibi non videtur? <hi rend="italic">D.</hi> Videretur frtasse, si mihi <lb/>
+						liqueret quid sit ipsa modulatio. <hi rend="italic">M.</hi> Numquidnam hoc
+						<lb/> verbum quod modulari dicitur, aut nunquam audisti, <lb/> aut uspiam
+						nisi in eo quod ad cantandum saltandumve <lb/> pertineret? <hi rend="italic"
+							>D.</hi> Ita cst quidem : sed quia video modu­ <lb/> lari a modo esse
+						dictum, cum in omnibus bene factis <lb/> modus servandua sit, ei multa etiam
+						in canendo ac <lb/> saltando quamvis delectent, vilissima sint; volo plc­
+						<lb/> nissime accipere quid prorsus sii ipsa modulatio, quo <note
+							type="footnote">
+							<hi rend="italic">1 Itistant,</hi> juxta r.d. Vs. A ct edd. rr. !u.'!.
+							M. </note>
+						<lb/> uno pene verbo tantæ disciplinæ dcfinitio continetur. <lb/> Nan enim
+						tale aliquid hic discendum est, quale qui­ <lb/> libet cantorcs
+						histrionesque novcrunt. <hi rend="italic">M.</hi> Illud supe­ <lb/> rus,
+						quod in omnibus etiam præter musicam faetis <lb/> inodus servandus est, et
+						tamcn in musica modulatio <lb/> dicitur, non te moveat; nisi forte ignoras
+						dictionem <lb/> oratoris proprie nominari. <hi rend="italic">D.</hi> Non
+						ignoro : sed quor­ <lb/> sum istuc? <hi rend="italic">M.</hi> Quia et puer
+						tuus quamlibct impolitis­ <lb/> simus et rusticissimus, cum vcl uno verbo
+						interroganti <lb/> tibi respondet, fateris cum aliquid dicere? <hi
+							rend="italic">D.</hi> Fateor. <lb/>
+						<hi rend="italic">M.</hi> Ergo et ille orator est? D. Non. M. Non igitur
+						dictio­ <lb/> ne usus cst cum aliquid dixerit, quamvis dictioncm a <lb/>
+						dicendo dictam esse fateamur. <hi rend="italic">D.</hi> Concedo : sed et hoc
+						<lb/> quo pertineat requiro. <hi rend="italic">M.</hi> Ad id scilicet ut
+						intelligas <lb/> modulationem posse ad solam musicam pertinere, <lb/>
+						quamvis nudus unde flexum verbum est, possit etiam <lb/> in aliis rebus
+						esse: quemadmodum dictio proprie tribui­ <lb/> tur oratoribus, quamvis dicat
+						aliquid omnis qui loqui­ <lb/> tur, et a discendo dictio nominata sit. <hi
+							rend="italic">D.</hi> Jam intelligo,</p>
+					</div>
+					<div type="textpart" subtype="dialog" n="3">
+						<p>3. M. Illud ergo quod abs te postea dictum est, multa <lb/> esse in canendo
+						et saltando vilia, in quibus si modula­ <lb/> tionis nomen accipimus, pene
+						divina ista disciplina <lb/> vilescit; cautissime omninoabs te
+						animadversumest. <lb/> Itaque discutiamus primum quid sit modulari, deinde
+						<lb/> quid sit bene modulari : non enim frustra est defini- <lb/> Hon!
+						additum. Postremo etiam quod ibi scientia po­ <lb/> sita est, non est
+						contemnendum : nam bis tribus, nisi <lb/> fallor, definitio illa perfecta
+						cst. <hi rend="italic">D.</hi> Ila fiat. <hi rend="italic">M.</hi> Igitur
+						<lb/> quoniam fatemur modulationem a modo csse nomina­ <lb/> tam; numquidnam
+						tibi videtur metuendum ne ant <lb/> excedatur modus, aut non impleatur nisi
+						in rebus <lb/> quæ motu aliquo fiunt? aut si nihil moveatur, possu­ <lb/>
+						mus formidare ne præter modum aliquid fiat? D. Nullo <lb/> pacto. <hi
+							rend="italic">M.</hi> Ergo modulatio non incongrue dicitur mo­ <lb/>
+						vendi quædam peritia, vel certe qua fit ut bene ali­ <lb/> quid moveatur.
+						Non cnim possumus dicere bene mo­ <lb/> veri aliquid, si modum non servat.
+							<hi rend="italic">D.</hi> Non possumus <lb/> quidcm : sed necesse crit
+						rursus istam modulationem <lb/> in omnibus bene factis intelligere. Nihil
+						quippe nisi <lb/> bene movendo, bene fieri video. M. Quid si forte ista
+						<lb/> omnia per musicam fiant, quamvis modulationis no­ <lb/> meu in
+						cujuscemodi I organis magis tritum sit, nec <lb/> immerito? Nam credo videri
+						libi aliud esse tornatum <lb/> aliquid ligneum, vel argenteum, vel cujusce
+						matcriae; <lb/> aliud autcm ipsum motum artificis, cum illa tornan­ <lb/>
+						tar. <hi rend="italic">D.</hi> Assentior multum differre. <hi rend="italic"
+							>M.</hi> Numquidnam <lb/> ergo ipse motus propter se appetitur, et non
+						propter <lb/> id quod vult esse toruatum ? <hi rend="italic">D.</hi>
+						Manifestum est. M. <lb/> Quid ? si membra non ob aliud moveret, nisi ut
+						pulchre <lb/> ac decore moverentur, cum facere aliud nisi saltarcdi­ <lb/>
+						cercmus ? <hi rend="italic">D.</hi> Ita videtur. <hi rend="italic">M.</hi>
+						Quando ergo censes ali­ <lb/> quam rcm præstare et quasi dominari? cum
+						propter se­ <lb/> ipsam, an cum propter aliud appelitur? <hi rend="italic"
+							>D.</hi> Quis negai <lb/> cum propter scipsam? <hi rend="italic">M.</hi>
+						Repete nunc illud supertus <lb/> quod de modulatione diximus : nam ita cam
+						posuera­ <lb/> mus, quasi quamdam movendi esse pcriliam. ct vide <lb/> uhi
+						magis habere sedem debeat hoc nomen: in eo motu <lb/> qui velut liber cst,
+						id cst propter se ipse appetitur et <note type="footnote"> * sic &gt;:s. B;
+							at Ms. a, hujuscam (ti. Fdd. <hi rend="italic">ejuscemodi.</hi> M. </note>
 						<lb/>
-						<pb n="1085"/> per se ipse delectat; an in eo qui servit quodammode . <lb/> nam quasi
-						serviunt omnia quæ non sibi suni, sed ad <lb/> aliquid aliud referuntur. <hi rend="italic">D.</hi> In eo sciHcet qui propter <lb/> se appetitur. <hi rend="italic">M.</hi> Ergo scientiam modulandi jam pro­ <lb/> babile est esse scientiam bene
-						movendi; ita ut motns <lb/> per se ipse appetatur, atque ob hoc per se ipse de­ <lb/>
-						lectet. <hi rend="italic">D.</hi> Probabile sane.</p>
-					<ab>
-						<title type="sub">CAPUT III. — <hi rend="italic">Bene</hi> modulari <hi rend="italic">quid sit, et cur in mu­ sicæ definitione</hi> positI.</title>
+						<pb n="1085"/> per se ipse delectat; an in eo qui servit quodammode . <lb/>
+						nam quasi serviunt omnia quæ non sibi suni, sed ad <lb/> aliquid aliud
+						referuntur. <hi rend="italic">D.</hi> In eo sciHcet qui propter <lb/> se
+						appetitur. <hi rend="italic">M.</hi> Ergo scientiam modulandi jam pro­ <lb/>
+						babile est esse scientiam bene movendi; ita ut motns <lb/> per se ipse
+						appetatur, atque ob hoc per se ipse de­ <lb/> lectet. <hi rend="italic"
+							>D.</hi> Probabile sane.</p>
+					</div>
+					</div>
+					<div type="textpart" subtype="chapter" n="3"><ab>
+						<title type="sub"><hi rend="italic">Bene</hi> modulari <hi
+								rend="italic">quid sit, et cur in mu­ sicæ definitione</hi>
+							positI.</title>
 					</ab>
-					<p>4. <hi rend="italic">M.</hi> Cur ergo additum est, bene; cum jam ipsa <lb/> modulatio
-						nisi bene moveatur, esse non possit? D. <lb/> Nescio, et quemadmodum milii ereptam sit
-						ignoro : <lb/> nam hoc requirendum animo hsescrat. M. Poterat <lb/> omnino nulla de hoc
-						verbo controversia fieri, ut jam <lb/> musicam sublato eo quod positum est, bene, tantum
-						<lb/> scientiam modulandi definiremus. <hi rend="italic">D.</hi> Quis cnim ferat, <lb/>
-						si enodare totum ita velis? <hi rend="italic">M.</hi> Musica est scientia <lb/> bene
-						movendi. Sed quia bene moveri jam dici potest, <lb/> quidquid numerose servatis temporum
-						1 atque inter­ <lb/> vallorum dimensionibus movetur ( jam enim delectat, <lb/> et ob hoc
-						modulatio non incongrue jam vocatur ) ; fieri <lb/> autem potest, ut ista numerositas
-						atque dimensio dc­ <lb/> lectet, quando non opus est; ut si quis suavissime ca­ <lb/>
-						nens, et pulchre saltans, velit eo ipso lascivire, cum <lb/> reS severitatem desidcrat :
-						non bene utique numerosa <lb/> modulatione utitur; id est ea motione quæ jam bona, <lb/>
-						ea eo quia numerosa est, dici potest, male ille, id est <lb/> iaco; grucnter utitur.
-						Unde aliud est modulari, aliud <lb/> bene modulari. Nam modulatio ad quemvis cantorem,
-						<lb/> tantum qui non erret in illis dimensionibus vocum ac <lb/> sonorum ; bona vero
-						modulatio ad hanc libcralcm dis­ <lb/> ciplinam, id est ad musicam, pertinere arbitranda
-						cs t. <lb/> Quod si nec illa bona tibi motio vidctur, ex eo quia <lb/> inepta est,
-						quamvis artificiose numerosam esse fateare; <lb/> teneamus illud nostrum, quod ubique
-						servandum est, <lb/> ne certamen verbi, re satis elucente, nos torqueat ; <lb/> nlhilque
-						curemus, utrum musica modulandi, an bene <lb/> modulandi scientia describatur. <hi rend="italic">D.</hi> Amo quidem rixas <lb/> verborum præterire atque contemnere, non
-						tamen <lb/> mihi displicet ista distinctio.</p>
-					<ab>
-						<title type="sub">CAPUT <hi rend="italic">IV .- Scientia cur</hi> in <hi rend="italic">musicæ definitione ponitur.</hi>
+					<div type="textpart" subtype="dialog" n="4">
+						<p>4. <hi rend="italic">M.</hi> Cur ergo additum est, bene; cum jam ipsa <lb/>
+						modulatio nisi bene moveatur, esse non possit? D. <lb/> Nescio, et
+						quemadmodum milii ereptam sit ignoro : <lb/> nam hoc requirendum animo
+						hsescrat. M. Poterat <lb/> omnino nulla de hoc verbo controversia fieri, ut
+						jam <lb/> musicam sublato eo quod positum est, bene, tantum <lb/> scientiam
+						modulandi definiremus. <hi rend="italic">D.</hi> Quis cnim ferat, <lb/> si
+						enodare totum ita velis? <hi rend="italic">M.</hi> Musica est scientia <lb/>
+						bene movendi. Sed quia bene moveri jam dici potest, <lb/> quidquid numerose
+						servatis temporum 1 atque inter­ <lb/> vallorum dimensionibus movetur ( jam
+						enim delectat, <lb/> et ob hoc modulatio non incongrue jam vocatur ) ; fieri
+						<lb/> autem potest, ut ista numerositas atque dimensio dc­ <lb/> lectet,
+						quando non opus est; ut si quis suavissime ca­ <lb/> nens, et pulchre
+						saltans, velit eo ipso lascivire, cum <lb/> reS severitatem desidcrat : non
+						bene utique numerosa <lb/> modulatione utitur; id est ea motione quæ jam
+						bona, <lb/> ea eo quia numerosa est, dici potest, male ille, id est <lb/>
+						iaco; grucnter utitur. Unde aliud est modulari, aliud <lb/> bene modulari.
+						Nam modulatio ad quemvis cantorem, <lb/> tantum qui non erret in illis
+						dimensionibus vocum ac <lb/> sonorum ; bona vero modulatio ad hanc libcralcm
+						dis­ <lb/> ciplinam, id est ad musicam, pertinere arbitranda cs t. <lb/>
+						Quod si nec illa bona tibi motio vidctur, ex eo quia <lb/> inepta est,
+						quamvis artificiose numerosam esse fateare; <lb/> teneamus illud nostrum,
+						quod ubique servandum est, <lb/> ne certamen verbi, re satis elucente, nos
+						torqueat ; <lb/> nlhilque curemus, utrum musica modulandi, an bene <lb/>
+						modulandi scientia describatur. <hi rend="italic">D.</hi> Amo quidem rixas
+						<lb/> verborum præterire atque contemnere, non tamen <lb/> mihi displicet
+						ista distinctio.</p>
+					</div>
+					</div>
+					<div type="textpart" subtype="chapter" n="4"><ab>
+						<title type="sub"><hi rend="italic">Scientia cur</hi> in <hi
+								rend="italic">musicæ definitione ponitur.</hi>
 						</title>
 					</ab>
-					<p>5. <hi rend="italic">M.</hi> Restat ut quæramus cur sit in definitione <lb/> scientia.
-							<hi rend="italic">D.</hi> Ita fiat : nam hoc flagitare ordinem me­ <lb/> mini. <hi rend="italic">M.</hi> Responde igitur, utrum tihi videatur bene <lb/> modulari vocem
-						luscinia verna parte anni : nam et <lb/> numerosus est et suavissimus ille cantus, et,
-						nisi fal­ <lb/> lor, tempori congruit. <hi rend="italic">D.</hi> Videtur omnino. <hi rend="italic">M.</hi> Num­ <lb/> quidnam liberalis hujus disciplinæ perita est? <hi rend="italic">D.</hi> Non. <lb/> M. Vides igitur nomen scientiae definitioni perneces­
-						<lb/> sarium. D. Video prorsus. <hi rend="italic">M.</hi> Dic niihi ergo, quæso <lb/>
-						te; nonne tales tibi omnes videntur, qualis illa lusci­ <lb/> nia est, qui sensu quodam
-						ducti bene canunt, hoc est <lb/> numerose id faciunt ac suaviter, quamvis interrogati
-						<lb/> de ipsis numeris, vel de intervallis acutarum gravium­ <lb/> que vocum, respondere
-						non possint? <hi rend="italic">D.</hi> Simillimos <lb/> eos puto. <hi rend="italic">M.</hi> Quid ? ii qui illos sine ista scientia liben- <note type="footnote"> I Sic in
-							vss.; at tov., <hi rend="italic">quidquid numerositatis tmponmi.</hi>
+					<div type="textpart" subtype="dialog" n="5">
+						<p>5. <hi rend="italic">M.</hi> Restat ut quæramus cur sit in definitione <lb/>
+						scientia. <hi rend="italic">D.</hi> Ita fiat : nam hoc flagitare ordinem me­
+						<lb/> mini. <hi rend="italic">M.</hi> Responde igitur, utrum tihi videatur
+						bene <lb/> modulari vocem luscinia verna parte anni : nam et <lb/> numerosus
+						est et suavissimus ille cantus, et, nisi fal­ <lb/> lor, tempori congruit.
+							<hi rend="italic">D.</hi> Videtur omnino. <hi rend="italic">M.</hi> Num­
+						<lb/> quidnam liberalis hujus disciplinæ perita est? <hi rend="italic"
+							>D.</hi> Non. <lb/> M. Vides igitur nomen scientiae definitioni
+						perneces­ <lb/> sarium. D. Video prorsus. <hi rend="italic">M.</hi> Dic
+						niihi ergo, quæso <lb/> te; nonne tales tibi omnes videntur, qualis illa
+						lusci­ <lb/> nia est, qui sensu quodam ducti bene canunt, hoc est <lb/>
+						numerose id faciunt ac suaviter, quamvis interrogati <lb/> de ipsis numeris,
+						vel de intervallis acutarum gravium­ <lb/> que vocum, respondere non
+						possint? <hi rend="italic">D.</hi> Simillimos <lb/> eos puto. <hi
+							rend="italic">M.</hi> Quid ? ii qui illos sine ista scientia liben-
+							<note type="footnote"> I Sic in vss.; at tov., <hi rend="italic"
+								>quidquid numerositatis tmponmi.</hi>
 							<lb/> Ain. ct Kr. habeat, <hi rend="italic">quiaquid numerositatis, ql.æ
 								temporum.</hi>
 							<lb/> — BenediclmU a lst:i utatur valic. Cd. M. </note>
-						<lb/> ler audiunt; cum videamus elephantos, <unclear>urs</unclear> os, aliaque <lb/>
-						nonnulla genera bestiarum ad Cantus moveri, avesque <lb/> ipsas delectari suis vocibus
-						(non enim nullo extra <lb/> propasito I commodo tam impense id agerent sine <lb/> quadam
-						libidinc); nonne pecoribns comparandi sunt <lb/>
-						<hi rend="italic">D.</hi> Censco : sed pene in omne genus humanum tendit <lb/> hæc
-						contumelia. <hi rend="italic">M.</hi> Non cst quod putas. Nani magni <lb/> viri, etsi
-						musicam nesciunt, aut congruere plebi vo­ <lb/> lunt, quæ non mullum a pecoribus distat,
-						ct cujus <lb/> ingens est numerus, quod modestissime ac prudentis­ <lb/> sime faciunt
-						(scd de hoc nunc disserendi locus non <lb/> est); aut post magnas curas relaxandi ao
-						reparandi <lb/> animi gratia moderatissime ab iis aliquid voluptatis <lb/> assumitur.
-						Quam interdum sic capere modestissimumu <lb/> est ; ab ea vero capi vel interdum , turpc
-						atque inde­ <lb/> corum est.</p>
-					<p>6. Sed quid tibi videtur ? qui vel tibiis canunt vel <lb/> cithara, atque hujusmodi
-						instrumentis, numquidnam <lb/> possunt lusciniæ comparari ? <hi rend="italic">D.</hi>
-						Nou. <hi rend="italic">M.</hi> Quid igitur <lb/> distant? <hi rend="italic">D.</hi> Quod
-						in istis artem quamdam esse video, <lb/> in illa vero solam naturam. <hi rend="italic">M.</hi> Verisimile dicis; sed <lb/> ars tibi videtur ista esse dicenda, etiamsi
-						quadam imi­ <lb/> tatione id faciunt? <hi rend="italic">D.</hi> Cur non? Nam video
-						tantum <lb/> valcre in artibus imitationem, ut, ea sublata, omnes <lb/> pene perimantur.
-						Præbent cnim se magistri ad imi­ <lb/> tandum, et hoc ipsum est quod vocant docere. M.
-						Vi­ <lb/> detur tibi ars ratio esse quædam, et ii qui ane utun­ <lb/>
-						<lb/> tur, ratione uti: an aliter putas? D. Videtur. M. <lb/> Quisquis igitur ratione
-						uti non potest, arte non utitur. <lb/>
-						<hi rend="italic">D.</hi> Et hoc concedo. <hi rend="italic">M.</hi> Censesne muta
-						animalia, quæ <lb/> etiam irrationalia dicuntur, uti posse ratione? <hi rend="italic">D.</hi> Nullo <lb/> modo. <hi rend="italic">M.</hi> Aut igitur picas et psittacos et
-						corvos ra­ <lb/> tionalia esse dicturus es animalia, aut imitationem <lb/> norninc artis
-						temere vocasti. Videmus enim has aves <lb/> et multa canere ac sonare quodam humano usu,
-						et <lb/> nonnisi imitando facere : nisi tu aliter credis. <hi rend="italic">D.</hi> Quo­
-						<lb/> modo hoc confeceris, et quantum contra responsionem <lb/> meam valeat, nondum
-						plane intelligo. <hi rend="italic">M.</hi> Quæsive­ <lb/> ram ex te, utrum citharistas
-						et tibicines, et hujusmodi <lb/> aliud genus hominum, artem diceres habere, etiamsi
-						<lb/> id quod in canendo faciunt, imitatione assecuti suut. <lb/> Dixisti esse artem ,
-						tantumque id valere affirmasti, ut <lb/> omnes pene libi artes periclitari viderentur
-						imitatione <lb/> sublata. Ex quo iam colligi potest, omnem qui imi­ <lb/> tando
-						assequitur aliquid, arte uti; etiamsi forte non <lb/> omnis qui arte utitur, imitando
-						eam perceperit. At 2 <lb/> si omnis imitatio ars est, et ars omnis ratio; omnis <lb/>
-						imitatio ratio : ratione autem non utitur irrationale <lb/> animal; non igitur habet
-						artem : habet autem imita­ <lb/> tionem; non est igitur ars imitatio. <hi rend="italic">D.</hi> Ego multas <lb/> artes imitatione constare dixi, non ipsam imitationem <lb/>
-						artem vocavi. M. Quæ igitur artes imitatione constant, <lb/> non eas censes ratione
-						consLare? <hi rend="italic">D.</hi> Imo utroque <lb/> puto cas constare. <hi rend="italic">M.</hi> Nihil repugno, sed scientiam in <lb/> quo ponis; in ratione, an
-						in imitatione ? <hi rend="italic">D.</hi> Et hoc in <lb/> utroque. <hi rend="italic">hI.</hi> Ergo scientiam illis avibus dabis, quibus <lb/> imitationem non adimis. <hi rend="italic">D.</hi> Non dało ila enim dixi <note type="footnote"> I inB., <hi rend="italic">pofito.</hi> vs A, Vatic. C(i., <hi rend="italic">proposito.</hi> Y.
-							</note><note type="footnote"> * In B., al. Mss. A ut B, <hi rend="italic">ut.</hi> M. </note>
+						<lb/> ler audiunt; cum videamus elephantos, <unclear>urs</unclear> os,
+						aliaque <lb/> nonnulla genera bestiarum ad Cantus moveri, avesque <lb/>
+						ipsas delectari suis vocibus (non enim nullo extra <lb/> propasito I commodo
+						tam impense id agerent sine <lb/> quadam libidinc); nonne pecoribns
+						comparandi sunt <lb/>
+						<hi rend="italic">D.</hi> Censco : sed pene in omne genus humanum tendit
+						<lb/> hæc contumelia. <hi rend="italic">M.</hi> Non cst quod putas. Nani
+						magni <lb/> viri, etsi musicam nesciunt, aut congruere plebi vo­ <lb/> lunt,
+						quæ non mullum a pecoribus distat, ct cujus <lb/> ingens est numerus, quod
+						modestissime ac prudentis­ <lb/> sime faciunt (scd de hoc nunc disserendi
+						locus non <lb/> est); aut post magnas curas relaxandi ao reparandi <lb/>
+						animi gratia moderatissime ab iis aliquid voluptatis <lb/> assumitur. Quam
+						interdum sic capere modestissimumu <lb/> est ; ab ea vero capi vel interdum
+						, turpc atque inde­ <lb/> corum est.</p></div>
+					<div type="textpart" subtype="dialog" n="6">
+						<p>6. Sed quid tibi videtur ? qui vel tibiis canunt vel <lb/> cithara, atque
+						hujusmodi instrumentis, numquidnam <lb/> possunt lusciniæ comparari ? <hi
+							rend="italic">D.</hi> Nou. <hi rend="italic">M.</hi> Quid igitur <lb/>
+						distant? <hi rend="italic">D.</hi> Quod in istis artem quamdam esse video,
+						<lb/> in illa vero solam naturam. <hi rend="italic">M.</hi> Verisimile
+						dicis; sed <lb/> ars tibi videtur ista esse dicenda, etiamsi quadam imi­
+						<lb/> tatione id faciunt? <hi rend="italic">D.</hi> Cur non? Nam video
+						tantum <lb/> valcre in artibus imitationem, ut, ea sublata, omnes <lb/> pene
+						perimantur. Præbent cnim se magistri ad imi­ <lb/> tandum, et hoc ipsum est
+						quod vocant docere. M. Vi­ <lb/> detur tibi ars ratio esse quædam, et ii qui
+						ane utun­ <lb/>
+						<lb/> tur, ratione uti: an aliter putas? D. Videtur. M. <lb/> Quisquis
+						igitur ratione uti non potest, arte non utitur. <lb/>
+						<hi rend="italic">D.</hi> Et hoc concedo. <hi rend="italic">M.</hi> Censesne
+						muta animalia, quæ <lb/> etiam irrationalia dicuntur, uti posse ratione? <hi
+							rend="italic">D.</hi> Nullo <lb/> modo. <hi rend="italic">M.</hi> Aut
+						igitur picas et psittacos et corvos ra­ <lb/> tionalia esse dicturus es
+						animalia, aut imitationem <lb/> norninc artis temere vocasti. Videmus enim
+						has aves <lb/> et multa canere ac sonare quodam humano usu, et <lb/> nonnisi
+						imitando facere : nisi tu aliter credis. <hi rend="italic">D.</hi> Quo­
+						<lb/> modo hoc confeceris, et quantum contra responsionem <lb/> meam valeat,
+						nondum plane intelligo. <hi rend="italic">M.</hi> Quæsive­ <lb/> ram ex te,
+						utrum citharistas et tibicines, et hujusmodi <lb/> aliud genus hominum,
+						artem diceres habere, etiamsi <lb/> id quod in canendo faciunt, imitatione
+						assecuti suut. <lb/> Dixisti esse artem , tantumque id valere affirmasti, ut
+						<lb/> omnes pene libi artes periclitari viderentur imitatione <lb/> sublata.
+						Ex quo iam colligi potest, omnem qui imi­ <lb/> tando assequitur aliquid,
+						arte uti; etiamsi forte non <lb/> omnis qui arte utitur, imitando eam
+						perceperit. At 2 <lb/> si omnis imitatio ars est, et ars omnis ratio; omnis
+						<lb/> imitatio ratio : ratione autem non utitur irrationale <lb/> animal;
+						non igitur habet artem : habet autem imita­ <lb/> tionem; non est igitur ars
+						imitatio. <hi rend="italic">D.</hi> Ego multas <lb/> artes imitatione
+						constare dixi, non ipsam imitationem <lb/> artem vocavi. M. Quæ igitur artes
+						imitatione constant, <lb/> non eas censes ratione consLare? <hi
+							rend="italic">D.</hi> Imo utroque <lb/> puto cas constare. <hi
+							rend="italic">M.</hi> Nihil repugno, sed scientiam in <lb/> quo ponis;
+						in ratione, an in imitatione ? <hi rend="italic">D.</hi> Et hoc in <lb/>
+						utroque. <hi rend="italic">hI.</hi> Ergo scientiam illis avibus dabis,
+						quibus <lb/> imitationem non adimis. <hi rend="italic">D.</hi> Non dało ila
+						enim dixi <note type="footnote"> I inB., <hi rend="italic">pofito.</hi> vs
+							A, Vatic. C(i., <hi rend="italic">proposito.</hi> Y. </note><note
+							type="footnote"> * In B., al. Mss. A ut B, <hi rend="italic">ut.</hi> M. </note>
 						<lb/>
-						<pb n="1087"/> in utroquc esse scientiam, ut in sola imitatione esse <lb/> non possit.
-							<hi rend="italic">M.</hi> Quid? in sola ratione vidctur tibi esse <lb/> posse? <hi rend="italic">D.</hi> Videtur. <hi rend="italic">M.</hi> Aliud igitur putas esse
-						artem, <lb/> aliud scientiam. Siquidem scientia ct in sola ratione <lb/> esse potest,
-						ars autem rationi jungit imitationem. <lb/>
-						<hi rend="italic">D.</hi> Non video esse consequens. Non enim omnes, sed <lb/> multas
-						artes dixeram, simul ratione atque imitatione <lb/> constare. <hi rend="italic">II.</hi>
-						Quid? scientiam vocabisne etiam illam, <lb/> quae his duobus simul constat; an ei solam
-						partem <lb/> rationis attribues? <hi rend="italic">D.</hi> Quid enim me prohibet vocare
-						<lb/> scientiam, cum rationi adjungitur imitatio?</p>
-					<p>7. <hi rend="italic">M.</hi> Quoniam nunc agimus de citharista et tibi­ <lb/> cine, id
-						esi de musicis rebus; volo milii dicas, utrum <lb/> corpori tribuendum sit, id est
-						obtemperationi cuidam <lb/> corporis, si quid isti homines imitatione faciunt. <lb/>
-						<hi rend="italic">D.</hi> Ego istam ct animo simul et corpori tribuendam <lb/> puto :
-						quanquam idipsum verbum satis proprie abs te <lb/> positum est, quod obtemperationem
-						corporis appel­ <lb/> lasti : non enim obtemperare nisi animo potest. <lb/> M. Video te
-						cautissime imitationem non soli corpori <lb/> voluisse concedere. Sed numquid scientiam
-						negabis <lb/> ad solum animum pertincre? <hi rend="italic">D.</hi> Quis boc negaverit?
-						<lb/> M. Nullo modo igitur scientiam in sonis nervorum i ct <lb/> tibiarum, simul et
-						rationi et imitationi tribuere sine­ <lb/> lis. Illa enim imitatio non est, ut confessus
-						es, sine <lb/> corpore; scientiam vero solius animi esse dixisti. <lb/> i. Ex iis quidem
-						quae tibi concessi , fateor hoc esse <lb/> confectum : sed quid no rem ? Habebit enim et
-						tibicen <lb/> scientiam in animo. Neque enim cum ei accedit imi­ <lb/> tatio, quam sine
-						corpore dedi esse non posse, adimct <lb/> illud quod animo amplectitur. <hi rend="italic">M.</hi> Non adimct qui­ <lb/> dem : nee ego affirmo eos, a quibus organa
-						ista tra­ <lb/> ctantur, omnes carere scientia, sed non habere omnes <lb/> dico. Istam
-						cnim ad hoc volvimus quaestionem , ut <lb/> intelligamus, si possumus, quam recte sit
-						scientia in <lb/> illa definitione musicae posita; quam si omnes tibici­ <lb/> nes et
-						fidicines , et id genus alii quilibet habent, nihil <lb/> ista disciplina puto esse
-						vilius, nibil abjectius.</p>
-					<p>8. Sed attende quam diligentissime, ul quod diu <lb/> jam molimur appareat. Certe enim
-						jam milii dedisti <lb/> in solo animo habitare scientiam. D. Quidni dederim? <lb/> M.
-						Quid? sensum aurium animonc, an corpori, an <lb/> utique concedis? <hi rend="italic">D.</hi> Utrique. M. Quid memoriam? <lb/>
-						<hi rend="italic">D.</hi> Animo puto esse tribuendam. Non enin. si per sen­ <lb/> sus
-						percipimus aliquid quod memoriæ commenda­ <lb/> mus , idco in corpore memoria esse
-						putanda est. <lb/> II. Magna fortasse ista quæstio est, neque huic oppor­ <lb/> tuna
-						sermoni. Sed quod proposito sat est, puto te <lb/> ncgare non posse, bestias babere
-						memoriam. Nam et <lb/> nidos post annum revisunt hirundines, et de capellis <lb/>
-						verissime dictum est: <lb/> Atque ipse memorcs redeunt in tecta capellæ. <lb/>
-						<hi rend="italic">(Georg. lib.</hi> 5, <hi rend="italic">v.</hi> 310.) <lb/> Et canis
-						heroem dominum, jam suis hominibus obli­ <lb/> lum recognovisse <hi rend="italic">prædicatur (Odysseæ <foreign xml:lang="grc">ρ</foreign>, v.</hi> 291 <hi rend="italic">seqq.).</hi>
-						<lb/> Et manumerabilia, si velimus, animadvertere possu­ <lb/> mus, quibus id quod dico
-						manifestum est. <hi rend="italic">D.</hi> Nee ego <lb/> istud nego, et quid te adjuvct,
-						vehementer exspecto. <note type="footnote">
+						<pb n="1087"/> in utroquc esse scientiam, ut in sola imitatione esse <lb/>
+						non possit. <hi rend="italic">M.</hi> Quid? in sola ratione vidctur tibi
+						esse <lb/> posse? <hi rend="italic">D.</hi> Videtur. <hi rend="italic"
+							>M.</hi> Aliud igitur putas esse artem, <lb/> aliud scientiam. Siquidem
+						scientia ct in sola ratione <lb/> esse potest, ars autem rationi jungit
+						imitationem. <lb/>
+						<hi rend="italic">D.</hi> Non video esse consequens. Non enim omnes, sed
+						<lb/> multas artes dixeram, simul ratione atque imitatione <lb/> constare.
+							<hi rend="italic">II.</hi> Quid? scientiam vocabisne etiam illam, <lb/>
+						quae his duobus simul constat; an ei solam partem <lb/> rationis attribues?
+							<hi rend="italic">D.</hi> Quid enim me prohibet vocare <lb/> scientiam,
+						cum rationi adjungitur imitatio?</p></div>
+					<div type="textpart" subtype="dialog" n="7">
+						<p>7. <hi rend="italic">M.</hi> Quoniam nunc agimus de citharista et tibi­ <lb/>
+						cine, id esi de musicis rebus; volo milii dicas, utrum <lb/> corpori
+						tribuendum sit, id est obtemperationi cuidam <lb/> corporis, si quid isti
+						homines imitatione faciunt. <lb/>
+						<hi rend="italic">D.</hi> Ego istam ct animo simul et corpori tribuendam
+						<lb/> puto : quanquam idipsum verbum satis proprie abs te <lb/> positum est,
+						quod obtemperationem corporis appel­ <lb/> lasti : non enim obtemperare nisi
+						animo potest. <lb/> M. Video te cautissime imitationem non soli corpori
+						<lb/> voluisse concedere. Sed numquid scientiam negabis <lb/> ad solum
+						animum pertincre? <hi rend="italic">D.</hi> Quis boc negaverit? <lb/> M.
+						Nullo modo igitur scientiam in sonis nervorum i ct <lb/> tibiarum, simul et
+						rationi et imitationi tribuere sine­ <lb/> lis. Illa enim imitatio non est,
+						ut confessus es, sine <lb/> corpore; scientiam vero solius animi esse
+						dixisti. <lb/> i. Ex iis quidem quae tibi concessi , fateor hoc esse <lb/>
+						confectum : sed quid no rem ? Habebit enim et tibicen <lb/> scientiam in
+						animo. Neque enim cum ei accedit imi­ <lb/> tatio, quam sine corpore dedi
+						esse non posse, adimct <lb/> illud quod animo amplectitur. <hi rend="italic"
+							>M.</hi> Non adimct qui­ <lb/> dem : nee ego affirmo eos, a quibus
+						organa ista tra­ <lb/> ctantur, omnes carere scientia, sed non habere omnes
+						<lb/> dico. Istam cnim ad hoc volvimus quaestionem , ut <lb/> intelligamus,
+						si possumus, quam recte sit scientia in <lb/> illa definitione musicae
+						posita; quam si omnes tibici­ <lb/> nes et fidicines , et id genus alii
+						quilibet habent, nihil <lb/> ista disciplina puto esse vilius, nibil
+						abjectius.</p></div>
+						<div type="textpart" subtype="dialog" n="8">
+							<p>8. Sed attende quam diligentissime, ul quod diu <lb/> jam molimur appareat.
+						Certe enim jam milii dedisti <lb/> in solo animo habitare scientiam. D.
+						Quidni dederim? <lb/> M. Quid? sensum aurium animonc, an corpori, an <lb/>
+						utique concedis? <hi rend="italic">D.</hi> Utrique. M. Quid memoriam? <lb/>
+						<hi rend="italic">D.</hi> Animo puto esse tribuendam. Non enin. si per sen­
+						<lb/> sus percipimus aliquid quod memoriæ commenda­ <lb/> mus , idco in
+						corpore memoria esse putanda est. <lb/> II. Magna fortasse ista quæstio est,
+						neque huic oppor­ <lb/> tuna sermoni. Sed quod proposito sat est, puto te
+						<lb/> ncgare non posse, bestias babere memoriam. Nam et <lb/> nidos post
+						annum revisunt hirundines, et de capellis <lb/> verissime dictum est: <lb/>
+						Atque ipse memorcs redeunt in tecta capellæ. <lb/>
+						<hi rend="italic">(Georg. lib.</hi> 5, <hi rend="italic">v.</hi> 310.) <lb/>
+						Et canis heroem dominum, jam suis hominibus obli­ <lb/> lum recognovisse <hi
+							rend="italic">prædicatur (Odysseæ <foreign xml:lang="grc">ρ</foreign>,
+							v.</hi> 291 <hi rend="italic">seqq.).</hi>
+						<lb/> Et manumerabilia, si velimus, animadvertere possu­ <lb/> mus, quibus
+						id quod dico manifestum est. <hi rend="italic">D.</hi> Nee ego <lb/> istud
+						nego, et quid te adjuvct, vehementer exspecto. <note type="footnote">
 							<hi rend="italic">1 yeiborum,</hi> juxta diss. A et B. M. </note>
-						<lb/> M. Quid putas, msi quod scientiam qui soli animo <lb/> tribuit, eamque omnibus
-						irrationalibus animantibus <lb/> adimit, neque in sensu eam, neque in memoria ( nam
-						<lb/> illud non est sine corpore, et utrumque etiam in <lb/> bestia est), sed in solo
-						intellectu collocavit? <hi rend="italic">D.</hi> Et <lb/> boc exspecto quid te adjuvet.
-							<hi rend="italic">M.</hi> Nihil aliud, nisi <lb/> omnes qui sensum sequuntur, et quod
-						in eo delectat, <lb/> metnoriaj commendant, atque secundum id corpus <lb/> moventes, vim
-						quamdam imitationis adjungunt; non <lb/> eos habere scientiam, quamvis perite ac docte
-						multa <lb/> facere videantur, si rem ipsam quam profitentur aut <lb/> exhibent,
-						intellectus puritate ac veritate non teneant. <lb/> At si tales esse istos theatricos
-						operarios ratio de.. <lb/> monstravcrit; nihil erit, ut opinor, cur dubites eis <lb/>
-						negare scientiam, et ob hoc musicam, quæ scicntia <lb/> modulandi est, nequaquam
-						coucedcre. <hi rend="italic">D.</hi> Explica <lb/> hoc; videamus quale sit.</p>
-					<p>9. <hi rend="italic">M.</hi> Mobilitatem digitorum celeriorem vel pigrio- <lb/> rem
-						credo te non scientine, sed usui dare. <hi rend="italic">D.</hi> Cur ita <lb/> credis
-						id? <hi rend="italic">M.</hi> Quia superius soli animo scientiam tri­ <lb/> buebas , hoc
-						autem quanquam imperante animo ta­ <lb/> men esse corporis vides. <hi rend="italic">D.</hi> Sed cum scicns animus <lb/> hoc imperat corpori, magis hoc scicnti animo,
-						quan <lb/> servientibus membris tribuendum puto. <hi rend="italic">M.</hi> Nonne <lb/>
-						censes posse fieri ut unus aliam scientia præcedat, <lb/> cum ille imperitior multo
-						facilius et expeditius dig!­ <lb/> tos moveat? <hi rend="italic">D.</hi> Censco. <hi rend="italic">M.</hi> At si motus celer et ex­ <lb/> pedilior digitorum scientiæ
-						tribuendus esset, tanto in <lb/> eo quisque excelleret, quanto esset scientior. <hi rend="italic">D.</hi> Con­ <lb/> cedo. <hi rend="italic">M.</hi> Attende ctiam istud.
-						Nam opinor nonnun­ <lb/> quam te animadvertisse fabros, vel hujusmodi opificcs, <lb/>
-						ascia sive securi cumdem locum feriendo repetere, <lb/> et non alio quam eo quo intendit
-						animus ictum per­ <lb/> ducere; quod nos tentantes cum assequi nequimus, <lb/> ab cis
-						sæpe irridemur. <hi rend="italic">D.</hi> Ila est ut dicis. <hi rend="italic">M.</hi>
-						Ergo <lb/> cum id nos facere non valemus, numquid ignoramus <lb/> quid feriri debeat,
-						vel quantum debeat ampulari? <hi rend="italic">D.</hi>
-						<lb/> Sæpe ignoramus, sæpe scimus. <hi rend="italic">M.</hi> Fac ergo aliquem <lb/>
-						nosse omnia, quae fabri facere debeant, et perfecte <lb/> nosse, minus tamen valere in
-						opere; sed eisdem <lb/> ipsis qui facillime operantur, multa dictare solertius <lb/>
-						qnam illL per se judicare 1 possent; an id usu evenire <lb/> negas? <hi rend="italic">D.</hi> Non nego. <hi rend="italic">M.</hi> Non igitur solum movendi <lb/> celcrilas
-						atque facilitas, sed etiam motionis modus <lb/> ipse in membris, usui potius quam
-						scientiæ tribuen­ <lb/> dus est. Nam si aliter esset, eo quisque manibus me­ <lb/> lius
-						uteretur quo esset peritior: quod licet ad tibias <lb/> citharasve referamus, ne quod
-						ibi digiti atque articuli <lb/> faciunt, quia difficile nobis est, scientia potius quam
-						<lb/> usu et sedula imitatione ac meditatione fieri putemus. <lb/>
-						<hi rend="italic">D.</hi> Non queo resisterc ; nam et medicos audire soleo <lb/>
-						doctissimos viros, sæpe in secandis, vel quoquo modo <lb/> comprimendis membris, in eo
-						quod manu ac ferro <lb/> fiat, ab imperitioribus antecedi : quod genus curandi <lb/>
-						chirurgiam nominant, quo vocabulo satis significatur <lb/> opcraria quaedam in manibus
-						medendi consuetudo. <lb/> Perge itaque ad caetera, et jam istam confice
-							<unclear>cuæstio­</unclear>
-						<lb/> nem. <note type="footnote"> I in R., <hi rend="italic">indicare;</hi> sic etiam
-							-Lov.; at Er. Lugd. ven. MSS. <lb/> A et B. <hi rend="italic">judicare.</hi> M.
-						</note></p>
+						<lb/> M. Quid putas, msi quod scientiam qui soli animo <lb/> tribuit, eamque
+						omnibus irrationalibus animantibus <lb/> adimit, neque in sensu eam, neque
+						in memoria ( nam <lb/> illud non est sine corpore, et utrumque etiam in
+						<lb/> bestia est), sed in solo intellectu collocavit? <hi rend="italic"
+							>D.</hi> Et <lb/> boc exspecto quid te adjuvet. <hi rend="italic"
+							>M.</hi> Nihil aliud, nisi <lb/> omnes qui sensum sequuntur, et quod in
+						eo delectat, <lb/> metnoriaj commendant, atque secundum id corpus <lb/>
+						moventes, vim quamdam imitationis adjungunt; non <lb/> eos habere scientiam,
+						quamvis perite ac docte multa <lb/> facere videantur, si rem ipsam quam
+						profitentur aut <lb/> exhibent, intellectus puritate ac veritate non
+						teneant. <lb/> At si tales esse istos theatricos operarios ratio de.. <lb/>
+						monstravcrit; nihil erit, ut opinor, cur dubites eis <lb/> negare scientiam,
+						et ob hoc musicam, quæ scicntia <lb/> modulandi est, nequaquam coucedcre.
+							<hi rend="italic">D.</hi> Explica <lb/> hoc; videamus quale sit.</p></div>
+					<div type="textpart" subtype="dialog" n="9">
+						<p>9. <hi rend="italic">M.</hi> Mobilitatem digitorum celeriorem vel pigrio-
+						<lb/> rem credo te non scientine, sed usui dare. <hi rend="italic">D.</hi>
+						Cur ita <lb/> credis id? <hi rend="italic">M.</hi> Quia superius soli animo
+						scientiam tri­ <lb/> buebas , hoc autem quanquam imperante animo ta­ <lb/>
+						men esse corporis vides. <hi rend="italic">D.</hi> Sed cum scicns animus
+						<lb/> hoc imperat corpori, magis hoc scicnti animo, quan <lb/> servientibus
+						membris tribuendum puto. <hi rend="italic">M.</hi> Nonne <lb/> censes posse
+						fieri ut unus aliam scientia præcedat, <lb/> cum ille imperitior multo
+						facilius et expeditius dig!­ <lb/> tos moveat? <hi rend="italic">D.</hi>
+						Censco. <hi rend="italic">M.</hi> At si motus celer et ex­ <lb/> pedilior
+						digitorum scientiæ tribuendus esset, tanto in <lb/> eo quisque excelleret,
+						quanto esset scientior. <hi rend="italic">D.</hi> Con­ <lb/> cedo. <hi
+							rend="italic">M.</hi> Attende ctiam istud. Nam opinor nonnun­ <lb/> quam
+						te animadvertisse fabros, vel hujusmodi opificcs, <lb/> ascia sive securi
+						cumdem locum feriendo repetere, <lb/> et non alio quam eo quo intendit
+						animus ictum per­ <lb/> ducere; quod nos tentantes cum assequi nequimus,
+						<lb/> ab cis sæpe irridemur. <hi rend="italic">D.</hi> Ila est ut dicis. <hi
+							rend="italic">M.</hi> Ergo <lb/> cum id nos facere non valemus, numquid
+						ignoramus <lb/> quid feriri debeat, vel quantum debeat ampulari? <hi
+							rend="italic">D.</hi>
+						<lb/> Sæpe ignoramus, sæpe scimus. <hi rend="italic">M.</hi> Fac ergo
+						aliquem <lb/> nosse omnia, quae fabri facere debeant, et perfecte <lb/>
+						nosse, minus tamen valere in opere; sed eisdem <lb/> ipsis qui facillime
+						operantur, multa dictare solertius <lb/> qnam illL per se judicare 1
+						possent; an id usu evenire <lb/> negas? <hi rend="italic">D.</hi> Non nego.
+							<hi rend="italic">M.</hi> Non igitur solum movendi <lb/> celcrilas atque
+						facilitas, sed etiam motionis modus <lb/> ipse in membris, usui potius quam
+						scientiæ tribuen­ <lb/> dus est. Nam si aliter esset, eo quisque manibus me­
+						<lb/> lius uteretur quo esset peritior: quod licet ad tibias <lb/>
+						citharasve referamus, ne quod ibi digiti atque articuli <lb/> faciunt, quia
+						difficile nobis est, scientia potius quam <lb/> usu et sedula imitatione ac
+						meditatione fieri putemus. <lb/>
+						<hi rend="italic">D.</hi> Non queo resisterc ; nam et medicos audire soleo
+						<lb/> doctissimos viros, sæpe in secandis, vel quoquo modo <lb/>
+						comprimendis membris, in eo quod manu ac ferro <lb/> fiat, ab imperitioribus
+						antecedi : quod genus curandi <lb/> chirurgiam nominant, quo vocabulo satis
+						significatur <lb/> opcraria quaedam in manibus medendi consuetudo. <lb/>
+						Perge itaque ad caetera, et jam istam confice <unclear>cuæstio­</unclear>
+						<lb/> nem. <note type="footnote"> I in R., <hi rend="italic">indicare;</hi>
+							sic etiam -Lov.; at Er. Lugd. ven. MSS. <lb/> A et B. <hi rend="italic"
+								>judicare.</hi> M. </note></p>
 					<pb n="1089"/>
-
-					<ab>
-						<title type="sub">CAPUT V. — Sensus <hi rend="italic">musices an</hi> insit a
-							natura.</title>
+					</div>
+					</div>
+					<div type="textpart" subtype="chapter" n="5"><ab>
+						<title type="sub">Sensus <hi rend="italic">musices an</hi> insit
+							a natura.</title>
 					</ab>
-					<p>10. <hi rend="italic">M.</hi> Illud restat, ut opinor, ut inveniamus, si <lb/>
-						possumus, has ipsas artes quae nobis per manus pla­ <lb/> cent' ut illius usus potentes
-						essent, non continuo <lb/> scientiam, sed sensum ac memoriam secutas : ne <lb/> forte
-						mihi dicas fieri quidem possc, ut scientia sine <lb/> usu sit, et major plerumque quam
-						cst in eis qui usu <lb/> excellunt; sed tamen etiam illos ad usum tantum non <lb/>
-						potuisse sine ulla scientia pervenire. D. Aggredcre : <lb/> nam ita deberi manifestum
-						est. <hi rend="italic">II.</hi> Nunquamne hu­ <lb/> jusmodi histriones audisti
-						studiosius? D. Plus fortasse <lb/> quam vellem. <hi rend="italic">M.</hi> Unde fieri
-						putas, ut imperita multitudo <lb/> explodat saepe tibicinem nugatorios sonos efferentem;
-						<lb/> rursumque plaudat bene canenti, et prorsus quanto <lb/> suavius canitur, tanto
-						amplius et studiosius moveatur ? <lb/> Numquidnam id a vulgo per artem musicam fieri
-						cre­ <lb/> dendum est? D. Non. <hi rend="italic">M.</hi> Quid igitur? D. Natura id <lb/>
-						fieri puto, quae omnibus dedit sensum audiendi, quo <lb/> ista judicantur. ii. Recte
-						putas. Sed jam etiam illud <lb/> vide, utrum et tibicen ipse hoc sensu praeditus sit.
-						<lb/> Quod si ita est, potest ejus sequens judicium movcre <lb/> digitos cum tibias
-						inflaverit, et quod satis commode <lb/> . pro arbitrio sonuerit, id notare ac mandare
-						memoriæ, <lb/> atque id repetendo consuefacere digitos eo ferri sine <lb/> ulla
-						trepidatione et errore, sive ab alio accipiat id <lb/> quod cauLet, sive ipse inveniat,
-						illa de qua dictum est <lb/> ducente atque approbante natura. Itaque cum sensum <lb/>
-						memoria, et articuli memoriam sequuntur, usu jam <lb/> edomiti atque præparati; canit
-						cum vult lauto mclius <lb/> atque jucundius, quanto illis omnibus præstat qua; <lb/>
-						superius ratio docuit cum bestiis nos habere commu­ <lb/> nia, appetitum scilicet
-						imitandi, sensum atque mcmo­ <lb/> riam. Numquid habes adversum ista quod dicas? <hi rend="italic">D.</hi>
-						<lb/> Ego vero nihil habeo. Jam audire cupio cujusmodi sit <lb/> illa disciplina, quam
-						profecto a cognitione vilissimo­ <lb/> rum aniniorum video subtilissime vindicatam.</p>
-					<ab>
-						<title type="sub">CAPUT VI. — <hi rend="italic">Cantores theatricos nescire
+					<div type="textpart" subtype="dialog" n="10"><p>10. <hi rend="italic">M.</hi> Illud restat, ut opinor, ut inveniamus, si
+						<lb/> possumus, has ipsas artes quae nobis per manus pla­ <lb/> cent' ut
+						illius usus potentes essent, non continuo <lb/> scientiam, sed sensum ac
+						memoriam secutas : ne <lb/> forte mihi dicas fieri quidem possc, ut scientia
+						sine <lb/> usu sit, et major plerumque quam cst in eis qui usu <lb/>
+						excellunt; sed tamen etiam illos ad usum tantum non <lb/> potuisse sine ulla
+						scientia pervenire. D. Aggredcre : <lb/> nam ita deberi manifestum est. <hi
+							rend="italic">II.</hi> Nunquamne hu­ <lb/> jusmodi histriones audisti
+						studiosius? D. Plus fortasse <lb/> quam vellem. <hi rend="italic">M.</hi>
+						Unde fieri putas, ut imperita multitudo <lb/> explodat saepe tibicinem
+						nugatorios sonos efferentem; <lb/> rursumque plaudat bene canenti, et
+						prorsus quanto <lb/> suavius canitur, tanto amplius et studiosius moveatur ?
+						<lb/> Numquidnam id a vulgo per artem musicam fieri cre­ <lb/> dendum est?
+						D. Non. <hi rend="italic">M.</hi> Quid igitur? D. Natura id <lb/> fieri
+						puto, quae omnibus dedit sensum audiendi, quo <lb/> ista judicantur. ii.
+						Recte putas. Sed jam etiam illud <lb/> vide, utrum et tibicen ipse hoc sensu
+						praeditus sit. <lb/> Quod si ita est, potest ejus sequens judicium movcre
+						<lb/> digitos cum tibias inflaverit, et quod satis commode <lb/> . pro
+						arbitrio sonuerit, id notare ac mandare memoriæ, <lb/> atque id repetendo
+						consuefacere digitos eo ferri sine <lb/> ulla trepidatione et errore, sive
+						ab alio accipiat id <lb/> quod cauLet, sive ipse inveniat, illa de qua
+						dictum est <lb/> ducente atque approbante natura. Itaque cum sensum <lb/>
+						memoria, et articuli memoriam sequuntur, usu jam <lb/> edomiti atque
+						præparati; canit cum vult lauto mclius <lb/> atque jucundius, quanto illis
+						omnibus præstat qua; <lb/> superius ratio docuit cum bestiis nos habere
+						commu­ <lb/> nia, appetitum scilicet imitandi, sensum atque mcmo­ <lb/>
+						riam. Numquid habes adversum ista quod dicas? <hi rend="italic">D.</hi>
+						<lb/> Ego vero nihil habeo. Jam audire cupio cujusmodi sit <lb/> illa
+						disciplina, quam profecto a cognitione vilissimo­ <lb/> rum aniniorum video
+						subtilissime vindicatam.</p></div>
+					</div>
+			</div> 
+					<div type="textpart" subtype="chapter" n="6"><ab>
+						<title type="sub"><hi rend="italic">Cantores theatricos nescire
 								musicam.</hi>
 						</title>
 					</ab>
-					<p>ii. M. Nondum est satis quod factum est, nec ad ejus <lb/> explicationem transire nos
-						sinam, nisi quemadmodum <lb/> constitit inter nos posse histriones sine ista scientia
-						<lb/> satisfacere voluptati aurium popularium; ita etiam <lb/> nullo modo esse posse
-						hislrioncs musicae studiosos <lb/> peritosque constiterit. <hi rend="italic">D.</hi>
-						Mirum si hoc effeceris. M. <lb/> Facile id quidem, sed attentiore te milii opus est. <hi rend="italic">D.</hi>
-						<lb/> Nunquam equidem, quod sciam, rcmissior in audien­ <lb/> do fui, ab usque sermo
-						iste sumpsit cxordium : sed <lb/> nunc me, fateor, multo erectiorem reddidisti. M. Gra­
-						<lb/> tum habeo, quanquam tibi te commodes magis. Itaque <lb/> responde, si placet,
-						utrum tibi vidcatur scire quid <lb/> vil aureus solidus, qui eum æquo pretio vendere cu­
-						<lb/> piens, decent nummus eum valerc putaverit? <hi rend="italic">D.</hi> Cui <lb/> hoc
-						videatur? <hi rend="italic">Al.</hi> Nunc age, dic mihi, quid charius <lb/> habendum
-						sit, quod nostra intelligentia comminetur, <lb/> an quod nobis fortuito imperitorum
-						judicio lribuitur? <lb/>
-						<hi rend="italic">D.</hi> Nulli dubium est, longe illud priulum præstare <lb/> cæteris
-						omnibus, quoe ne nostra quidem putanda sunt. <note type="footnote"> ' tis. A, <hi rend="italic">has</hi> tpsas <hi rend="italic">quæ nobis perplacenI</hi> manus. u. </note>
+					<div type="textpart" subtype="dialog" n="11">
+						<p>11. M. Nondum est satis quod factum est, nec ad ejus <lb/> explicationem
+						transire nos sinam, nisi quemadmodum <lb/> constitit inter nos posse
+						histriones sine ista scientia <lb/> satisfacere voluptati aurium popularium;
+						ita etiam <lb/> nullo modo esse posse hislrioncs musicae studiosos <lb/>
+						peritosque constiterit. <hi rend="italic">D.</hi> Mirum si hoc effeceris. M.
+						<lb/> Facile id quidem, sed attentiore te milii opus est. <hi rend="italic"
+							>D.</hi>
+						<lb/> Nunquam equidem, quod sciam, rcmissior in audien­ <lb/> do fui, ab
+						usque sermo iste sumpsit cxordium : sed <lb/> nunc me, fateor, multo
+						erectiorem reddidisti. M. Gra­ <lb/> tum habeo, quanquam tibi te commodes
+						magis. Itaque <lb/> responde, si placet, utrum tibi vidcatur scire quid
+						<lb/> vil aureus solidus, qui eum æquo pretio vendere cu­ <lb/> piens,
+						decent nummus eum valerc putaverit? <hi rend="italic">D.</hi> Cui <lb/> hoc
+						videatur? <hi rend="italic">Al.</hi> Nunc age, dic mihi, quid charius <lb/>
+						habendum sit, quod nostra intelligentia comminetur, <lb/> an quod nobis
+						fortuito imperitorum judicio lribuitur? <lb/>
+						<hi rend="italic">D.</hi> Nulli dubium est, longe illud priulum præstare
+						<lb/> cæteris omnibus, quoe ne nostra quidem putanda sunt. <note
+							type="footnote"> ' tis. A, <hi rend="italic">has</hi> tpsas <hi
+								rend="italic">quæ nobis perplacenI</hi> manus. u. </note>
 						<lb/>
-						<hi rend="italic">M.</hi> Num ergo negas omnem scientiam intelligentia <lb/> contineri?
-							<hi rend="italic">D.</hi> Quis negat ? M. Et musica igitur ibi est. <lb/> D. Video ex
-						ejus definitione id esse consequens. <hi rend="italic">M.</hi>
-						<lb/> Quid? plausus populi et omnia illa theatrica præmia, <lb/> nonne tibi ex eo genere
-						videntur, quod in potestate <lb/> fortunæ et imperitorum judicio positum est? <hi rend="italic">D.</hi> Nihil <lb/> magis arbitror esse fortuitum obnoxiumquc casibus et
-						<lb/> plebeiæ dominationi nutibusque subjectum, quam illa <lb/> sunt omnia. <hi rend="italic">M.</hi> Hoccine igitur pretio cantus suus vcn <lb/> derent histriones,
-						si musicam scirent ? <hi rend="italic">D.</hi> Non parum <lb/> quidem bac conclusione
-						commoveor, sed nonnilul <lb/> habeo quod contradicam. Nam ille venditor solidi cum <lb/>
-						isto comparandus non videtur : non enim accepto <lb/> plausu aut qualibet sibi largita
-						pecunia scientiam, si <lb/> quam forte habet qua populum delectavit, amittit; sed <lb/>
-						onustior nummo, et laude hominum latior, cum ea­ <lb/> dem disciplina incolumi atque
-						integra domum discc­ <lb/> dit: stultus autcm esset, si commoda illa contemne­ <lb/>
-						ret, quæ non adeptus multo esset ignobilior atque <lb/> pauperior; adeptus autem nihilo
-						esset indoctior.</p>
-					<p>12. <hi rend="italic">M.</hi> Vide ergo utrum vel isto conficiamus qnod <lb/> volumus.
-						Nam credo videri tibi multo esse praestan - <lb/> tius, id propter quod aliquid facimus,
-						quam idipsum <lb/> quod facimus. <hi rend="italic">D.</hi> Manifestum est. <hi rend="italic">M.</hi> Qui ergo can­ <lb/> tat vel cantare discit, non ob aliud nisi ut
-						laudetur :t <lb/> populo, vel omnino abs quovis homine, nonne judi­ <lb/> cat meliorem
-						laudem illam esse quam cantum? <hi rend="italic">D.</hi>
-						<lb/> Negare non possum. <hi rend="italic">M.</hi> Quid? ille qui male de aliqua <lb/>
-						re judicat, videtur tibi cam scire? D. Nullo modo, <lb/> nisi forte quoquo modo
-						corruptus. <hi rend="italic">M.</hi> Ergo qui vcre <lb/> putat melius esse aliquid quod
-						deterius est, nullo du­ <lb/> bitante scientia ejus caret. D. Ila est. <hi rend="italic">M.</hi> Quando igi­ <lb/> tur milii vel persuaseris vel ostenderis quemlibet hi.
-						<lb/> strionum non ideo iilam, si quam habet facultatem, <lb/> vel assecutum esse vel
-						exhibere ut populo placeat <lb/> propter quaestum ant famam; concedam posse quem­ <lb/>
-						quam et musicæ habere scientiam, et esse histrionem. <lb/> v Si autem perprohabile est,
-						neminem esse histrionum <lb/> qui non sibi professionis finem in pecunia seu gloria
-						<lb/> constituat ac proponat, fateare necesse est aut musi­ <lb/> cam nescire
-						histriones, aut magis expetendam esse ab <lb/> aliis laudem, vel quæque ałia fortuita
-						commoda, quam <lb/> a nobismetipsis inteliigentiam 1. D. Video me, qui su­ <lb/> pcriora
-						concesserim, eliam istis cedere debcre. Non <lb/> enim mihi ullo modo videri potest de
-						scena inveniri <lb/> posse talem virum, qui artem suam propter seipsam, <lb/> non
-						propter extra posita commoda diligat; cum de <lb/> gymnasio vix talis inveniatur :
-						quanquam si quis exi. <lb/> stit, vel exstiterit, non eo contemnendi musici, sed <lb/>
-						honorandi aliquando histriones possint videri. Quam­ <lb/> obrem explica jam, si placet,
-						tantam istam, quae jam <lb/> vilis mihi videri non potest, disciplinam.</p>
-					<ab>
-						<title type="sub">CAPUT VII. — Diu <hi rend="italic">et non diu in</hi> motu.</title>
+						<hi rend="italic">M.</hi> Num ergo negas omnem scientiam intelligentia <lb/>
+						contineri? <hi rend="italic">D.</hi> Quis negat ? M. Et musica igitur ibi
+						est. <lb/> D. Video ex ejus definitione id esse consequens. <hi
+							rend="italic">M.</hi>
+						<lb/> Quid? plausus populi et omnia illa theatrica præmia, <lb/> nonne tibi
+						ex eo genere videntur, quod in potestate <lb/> fortunæ et imperitorum
+						judicio positum est? <hi rend="italic">D.</hi> Nihil <lb/> magis arbitror
+						esse fortuitum obnoxiumquc casibus et <lb/> plebeiæ dominationi nutibusque
+						subjectum, quam illa <lb/> sunt omnia. <hi rend="italic">M.</hi> Hoccine
+						igitur pretio cantus suus vcn <lb/> derent histriones, si musicam scirent ?
+							<hi rend="italic">D.</hi> Non parum <lb/> quidem bac conclusione
+						commoveor, sed nonnilul <lb/> habeo quod contradicam. Nam ille venditor
+						solidi cum <lb/> isto comparandus non videtur : non enim accepto <lb/>
+						plausu aut qualibet sibi largita pecunia scientiam, si <lb/> quam forte
+						habet qua populum delectavit, amittit; sed <lb/> onustior nummo, et laude
+						hominum latior, cum ea­ <lb/> dem disciplina incolumi atque integra domum
+						discc­ <lb/> dit: stultus autcm esset, si commoda illa contemne­ <lb/> ret,
+						quæ non adeptus multo esset ignobilior atque <lb/> pauperior; adeptus autem
+						nihilo esset indoctior.</p></div>
+					<div type="textpart" subtype="dialog" n="12"><p>12. <hi rend="italic">M.</hi> Vide ergo utrum vel isto conficiamus qnod <lb/>
+						volumus. Nam credo videri tibi multo esse praestan - <lb/> tius, id propter
+						quod aliquid facimus, quam idipsum <lb/> quod facimus. <hi rend="italic"
+							>D.</hi> Manifestum est. <hi rend="italic">M.</hi> Qui ergo can­ <lb/>
+						tat vel cantare discit, non ob aliud nisi ut laudetur :t <lb/> populo, vel
+						omnino abs quovis homine, nonne judi­ <lb/> cat meliorem laudem illam esse
+						quam cantum? <hi rend="italic">D.</hi>
+						<lb/> Negare non possum. <hi rend="italic">M.</hi> Quid? ille qui male de
+						aliqua <lb/> re judicat, videtur tibi cam scire? D. Nullo modo, <lb/> nisi
+						forte quoquo modo corruptus. <hi rend="italic">M.</hi> Ergo qui vcre <lb/>
+						putat melius esse aliquid quod deterius est, nullo du­ <lb/> bitante
+						scientia ejus caret. D. Ila est. <hi rend="italic">M.</hi> Quando igi­ <lb/>
+						tur milii vel persuaseris vel ostenderis quemlibet hi. <lb/> strionum non
+						ideo iilam, si quam habet facultatem, <lb/> vel assecutum esse vel exhibere
+						ut populo placeat <lb/> propter quaestum ant famam; concedam posse quem­
+						<lb/> quam et musicæ habere scientiam, et esse histrionem. <lb/> v Si autem
+						perprohabile est, neminem esse histrionum <lb/> qui non sibi professionis
+						finem in pecunia seu gloria <lb/> constituat ac proponat, fateare necesse
+						est aut musi­ <lb/> cam nescire histriones, aut magis expetendam esse ab
+						<lb/> aliis laudem, vel quæque ałia fortuita commoda, quam <lb/> a
+						nobismetipsis inteliigentiam 1. D. Video me, qui su­ <lb/> pcriora
+						concesserim, eliam istis cedere debcre. Non <lb/> enim mihi ullo modo videri
+						potest de scena inveniri <lb/> posse talem virum, qui artem suam propter
+						seipsam, <lb/> non propter extra posita commoda diligat; cum de <lb/>
+						gymnasio vix talis inveniatur : quanquam si quis exi. <lb/> stit, vel
+						exstiterit, non eo contemnendi musici, sed <lb/> honorandi aliquando
+						histriones possint videri. Quam­ <lb/> obrem explica jam, si placet, tantam
+						istam, quae jam <lb/> vilis mihi videri non potest, disciplinam.</p>
+					</div>
+					</div>
+					<div type="textpart" subtype="chapter" n="7"><ab>
+						<title type="sub">Diu <hi rend="italic">et non diu in</hi>
+							motu.</title>
 					</ab>
-					<p>13. <hi rend="italic">M.</hi> Faciam, imo tu facies. Nam ego nihil aliud <lb/> quam
-						rogabo te ac percontabor : tu vero totum hoc <lb/> quidquid est, et quod nunc nesciens
-						quærere videris, <note type="footnote"> I Ms. A addit: <hi rend="italic">Ft q,ria ab
-								atiis expetunt laudem et covt­ <lb/> moda, et a nobis intelligentiam non</hi>
-							ejyrelrrut, <hi rend="italic">cum prarjiuli­ <lb/> cant id quod lilivs e: t, eo</hi>
-							qvod <hi rend="italic">est citi ins. constat, qttii ejm <lb/> scienti an n(:M
-								habent;</hi> addita saue j eri eram. Y. </note>
+					<div type="textpart" subtype="dialog" n="13"><p>13. <hi rend="italic">M.</hi> Faciam, imo tu facies. Nam ego nihil aliud
+						<lb/> quam rogabo te ac percontabor : tu vero totum hoc <lb/> quidquid est,
+						et quod nunc nesciens quærere videris, <note type="footnote"> I Ms. A addit:
+								<hi rend="italic">Ft q,ria ab atiis expetunt laudem et covt­ <lb/>
+								moda, et a nobis intelligentiam non</hi> ejyrelrrut, <hi
+								rend="italic">cum prarjiuli­ <lb/> cant id quod lilivs e: t, eo</hi>
+							qvod <hi rend="italic">est citi ins. constat, qttii ejm <lb/> scienti an
+								n(:M habent;</hi> addita saue j eri eram. Y. </note>
 						<lb/>
-						<pb n="1091"/> respondendo explicabis Itaque jain ex te quæro, utrum <lb/> quisquam p
-						ussit, et diu et volociter currere. <hi rend="italic">D.</hi> Po­ <lb/> test. <hi rend="italic">M.</hi> Quid, tarde et velociter ? D. Nullo modo. <hi rend="italic">M.</hi>
-						<lb/> Aliud ergo cst diu, aHud tarde. <hi rend="italic">D.</hi> Aliud omnino. <hi rend="italic">M.</hi>
-						<lb/> Item quæro, quid putes diuturnitati esse contrarium, <lb/> sicuti est tarditati
-						velocitas. <hi rend="italic">D.</hi> Non mihi occurrii usi­ <lb/> tatum nomen. Itaque
-						diuturno nihil video quod op­ <lb/> ponam, nisi non diuturnum, ut ei quod dicitur, diu,
-						<lb/> contrarium sit non diu, quia et vclocitcr si nollem <lb/> dicere, et pro eo non
-						tarde dicercm,ni!iil aliud signi­ <lb/> licarctur. <hi rend="italic">M.</hi> Verum
-						dicis. Nihil enim deperit, cum <lb/> ita loquimur, veritati. Nam et mihi si est hoc
-						nomen, <lb/> quod tibi non occurrisse dicis, aut ignoratur a me, aut <lb/> in pr;vsentia
-						non vcnit in luentem. Quamobrem sic <lb/> agamus, ut hæc bina contraria appellemus hoc
-						modo, <lb/> diu et non diu, tarde et velociter. Ac primum de diu­ <lb/> turno et non
-						diuturno disseramus, si placet. <hi rend="italic">D.</hi> Ila fiat.</p>
-					<ab>
-						<title type="sub">CAPUT VIII. —Propositio in <hi rend="italic">motu diuturno et non</hi>
-							diuturno.</title>
+						<pb n="1091"/> respondendo explicabis Itaque jain ex te quæro, utrum <lb/>
+						quisquam p ussit, et diu et volociter currere. <hi rend="italic">D.</hi> Po­
+						<lb/> test. <hi rend="italic">M.</hi> Quid, tarde et velociter ? D. Nullo
+						modo. <hi rend="italic">M.</hi>
+						<lb/> Aliud ergo cst diu, aHud tarde. <hi rend="italic">D.</hi> Aliud
+						omnino. <hi rend="italic">M.</hi>
+						<lb/> Item quæro, quid putes diuturnitati esse contrarium, <lb/> sicuti est
+						tarditati velocitas. <hi rend="italic">D.</hi> Non mihi occurrii usi­ <lb/>
+						tatum nomen. Itaque diuturno nihil video quod op­ <lb/> ponam, nisi non
+						diuturnum, ut ei quod dicitur, diu, <lb/> contrarium sit non diu, quia et
+						vclocitcr si nollem <lb/> dicere, et pro eo non tarde dicercm,ni!iil aliud
+						signi­ <lb/> licarctur. <hi rend="italic">M.</hi> Verum dicis. Nihil enim
+						deperit, cum <lb/> ita loquimur, veritati. Nam et mihi si est hoc nomen,
+						<lb/> quod tibi non occurrisse dicis, aut ignoratur a me, aut <lb/> in
+						pr;vsentia non vcnit in luentem. Quamobrem sic <lb/> agamus, ut hæc bina
+						contraria appellemus hoc modo, <lb/> diu et non diu, tarde et velociter. Ac
+						primum de diu­ <lb/> turno et non diuturno disseramus, si placet. <hi
+							rend="italic">D.</hi> Ila fiat.</p>
+					</div>
+					</div>
+					<div type="textpart" subtype="chapter" n="8"><ab>
+						<title type="sub">Propositio in <hi rend="italic">motu diuturno
+								et non</hi> diuturno.</title>
 					</ab>
-					<p>i4. <hi rend="italic">M.</hi> Manifestumne tibi est, id dici diu fieri qnod <lb/> per
-						longum, id autem non diu quod per breve tempus <lb/> fit ? <hi rend="italic">D.</hi>
-						Manifestum. <hi rend="italic">M.</hi> Motus igitur qui fit, verbi gra­ <lb/> tia, duabus
-						horis, nonne ad eum qui una hora lit, du­ <lb/> plum habet temporis? <hi rend="italic">D.</hi> Quis binc dubitaverit ? M. <lb/> Recipit ergo id quod diu vel non diu dicimus
-						dinlcu­ <lb/> siones hujusmodi ct numeros, ut alius motus ad alium, <lb/> tanquam duo ad
-						unum sit; id cst ut bis tantum habeat <lb/> alius quantum semel 1 : alius item ad alium
-						tanquam <lb/> tria ad duo, id est ut tantas tres partes temporis ha­ <lb/> beat, quantas
-						alius duas: atque ila per cæteros nume­ <lb/> ros licet currere, ut non sint spatia
-						indefinita et inde­ <lb/> terminata, sed habeant ad se duo motus aliquem nu­ <lb/> merum
-						; aut eumdem, velut unum ad unum, ad duo <lb/> duo, ad tria uia, quatuor ad quatuor*:
-						aut non eum­ <lb/> dem, ut unum ad duo, duo ad tria, tria ad quatuor ; <lb/> aut unum ad
-						tria, duo ad sex, et quidquid potest 3 ali­ <lb/> quid ad sese dimensionis obtinere. <hi rend="italic">D.</hi> Planius ista <lb/> qusrso. M. Revertere ergo ad illas horas, et
-						quod <lb/> satis putabam dictum, cum .de una hora et de dua­ <lb/> bus dixissem, per
-						omnia considera. Certe enim non <lb/> ncgasposse fieri aliqucm motum tempore unius. ho.
-						<lb/> rx&gt; et alium duarum. <hi rend="italic">D.</hi> Verum est. <hi rend="italic">M.</hi> Quid? <lb/> . alimn duarum, alium trium non fateris? D. Fatcor. <lb/>
-						<hi rend="italic">M.</hi> Et alium tribus horis fieri, alium quatuor; rursus <lb/> alium
-						una, alium tribus; aut alium duabus, alium sex, <lb/> norne manifestum est ? <hi rend="italic">D.</hi> Manifestum. M. Cur ergo <lb/> et illud non manifestum sit ? Nam
-						hoc dicebam cum <lb/> duos motus habere ad se posse aliquem numerum di­ <lb/> cerem,
-						velut unum ad duo, duo ad tria, tria ad qua­ <lb/> tuor; unum ad tria, duo ad sex, et si
-						quos al os re­ <lb/> censere volueris. Ilis enim coguitis, est et 4 potestatis <lb/>
-						persequi caetera, sive septem ad decem, sive quinque <note type="footnote"> 1 Mss. A et
-							B ac Edd. omnes non habent, <hi rend="italic">alius qucnilum <lb/> semet.</hi> sic
-							legit vatic. Cd. : f t <hi rend="italic">bis tantum iuibeai spuii,<lb/> quantum habet
-								ille qui una</hi> hora <hi rend="italic">fit.</hi> it. </note><note type="footnote">
-							* sic veteres MSS.; at Faci. habent: <hi rend="italic">Aut</hi> eumdem, <hi rend="italic">tit</hi> ,nan­ <lb/>
-							<hi rend="italic">tum</hi> temporis <hi rend="italic">unus, latiium tencat liller, aut
-								non cumdem,</hi> etc. <lb/> — sic etiam MS. A et cd. vatic. M. </note><note type="footnote">a cd. vatic., <hi rend="italic">potest onmirrl.,</hi> addita voce <hi rend="italic">omnino.</hi> M. </note><note type="footnote"> 4 Cd. vatic. legit
+					<div type="textpart" subtype="dialog">
+						<p>14. <hi rend="italic">M.</hi> Manifestumne tibi est, id dici diu fieri qnod
+						<lb/> per longum, id autem non diu quod per breve tempus <lb/> fit ? <hi
+							rend="italic">D.</hi> Manifestum. <hi rend="italic">M.</hi> Motus igitur
+						qui fit, verbi gra­ <lb/> tia, duabus horis, nonne ad eum qui una hora lit,
+						du­ <lb/> plum habet temporis? <hi rend="italic">D.</hi> Quis binc
+						dubitaverit ? M. <lb/> Recipit ergo id quod diu vel non diu dicimus dinlcu­
+						<lb/> siones hujusmodi ct numeros, ut alius motus ad alium, <lb/> tanquam
+						duo ad unum sit; id cst ut bis tantum habeat <lb/> alius quantum semel 1 :
+						alius item ad alium tanquam <lb/> tria ad duo, id est ut tantas tres partes
+						temporis ha­ <lb/> beat, quantas alius duas: atque ila per cæteros nume­
+						<lb/> ros licet currere, ut non sint spatia indefinita et inde­ <lb/>
+						terminata, sed habeant ad se duo motus aliquem nu­ <lb/> merum ; aut eumdem,
+						velut unum ad unum, ad duo <lb/> duo, ad tria uia, quatuor ad quatuor*: aut
+						non eum­ <lb/> dem, ut unum ad duo, duo ad tria, tria ad quatuor ; <lb/> aut
+						unum ad tria, duo ad sex, et quidquid potest 3 ali­ <lb/> quid ad sese
+						dimensionis obtinere. <hi rend="italic">D.</hi> Planius ista <lb/> qusrso.
+						M. Revertere ergo ad illas horas, et quod <lb/> satis putabam dictum, cum
+						.de una hora et de dua­ <lb/> bus dixissem, per omnia considera. Certe enim
+						non <lb/> ncgasposse fieri aliqucm motum tempore unius. ho. <lb/> rx&gt; et
+						alium duarum. <hi rend="italic">D.</hi> Verum est. <hi rend="italic">M.</hi>
+						Quid? <lb/> . alimn duarum, alium trium non fateris? D. Fatcor. <lb/>
+						<hi rend="italic">M.</hi> Et alium tribus horis fieri, alium quatuor; rursus
+						<lb/> alium una, alium tribus; aut alium duabus, alium sex, <lb/> norne
+						manifestum est ? <hi rend="italic">D.</hi> Manifestum. M. Cur ergo <lb/> et
+						illud non manifestum sit ? Nam hoc dicebam cum <lb/> duos motus habere ad se
+						posse aliquem numerum di­ <lb/> cerem, velut unum ad duo, duo ad tria, tria
+						ad qua­ <lb/> tuor; unum ad tria, duo ad sex, et si quos al os re­ <lb/>
+						censere volueris. Ilis enim coguitis, est et 4 potestatis <lb/> persequi
+						caetera, sive septem ad decem, sive quinque <note type="footnote"> 1 Mss. A
+							et B ac Edd. omnes non habent, <hi rend="italic">alius qucnilum <lb/>
+								semet.</hi> sic legit vatic. Cd. : f t <hi rend="italic">bis tantum
+								iuibeai spuii,<lb/> quantum habet ille qui una</hi> hora <hi
+								rend="italic">fit.</hi> it. </note><note type="footnote"> * sic
+							veteres MSS.; at Faci. habent: <hi rend="italic">Aut</hi> eumdem, <hi
+								rend="italic">tit</hi> ,nan­ <lb/>
+							<hi rend="italic">tum</hi> temporis <hi rend="italic">unus, latiium
+								tencat liller, aut non cumdem,</hi> etc. <lb/> — sic etiam MS. A et
+							cd. vatic. M. </note><note type="footnote">a cd. vatic., <hi
+								rend="italic">potest onmirrl.,</hi> addita voce <hi rend="italic"
+								>omnino.</hi> M. </note><note type="footnote"> 4 Cd. vatic. legit
 							simpliciter, eat poleatutis, subluta vocula <lb/>
 							<hi rend="italic">et.</hi> 51. </note>
-						<lb/> ad octo, et quidquid omnino cst in duobus motibus ita <lb/> partes dimensas
-						habentibus ad invicem, ut possint <lb/> dici tot ad tot; sivc æquales numeri sint, sive
-						alius <lb/> major, alius minor. <hi rend="italic">D.</hi> Jam intelligo, et fieri posse
-						<lb/> concedo.</p>
-					<ab>
-						<title type="sub">CAPUT IX. — <hi rend="italic">Motus rationabiles et irrationabiles,
-								connumerati et dinumerati.</hi>
+						<lb/> ad octo, et quidquid omnino cst in duobus motibus ita <lb/> partes
+						dimensas habentibus ad invicem, ut possint <lb/> dici tot ad tot; sivc
+						æquales numeri sint, sive alius <lb/> major, alius minor. <hi rend="italic"
+							>D.</hi> Jam intelligo, et fieri posse <lb/> concedo.</p>
+					</div>
+					</div>
+					<div type="textpart" subtype="chapter" n="9"><ab>
+						<title type="sub"><hi rend="italic">Motus rationabiles et
+								irrationabiles, connumerati et dinumerati.</hi>
 						</title>
 					</ab>
-					<p>15. <hi rend="italic">M.</hi> Illud etiam, ut opinor, intelligis, omnem <lb/> mensuram
-						et modum immoderationi et infinitati 1 <lb/> recte anteponi. D. Manifestissimum est. <hi rend="italic">M.</hi> Duo igitur <lb/> motus qui ad sese, ut dictum est, habent
-						aliquam nu­ <lb/> merosam dimensionem, iis qui cain non habent ante­ <lb/> ponendi sunt.
-						D. Et hoc manifestum est atque conse­ <lb/> quens : illos enim certus quidam modus,
-						atque men­ <lb/> sura quæ in numeris est, sibimet copulal; qua qui <lb/> carent, non
-						utique'sibi aliqua ratione junguntur. <lb/>
-						<hi rend="italic">M.</hi> Appellemus ergo, si placet, illos . qui inter se di­ <lb/>
-						mensi sunt, rationabiles; illos autem qui ea dimen­ <lb/> sione carent, irrationabiles.
-							<hi rend="italic">D.</hi> Placet vero. <hi rend="italic">M.</hi> Jam <lb/> illud
-						attende, utrurn tibi videatur major concordia in <lb/> motibus rationabilibus eorum qui
-						æquales sunt inter <lb/> se, quam eorum qui sunt illæquales. <hi rend="italic">D.</hi>
-						Cui hoc nou <lb/> videatur? II. Porro inæqualium, nonne alii sunt in <lb/> quibus
-						possumus dicere, quota parte sua major aut <lb/> coæquetur minori, aut eum cxcedat, ut
-						duo et quatuor, <lb/> vel sex et octo; alii autem in quibus non idem dici <lb/> potest,
-						sicut in his numeris, tria et decem, vel qua­ <lb/> tuor et undecim I? ? Cernis profecto
-						in illis duobus no­ <lb/> meris superioribus dimidia parte majorem minori <lb/> coa'quan
-						; in iis rursum quos posterius dixi, minorem <lb/> a majore quarta parte majoris excedi
-						: in his autem <lb/> aliis, qualcs sunt tria et decem, vel quatuor et unde­ <lb/> cini,
-						videmus quidem nonnullam convenientiam, quia <lb/> partes ad se habent, de quibus dici
-						possit, tot ad tot; <lb/> scd numquid talem , qualis est in superioribus? Nam <lb/>
-						neque quota parte minori major aequetur, neque quota <lb/> parte minorcm major excedat,
-						dici ullo modo potest. <lb/> Nam neque tria quota pars sit denarii numeri, neque <lb/>
-						quatuor quota pars sit undenarii, dixerit quispiam. <lb/> Cum autem dico ut consideres
-						quota sit pars, liqui­ <lb/> dam dico, ct sinc ullo additamento; sicuti est dimi­ <lb/>
-						dia, tertia, quarta, quinta, sexta, et deinceps; non ut <lb/> trientes et semiunciae, et
-						boc genus præcisionum ali­ <lb/> quid addatur. <hi rend="italic">D.</hi> Jam
-						intelligo.</p>
-					<p><hi rend="italic">16. M.</hi> Ergo ex his inæqualibus motibus rationabili­ <lb/> bus,
-						quoniam duo genera subjectis etiam numerorum <lb/> cxemplis proposui, quos quibus
-						-anteponendos arbi.. <lb/> traris? illosne in quibus illa quota pars dici potes!, an
-						<lb/> in quibus non potest? <hi rend="italic">D.</hi> Illos mihi ratio vidctur ante­
-						<lb/> ponendos jubere, in quibus potest dici, ut demon­ <lb/> stratum est, quota parte
-						sui major aut coaequetur mi- <lb/> Dori, aut eum excedat, iis in quibus idem non evenit.
-						<lb/> M. Recte. Sed visne etiam his nomina imponamus, <lb/> ut cum cos deinceps
-						commemorare necesse fuerit, <note type="footnote">1 *:ss. plures, <hi rend="italic">ct
-								informitati recte anteponi.—</hi> Quod etiam <lb/> ferunt Mss. nostri ct vatic. cd.
-							M. </note><note type="footnote">4 In B. : <hi rend="italic">inaiquulium, nonne alii
-								sunt in qitibaj possu­ <lb/> mus dicere, auota parte sua major aut cocequetnr
-								nrvw;i<lb/> cut cum excedal; atri aiitcm in qtibus non iitem dici potest, <lb/> Mcut
-								in his</hi> nnmerh, <hi rend="italic">dr,o ct qlw,kor,</hi> vel <hi rend="italic">sex ct octo.</hi> Locum <lb/> liuuc dainus ensentJatuuj ex vatic. Ai </note>
+					<div type="textpart" subtype="dialog" n="15"><p>15. <hi rend="italic">M.</hi> Illud etiam, ut opinor, intelligis, omnem <lb/>
+						mensuram et modum immoderationi et infinitati 1 <lb/> recte anteponi. D.
+						Manifestissimum est. <hi rend="italic">M.</hi> Duo igitur <lb/> motus qui ad
+						sese, ut dictum est, habent aliquam nu­ <lb/> merosam dimensionem, iis qui
+						cain non habent ante­ <lb/> ponendi sunt. D. Et hoc manifestum est atque
+						conse­ <lb/> quens : illos enim certus quidam modus, atque men­ <lb/> sura
+						quæ in numeris est, sibimet copulal; qua qui <lb/> carent, non utique'sibi
+						aliqua ratione junguntur. <lb/>
+						<hi rend="italic">M.</hi> Appellemus ergo, si placet, illos . qui inter se
+						di­ <lb/> mensi sunt, rationabiles; illos autem qui ea dimen­ <lb/> sione
+						carent, irrationabiles. <hi rend="italic">D.</hi> Placet vero. <hi
+							rend="italic">M.</hi> Jam <lb/> illud attende, utrurn tibi videatur
+						major concordia in <lb/> motibus rationabilibus eorum qui æquales sunt inter
+						<lb/> se, quam eorum qui sunt illæquales. <hi rend="italic">D.</hi> Cui hoc
+						nou <lb/> videatur? II. Porro inæqualium, nonne alii sunt in <lb/> quibus
+						possumus dicere, quota parte sua major aut <lb/> coæquetur minori, aut eum
+						cxcedat, ut duo et quatuor, <lb/> vel sex et octo; alii autem in quibus non
+						idem dici <lb/> potest, sicut in his numeris, tria et decem, vel qua­ <lb/>
+						tuor et undecim I? ? Cernis profecto in illis duobus no­ <lb/> meris
+						superioribus dimidia parte majorem minori <lb/> coa'quan ; in iis rursum
+						quos posterius dixi, minorem <lb/> a majore quarta parte majoris excedi : in
+						his autem <lb/> aliis, qualcs sunt tria et decem, vel quatuor et unde­ <lb/>
+						cini, videmus quidem nonnullam convenientiam, quia <lb/> partes ad se
+						habent, de quibus dici possit, tot ad tot; <lb/> scd numquid talem , qualis
+						est in superioribus? Nam <lb/> neque quota parte minori major aequetur,
+						neque quota <lb/> parte minorcm major excedat, dici ullo modo potest. <lb/>
+						Nam neque tria quota pars sit denarii numeri, neque <lb/> quatuor quota pars
+						sit undenarii, dixerit quispiam. <lb/> Cum autem dico ut consideres quota
+						sit pars, liqui­ <lb/> dam dico, ct sinc ullo additamento; sicuti est dimi­
+						<lb/> dia, tertia, quarta, quinta, sexta, et deinceps; non ut <lb/> trientes
+						et semiunciae, et boc genus præcisionum ali­ <lb/> quid addatur. <hi
+							rend="italic">D.</hi> Jam intelligo.</p>
+					</div>
+					<div type="textpart" subtype="dialog" n="16"><p>16. M. Ergo ex his inæqualibus motibus rationabili­
+						<lb/> bus, quoniam duo genera subjectis etiam numerorum <lb/> cxemplis
+						proposui, quos quibus -anteponendos arbi.. <lb/> traris? illosne in quibus
+						illa quota pars dici potes!, an <lb/> in quibus non potest? <hi
+							rend="italic">D.</hi> Illos mihi ratio vidctur ante­ <lb/> ponendos
+						jubere, in quibus potest dici, ut demon­ <lb/> stratum est, quota parte sui
+						major aut coaequetur mi- <lb/> Dori, aut eum excedat, iis in quibus idem non
+						evenit. <lb/> M. Recte. Sed visne etiam his nomina imponamus, <lb/> ut cum
+						cos deinceps commemorare necesse fuerit, <note type="footnote">1 *:ss.
+							plures, <hi rend="italic">ct informitati recte anteponi.—</hi> Quod
+							etiam <lb/> ferunt Mss. nostri ct vatic. cd. M. </note><note
+							type="footnote">4 In B. : <hi rend="italic">inaiquulium, nonne alii sunt
+								in qitibaj possu­ <lb/> mus dicere, auota parte sua major aut
+								cocequetnr nrvw;i<lb/> cut cum excedal; atri aiitcm in qtibus non
+								iitem dici potest, <lb/> Mcut in his</hi> nnmerh, <hi rend="italic"
+								>dr,o ct qlw,kor,</hi> vel <hi rend="italic">sex ct octo.</hi> Locum
+							<lb/> liuuc dainus ensentJatuuj ex vatic. Ai </note>
 						<lb/>
-						<pb n="1093"/> expeditius loquamur? <hi rend="italic">D.</hi> Volo sane. M. Appellemus
-						<lb/> crgo istos quos præponimus, connumeratos ; illos au­ <lb/> tem qnibus hos
-						præponimus, dinumeratos : propterea <lb/> quia isti superiores non solum singuli
-						numerantur, <lb/> sed etiam ea parte qua major minori æquatur vel eum <lb/> excedit, se
-						metiuntur et numerant; illi autem poste­ <lb/> riores singillatim tantummodo ad sc
-						numerantur, ca <lb/> vero parte qua vel aequatur minori major, vel cxcedit <lb/> non se
-						metiuntur et numerant. Non eniin potest in eis <lb/> dici, aut qnoties habeat minorem
-						major; aut illud quo <lb/> Excedit major minorem quoties habeat et major et <lb/> minor.
-						D. Accipio et ista vocabula, et quantum valco, <lb/> faciam ut meminerim.</p>
-					<ab>
-						<title type="sub">CAPUT X. — <hi rend="italic">Motus</hi> complicati <hi rend="italic">et sesquali.</hi>
+						<pb n="1093"/> expeditius loquamur? <hi rend="italic">D.</hi> Volo sane. M.
+						Appellemus <lb/> crgo istos quos præponimus, connumeratos ; illos au­ <lb/>
+						tem qnibus hos præponimus, dinumeratos : propterea <lb/> quia isti
+						superiores non solum singuli numerantur, <lb/> sed etiam ea parte qua major
+						minori æquatur vel eum <lb/> excedit, se metiuntur et numerant; illi autem
+						poste­ <lb/> riores singillatim tantummodo ad sc numerantur, ca <lb/> vero
+						parte qua vel aequatur minori major, vel cxcedit <lb/> non se metiuntur et
+						numerant. Non eniin potest in eis <lb/> dici, aut qnoties habeat minorem
+						major; aut illud quo <lb/> Excedit major minorem quoties habeat et major et
+						<lb/> minor. D. Accipio et ista vocabula, et quantum valco, <lb/> faciam ut
+						meminerim.</p>
+					</div>
+					</div>
+				<div type="textpart" subtype="chapter" n="10"><ab>
+						<title type="sub"><hi rend="italic">Motus</hi> complicati <hi
+								rend="italic">et sesquali.</hi>
 						</title>
-					</ab>
-					<p>17. M. Age nunc videamus connumeratorum qu:c <lb/> possit esse partitio : namque
-						arbitror cam esse per. <lb/> spicuam. Unuin cnim genus est connumeratorum, in <lb/> quo
-						minor numerus metilur majorem; id est ali­ <lb/> quoties eum habet major sicut numeros
-						duo et qua­ <lb/> tuor esse diximus : vidcmus enim duo a quatuor bis <lb/> haberi; quae
-						tcr haberemur, si non quatuor, sed sex <lb/> ad duo poneremus ; quater autem, si octo;
-						quinquics, <lb/> si decem. Aliud genus est, in quo ea pars qua excedit <lb/> major
-						minorem, ambos metitur; id est aliquoties ha­ <lb/> bent eam et major et minor, quod in
-						illis numeris jam <lb/> perspeximus, sex et octo. Nam pars illa qua exceditur <lb/>
-						minor, duo sunt, quos vides esse in octonario numero <lb/> quater, in senario ter :
-						quare hos quoque motus de <lb/> quibns agitur, et numeros pcr quos illustratur quod
-						<lb/> in motibus discere volumus, notemus atque signemus <lb/> vocabulis. Nam eorum
-						distinctio jamdudum, nisi <lb/> fillor, apparet. Quocirca, si tibi jam videtur, illi ubi
-						<lb/> multiplicato minore fit major, vocentur complicati; <lb/> illi autem sesquali,
-						veteri jam nomine. Nam sesque <lb/> appellatur !, ob! duo numeri ad se ea ratione
-						affecti <lb/> sunt, ut tot partes habeat ad minorem major, quota <lb/> parte sui eum
-						præcedit: nam si est tria ad duo, tertia <lb/> parte sui præcedit major minorem; si
-						quatuor ad <lb/> tria, quarta : si quinque ad quatuor, quinta, atque ita <lb/> dcinceps
-						: eadem ratio esi, et in sex ad quatuor, octo <lb/> ad sex, doccm ad octo; et inde licet
-						hanc rationem <lb/> et 2in consequentibus et in majoribus numeris anim­ <lb/> advertere
-						alque explorare. Nominis autem hujus ori­ <lb/> ginem non facile dixerim : nisi forte
-						sesqne quasi se <lb/> ahsque dictum, id est absque se, quia quinque ad qua­ <lb/> tuor
-						absque quinta parte sua major hoc est quod <lb/> minor. Quibus de rebus quaero quid tihi
-						vidcalur. <lb/>
-						<hi rend="italic">D.</hi> Mihi vero et illa ratio dimensionum atque ,nume­ <lb/> rorum
-						videtur verissima ; et vocabula quæ abs te inl­ <lb/> posita sunt, congrua mihi videntur
-						commemorandis <lb/> cia rebus quas intelleximus : et hujus origo nomi­ <lb/> nis quam
-						nunc explicasti, non est absurda, etiamsi <lb/> forte non ea sit quam secutus est qui
-						hoc nomen <lb/> instituit. 8 <note type="footnote">' <hi rend="italic">AttquOtte* habent
-								minorem</hi> major, juxta vatic. M. </note><note type="footnote"> -in B., <hi rend="italic">appellantur.</hi> vatic., <hi rend="italic">appellatur.</hi>
-						</note><note type="footnote"> a In B omittitur, <hi rend="italic">et,</hi> quod ex
-							vatic. restituimus. M. </note><note type="footnote"> si <hi rend="italic">quinque est
-								ad quatuor,</hi> juxta Ms. A et v'auc. M. </note>
+						</ab>
+					<div type="textpart" subtype="dialog" n="17"><p>17. M. Age nunc videamus connumeratorum qu:c <lb/> possit esse partitio :
+						namque arbitror cam esse per. <lb/> spicuam. Unuin cnim genus est
+						connumeratorum, in <lb/> quo minor numerus metilur majorem; id est ali­
+						<lb/> quoties eum habet major sicut numeros duo et qua­ <lb/> tuor esse
+						diximus : vidcmus enim duo a quatuor bis <lb/> haberi; quae tcr haberemur,
+						si non quatuor, sed sex <lb/> ad duo poneremus ; quater autem, si octo;
+						quinquics, <lb/> si decem. Aliud genus est, in quo ea pars qua excedit <lb/>
+						major minorem, ambos metitur; id est aliquoties ha­ <lb/> bent eam et major
+						et minor, quod in illis numeris jam <lb/> perspeximus, sex et octo. Nam pars
+						illa qua exceditur <lb/> minor, duo sunt, quos vides esse in octonario
+						numero <lb/> quater, in senario ter : quare hos quoque motus de <lb/> quibns
+						agitur, et numeros pcr quos illustratur quod <lb/> in motibus discere
+						volumus, notemus atque signemus <lb/> vocabulis. Nam eorum distinctio
+						jamdudum, nisi <lb/> fillor, apparet. Quocirca, si tibi jam videtur, illi
+						ubi <lb/> multiplicato minore fit major, vocentur complicati; <lb/> illi
+						autem sesquali, veteri jam nomine. Nam sesque <lb/> appellatur !, ob! duo
+						numeri ad se ea ratione affecti <lb/> sunt, ut tot partes habeat ad minorem
+						major, quota <lb/> parte sui eum præcedit: nam si est tria ad duo, tertia
+						<lb/> parte sui præcedit major minorem; si quatuor ad <lb/> tria, quarta :
+						si quinque ad quatuor, quinta, atque ita <lb/> dcinceps : eadem ratio esi,
+						et in sex ad quatuor, octo <lb/> ad sex, doccm ad octo; et inde licet hanc
+						rationem <lb/> et 2in consequentibus et in majoribus numeris anim­ <lb/>
+						advertere alque explorare. Nominis autem hujus ori­ <lb/> ginem non facile
+						dixerim : nisi forte sesqne quasi se <lb/> ahsque dictum, id est absque se,
+						quia quinque ad qua­ <lb/> tuor absque quinta parte sua major hoc est quod
+						<lb/> minor. Quibus de rebus quaero quid tihi vidcalur. <lb/>
+						<hi rend="italic">D.</hi> Mihi vero et illa ratio dimensionum atque ,nume­
+						<lb/> rorum videtur verissima ; et vocabula quæ abs te inl­ <lb/> posita
+						sunt, congrua mihi videntur commemorandis <lb/> cia rebus quas intelleximus
+						: et hujus origo nomi­ <lb/> nis quam nunc explicasti, non est absurda,
+						etiamsi <lb/> forte non ea sit quam secutus est qui hoc nomen <lb/>
+						instituit. 8 <note type="footnote">' <hi rend="italic">AttquOtte* habent
+								minorem</hi> major, juxta vatic. M. </note><note type="footnote">
+							-in B., <hi rend="italic">appellantur.</hi> vatic., <hi rend="italic"
+								>appellatur.</hi>
+						</note><note type="footnote"> a In B omittitur, <hi rend="italic">et,</hi>
+							quod ex vatic. restituimus. M. </note><note type="footnote"> si <hi
+								rend="italic">quinque est ad quatuor,</hi> juxta Ms. A et v'auc. M.
+						</note>
 					</p>
-					<ab>
-						<title type="sub">CAPUT X I. — <hi rend="italic">Motus ft</hi> numerus in <hi rend="italic">infinitum progre­ diens ut ad certam formam coercetur.</hi>
+					</div>
+				</div>
+					<div type="textpart" subtype="chapter" n="11"><ab>
+						<title type="sub"><hi rend="italic">Motus ft</hi> numerus in
+								<hi rend="italic">infinitum progre­ diens ut ad certam formam
+								coercetur.</hi>
 						</title>
 					</ab>
-					<p>18. 11. Probo et accipio sententiam tuam : sed vi­ <lb/> desne omnes istos rationabiles
-						motus, id est qui ad <lb/> sese habent aliquam numcrorum dimensionem, in <lb/> infinitum
-						posse per numeros pergere, nisi mrsus eos <lb/> cer ta ratio coercuerit, et ad quemdam
-						modum formam­ <lb/> que revocaverit? Nam ut primo de ipsis æqualibus <lb/> dicain ; unum
-						ad unum, duo ad duo, tria ad tria, qua­ <lb/> tuor ad qnatuor, ac deinceps si persequar,
-						quis finis <lb/> erit, cum ipsius numeri finis nullus sit ? Namque ista <lb/> vis numero
-						inest, ut omnis dictus finitus sit, non di­ <lb/> ctus autem infinitus. Et quod
-						æqualibus evenit, hoc <lb/> eliam inæqualibus evenire potes animadvertere, sive <lb/>
-						complicatis, sive sesquatis, sive connumeratis, sive <lb/> dinumeratis. Si enim unum ad
-						duo constituas, et in <lb/> ea multiplicatione permancre velis, dicendo unum ad <lb/>
-						tria, unum ad quatuor, unum ad quinque, et deinceps; <lb/> non cril finis : sive sola
-						dupla, ut unum ad duo, duo <lb/> ad quatuor, quatuor ad octo, octo ad sexdecim , et
-						<lb/> deinde ; hic quoque nullus est finis : ita et tripla sola <lb/> et quadrupla sola,
-						et quidquid horum tentare volueris, <lb/> in infinitum progrediuntur. Ita ctiam sesquali
-						: nam <lb/> duo ad tria, tria ad quatuor, guatuor ad quinque cum <lb/> dicimus; vides
-						nihil prohibere caetera persequi, nullo <lb/> resistente fine : sive isto modo velis in
-						eodem genere <lb/> perseverans, ut duo ad tria, quatuor ad sex, sex ad <lb/> novem, octo
-						ad duodecim , decem ad quindecim, et <lb/> deinceps ; sive in hoc genere, sive in
-						cæteris, nullus <lb/> finis occurrit. Quid opus est de dinumcratis jam Ji­ <lb/> cere,
-						cum ex iis quae jam dicta sunt quivis intelligere <lb/> possit, in iis quoque gradatim
-						surgentibus nullum esse <lb/> finem ? An tibi non videtur?</p>
-					<p>i9. <hi rend="italic">D.</hi> Quid hoc vcro verius dici potest? Sed jam <lb/> illam
-						rationem quæ istam infinitatem revocat ad cer­ <lb/> lum modum formam que præscribit
-						quam excedere non <lb/> oporteat, avidissime cognoscere exspecto. M. Hanc <lb/> quoque,
-						ut alia, temetipsum nosse cognosces, cum <lb/> me interrogante vera responderis. Nam
-						primo abs te <lb/> qu:ero, quoniam de numerosis motibus agimus, utrum <lb/> ipsos
-						debeamus consulere numeros, ut quas nobis le­ <lb/> gcs certas fixasque monstraverint,
-						eas in illis mo­ <lb/> tibus animadvertendas observandasque judicemus. <lb/>
-						<hi rend="italic">D.</hi> Placet vcro : non enim quidquam ordinatius fieri <lb/> I osse
-						arbitror. <hi rend="italic">II.</hi> Ergo 2b ipso, si videtur, principio <lb/> numerorum
-						capiamus considerationis hujus exordium <lb/> et videamus, quantum pro viribus mentis
-						nostræ talia <lb/> valemus intueri, qurrnam sit ratio, ut quamvis per in- f <lb/>
-						linitum, ut dictum est, numeris progrediatur, arti­ <lb/> culos quosdam homines in
-						numerando fecerint; a <lb/> quibus ad unum rursus redeant, quod est principium <lb/>
-						numcromm. In numerando enim progreditnur ab uno <lb/> usque ad decem, atque inde ad unum
-						-revertimur : <lb/> ac I si denariam complicationem persequi velis, tit <lb/> hoc modo
-						progrediaris, decem. viginti, triginta,qua­ <lb/> draginta ; usque ad centum est
-						progressio : si cente­ <lb/> nan iam, centum, ducenta, trecenta, quadringenta ; n <note type="footnote"> I in a., <hi rend="italic">at.</hi> h's. A, <hi rend="italic">ac,</hi> ct mclius. M. </note>
+					<div type="textpart" subtype="dialog" n="18"><p>18. 11. Probo et accipio sententiam tuam : sed vi­ <lb/> desne omnes istos
+						rationabiles motus, id est qui ad <lb/> sese habent aliquam numcrorum
+						dimensionem, in <lb/> infinitum posse per numeros pergere, nisi mrsus eos
+						<lb/> cer ta ratio coercuerit, et ad quemdam modum formam­ <lb/> que
+						revocaverit? Nam ut primo de ipsis æqualibus <lb/> dicain ; unum ad unum,
+						duo ad duo, tria ad tria, qua­ <lb/> tuor ad qnatuor, ac deinceps si
+						persequar, quis finis <lb/> erit, cum ipsius numeri finis nullus sit ?
+						Namque ista <lb/> vis numero inest, ut omnis dictus finitus sit, non di­
+						<lb/> ctus autem infinitus. Et quod æqualibus evenit, hoc <lb/> eliam
+						inæqualibus evenire potes animadvertere, sive <lb/> complicatis, sive
+						sesquatis, sive connumeratis, sive <lb/> dinumeratis. Si enim unum ad duo
+						constituas, et in <lb/> ea multiplicatione permancre velis, dicendo unum ad
+						<lb/> tria, unum ad quatuor, unum ad quinque, et deinceps; <lb/> non cril
+						finis : sive sola dupla, ut unum ad duo, duo <lb/> ad quatuor, quatuor ad
+						octo, octo ad sexdecim , et <lb/> deinde ; hic quoque nullus est finis : ita
+						et tripla sola <lb/> et quadrupla sola, et quidquid horum tentare volueris,
+						<lb/> in infinitum progrediuntur. Ita ctiam sesquali : nam <lb/> duo ad
+						tria, tria ad quatuor, guatuor ad quinque cum <lb/> dicimus; vides nihil
+						prohibere caetera persequi, nullo <lb/> resistente fine : sive isto modo
+						velis in eodem genere <lb/> perseverans, ut duo ad tria, quatuor ad sex, sex
+						ad <lb/> novem, octo ad duodecim , decem ad quindecim, et <lb/> deinceps ;
+						sive in hoc genere, sive in cæteris, nullus <lb/> finis occurrit. Quid opus
+						est de dinumcratis jam Ji­ <lb/> cere, cum ex iis quae jam dicta sunt quivis
+						intelligere <lb/> possit, in iis quoque gradatim surgentibus nullum esse
+						<lb/> finem ? An tibi non videtur?</p>
+					</div>
+					<div type="textpart" subtype="dialog" n="19">
+						<p>19. <hi rend="italic">D.</hi> Quid hoc vcro verius dici potest? Sed jam <lb/>
+						illam rationem quæ istam infinitatem revocat ad cer­ <lb/> lum modum formam
+						que præscribit quam excedere non <lb/> oporteat, avidissime cognoscere
+						exspecto. M. Hanc <lb/> quoque, ut alia, temetipsum nosse cognosces, cum
+						<lb/> me interrogante vera responderis. Nam primo abs te <lb/> qu:ero,
+						quoniam de numerosis motibus agimus, utrum <lb/> ipsos debeamus consulere
+						numeros, ut quas nobis le­ <lb/> gcs certas fixasque monstraverint, eas in
+						illis mo­ <lb/> tibus animadvertendas observandasque judicemus. <lb/>
+						<hi rend="italic">D.</hi> Placet vcro : non enim quidquam ordinatius fieri
+						<lb/> I osse arbitror. <hi rend="italic">II.</hi> Ergo 2b ipso, si videtur,
+						principio <lb/> numerorum capiamus considerationis hujus exordium <lb/> et
+						videamus, quantum pro viribus mentis nostræ talia <lb/> valemus intueri,
+						qurrnam sit ratio, ut quamvis per in- f <lb/> linitum, ut dictum est,
+						numeris progrediatur, arti­ <lb/> culos quosdam homines in numerando
+						fecerint; a <lb/> quibus ad unum rursus redeant, quod est principium <lb/>
+						numcromm. In numerando enim progreditnur ab uno <lb/> usque ad decem, atque
+						inde ad unum -revertimur : <lb/> ac I si denariam complicationem persequi
+						velis, tit <lb/> hoc modo progrediaris, decem. viginti, triginta,qua­ <lb/>
+						draginta ; usque ad centum est progressio : si cente­ <lb/> nan iam, centum,
+						ducenta, trecenta, quadringenta ; n <note type="footnote"> I in a., <hi
+								rend="italic">at.</hi> h's. A, <hi rend="italic">ac,</hi> ct mclius.
+							M. </note>
 						<lb/>
-						<pb n="1095"/> mille est articulus a quo redeatur. Quid jam opus est <lb/> ultra
-						quaerere? Vides certe quos articulos dicam, quo­ <lb/> rum prima regula denario numero
-						praescribitur. Nam <lb/> ut decem, decies habent unum; ita centum, decies <lb/> habent
-						eosdem decem ; et mille, decies habent cen­ <lb/> tum ; ct ita deinceps quousque libitum
-						est progredi , <lb/> ibit 1 in hujuscemodi quasi articulis, quod in denario <lb/> numero
-						præfinitum cst. An aliquid horum non intel­ <lb/> ligis ? <hi rend="italic">D.</hi>
+						<pb n="1095"/> mille est articulus a quo redeatur. Quid jam opus est <lb/>
+						ultra quaerere? Vides certe quos articulos dicam, quo­ <lb/> rum prima
+						regula denario numero praescribitur. Nam <lb/> ut decem, decies habent unum;
+						ita centum, decies <lb/> habent eosdem decem ; et mille, decies habent cen­
+						<lb/> tum ; ct ita deinceps quousque libitum est progredi , <lb/> ibit 1 in
+						hujuscemodi quasi articulis, quod in denario <lb/> numero præfinitum cst. An
+						aliquid horum non intel­ <lb/> ligis ? <hi rend="italic">D.</hi>
 						Manifestissima sunt omnia, ct verissima.</p>
-					<ab>
-						<title type="sub">CAPUT XII. — <hi rend="italic">Cur ab uno ad decem</hi> progressus,
-								<hi rend="italic">et inde ad unum</hi> reditu. <hi rend="italic">in numerando
-								fiat.</hi>
+					</div>
+					</div>
+					<div type="textpart" subtype="chapter" n="12">
+						<ab>
+						<title type="sub"><hi rend="italic">Cur ab uno ad decem</hi>
+							progressus, <hi rend="italic">et inde ad unum</hi> reditu. <hi
+								rend="italic">in numerando fiat.</hi>
 						</title>
 					</ab>
-					<p>20. <hi rend="italic">M.</hi> Hoe ergo quantum diligenter possumus per­ <lb/>
-						scrulcmur, quænam sit ratio ut ab uno usque ad de.. <lb/> cem progressus, et inde rursus
-						ad unum reditus fiat. <lb/> Unde abs te quæro, utmm quod vocamus principium, <lb/>
-						possit omnino nisi alicujus esse principium. <hi rend="italic">D.</hi> Nullo <lb/> modo
-						potest. <hi rend="italic">M.</hi> Item quod dicimus finem, potestne <lb/> nisi alicujus
-						rei finis esse? <hi rend="italic">D.</hi> Etiam id non potest. <lb/>
-						<hi rend="italic">M.</hi> Quid? a principio ad finem num putas perveniri <lb/> posse,
-						nisi per aliquod medium? <hi rend="italic">D.</hi> Non puto. <hi rend="italic">M.</hi>
-						Ergo <lb/> ut totum aliquid sit, principio et medio ct fine constat. <lb/>
-						<hi rend="italic">D.</hi> Ita videtur. <hi rend="italic">M.</hi> Dic itaque nunc,
-						principium, me­ <lb/> dium et finis, quo numero libi contineri videantur. <lb/>
-						<hi rend="italic">D.</hi> Arbitror ternarium numerum te velle ut respon­ <lb/> duam :
-						tria enim quædam sunt, de quibus quaeris. <lb/>
-						<hi rend="italic">M.</hi> Recta arbitraris. Quare in ternario numero quam­ <lb/> darn
-						esse perfectionem vides, quia totus est: habet <lb/> cnim principium, medium et finem.
-							<hi rend="italic">D.</hi> Video plane. <lb/>
-						<hi rend="italic">M.</hi> Quid? illud nonne ab incunte puerilia didicimus, <lb/> omnem
-						numcrum aut parem esse, aut imparem? <lb/>
-						<hi rend="italic">D.</hi> Verum dicis. <hi rend="italic">M.</hi> Recordare ergo et dic
-						mihi, quem <lb/> soleamus dicere parem , quem imparem numerum. <lb/>
-						<hi rend="italic">D.</hi> Ille qui potest in duas partes æquales dividi, par; <lb/> qui
-						autem non potest, impar vocatur.</p>
-					<p>it. <hi rend="italic">M.</hi> Rem tenes. Cum igitur ternarius primus sit <lb/> totus
-						impar; cl principio conio, et medio, et fine con­ <lb/> stat, ut dictum est; nonne
-						oportet etiam parcm esse <lb/> lotum atque perfectum , ut in eo etiam principium, <lb/>
-						medium, finisque inveniatur? <hi rend="italic">D.</hi> Oportet sane. M. At <lb/> iste
-						quisquis est, non potest habere individuum me­ <lb/> dium sicut impar: si enim habcret,
-						non posset in duas <lb/> æquales partes dividi, quod esse proprium paris nu­ <lb/> ncri
-						diximus. Individuum autem medium est unum, <lb/> dividuum duo. Medium autcm est in
-						numeris, a quo <lb/> ambo latera sibimet sunt æqualia. An aliquid obscure <lb/> dictum
-						est, minusquc assequeris? <hi rend="italic">D.</hi> Imo mihi et hæc <lb/> manifesta
-						sunt, cl dum quæro totum numerum parem, <lb/> quaternarius primus occurrit. Nam in
-						duobus quomodo <lb/> possunt tria illa inveniri, per quæ totus est numerus, <lb/> id est
-						principium, medium et finis? M. Idipsum <lb/> omnino abs te responsum est quod volcbain,
-						et quod <lb/> ipsa ratio cogit fateri. Repete itaque ab ipso uno tra­ <lb/> cta;ionem,
-						atque considera; videbis profecto ideo <lb/> unum non habere medium ct finem, quia
-						tantum prin­ <lb/> cipium est; vel ideo esse principium , qnia medio et <lb/> fine
-						caret. <hi rend="italic">D.</hi> Manifestum est. <hi rend="italic">M.</hi> Quid ergo
-						dicemus <note type="footnote"> * LOT., <hi rend="italic">progrediuntur in hujuscemodi
-								quasi articulis.</hi> ARN. <lb/> ft Er., <hi rend="italic">progredi, ririt</hi> in
-								<hi rend="italic">hujuscemodi</hi> etc.; at Ibs. meliores <lb/> habent, <hi rend="italic">progredi ibit,</hi> eu. </note>
+						<div type="textpart" subtype="dialog" n="20">
+							<p>20. <hi rend="italic">M.</hi> Hoe ergo quantum diligenter possumus per­ <lb/>
+						scrulcmur, quænam sit ratio ut ab uno usque ad de.. <lb/> cem progressus, et
+						inde rursus ad unum reditus fiat. <lb/> Unde abs te quæro, utmm quod vocamus
+						principium, <lb/> possit omnino nisi alicujus esse principium. <hi
+							rend="italic">D.</hi> Nullo <lb/> modo potest. <hi rend="italic">M.</hi>
+						Item quod dicimus finem, potestne <lb/> nisi alicujus rei finis esse? <hi
+							rend="italic">D.</hi> Etiam id non potest. <lb/>
+						<hi rend="italic">M.</hi> Quid? a principio ad finem num putas perveniri
+						<lb/> posse, nisi per aliquod medium? <hi rend="italic">D.</hi> Non puto.
+							<hi rend="italic">M.</hi> Ergo <lb/> ut totum aliquid sit, principio et
+						medio ct fine constat. <lb/>
+						<hi rend="italic">D.</hi> Ita videtur. <hi rend="italic">M.</hi> Dic itaque
+						nunc, principium, me­ <lb/> dium et finis, quo numero libi contineri
+						videantur. <lb/>
+						<hi rend="italic">D.</hi> Arbitror ternarium numerum te velle ut respon­
+						<lb/> duam : tria enim quædam sunt, de quibus quaeris. <lb/>
+						<hi rend="italic">M.</hi> Recta arbitraris. Quare in ternario numero quam­
+						<lb/> darn esse perfectionem vides, quia totus est: habet <lb/> cnim
+						principium, medium et finem. <hi rend="italic">D.</hi> Video plane. <lb/>
+						<hi rend="italic">M.</hi> Quid? illud nonne ab incunte puerilia didicimus,
+						<lb/> omnem numcrum aut parem esse, aut imparem? <lb/>
+						<hi rend="italic">D.</hi> Verum dicis. <hi rend="italic">M.</hi> Recordare
+						ergo et dic mihi, quem <lb/> soleamus dicere parem , quem imparem numerum. <lb/>
+						<hi rend="italic">D.</hi> Ille qui potest in duas partes æquales dividi,
+						par; <lb/> qui autem non potest, impar vocatur.</p>
+						</div>
+						<div type="textpart" subtype="dialog" n="21"><p>21. <hi rend="italic">M.</hi> Rem tenes. Cum igitur ternarius primus sit
+						<lb/> totus impar; cl principio conio, et medio, et fine con­ <lb/> stat, ut
+						dictum est; nonne oportet etiam parcm esse <lb/> lotum atque perfectum , ut
+						in eo etiam principium, <lb/> medium, finisque inveniatur? <hi rend="italic"
+							>D.</hi> Oportet sane. M. At <lb/> iste quisquis est, non potest habere
+						individuum me­ <lb/> dium sicut impar: si enim habcret, non posset in duas
+						<lb/> æquales partes dividi, quod esse proprium paris nu­ <lb/> ncri
+						diximus. Individuum autem medium est unum, <lb/> dividuum duo. Medium autcm
+						est in numeris, a quo <lb/> ambo latera sibimet sunt æqualia. An aliquid
+						obscure <lb/> dictum est, minusquc assequeris? <hi rend="italic">D.</hi> Imo
+						mihi et hæc <lb/> manifesta sunt, cl dum quæro totum numerum parem, <lb/>
+						quaternarius primus occurrit. Nam in duobus quomodo <lb/> possunt tria illa
+						inveniri, per quæ totus est numerus, <lb/> id est principium, medium et
+						finis? M. Idipsum <lb/> omnino abs te responsum est quod volcbain, et quod
+						<lb/> ipsa ratio cogit fateri. Repete itaque ab ipso uno tra­ <lb/>
+						cta;ionem, atque considera; videbis profecto ideo <lb/> unum non habere
+						medium ct finem, quia tantum prin­ <lb/> cipium est; vel ideo esse
+						principium , qnia medio et <lb/> fine caret. <hi rend="italic">D.</hi>
+						Manifestum est. <hi rend="italic">M.</hi> Quid ergo dicemus <note
+							type="footnote"> * LOT., <hi rend="italic">progrediuntur in hujuscemodi
+								quasi articulis.</hi> ARN. <lb/> ft Er., <hi rend="italic">progredi,
+								ririt</hi> in <hi rend="italic">hujuscemodi</hi> etc.; at Ibs.
+							meliores <lb/> habent, <hi rend="italic">progredi ibit,</hi> eu. </note>
 						<lb/> de duobus? Num possumus in eis intelligere <unclear>prin­</unclear>
-						<lb/> cipium et medium, cum medium esse non possit, ,.ibi <lb/> ubi finis est; aut
-						principium et finem, cum ad finem <lb/> nisi per medium non queat perveniri ? <hi rend="italic">D.</hi> Urget ratio <lb/> confileri; et quid de hoc numero respondcam,
-						prorsus <lb/> incertus sum. M. Vide ne iste quoque numerus possit <lb/> principium esse
-						numerorum. Nam si medio care: <lb/> et fine, quod, ut dixisti, cogit ratio confiteri;
-						quid re­ <lb/> slat, nisi ut sit hoc quoque principium? An dubitas <lb/> duo principia
-						constituere? D. Vehementer dubito. <lb/>
-						<hi rend="italic">M.</hi> Bene faceres, si ex adverso sibi constituerentur <lb/> duo
-						principia : nunc autem hoc alterum principium <lb/> de illo primo est, ut illud a nullo
-						sit, boc vero ab illo : <lb/> unum enim et unum duo sunt, et principia ita sunt <lb/>
-						ambo, ut omnes numeri quidem ab uno sint; sed quia <lb/> per complicationem atque
-						adjunctionem quamdam <lb/> fiunt, origo autem complicalionis et adjunctionis duali <lb/>
-						numero recte tribuitur: fit ut illud primum principium <lb/> a quo numeri omnes; hoc
-						autem alterum per quod <lb/> numeri omnes, esse inveniantur. Nisi quid habes ad­ <lb/>
-						versum ista quod disseras. <hi rend="italic">D.</hi> Ego vero nihil, et sine <lb/>
-						admiratione ista non cogito; quamvis ea, icterrogatas <lb/> abs te, ipse respondeam.</p>
-					<p>22. M. Subtilius ista quæruntur atque abstrusius in <lb/> ea disciplina qux est de
-						numeris : hie autem nos ad <lb/> institutum opus quanto citius possumus, redeamus. <lb/>
-						Quocirca quæro, uni duo juncta quid faciunt? <hi rend="italic">D.</hi> Tria. <lb/>
-						<hi rend="italic">M.</hi> Ergo haec duo principia numerorum sibimet co* <lb/> pulata,
-						totum numerum faciunt atque perfectum. <lb/>
-						<hi rend="italic">D.</hi> Ita est. <hi rend="italic">M.</hi> Quid ? in numerando post
-						unum etduo <lb/> quem numerum ponimus? <hi rend="italic">II.</hi> Eadem tria. <hi rend="italic">M.</hi> Idem <lb/> igitur numerus, qui fit ex uno et duobus, post utrum­
-						<lb/> que in ordine collocatur, ita ut nullus alius interponi <lb/> queat. <hi rend="italic">D.</hi> Ita video. <hi rend="italic">M.</hi> Atqui et illud videas
-						oportet, <lb/> in nullis reliquis numcris id posse contingere, ut cum <lb/> duos
-						quoslibet sibimet in numerandi ordine copulatos <lb/> notaveris, consequatur cos ille
-						qui ex ambobus con­ <lb/> ficitur, nullo interposito. <hi rend="italic">D.</hi> Id
-						quoque vidco : nam <lb/> duo et tria, qui sibi numeri copulati sunt, in summa <lb/>
-						quinque faciunt: non autem quinque continuatim se­ <lb/> quuntur, sed quatuor. Rursus
-						tria et quatuor septem <lb/> couficiunt: inter quatuor autem ac septem , quinque <lb/>
-						atque sex ordinati sunt. Et quanto progredi volucro, <lb/> tanto plurcs interponuntur.
-						II. Magna hu c ergo con­ <lb/> cordia est in prioribus tribus numeris : unum euim et
-						<lb/> duo ct tria dicimus, quibus nihil interponi potest: <lb/> unum autem ct duo, ipsa
-						sunt tria. <hi rend="italic">D.</hi> Magna prorsus. <lb/>
-						<hi rend="italic">Al.</hi> Quid? illud nullane consideratione dignum putas, <lb/> quod
-						ista concordia quanto est arctior atque conjun­ <lb/> ctior, tanto magis in unitatem
-						quamdam tendit, et <lb/> unum quiddam de pluribus efficit? <hi rend="italic">D.</hi> laO
-						maxima, <lb/> et nescio quomodo, et miror, et amo istam quain <lb/> commendas unitatem.
-						Af. Multum. probo; sed certe <lb/> quælibet rerum copulatio atque couucxio tunc maxi­
-						<lb/> me unum quiddam eflicit, cum et media extremis, et <lb/> mediis extrema
-						consentiunt. <hi rend="italic">D.</hi> Ita certe oportet.</p>
-					<p>23. <hi rend="italic">M.</hi> Attende igitur ut hoc in ibta connexione vi­ <note type="footnote">t <hi rend="italic">ride an iste,</hi> juxta Ms. A. Y.</note>
+						<lb/> cipium et medium, cum medium esse non possit, ,.ibi <lb/> ubi finis
+						est; aut principium et finem, cum ad finem <lb/> nisi per medium non queat
+						perveniri ? <hi rend="italic">D.</hi> Urget ratio <lb/> confileri; et quid
+						de hoc numero respondcam, prorsus <lb/> incertus sum. M. Vide ne iste quoque
+						numerus possit <lb/> principium esse numerorum. Nam si medio care: <lb/> et
+						fine, quod, ut dixisti, cogit ratio confiteri; quid re­ <lb/> slat, nisi ut
+						sit hoc quoque principium? An dubitas <lb/> duo principia constituere? D.
+						Vehementer dubito. <lb/>
+						<hi rend="italic">M.</hi> Bene faceres, si ex adverso sibi constituerentur
+						<lb/> duo principia : nunc autem hoc alterum principium <lb/> de illo primo
+						est, ut illud a nullo sit, boc vero ab illo : <lb/> unum enim et unum duo
+						sunt, et principia ita sunt <lb/> ambo, ut omnes numeri quidem ab uno sint;
+						sed quia <lb/> per complicationem atque adjunctionem quamdam <lb/> fiunt,
+						origo autem complicalionis et adjunctionis duali <lb/> numero recte
+						tribuitur: fit ut illud primum principium <lb/> a quo numeri omnes; hoc
+						autem alterum per quod <lb/> numeri omnes, esse inveniantur. Nisi quid habes
+						ad­ <lb/> versum ista quod disseras. <hi rend="italic">D.</hi> Ego vero
+						nihil, et sine <lb/> admiratione ista non cogito; quamvis ea, icterrogatas
+						<lb/> abs te, ipse respondeam.</p>
+						</div>
+						<div type="textpart" subtype="dialog" n="22">
+					<p>22. M. Subtilius ista quæruntur atque abstrusius in <lb/> ea disciplina qux
+						est de numeris : hie autem nos ad <lb/> institutum opus quanto citius
+						possumus, redeamus. <lb/> Quocirca quæro, uni duo juncta quid faciunt? <hi
+							rend="italic">D.</hi> Tria. <lb/>
+						<hi rend="italic">M.</hi> Ergo haec duo principia numerorum sibimet co*
+						<lb/> pulata, totum numerum faciunt atque perfectum. <lb/>
+						<hi rend="italic">D.</hi> Ita est. <hi rend="italic">M.</hi> Quid ? in
+						numerando post unum etduo <lb/> quem numerum ponimus? <hi rend="italic"
+							>II.</hi> Eadem tria. <hi rend="italic">M.</hi> Idem <lb/> igitur
+						numerus, qui fit ex uno et duobus, post utrum­ <lb/> que in ordine
+						collocatur, ita ut nullus alius interponi <lb/> queat. <hi rend="italic"
+							>D.</hi> Ita video. <hi rend="italic">M.</hi> Atqui et illud videas
+						oportet, <lb/> in nullis reliquis numcris id posse contingere, ut cum <lb/>
+						duos quoslibet sibimet in numerandi ordine copulatos <lb/> notaveris,
+						consequatur cos ille qui ex ambobus con­ <lb/> ficitur, nullo interposito.
+							<hi rend="italic">D.</hi> Id quoque vidco : nam <lb/> duo et tria, qui
+						sibi numeri copulati sunt, in summa <lb/> quinque faciunt: non autem quinque
+						continuatim se­ <lb/> quuntur, sed quatuor. Rursus tria et quatuor septem
+						<lb/> couficiunt: inter quatuor autem ac septem , quinque <lb/> atque sex
+						ordinati sunt. Et quanto progredi volucro, <lb/> tanto plurcs interponuntur.
+						II. Magna hu c ergo con­ <lb/> cordia est in prioribus tribus numeris : unum
+						euim et <lb/> duo ct tria dicimus, quibus nihil interponi potest: <lb/> unum
+						autem ct duo, ipsa sunt tria. <hi rend="italic">D.</hi> Magna prorsus. <lb/>
+						<hi rend="italic">Al.</hi> Quid? illud nullane consideratione dignum putas,
+						<lb/> quod ista concordia quanto est arctior atque conjun­ <lb/> ctior,
+						tanto magis in unitatem quamdam tendit, et <lb/> unum quiddam de pluribus
+						efficit? <hi rend="italic">D.</hi> laO maxima, <lb/> et nescio quomodo, et
+						miror, et amo istam quain <lb/> commendas unitatem. Af. Multum. probo; sed
+						certe <lb/> quælibet rerum copulatio atque couucxio tunc maxi­ <lb/> me unum
+						quiddam eflicit, cum et media extremis, et <lb/> mediis extrema consentiunt.
+							<hi rend="italic">D.</hi> Ita certe oportet.</p>
+						</div>
+						<div type="textpart" subtype="dialog" n="23"> 
+							
+							
+							<!-- REPRENDRE ICI ***************************************************************************************** --> 
+							
+							
+					<p>23. <hi rend="italic">M.</hi> Attende igitur ut hoc in ibta connexione vi­
+							<note type="footnote">t <hi rend="italic">ride an iste,</hi> juxta Ms.
+							A. Y.</note>
 						<lb/>
-						<pb n="1097"/> Jeamus. Nam cum unum , duo, tria dicimus, nonne <lb/> quanto unum a
-						duobus, tanto duo a tribus superantur? <lb/>
-						<hi rend="italic">D.</hi> Verissimum est. <hi rend="italic">M.</hi> Dic jam nunc mihi,
-						in ista <lb/> collatione quoties unum nominaverim. <hi rend="italic">D.</hi> Semet. <lb/>
-						<hi rend="italic">M.</hi> Tria quoties ? <hi rend="italic">D.</hi> Semel. <hi rend="italic">II.</hi> Quid, duo? <hi rend="italic">D.</hi> Bis. <lb/>
-						<hi rend="italic">M.</hi> Remcl ergo,. et bis, ei semel, quoties fit in summa? <lb/>
-						<hi rend="italic">D.</hi> Quater. <hi rend="italic">M.</hi> Recte igitur istos tres
-						quaternarius na­ <lb/> merus sequitur; ci quippe tribuitur ista proportione <lb/>
-						collatio. Quæ quantum valeat, eo jam assuesce cogno- <lb/> Iceret quod illa irritas quam
-						te amare dixisti, in rebus <lb/> ordinatis hac una effici potest, cujus græcum nomen <lb/>
-						<foreign xml:lang="grc">άναλογία</foreign> est, nostri quidam proportionem vocaverunt,
-						<lb/> quo nomine utamur, si placct : non enim libenter, <lb/> . nisi nccessitate, græca
-						vocabula in latino sermone <lb/> usurpaverim. D. Mihi vero placet; sed perge quo in­
-						<lb/> tenderas. M. Faciam. Nam quid sit proportio, quan­ <lb/> tumque in rebus juris
-						babeat, ct suo loco in hac disci­ <lb/> plina diligentius requiremus; et quanto in
-						eruditione <lb/> promotior cris, tanto ejus vim melius naturamque <lb/> cognosces. Sed
-						vides certe, quod in præsentia satis <lb/> est, tres illos numeros, quor um mirabare
-						concordiam, <lb/> sibimet in cadem connexione nisi per quaternarium <lb/> numerum non
-						potuisse conferri. Quamobrem post <lb/> illos se ordinari, sic ut illa concordia cum his
-						arctiore <lb/> copuletur, quantum intelligis jure impetravit1; ut jam <lb/> non unum,
-						duo, tria tantum ; sed unum, duo, tria, <lb/> quatuor, sit amicissime copulata
-						progressio numcro­ <lb/> rum. <hi rend="italic">D.</hi> Omnino assentior.</p>
-					<p>i. II. At cætera intuere, ne arbitreris nihil habere <lb/> proprium quaternarium
-						numerum, quo reliqui omnes <lb/> numeri careant, quod valeat ad istam connexionem <lb/>
-						de qua loquor, ut ab uno usque ad quatuor certus sit <lb/> numerus, et pulcherrimus
-						progrediendi modus. Cen­ <lb/> venerat quippe inter nos superius, tunc ex pluribus <lb/>
-						unum aliquid maxime fieri, cum extremis media, et <lb/> mediis extrema consentiunt. <hi rend="italic">D.</hi> Ita est. <hi rend="italic">II.</hi> Cum ergo <lb/> collocamus
-						unum et duo ct tria , dic quæ sint extre­ <lb/> ma,quod medium. <hi rend="italic">D.</hi> Unum ct tria extrema video, <lb/> duo mediam. II. Responde nunc, ex uno et
-						tribus <lb/> quid conficiatur. <hi rend="italic">D.</hi> Quatuor. M. Quid? duo qui unus
-						<lb/> in medio numerus est, num potest nisi sibi con­ <lb/> ferri? Quamobrem dic etiam
-						duo bis quid conficiant. <lb/>
-						<hi rend="italic">D.</hi> Quatuor. <hi rend="italic">M.</hi> Ila ergo medium extremis,
-						et medio <lb/> extrema consentiunt. Quamobrem sicut excellit in <lb/> tribus, quod post
-						unum et dno collocantur, cum ex <lb/> uno et duobus constent; sie excellit in quatuor,
-						quod <lb/> post unum et duo et tria numerantur, cum constent <lb/> ex uno et tribus, vel
-						bis duobus : quæ extremorum <lb/> cum medio, et medii cum extremis, in illa quæ græce <lb/>
-						<foreign xml:lang="grc">άναλογία</foreign> dicitur, proportione consensio est. Quod
-						<lb/> utrum intellexeris pande. <hi rend="italic">D.</hi> Satis intelligo.</p>
-					<p>i. <hi rend="italic">M.</hi> Tenta ergo in reliquis numeris, utrumne <lb/> inveniatur
-						quod quaternarii numcri proprium ease <lb/> dixamus. <hi rend="italic">D.</hi> Faciam.
-						Nam si constituamus duo, tria, <lb/> quatuor , extrema collata fiunt sex ; hoc facit et
-						me­ <lb/> dium sibi collatum : lace tamen SCI, scd quinque con­ <lb/> sequunlur. Rursus
-						tria, quatuor ct quinque constituo; <lb/> extrema octo faciunt, medium quoque bis ductum
-						: at <note type="footnote"><hi rend="italic">1 imperavit,</hi> juxta Mss. A et B. at </note>
-						<lb/> inter quinque ct octo, non jam unum, sed duos, se­ <lb/> narium scilicet et
-						septenarium numeros interpositos <lb/> video. Atque illa ratione quantum progredior,
-						tanto <lb/> hæc fiunt intervalla majora1. <hi rend="italic">M.</hi> Video tc
-						intellexisse, <lb/> et omnino scire quod dictum est: sed jam ne immo­ <lb/> remur,
-						animadvertis certe ab uno usque ad quatuor <lb/> justissimam ficti progressionem ; sive
-						propter impa­ <lb/> rem ac parem numcrum , quoniam primus impar <lb/> totus tria, et
-						primus par totus quatuor, de qua re <lb/> paulo ante tractatum est; sive quia Unum et
-						duo prin­ <lb/> cipia sunt, et quasi semina numcrorum, e quibus tcr­ <lb/> narius
-						conficitur, ut sint jam tres numcri; qui sibi <lb/> dum proportione conferuntur,
-						quaternarius clucesCit <lb/> et gignitur, et propterea cis jure conjungitur, ut usque
-						<lb/> ad illum fiat ea, quam quærimus moderata progressio. <lb/> D. Intelligo.</p>
-					<p>36. M. Bene sane. Sed meministine tandem quid <lb/> . institueramus inquirere? Nam, ut
-						opinor, proposi­ <lb/> tum erat, si quomodo invenire possemus, cum in Illa <lb/>
-						infinitate numerorum certi articuli cssent numeranti­ <lb/> bus constituti, quid esset
-						causæcur ipse primus arti­ <lb/> culus in denario numero esset, qui per omnes cæteros I
-						<lb/> valet plurimum; id est, cur ab uno usque ad decem <lb/> progressi numerantes
-						rursum ad uaum remearent? <lb/>
-						<hi rend="italic">D.</hi> Recordor plane quæstionis hujus causa nos tantum <lb/>
-						circumisse : sed quid effecerimus quod ad cam sol­ <lb/> vendam pertineat, non invenio.
-						Siquidem illa omnis <lb/> nostra ratiocinatio ad id conclusa est, ut non usque <lb/> ad
-						denarium, sed usque ad quaternarium nume­ <lb/> rum sit justa et moderata progressio. M.
-						Tune <lb/> igitur non vides, ex uno et duobus, et tribus <lb/> et quatuor quæ summa
-						conficiatur! <hi rend="italic">D.</hi> Video jam, <lb/> video, et miror omnia, et ortam
-						quætionem so- <lb/> Intam esse confiteor : unum enim ct duo et tria et <lb/> quatuor
-						simul decem sunt. <hi rend="italic">M.</hi> Ergo istos quatuor <lb/> primos numeros,
-						seriemque et connexionem corum <lb/> honorabilius haberi, quam cætera, in numeris con­
-						<lb/> venit.</p>
-					<ab>
-						<title type="sub">CAPUT XIII. — <hi rend="italic">De proportionatorum moluum decore
-								quatenus sensibus judicatur.</hi>
+						<pb n="1097"/> Jeamus. Nam cum unum , duo, tria dicimus, nonne <lb/> quanto
+						unum a duobus, tanto duo a tribus superantur? <lb/>
+						<hi rend="italic">D.</hi> Verissimum est. <hi rend="italic">M.</hi> Dic jam
+						nunc mihi, in ista <lb/> collatione quoties unum nominaverim. <hi
+							rend="italic">D.</hi> Semet. <lb/>
+						<hi rend="italic">M.</hi> Tria quoties ? <hi rend="italic">D.</hi> Semel.
+							<hi rend="italic">II.</hi> Quid, duo? <hi rend="italic">D.</hi> Bis. <lb/>
+						<hi rend="italic">M.</hi> Remcl ergo,. et bis, ei semel, quoties fit in
+						summa? <lb/>
+						<hi rend="italic">D.</hi> Quater. <hi rend="italic">M.</hi> Recte igitur
+						istos tres quaternarius na­ <lb/> merus sequitur; ci quippe tribuitur ista
+						proportione <lb/> collatio. Quæ quantum valeat, eo jam assuesce cogno- <lb/>
+						Iceret quod illa irritas quam te amare dixisti, in rebus <lb/> ordinatis hac
+						una effici potest, cujus græcum nomen <lb/>
+						<foreign xml:lang="grc">άναλογία</foreign> est, nostri quidam proportionem
+						vocaverunt, <lb/> quo nomine utamur, si placct : non enim libenter, <lb/> .
+						nisi nccessitate, græca vocabula in latino sermone <lb/> usurpaverim. D.
+						Mihi vero placet; sed perge quo in­ <lb/> tenderas. M. Faciam. Nam quid sit
+						proportio, quan­ <lb/> tumque in rebus juris babeat, ct suo loco in hac
+						disci­ <lb/> plina diligentius requiremus; et quanto in eruditione <lb/>
+						promotior cris, tanto ejus vim melius naturamque <lb/> cognosces. Sed vides
+						certe, quod in præsentia satis <lb/> est, tres illos numeros, quor um
+						mirabare concordiam, <lb/> sibimet in cadem connexione nisi per quaternarium
+						<lb/> numerum non potuisse conferri. Quamobrem post <lb/> illos se ordinari,
+						sic ut illa concordia cum his arctiore <lb/> copuletur, quantum intelligis
+						jure impetravit1; ut jam <lb/> non unum, duo, tria tantum ; sed unum, duo,
+						tria, <lb/> quatuor, sit amicissime copulata progressio numcro­ <lb/> rum.
+							<hi rend="italic">D.</hi> Omnino assentior.</p>
+					<p>i. II. At cætera intuere, ne arbitreris nihil habere <lb/> proprium
+						quaternarium numerum, quo reliqui omnes <lb/> numeri careant, quod valeat ad
+						istam connexionem <lb/> de qua loquor, ut ab uno usque ad quatuor certus sit
+						<lb/> numerus, et pulcherrimus progrediendi modus. Cen­ <lb/> venerat quippe
+						inter nos superius, tunc ex pluribus <lb/> unum aliquid maxime fieri, cum
+						extremis media, et <lb/> mediis extrema consentiunt. <hi rend="italic"
+							>D.</hi> Ita est. <hi rend="italic">II.</hi> Cum ergo <lb/> collocamus
+						unum et duo ct tria , dic quæ sint extre­ <lb/> ma,quod medium. <hi
+							rend="italic">D.</hi> Unum ct tria extrema video, <lb/> duo mediam. II.
+						Responde nunc, ex uno et tribus <lb/> quid conficiatur. <hi rend="italic"
+							>D.</hi> Quatuor. M. Quid? duo qui unus <lb/> in medio numerus est, num
+						potest nisi sibi con­ <lb/> ferri? Quamobrem dic etiam duo bis quid
+						conficiant. <lb/>
+						<hi rend="italic">D.</hi> Quatuor. <hi rend="italic">M.</hi> Ila ergo medium
+						extremis, et medio <lb/> extrema consentiunt. Quamobrem sicut excellit in
+						<lb/> tribus, quod post unum et dno collocantur, cum ex <lb/> uno et duobus
+						constent; sie excellit in quatuor, quod <lb/> post unum et duo et tria
+						numerantur, cum constent <lb/> ex uno et tribus, vel bis duobus : quæ
+						extremorum <lb/> cum medio, et medii cum extremis, in illa quæ græce <lb/>
+						<foreign xml:lang="grc">άναλογία</foreign> dicitur, proportione consensio
+						est. Quod <lb/> utrum intellexeris pande. <hi rend="italic">D.</hi> Satis
+						intelligo.</p>
+					<p>i. <hi rend="italic">M.</hi> Tenta ergo in reliquis numeris, utrumne <lb/>
+						inveniatur quod quaternarii numcri proprium ease <lb/> dixamus. <hi
+							rend="italic">D.</hi> Faciam. Nam si constituamus duo, tria, <lb/>
+						quatuor , extrema collata fiunt sex ; hoc facit et me­ <lb/> dium sibi
+						collatum : lace tamen SCI, scd quinque con­ <lb/> sequunlur. Rursus tria,
+						quatuor ct quinque constituo; <lb/> extrema octo faciunt, medium quoque bis
+						ductum : at <note type="footnote"><hi rend="italic">1 imperavit,</hi> juxta
+							Mss. A et B. at </note>
+						<lb/> inter quinque ct octo, non jam unum, sed duos, se­ <lb/> narium
+						scilicet et septenarium numeros interpositos <lb/> video. Atque illa ratione
+						quantum progredior, tanto <lb/> hæc fiunt intervalla majora1. <hi
+							rend="italic">M.</hi> Video tc intellexisse, <lb/> et omnino scire quod
+						dictum est: sed jam ne immo­ <lb/> remur, animadvertis certe ab uno usque ad
+						quatuor <lb/> justissimam ficti progressionem ; sive propter impa­ <lb/> rem
+						ac parem numcrum , quoniam primus impar <lb/> totus tria, et primus par
+						totus quatuor, de qua re <lb/> paulo ante tractatum est; sive quia Unum et
+						duo prin­ <lb/> cipia sunt, et quasi semina numcrorum, e quibus tcr­ <lb/>
+						narius conficitur, ut sint jam tres numcri; qui sibi <lb/> dum proportione
+						conferuntur, quaternarius clucesCit <lb/> et gignitur, et propterea cis jure
+						conjungitur, ut usque <lb/> ad illum fiat ea, quam quærimus moderata
+						progressio. <lb/> D. Intelligo.</p>
+					<p>36. M. Bene sane. Sed meministine tandem quid <lb/> . institueramus
+						inquirere? Nam, ut opinor, proposi­ <lb/> tum erat, si quomodo invenire
+						possemus, cum in Illa <lb/> infinitate numerorum certi articuli cssent
+						numeranti­ <lb/> bus constituti, quid esset causæcur ipse primus arti­ <lb/>
+						culus in denario numero esset, qui per omnes cæteros I <lb/> valet plurimum;
+						id est, cur ab uno usque ad decem <lb/> progressi numerantes rursum ad uaum
+						remearent? <lb/>
+						<hi rend="italic">D.</hi> Recordor plane quæstionis hujus causa nos tantum
+						<lb/> circumisse : sed quid effecerimus quod ad cam sol­ <lb/> vendam
+						pertineat, non invenio. Siquidem illa omnis <lb/> nostra ratiocinatio ad id
+						conclusa est, ut non usque <lb/> ad denarium, sed usque ad quaternarium
+						nume­ <lb/> rum sit justa et moderata progressio. M. Tune <lb/> igitur non
+						vides, ex uno et duobus, et tribus <lb/> et quatuor quæ summa conficiatur!
+							<hi rend="italic">D.</hi> Video jam, <lb/> video, et miror omnia, et
+						ortam quætionem so- <lb/> Intam esse confiteor : unum enim ct duo et tria et
+						<lb/> quatuor simul decem sunt. <hi rend="italic">M.</hi> Ergo istos quatuor
+						<lb/> primos numeros, seriemque et connexionem corum <lb/> honorabilius
+						haberi, quam cætera, in numeris con­ <lb/> venit.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT XIII. — <hi rend="italic">De proportionatorum moluum
+								decore quatenus sensibus judicatur.</hi>
 						</title>
 					</ab>
-					<p>27. Tempus est autem ad illos motus rcdirc tra­ <lb/> ctandos et discutiendos, qui huic
-						disciplinæ proprie <lb/> tribuuntur, et propter quos ista de numeris f de alia <lb/>
-						scilicct disciplina , quantum pro negotio satis visum <lb/> est, considcravimus. Itaque
-						nunc abs te quæo, quo­ <lb/> niam intelligendi gratia in horarum spatio motus <lb/>
-						constituebamus , quos ad se invicem habere aliquam <lb/> numerosam dimensionem ratio
-						demonstrabat; utrum <lb/> si quisquam mora unius horæ currat, et alius dc:n­ <lb/> ceps
-						duarum , possis non inspecto horologio vel cic. <lb/> psydra , vcl aliqna hujuscemodi
-						temporum notatione <lb/> sentire illos duos motus, quod unus simplus, alius <lb/> duplus
-						sit : vel etiamsi id non possis dicere, illa ta­ <lb/> mch congruentia delectari, atque
-						aliqua voluptate af­ <lb/> fici. <hi rend="italic">D.</hi> Nullo modo possum. <hi rend="italic">M.</hi> Quid, si quispiam nu­ <lb/> mcrosc plaudat, iti ut unus sonitus
-						simplum , alter <lb/> duplum temporis teneat, quos iambos pedes vocant, <lb/> eosque
-						continuct atque contexat; alius antem ad <note type="footnote">1 In. a., <hi rend="italic">(tfcitmt interrella majora.</hi> Ms. A, <hi rend="italic">fiunt.</hi>
-							II. </note><note type="footnote">PATROL. XXXII. </note>
+					<p>27. Tempus est autem ad illos motus rcdirc tra­ <lb/> ctandos et
+						discutiendos, qui huic disciplinæ proprie <lb/> tribuuntur, et propter quos
+						ista de numeris f de alia <lb/> scilicct disciplina , quantum pro negotio
+						satis visum <lb/> est, considcravimus. Itaque nunc abs te quæo, quo­ <lb/>
+						niam intelligendi gratia in horarum spatio motus <lb/> constituebamus , quos
+						ad se invicem habere aliquam <lb/> numerosam dimensionem ratio demonstrabat;
+						utrum <lb/> si quisquam mora unius horæ currat, et alius dc:n­ <lb/> ceps
+						duarum , possis non inspecto horologio vel cic. <lb/> psydra , vcl aliqna
+						hujuscemodi temporum notatione <lb/> sentire illos duos motus, quod unus
+						simplus, alius <lb/> duplus sit : vel etiamsi id non possis dicere, illa ta­
+						<lb/> mch congruentia delectari, atque aliqua voluptate af­ <lb/> fici. <hi
+							rend="italic">D.</hi> Nullo modo possum. <hi rend="italic">M.</hi> Quid,
+						si quispiam nu­ <lb/> mcrosc plaudat, iti ut unus sonitus simplum , alter
+						<lb/> duplum temporis teneat, quos iambos pedes vocant, <lb/> eosque
+						continuct atque contexat; alius antem ad <note type="footnote">1 In. a., <hi
+								rend="italic">(tfcitmt interrella majora.</hi> Ms. A, <hi
+								rend="italic">fiunt.</hi> II. </note><note type="footnote">PATROL.
+							XXXII. </note>
 						<note type="footnote"><hi rend="italic">(Trentc-cinq.) .</hi>
 						</note>
 						<lb/>
-						<pb n="1099"/> eumdem sonum saltet, secundum ca scilicet tempora <lb/> movens membra ?
-						nonne 1 aut etiam dicas ipsum <lb/> modulum temporum, id est quod simplum ad duplum
-						<lb/> spatia in motibus alternent, sive in illo plausu qui au­ <lb/> ditur, sive in illa
-						saltatione quæ cernitur; aut saltem <lb/> delecteris numerositate quam sentias, tametsi
-						non <lb/> possis numeros ejus dimensionis edicere? <hi rend="italic">D.</hi> Ita vero
-						<lb/> cst, ut dicis : nam et illi qui hos numeros noverunt, <lb/> sentiunt cos in plausu
-						atque saltatione , quique sint <lb/> facile dicunt; et qui cos non noverunt nee possunt
-						<lb/> uiccre, non negant tamen ex his se voluptate aliqua <lb/> perfrui.</p>
-					<p>is. M. Cum igitur ad ipsam rationem disciplinæ <lb/> hujus, siquidem scientia est bene
-						modulandi, non <lb/> possit negari omnes pertinere motus qui bene modu­ <lb/> lati sunt,
-						et cos potissimum qui non referuntur ad <lb/> aliud aliquid, sed in seipsis finem
-						dccoris delectatio­ <lb/> nisve conservant; hi tamen motus, ut nunc a me ro­ <lb/> gatus
-						recte vereque dixisti, si longo spatio temporis <note type="footnote">1 Ms. A addit,
-							adverku. IL </note>
-						<lb/> fiant, inque ipsa dimensione quae decora est, horam <lb/> vel etiam majus tempus
-						obtineant, non possunt con­ <lb/> grucre nostris sensibus i. Quamobrem cum procedens
-						<lb/> quodammodo de secretissimis penetralibus musica, iu <lb/> nostris etiam sensibus,
-						vel his rebus quae a nobii <lb/> sentiuntur, vestigia quaedam posuerit; nonne oportet
-						<lb/> eadem vestigia prius persequi, ut commodius ad ipsa <lb/> si potuerimus, quae dixi
-						penetralia, sine ullo errore <lb/> ducamur? <hi rend="italic">D.</hi> Oportet vero, et
-						hoc jamjamque ut fa­ <lb/> ciamus, efflagito. II. Omittamus ergo illas ultra 2 ca­ <lb/>
-						pacitatem sensus nostri porrectas temporum metas, <lb/> et de his brevibus intervallorum
-						spatiis, qun in can­ <lb/> lando saltandoque nos mulcent, quantum ratio nos <lb/>
-						duxerit, disseramus. Nisi tu forte aliter putas illa <lb/> vestigia indagari posse, quæ
-						in nostris sensibus, his­ <lb/> que rebus quas valemus sentire, hanc disciplinam <lb/>
-						posuisse prædictum est. <hi rend="italic">D.</hi> Nullo moda aliter puto. <note type="footnote"> 1 Addit vatic.: <hi rend="italic">licel aUcjuanto idern</hi> pes in
-								<hi rend="italic">canendo, seT- <lb/> VIlla collationis ratione, alias longforihi,
-								alias brerilniblu</hi>
-							<lb/> pmit fieri sonis. M. </note><note type="footnote">* vatic., <hi rend="italic">extra. II.</hi>
+						<pb n="1099"/> eumdem sonum saltet, secundum ca scilicet tempora <lb/>
+						movens membra ? nonne 1 aut etiam dicas ipsum <lb/> modulum temporum, id est
+						quod simplum ad duplum <lb/> spatia in motibus alternent, sive in illo
+						plausu qui au­ <lb/> ditur, sive in illa saltatione quæ cernitur; aut saltem
+						<lb/> delecteris numerositate quam sentias, tametsi non <lb/> possis numeros
+						ejus dimensionis edicere? <hi rend="italic">D.</hi> Ita vero <lb/> cst, ut
+						dicis : nam et illi qui hos numeros noverunt, <lb/> sentiunt cos in plausu
+						atque saltatione , quique sint <lb/> facile dicunt; et qui cos non noverunt
+						nee possunt <lb/> uiccre, non negant tamen ex his se voluptate aliqua <lb/>
+						perfrui.</p>
+					<p>is. M. Cum igitur ad ipsam rationem disciplinæ <lb/> hujus, siquidem scientia
+						est bene modulandi, non <lb/> possit negari omnes pertinere motus qui bene
+						modu­ <lb/> lati sunt, et cos potissimum qui non referuntur ad <lb/> aliud
+						aliquid, sed in seipsis finem dccoris delectatio­ <lb/> nisve conservant; hi
+						tamen motus, ut nunc a me ro­ <lb/> gatus recte vereque dixisti, si longo
+						spatio temporis <note type="footnote">1 Ms. A addit, adverku. IL </note>
+						<lb/> fiant, inque ipsa dimensione quae decora est, horam <lb/> vel etiam
+						majus tempus obtineant, non possunt con­ <lb/> grucre nostris sensibus i.
+						Quamobrem cum procedens <lb/> quodammodo de secretissimis penetralibus
+						musica, iu <lb/> nostris etiam sensibus, vel his rebus quae a nobii <lb/>
+						sentiuntur, vestigia quaedam posuerit; nonne oportet <lb/> eadem vestigia
+						prius persequi, ut commodius ad ipsa <lb/> si potuerimus, quae dixi
+						penetralia, sine ullo errore <lb/> ducamur? <hi rend="italic">D.</hi>
+						Oportet vero, et hoc jamjamque ut fa­ <lb/> ciamus, efflagito. II. Omittamus
+						ergo illas ultra 2 ca­ <lb/> pacitatem sensus nostri porrectas temporum
+						metas, <lb/> et de his brevibus intervallorum spatiis, qun in can­ <lb/>
+						lando saltandoque nos mulcent, quantum ratio nos <lb/> duxerit, disseramus.
+						Nisi tu forte aliter putas illa <lb/> vestigia indagari posse, quæ in
+						nostris sensibus, his­ <lb/> que rebus quas valemus sentire, hanc
+						disciplinam <lb/> posuisse prædictum est. <hi rend="italic">D.</hi> Nullo
+						moda aliter puto. <note type="footnote"> 1 Addit vatic.: <hi rend="italic"
+								>licel aUcjuanto idern</hi> pes in <hi rend="italic">canendo, seT-
+								<lb/> VIlla collationis ratione, alias longforihi, alias
+								brerilniblu</hi>
+							<lb/> pmit fieri sonis. M. </note><note type="footnote">* vatic., <hi
+								rend="italic">extra. II.</hi>
 						</note></p>
 				</div>
-				<div type="textpart" subtype="chapter">
+				<div type="textpart" subtype="livre">
 					<head>
-						<title type="main"><hi rend="italic">LIBER SECUNDUS.</hi> In quo de syllabis et pedibus
-							metricis disputatur.</title>
+						<title type="main"><hi rend="italic">LIBER SECUNDUS.</hi> In quo de syllabis
+							et pedibus metricis disputatur.</title>
 					</head>
-					<ab>
-						<title type="sub">CAPUT PRIMUM.—Syllabarum <hi rend="italic">spatia aliunde gram­
-								maticus, aliunde</hi> musicus attendit.</title>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT PRIMUM.—Syllabarum <hi rend="italic">spatia aliunde
+								gram­ maticus, aliunde</hi> musicus attendit.</title>
 					</ab>
-					<p>i. M. Attende igitur diligenter, et nunc demum <lb/> accipe quasi alterum nostra
-						disputationis exordium. <lb/> Ac primum responde, utrum bene didiceris eam <lb/> quam
-						grammatici docent, syllabarum brevium longa­ <lb/> rumque distantiam; an vero sive ista
-						Doris sive ignores, <lb/> tnalis ut ita quæramus, quasi omnino rudes harum re­ <lb/> rum
-						simus, ut ad omnia nos ratio potius perducat, quam <lb/> inveterata consuetudo, aut
-						praejudicata cogat auctori­ <lb/> tas. <hi rend="italic">D.</hi> Ita plane malle me, non
-						modo ipsa ratio, sed <lb/> istarum etiam syllabarum imperitia (quid enim fateri <lb/>
-						dubitem?) impellit. M. Age jam, saltem illud elo­ <lb/> quere, utrum tu ipse per te
-						nunquam animadverteris <lb/> in locutione nostra alias syllabas raptim et minime <lb/>
-						.litt, alias autem productius ct diutius enuntiari. D. <lb/> Ncgare non possum non me ad
-						ista etiam surdum <lb/> fuissc. <hi rend="italic">M.</hi> Atqui scias velim totam illam
-						scientiam, <lb/> quæ grammatica græce , latine antem litteratura no­ <lb/> minatur,
-						historie custodiam profiteri, vel solam , ut <lb/> subtilior ducet ratio; vel maxime, ut
-						etiam pinguia <lb/> corda concedunt. itaque verbigratia cumdixeris, <hi rend="italic">cano,</hi>
-						<lb/> vel in versu forte posueris, ita ut vel tu pronuntians <lb/> producas hujus verbi
-						syllabam primam, vel in versu <lb/> ♦o loco ponas , ubi esse productam oportebat; repre­
-						<lb/> hendet grammaticus , custos ille videlicet historiæ, <lb/> nihil aliud asserens
-						cur hunc'corripi oporteat, nisi <lb/> quod hi qui ante nos fuerunt, et quorum libri
-						exstant <lb/> tractanturque a grammaticis, ea correpta 1 non pro­ <lb/> ducta usi
-						fuerint. Quare hic quidquid valet, auctoritas <lb/> valet. At vero musicæ ratio, ad quam
-						dimensio ipsa <lb/> vocum rationabilis et numerositas pertinet, non curat <note type="footnote"> I vatic., <hi rend="italic">pro correpta.</hi> M. </note>
-						<lb/> nisi ut corripiatur vel producatur syllaba, quæ illo vel <lb/> illo loco est
-						secundum rationem mensurarum suarum. <lb/> Nam si eo loco ubi duas longas syllabas poni
-						decet, <lb/> hoc verbum posueris, et primam quae brevis est, pro­ <lb/> nuntiatione
-						longain feceris, nibil musica omnino suc­ <lb/> censet 1 : tempora enim vocum ea
-						pervenerc ad au­ <lb/> res, quæ illi numero debita fuerunt. Grammaticus <lb/> autem
-						jubet emeudari, et illud te verbum ponere <lb/> cujus prima .syllaba producenda sit,
-						secundum majo­ <lb/> rum, ut dictum est, auctoritatem, quorum scripta <lb/>
-						custodit2.</p>
-					<ab>
-						<title type="sub">CAPUT II. — <hi rend="italic">De versu judicat</hi> grammaticas <hi rend="italic">ex aucto­</hi> ritate, musicus ex <hi rend="italic">ratione et</hi>
-							sensu.</title>
+					<p>1. M. Attende igitur diligenter, et nunc demum <lb/> accipe quasi alterum
+						nostra disputationis exordium. <lb/> Ac primum responde, utrum bene
+						didiceris eam <lb/> quam grammatici docent, syllabarum brevium longa­ <lb/>
+						rumque distantiam; an vero sive ista Doris sive ignores, <lb/> tnalis ut ita
+						quæramus, quasi omnino rudes harum re­ <lb/> rum simus, ut ad omnia nos
+						ratio potius perducat, quam <lb/> inveterata consuetudo, aut praejudicata
+						cogat auctori­ <lb/> tas. <hi rend="italic">D.</hi> Ita plane malle me, non
+						modo ipsa ratio, sed <lb/> istarum etiam syllabarum imperitia (quid enim
+						fateri <lb/> dubitem?) impellit. M. Age jam, saltem illud elo­ <lb/> quere,
+						utrum tu ipse per te nunquam animadverteris <lb/> in locutione nostra alias
+						syllabas raptim et minime <lb/> .litt, alias autem productius ct diutius
+						enuntiari. D. <lb/> Ncgare non possum non me ad ista etiam surdum <lb/>
+						fuissc. <hi rend="italic">M.</hi> Atqui scias velim totam illam scientiam,
+						<lb/> quæ grammatica græce , latine antem litteratura no­ <lb/> minatur,
+						historie custodiam profiteri, vel solam , ut <lb/> subtilior ducet ratio;
+						vel maxime, ut etiam pinguia <lb/> corda concedunt. itaque verbigratia
+						cumdixeris, <hi rend="italic">cano,</hi>
+						<lb/> vel in versu forte posueris, ita ut vel tu pronuntians <lb/> producas
+						hujus verbi syllabam primam, vel in versu <lb/> ♦o loco ponas , ubi esse
+						productam oportebat; repre­ <lb/> hendet grammaticus , custos ille videlicet
+						historiæ, <lb/> nihil aliud asserens cur hunc'corripi oporteat, nisi <lb/>
+						quod hi qui ante nos fuerunt, et quorum libri exstant <lb/> tractanturque a
+						grammaticis, ea correpta 1 non pro­ <lb/> ducta usi fuerint. Quare hic
+						quidquid valet, auctoritas <lb/> valet. At vero musicæ ratio, ad quam
+						dimensio ipsa <lb/> vocum rationabilis et numerositas pertinet, non curat
+							<note type="footnote"> I vatic., <hi rend="italic">pro correpta.</hi> M. </note>
+						<lb/> nisi ut corripiatur vel producatur syllaba, quæ illo vel <lb/> illo
+						loco est secundum rationem mensurarum suarum. <lb/> Nam si eo loco ubi duas
+						longas syllabas poni decet, <lb/> hoc verbum posueris, et primam quae brevis
+						est, pro­ <lb/> nuntiatione longain feceris, nibil musica omnino suc­ <lb/>
+						censet 1 : tempora enim vocum ea pervenerc ad au­ <lb/> res, quæ illi numero
+						debita fuerunt. Grammaticus <lb/> autem jubet emeudari, et illud te verbum
+						ponere <lb/> cujus prima .syllaba producenda sit, secundum majo­ <lb/> rum,
+						ut dictum est, auctoritatem, quorum scripta <lb/> custodit2.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT II. — <hi rend="italic">De versu judicat</hi>
+							grammaticas <hi rend="italic">ex aucto­</hi> ritate, musicus ex <hi
+								rend="italic">ratione et</hi> sensu.</title>
 					</ab>
-					<p>i. Quamobrem nos, cum rationes musicae perse­ <lb/> qoendas susceperimus, etiam si
-						nescis quæ syllaba <lb/> corripienda, quæ producenda sit; possumus tamen <lb/> non
-						impediri hac ignorantia tua, satisque habere, <lb/> quod te animadvertisse dixisti alias
-						syitabas corre­ <lb/> ptiores, alias productiores. Quare illud nunc quæro, <lb/> utrum
-						sonos versuum aliquando te aliqua per aures <lb/> voluptate commoverit. <hi rend="italic">D.</hi> Prorsus sæpissime, ita ut <lb/> nunquam fere sine delectatione
-						versum audierim. M. <lb/> Si quis ergo in versu , quo audito delectaris, eo loco <lb/>
-						quo ratio ejusdem versus non postulat , vel producat <lb/> syllabas, Tel corripiat, uum
-						eodem modo delectari <lb/> potes? D. Imo audire hoc sineoffensione non possum. <lb/> M.
-						Nullo modo igitur dubium est, quin te in sotio quo <lb/> te delectari dicis, dimensio
-						quædam numerorum de­ <lb/> lectet, qua perturbata delectatio illa exhiberi acribus <note type="footnote"> I <hi rend="italic">offendutur,</hi> juxta vatic. M. </note><note type="footnote"> I in B., <hi rend="italic">ciiftorfiuntur.</hi> F.r. l.ugd. vcn., <hi rend="italic">custodtuni;</hi> sic <lb/> etiam bIS. B.; at lls. A , <hi rend="italic">custodit,</hi> ut sigaiflceiur coatodire <lb/> gram?naiicus quem t
-							au!o ante Augustinus hisLoriæ custodem <lb/> nunl4; at. M. </note>
+					<p>i. Quamobrem nos, cum rationes musicae perse­ <lb/> qoendas susceperimus,
+						etiam si nescis quæ syllaba <lb/> corripienda, quæ producenda sit; possumus
+						tamen <lb/> non impediri hac ignorantia tua, satisque habere, <lb/> quod te
+						animadvertisse dixisti alias syitabas corre­ <lb/> ptiores, alias
+						productiores. Quare illud nunc quæro, <lb/> utrum sonos versuum aliquando te
+						aliqua per aures <lb/> voluptate commoverit. <hi rend="italic">D.</hi>
+						Prorsus sæpissime, ita ut <lb/> nunquam fere sine delectatione versum
+						audierim. M. <lb/> Si quis ergo in versu , quo audito delectaris, eo loco
+						<lb/> quo ratio ejusdem versus non postulat , vel producat <lb/> syllabas,
+						Tel corripiat, uum eodem modo delectari <lb/> potes? D. Imo audire hoc
+						sineoffensione non possum. <lb/> M. Nullo modo igitur dubium est, quin te in
+						sotio quo <lb/> te delectari dicis, dimensio quædam numerorum de­ <lb/>
+						lectet, qua perturbata delectatio illa exhiberi acribus <note
+							type="footnote"> I <hi rend="italic">offendutur,</hi> juxta vatic. M.
+							</note><note type="footnote"> I in B., <hi rend="italic"
+								>ciiftorfiuntur.</hi> F.r. l.ugd. vcn., <hi rend="italic"
+								>custodtuni;</hi> sic <lb/> etiam bIS. B.; at lls. A , <hi
+								rend="italic">custodit,</hi> ut sigaiflceiur coatodire <lb/>
+							gram?naiicus quem t au!o ante Augustinus hisLoriæ custodem <lb/> nunl4;
+							at. M. </note>
 						<lb/>
-						<pb n="1101"/> non potest. D. Manifestum est, M. Dic mihi deiuceps <lb/> quod ad sonum
-						versus attinel, quid inlersil, utrum <lb/> dicam, <hi rend="italic">Anna virumque cano,
-							Trojw qui primus ub oris:</hi>
-						<lb/> an <hi rend="italic">qui primis ab oris.</hi> D. Mihi vero utrumque, quan­ <lb/>
-						tum ad illam dimensionem pertinet, idem sonat. M. <lb/> At I hoc mea pronuntiatione
-						factum cst, cum eo scili­ <lb/> cet vitio quod barbarismum grammatici vocant : nam <lb/>
-						<hi rend="italic">primus,</hi> longa cst et brevis syllaba; <hi rend="italic">primis</hi> autem , <lb/> ambæ producendæsunt : sed cgo ultimam earum cor­ <lb/>
-						ripui; ita nihil fraudis passæ sunt aures tuæ. Quam­ <lb/> obrem illud ctiam atque etiam
-						tentandum est, utrum <lb/> me pronuntiante sentias, quid sit I in syllabis diu et <lb/>
-						non din , m nostradisputatio, me interrogante ac te <lb/> respondente, sicut
-						instituimus, possit procedece. Ita­ <lb/> que jnm cumdem versum iu quo barbarismum fece­ <lb/>
-						<lb/> ram, repetam, et illam syllabam quam, ne tua: aures <lb/> offenderentur, corripui,
-						producam, ut grammotici ja­ <lb/> bent: tu mihi remuntiato, utrum illa versus dimensio
-						<lb/> sensum taum cadcm afficiat voluptato : sic enim pro­ <lb/> nuntiem, <hi rend="italic">Arma virumque cano,</hi> Trojæ qui priMus <hi rend="italic">ab<lb/>
-							oria. D.</hi> Nunc vero negare non possum, nescio qua <lb/> son! deformitate me
-						offensum. <hi rend="italic">II.</hi> Non injuria : quan- . <lb/> quam enim barbarismus
-						factus non sit, id tamen <lb/> vitium factum est, quod et grammatica reprehendat <lb/>
-						et mu-ica : grammatica, quia id verbum, cujus no­ <lb/> vissima syllaba producenda cst,
-						eo loco positum est <lb/> ubi corripienda poni debuit; musica vero tantum­ <lb/> modo
-						quia producta quælibet vox est eo loco, quo <lb/> corripi oportebat, et tempus debitum
-						quod numc­ <lb/> rosa dimensio postulabat, redditum non est. Quo­ <lb/> circa si jam
-						salis discernis quid sensus; quid au­ <lb/> ctoritas postulcL, sequitur ut vidcamus,
-						ille ipse <lb/> sensus cur alias delecietur in sonis vcl productis vel <lb/> correptis ,
-						alias offendatur : id est enim quod ad diu, <lb/> ct non diu pertinet. Qnam partem nos
-						explicaudam <lb/> suscepissc credo quod memineris. <hi rend="italic">D.</hi> Ego vero et
-						<lb/> illud discrevi , ei hoc memini, ct ca q'tae sequuntur <lb/> intentissime
-						exspecto.</p>
-					<ab>
+						<pb n="1101"/> non potest. D. Manifestum est, M. Dic mihi deiuceps <lb/>
+						quod ad sonum versus attinel, quid inlersil, utrum <lb/> dicam, <hi
+							rend="italic">Anna virumque cano, Trojw qui primus ub oris:</hi>
+						<lb/> an <hi rend="italic">qui primis ab oris.</hi> D. Mihi vero utrumque,
+						quan­ <lb/> tum ad illam dimensionem pertinet, idem sonat. M. <lb/> At I hoc
+						mea pronuntiatione factum cst, cum eo scili­ <lb/> cet vitio quod
+						barbarismum grammatici vocant : nam <lb/>
+						<hi rend="italic">primus,</hi> longa cst et brevis syllaba; <hi
+							rend="italic">primis</hi> autem , <lb/> ambæ producendæsunt : sed cgo
+						ultimam earum cor­ <lb/> ripui; ita nihil fraudis passæ sunt aures tuæ.
+						Quam­ <lb/> obrem illud ctiam atque etiam tentandum est, utrum <lb/> me
+						pronuntiante sentias, quid sit I in syllabis diu et <lb/> non din , m
+						nostradisputatio, me interrogante ac te <lb/> respondente, sicut
+						instituimus, possit procedece. Ita­ <lb/> que jnm cumdem versum iu quo
+						barbarismum fece­ <lb/>
+						<lb/> ram, repetam, et illam syllabam quam, ne tua: aures <lb/>
+						offenderentur, corripui, producam, ut grammotici ja­ <lb/> bent: tu mihi
+						remuntiato, utrum illa versus dimensio <lb/> sensum taum cadcm afficiat
+						voluptato : sic enim pro­ <lb/> nuntiem, <hi rend="italic">Arma virumque
+							cano,</hi> Trojæ qui priMus <hi rend="italic">ab<lb/> oria. D.</hi> Nunc
+						vero negare non possum, nescio qua <lb/> son! deformitate me offensum. <hi
+							rend="italic">II.</hi> Non injuria : quan- . <lb/> quam enim barbarismus
+						factus non sit, id tamen <lb/> vitium factum est, quod et grammatica
+						reprehendat <lb/> et mu-ica : grammatica, quia id verbum, cujus no­ <lb/>
+						vissima syllaba producenda cst, eo loco positum est <lb/> ubi corripienda
+						poni debuit; musica vero tantum­ <lb/> modo quia producta quælibet vox est
+						eo loco, quo <lb/> corripi oportebat, et tempus debitum quod numc­ <lb/>
+						rosa dimensio postulabat, redditum non est. Quo­ <lb/> circa si jam salis
+						discernis quid sensus; quid au­ <lb/> ctoritas postulcL, sequitur ut
+						vidcamus, ille ipse <lb/> sensus cur alias delecietur in sonis vcl productis
+						vel <lb/> correptis , alias offendatur : id est enim quod ad diu, <lb/> ct
+						non diu pertinet. Qnam partem nos explicaudam <lb/> suscepissc credo quod
+						memineris. <hi rend="italic">D.</hi> Ego vero et <lb/> illud discrevi , ei
+						hoc memini, ct ca q'tae sequuntur <lb/> intentissime exspecto.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT III, — <hi rend="italic">Syllabarum tempora.</hi>
 						</title>
 					</ab>
-					<p>3. X. Quæ putas, nisi ut incipiamus sibimet sylla­ <lb/> bas compararc, ct videre quos
-						numeros ad scse ha­ <lb/> beant; sicut de motibus jam inter nos tam longa supe­ <lb/>
-						rius ratione tractatum est? In motu cst eniin etiam <lb/> omne quod sonat; et syllabæ
-						utique sonant: an quid­ <lb/> quam horum negari potest? D. Nullo modo. <hi rend="italic">M.</hi> Cum <lb/> ergo inter se syllabæ conferuntur, motus quidain inter <lb/> se
-						conferuntur, in quibus possint numeri quidam tem­ <lb/> poris 9 mensura diuturnitatis
-						inquiri. <hi rend="italic">D.</hi> Ita est. <hi rend="italic">M.</hi>
-						<lb/> Num igitur potest tibi una syllaba comparari? Nam <lb/> omnem comparationem, nisi
-						tu aliud putes, singula­ <lb/> ritas fugit. <hi rend="italic">D.</hi> Nihil puto aliud.
-							<hi rend="italic">11.</hi> Quid? uno uni, aut <lb/> una vel duae duabus vcl tribus, ct
-						deinceps in pUtri­ <lb/> bus, quin possint sibimet conferri, num negas? <hi rend="italic">D.</hi>
-						<lb/> Quis boc negaverit? <hi rend="italic">II.</hi> Rursus boc vide, quamlibet <lb/> sy
-						llabam brevem minimeque diu pronuntiatam, et mox <lb/> ut cruperit desinentem, occupare
-						tameu in tempore <note type="footnote"> 1 In A., <hi rend="italic">et;</hi> Mss. A ct A,
-								<hi rend="italic">at.</hi> M. </note><note type="footnote"> 1 sic Mss. A et n. in
-							B., <hi rend="italic">quod fit,</hi> n1inus latine. K. </note><note type="footnote"> '
-								<hi rend="italic">Temporis, et,</hi> jutta Ms. A. М. </note>
-						<lb/> aliquid spatii, cl habere quamdam morulam suam. i . <lb/> Video necesse esse quod
-						dicis. M. Dic nunc, unde nu­ <lb/> merum exordiamur. D. Ab uno scilicet. <hi rend="italic">M.</hi> Non ab­ <lb/> surde igitur hoc in tempore quasi minimum spatii,
-						<lb/> quod brevis obtinet syllaba, unum tempus veteres vo­ <lb/> caverunt : a brevi cnim
-						ad longam progredimur. D. <lb/> Verum est. <hi rend="italic">M.</hi> Sequitur jam, ut
-						illud quoque animad­ <lb/> vertas, quoniam ut in Humeris ab uno ad duo est <lb/> prima
-						progressio; ita in syllabis, qua I scilicet a brevi <lb/> ad longam progredimur, longam
-						duplum temporis ha­ <lb/> bere debere : ac per hoc si spatium quod brevis oc­ <lb/>
-						cupat, recte unum tempus vocatur; spatium item quod <lb/> longa occupat, recte duo
-						tempora nominari. <hi rend="italic">D.</hi> Recte <lb/> prorsus : nam id rationem
-						postulare consentio.</p>
-					<ab>
-						<title type="sub">CAPUT IV. — <hi rend="italic">Pedes</hi> dissyllabi.</title>
+					<p>3. X. Quæ putas, nisi ut incipiamus sibimet sylla­ <lb/> bas compararc, ct
+						videre quos numeros ad scse ha­ <lb/> beant; sicut de motibus jam inter nos
+						tam longa supe­ <lb/> rius ratione tractatum est? In motu cst eniin etiam
+						<lb/> omne quod sonat; et syllabæ utique sonant: an quid­ <lb/> quam horum
+						negari potest? D. Nullo modo. <hi rend="italic">M.</hi> Cum <lb/> ergo inter
+						se syllabæ conferuntur, motus quidain inter <lb/> se conferuntur, in quibus
+						possint numeri quidam tem­ <lb/> poris 9 mensura diuturnitatis inquiri. <hi
+							rend="italic">D.</hi> Ita est. <hi rend="italic">M.</hi>
+						<lb/> Num igitur potest tibi una syllaba comparari? Nam <lb/> omnem
+						comparationem, nisi tu aliud putes, singula­ <lb/> ritas fugit. <hi
+							rend="italic">D.</hi> Nihil puto aliud. <hi rend="italic">11.</hi> Quid?
+						uno uni, aut <lb/> una vel duae duabus vcl tribus, ct deinceps in pUtri­
+						<lb/> bus, quin possint sibimet conferri, num negas? <hi rend="italic"
+							>D.</hi>
+						<lb/> Quis boc negaverit? <hi rend="italic">II.</hi> Rursus boc vide,
+						quamlibet <lb/> sy llabam brevem minimeque diu pronuntiatam, et mox <lb/> ut
+						cruperit desinentem, occupare tameu in tempore <note type="footnote"> 1 In
+							A., <hi rend="italic">et;</hi> Mss. A ct A, <hi rend="italic">at.</hi>
+							M. </note><note type="footnote"> 1 sic Mss. A et n. in B., <hi
+								rend="italic">quod fit,</hi> n1inus latine. K. </note><note
+							type="footnote"> ' <hi rend="italic">Temporis, et,</hi> jutta Ms. A. М. </note>
+						<lb/> aliquid spatii, cl habere quamdam morulam suam. i . <lb/> Video
+						necesse esse quod dicis. M. Dic nunc, unde nu­ <lb/> merum exordiamur. D. Ab
+						uno scilicet. <hi rend="italic">M.</hi> Non ab­ <lb/> surde igitur hoc in
+						tempore quasi minimum spatii, <lb/> quod brevis obtinet syllaba, unum tempus
+						veteres vo­ <lb/> caverunt : a brevi cnim ad longam progredimur. D. <lb/>
+						Verum est. <hi rend="italic">M.</hi> Sequitur jam, ut illud quoque animad­
+						<lb/> vertas, quoniam ut in Humeris ab uno ad duo est <lb/> prima
+						progressio; ita in syllabis, qua I scilicet a brevi <lb/> ad longam
+						progredimur, longam duplum temporis ha­ <lb/> bere debere : ac per hoc si
+						spatium quod brevis oc­ <lb/> cupat, recte unum tempus vocatur; spatium item
+						quod <lb/> longa occupat, recte duo tempora nominari. <hi rend="italic"
+							>D.</hi> Recte <lb/> prorsus : nam id rationem postulare consentio.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT IV. — <hi rend="italic">Pedes</hi>
+							dissyllabi.</title>
 					</ab>
-					<p><hi rend="italic">A. M.</hi> Agc, nunc collationes ips:is vidcamus : nam <lb/> una
-						brevis syllaba ad unam brevem syllabam quæro <lb/> quam rationem tibi habere videatur,
-						vel hi motus in­ <lb/> ter se quid vocentur. Meministi cnim, nisi fallor, in <lb/>
-						superiore sermone nos omnibus motibus, qui inter se <lb/> aliqua numerositate
-						conveniunt, imposuisse vocabula. <lb/>
-						<hi rend="italic">D.</hi> Æquales eos memini nominatos : tantumdem enim <lb/> ad sese
-						habent temporis. <hi rend="italic">it.</hi> Sed istam collationem <lb/> syllabarum qua
-						sihi jam conferuntur ut habeant ad se <lb/> aliquos numcros, num censes sine vocabulo
-						csso re­ <lb/> linquendam? <hi rend="italic">D.</hi> Non puto. M Atqui scias, voteres
-						<lb/> pedem nuncupasse talem collationem sonorum. Sed <lb/> quousque pedem progredi
-						ratio sinat, diligenter ad­ <lb/> vertendum est. Quamobrem jam dic etiam, brevis et
-						<lb/> longa syllaba qua sibi ratione conferuntur? D. Opinor, <lb/> ex illo gencre
-						numerorum, quos complicatos vocavi­ <lb/> mus, istam collationem manare : siquidcm in ea
-						sim­ <lb/> plum ad duplum collatum esso video, id £ stunum <lb/> tempus brevis syllabæ
-						ad dno tempora longæ syllabæ. <lb/>
-						<hi rend="italic">Al.</hi> Quid si ita ordinentur, ut prius longa, deinde bre­ <lb/> v
-						is syllaba pronuntietur ? num quia ordo mutatus est, <lb/> idco complicatorum numerorum
-						ratio non manet? <lb/> Nam ut in illo pede simplum ad duplum, iia in isto <lb/> duplum
-						ad simplum invenitur. <hi rend="italic">D.</hi> Ita est. M. Quid ? <lb/> in pede duarum
-						longarum, nonnc duo temp ora duo­ <lb/> bus temporibus conferuntur? <hi rend="italic">D.</hi> Manifestum est. M. <lb/> Ex qua crgo ratione ducitur ista collatio?<hi rend="italic">D.</hi> Ex eo­ <lb/> rum scilicet qui æquales appellati sunt.</p>
-					<p>5. M. Age, nunc dic milii, ex quo a duabus brevi­ <lb/> bus orsi ad duas syllabas
-						longas pervenimus, quot <lb/> pedum collationes tractaverimus. <hi rend="italic">D.</hi>
-						Quatuor: nam <lb/> primo do duabus brevibus dictum est, secundo d; <lb/> brevi et longa,
-						tertio de longa ci brevi, quarto d * <lb/> duabus longis. M. Num possunt esse plures
-						quam qua­ <lb/> tuor, cum dux syllabae sibimet conferuntur? D. Nul­ <lb/> lo modo : nam
-						cum syllabae hunc modum accepcrint, <lb/> ut brevis unum tempus, longa duo habeat,
-						cumque <lb/> sy llaba omnis aui brevis aut longa sit; quo pacto sibi <lb/> possunt dux
-						syllabae comparari atque copulari utpo­ <lb/> dem faciant, nisi aut brevis et brevis
-						sit, .ut brevis et <lb/> longa, aut longa ct brevis, aut lon ga et longa? M. Dir <lb/>
-						etiam quot habeat tempora binanlm syllabarum mioi-<note type="footnote"> I Qvut, juxta
-							alS. A. AL </note>
+					<p><hi rend="italic">A. M.</hi> Agc, nunc collationes ips:is vidcamus : nam
+						<lb/> una brevis syllaba ad unam brevem syllabam quæro <lb/> quam rationem
+						tibi habere videatur, vel hi motus in­ <lb/> ter se quid vocentur. Meministi
+						cnim, nisi fallor, in <lb/> superiore sermone nos omnibus motibus, qui inter
+						se <lb/> aliqua numerositate conveniunt, imposuisse vocabula. <lb/>
+						<hi rend="italic">D.</hi> Æquales eos memini nominatos : tantumdem enim
+						<lb/> ad sese habent temporis. <hi rend="italic">it.</hi> Sed istam
+						collationem <lb/> syllabarum qua sihi jam conferuntur ut habeant ad se <lb/>
+						aliquos numcros, num censes sine vocabulo csso re­ <lb/> linquendam? <hi
+							rend="italic">D.</hi> Non puto. M Atqui scias, voteres <lb/> pedem
+						nuncupasse talem collationem sonorum. Sed <lb/> quousque pedem progredi
+						ratio sinat, diligenter ad­ <lb/> vertendum est. Quamobrem jam dic etiam,
+						brevis et <lb/> longa syllaba qua sibi ratione conferuntur? D. Opinor, <lb/>
+						ex illo gencre numerorum, quos complicatos vocavi­ <lb/> mus, istam
+						collationem manare : siquidcm in ea sim­ <lb/> plum ad duplum collatum esso
+						video, id £ stunum <lb/> tempus brevis syllabæ ad dno tempora longæ syllabæ. <lb/>
+						<hi rend="italic">Al.</hi> Quid si ita ordinentur, ut prius longa, deinde
+						bre­ <lb/> v is syllaba pronuntietur ? num quia ordo mutatus est, <lb/> idco
+						complicatorum numerorum ratio non manet? <lb/> Nam ut in illo pede simplum
+						ad duplum, iia in isto <lb/> duplum ad simplum invenitur. <hi rend="italic"
+							>D.</hi> Ita est. M. Quid ? <lb/> in pede duarum longarum, nonnc duo
+						temp ora duo­ <lb/> bus temporibus conferuntur? <hi rend="italic">D.</hi>
+						Manifestum est. M. <lb/> Ex qua crgo ratione ducitur ista collatio?<hi
+							rend="italic">D.</hi> Ex eo­ <lb/> rum scilicet qui æquales appellati
+						sunt.</p>
+					<p>5. M. Age, nunc dic milii, ex quo a duabus brevi­ <lb/> bus orsi ad duas
+						syllabas longas pervenimus, quot <lb/> pedum collationes tractaverimus. <hi
+							rend="italic">D.</hi> Quatuor: nam <lb/> primo do duabus brevibus dictum
+						est, secundo d; <lb/> brevi et longa, tertio de longa ci brevi, quarto d *
+						<lb/> duabus longis. M. Num possunt esse plures quam qua­ <lb/> tuor, cum
+						dux syllabae sibimet conferuntur? D. Nul­ <lb/> lo modo : nam cum syllabae
+						hunc modum accepcrint, <lb/> ut brevis unum tempus, longa duo habeat, cumque
+						<lb/> sy llaba omnis aui brevis aut longa sit; quo pacto sibi <lb/> possunt
+						dux syllabae comparari atque copulari utpo­ <lb/> dem faciant, nisi aut
+						brevis et brevis sit, .ut brevis et <lb/> longa, aut longa ct brevis, aut
+						lon ga et longa? M. Dir <lb/> etiam quot habeat tempora binanlm syllabarum
+							mioi-<note type="footnote"> I Qvut, juxta alS. A. AL </note>
 						<lb/>
-						<pb n="1103"/> mus pes, quot item maximus. D. Duo ille, iste quatuor. <lb/> M. Videsne
-						ut progressio nisi usque ad quaternarium <lb/> numerum fieri non potuerit, sive in
-						pedibus , sive in <lb/> temporibus? <hi rend="italic">D.</hi> Video plane, et recordor
-						rationem <lb/> progressionis in numeris, atque illam vim hic etiam <lb/> inesse sentio
-						cum magna animi voluptate. <hi rend="italic">M.</hi> Nonne <lb/> ergo censes, cum pedes
-						syllabis constent, id est dis­ <lb/> tinctis et quasi articulatis motibus qui sant in
-						sonis, <lb/> syllabæ autem tendantur temporibus, oportere fieri <lb/> etiam usque ad
-						quatuor syllabas progressionem pedis, <lb/> Sicut jam factam usque ad quaternarium
-						numerum, et <lb/> ipsorum pedum et temporum cernis? <hi rend="italic">D.</hi> Ita plane
-						ut <lb/> dicis sentio, et hoc videri perfectæ rationi cognosco <lb/> et debitum
-						flagito.</p>
-					<ab>
+						<pb n="1103"/> mus pes, quot item maximus. D. Duo ille, iste quatuor. <lb/>
+						M. Videsne ut progressio nisi usque ad quaternarium <lb/> numerum fieri non
+						potuerit, sive in pedibus , sive in <lb/> temporibus? <hi rend="italic"
+							>D.</hi> Video plane, et recordor rationem <lb/> progressionis in
+						numeris, atque illam vim hic etiam <lb/> inesse sentio cum magna animi
+						voluptate. <hi rend="italic">M.</hi> Nonne <lb/> ergo censes, cum pedes
+						syllabis constent, id est dis­ <lb/> tinctis et quasi articulatis motibus
+						qui sant in sonis, <lb/> syllabæ autem tendantur temporibus, oportere fieri
+						<lb/> etiam usque ad quatuor syllabas progressionem pedis, <lb/> Sicut jam
+						factam usque ad quaternarium numerum, et <lb/> ipsorum pedum et temporum
+						cernis? <hi rend="italic">D.</hi> Ita plane ut <lb/> dicis sentio, et hoc
+						videri perfectæ rationi cognosco <lb/> et debitum flagito.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT V. — <hi rend="italic">Pedes trisyllubi.</hi>
 						</title>
 					</ab>
-					<p>6. <hi rend="italic">M.</hi> Age nunc ergo prius, ut ordo ipse postulat, <lb/> ternarum
-						syllabarum pedes quot esse possint, videa­ <lb/> mas, sicut binarum quatuor esse
-						comperimus. <hi rend="italic">D.</hi> Ita <lb/> fiat. M. Meministi ab una brevi syllaba,
-						id est unius <lb/> temporis istam nos inchoasse rationem, et cur ita <lb/> oporteret
-						satis intellexisse. D. Memini ab illa lege <lb/> numerandi, qua I ab uno incipimus, quod
-						principium <lb/> numerorum est, placuisse nobis non oportere disce­ <lb/> dere. II. Cum
-						igitur in pedibus binarum syllaba'ram <lb/> ille sit primus qui duabns brevibus constat
-						(cogebat <lb/> enim ratio uni tempori prius unum tempus jungi quam <lb/> duo); quem
-						tandem arbitraris ill pedibus ternarum <lb/> syllabarum primum esse debere? D. Quem,
-						nisi ci1m <lb/> qui a tribus brevibus confit? <hi rend="italic">M.</hi> Et iste quot
-						tempo­ <lb/> rum est? D. Trium scilicet. <hi rend="italic">M.</hi> Qnomodo ergo bu­
-						<lb/> jus partes sibi conferuntur? Nam omnem pedem pro­ <lb/> pter illam numerorum
-						collationem duas habere par­ <lb/> tes, quae sibimet aliqua ratione conferantur, nccesse
-						<lb/> est, idque superius egisse nos memini : sed numquid <lb/> ,,oBsumus hunc trium
-						brevium syllabarum pedem in <lb/> duas æquales pafles dividere? <hi rend="italic">D.</hi> Nullo modo. II. <lb/> Quomodo ergo dividitur ? <hi rend="italic">D.</hi>
-						Nihil aliud video, nisi ut <lb/> prima pars habeat unam syllabam, secunda duas; aut
-						<lb/> prima duas, secunda unam. <hi rend="italic">II.</hi> Dic etiam hoc a de qua <lb/>
-						regula numerorum sit? <hi rend="italic">D.</hi> De complicatorum genere <lb/> esse
-						cognosco.</p>
-					<p>i. <hi rend="italic">II.</hi> Age, nonc illud attende, tres sylLabæ in qui­ <lb/> bus
-						est una longa, cæterae breves, quoties variari <lb/> possint, id cst quot pedes facere ;
-						et responde, si in­ <lb/> veneris. <hi rend="italic">D.</hi> Unum pedem video esse, qui
-						longa et dua­ <lb/> bus brevibus constet; aliud non intelligo. <hi rend="italic">M.</hi>
-						Idemne <lb/> solus tibi vidctur habere unam in tribus longam, qui <lb/> eam primo habet
-						loco? <hi rend="italic">D.</hi> Nullo pacto istud putave­ <lb/> rim, cum possint dux
-						brevos priores esse, longa ul­ <lb/> tima. M. Considera utrum sit aliquid tertium. <hi rend="italic">D.</hi> Est <lb/> plane : nam hæc longa etiam in medio duarum bre­ <lb/>
-						vium collocari potest. <hi rend="italic">M.</hi> Vide etiamne sit aliquid <lb/> quartum,
-							<hi rend="italic">D.</hi> Omnino non potest. <hi rend="italic">II.</hi> Potesne jam
-						re­ <lb/> spondere, tres syllabæ habentes in se unam longam <lb/> et duas breves,
-							<unclear>quotica</unclear> variani possint, id osi quot pe- <note type="footnote"> I
-							ngfWOSfO, juxta MSS. A et B. M. </note><note type="footnote"> * in B., <hi rend="italic">quod.</hi> Ex Ms. A, <hi rend="italic">qua,</hi> rectius. M.
-							</note><note type="footnote">ffl 3 In B. eiBSt <hi rend="italic">hoc.</hi> quod i
+					<p>6. <hi rend="italic">M.</hi> Age nunc ergo prius, ut ordo ipse postulat,
+						<lb/> ternarum syllabarum pedes quot esse possint, videa­ <lb/> mas, sicut
+						binarum quatuor esse comperimus. <hi rend="italic">D.</hi> Ita <lb/> fiat.
+						M. Meministi ab una brevi syllaba, id est unius <lb/> temporis istam nos
+						inchoasse rationem, et cur ita <lb/> oporteret satis intellexisse. D. Memini
+						ab illa lege <lb/> numerandi, qua I ab uno incipimus, quod principium <lb/>
+						numerorum est, placuisse nobis non oportere disce­ <lb/> dere. II. Cum
+						igitur in pedibus binarum syllaba'ram <lb/> ille sit primus qui duabns
+						brevibus constat (cogebat <lb/> enim ratio uni tempori prius unum tempus
+						jungi quam <lb/> duo); quem tandem arbitraris ill pedibus ternarum <lb/>
+						syllabarum primum esse debere? D. Quem, nisi ci1m <lb/> qui a tribus
+						brevibus confit? <hi rend="italic">M.</hi> Et iste quot tempo­ <lb/> rum
+						est? D. Trium scilicet. <hi rend="italic">M.</hi> Qnomodo ergo bu­ <lb/> jus
+						partes sibi conferuntur? Nam omnem pedem pro­ <lb/> pter illam numerorum
+						collationem duas habere par­ <lb/> tes, quae sibimet aliqua ratione
+						conferantur, nccesse <lb/> est, idque superius egisse nos memini : sed
+						numquid <lb/> ,,oBsumus hunc trium brevium syllabarum pedem in <lb/> duas
+						æquales pafles dividere? <hi rend="italic">D.</hi> Nullo modo. II. <lb/>
+						Quomodo ergo dividitur ? <hi rend="italic">D.</hi> Nihil aliud video, nisi
+						ut <lb/> prima pars habeat unam syllabam, secunda duas; aut <lb/> prima
+						duas, secunda unam. <hi rend="italic">II.</hi> Dic etiam hoc a de qua <lb/>
+						regula numerorum sit? <hi rend="italic">D.</hi> De complicatorum genere
+						<lb/> esse cognosco.</p>
+					<p>i. <hi rend="italic">II.</hi> Age, nonc illud attende, tres sylLabæ in qui­
+						<lb/> bus est una longa, cæterae breves, quoties variari <lb/> possint, id
+						cst quot pedes facere ; et responde, si in­ <lb/> veneris. <hi rend="italic"
+							>D.</hi> Unum pedem video esse, qui longa et dua­ <lb/> bus brevibus
+						constet; aliud non intelligo. <hi rend="italic">M.</hi> Idemne <lb/> solus
+						tibi vidctur habere unam in tribus longam, qui <lb/> eam primo habet loco?
+							<hi rend="italic">D.</hi> Nullo pacto istud putave­ <lb/> rim, cum
+						possint dux brevos priores esse, longa ul­ <lb/> tima. M. Considera utrum
+						sit aliquid tertium. <hi rend="italic">D.</hi> Est <lb/> plane : nam hæc
+						longa etiam in medio duarum bre­ <lb/> vium collocari potest. <hi
+							rend="italic">M.</hi> Vide etiamne sit aliquid <lb/> quartum, <hi
+							rend="italic">D.</hi> Omnino non potest. <hi rend="italic">II.</hi>
+						Potesne jam re­ <lb/> spondere, tres syllabæ habentes in se unam longam
+						<lb/> et duas breves, <unclear>quotica</unclear> variani possint, id osi
+						quot pe- <note type="footnote"> I ngfWOSfO, juxta MSS. A et B. M.
+							</note><note type="footnote"> * in B., <hi rend="italic">quod.</hi> Ex
+							Ms. A, <hi rend="italic">qua,</hi> rectius. M. </note><note
+							type="footnote">ffl 3 In B. eiBSt <hi rend="italic">hoc.</hi> quod i
 							1Yl'uitur al.ud editos omnes et </note>
-						<lb/> des facere ? <hi rend="italic">D.</hi> Possum sane : nam ler sont variatne, <lb/>
-						et tres fecerunt pedes. <hi rend="italic">II.</hi> Quid? isti tres pedes quo­ <lb/> modo
-						sint ordinandi jamnc ipse colligis, an ad hoc <lb/> eliam minutatim es perducendus ? D.
-						Displicet enim <lb/> tibi ordo ille quo ipsam varietatem comperi ? nam <lb/> primo
-						adverti unam longam et duas breves, deinde <lb/> duas breves et unam longam, postremo
-						brevem et <lb/> longam et brevem. <hi rend="italic">M.</hi> Itane vero tibi non
-						displiceat <lb/> qui sic ordinat, ut a primo ad tertium vcniat, a tertio <lb/> ad
-						sccundum ; ac non potius a primo ad secundum, et <lb/> deinde ad tertium? <hi rend="italic">D.</hi> Displicet prorsus : sed quid hic <lb/> tandem tale advertisti,
-						rogo? <hi rend="italic">M.</hi> Cum ideo in hac tri <lb/> partita differentia illum
-						pedem primum posueris, qui <lb/> primo loco habet lOngam, quia sensisti unitatem ipsam
-						<lb/> longæ syllabae principatum tenere ( siquidem ipsa <lb/> ibi una est). et propterea
-						eam debere ordinem gignere, <lb/> ut ille sit primas pes ubi prima ipsa est: simul etiam
-						<lb/> videre debuisti eum esse secundum ubi ipsa secunda <lb/> est, eum tertium ubi
-						eadem tertia est. An adhuc in <lb/> illa sententia manendum putas? <hi rend="italic">D.</hi> Imo eam sine du­ <lb/> bitatione condemno : hunc enim esse meliorem ord:­
-						<lb/> nem, vel potius hunc esse ordinem, quis non assen­ <lb/> tiatur? M. Nunc ergo dic
-						qua numerorum regula isti <lb/> quoque dividantur pedes, eorumque sibi partes con­ <lb/>
-						ferantur. <hi rend="italic">D.</hi> Primum et postremum æquali regula di­ <lb/> vidi
-						video, quia et ille in longam et duas breves ct <lb/> iste in duas breves et longam
-						dividi potest, ut singula: <lb/> partes habeant bina tempora, et ob hoc sint æquales.
-						<lb/> In secundo autem quoniam mediam habet longnin syl­ <lb/> labam, sive priori sive
-						posteriori parti tribuatur, aut <lb/> in tria ei unum, aut in unum et tria tempora
-						dividi­ <lb/> tur : ac per hoc in ejus divisione complicatorum nu­ <lb/> merorum ratio
-						valet.</p>
-					<p>8. M. Volo mihi jam dicas per te ipse si potes, <lb/> post istos qui a nobis tractati
-						sunt, quos pedes ordi­ <lb/> nandos putes. Tractati enim sunt primo binarum syl­ <lb/>
-						labarum quatuor, quorum ordo ductus est a nnmero­ <lb/> rum ordine, ut a brevibus
-						syllabis ordirmnur. Deinde <lb/> jam productiores ternarum syllabarum pedes tractan­
-						<lb/> dos suscepimus, et quod facilc erat cx superiore ra­ <lb/> tione, a tribus
-						brevibus orsi sumus. Quid deinde se­ <lb/> quebatur, nisi ut una longa cum duabus
-						brevibus quot <lb/> fonnas ederct videremus? Visum est; et tres pedes <lb/> post illum
-						primum, iia ut oportebat, ordinati sunt. <lb/> Qui deinceps consequantur nonne per i
-						ipsuiu videre <lb/> jam debes, ne omnia <unclear>minutissimis</unclear>
-						interrogatiunculis <lb/> .eruamus ? D. Recte dicis : nam quis non videat eos <lb/> jam
-						sequi, in quibus una brevis sit, cæteræ lougn;: <lb/> cui brevi, quia una est, cum
-						superiore ratione prin­ <lb/> cipatus tribuatur, primus erit profecto in his ubi <lb/>
-						prima est, secundus ubi secunda, tertius ubi trtia, <lb/> quae etiam ultima est. M.
-						Cernis, ut opinor, quibus <lb/> etiam rationibus dividantur, ut sibi eoram partes con­
-						<lb/> ferri queant. <hi rend="italic">D.</hi> Ceroo prorsus : nam ijle qui ex una <lb/>
-						brevi et duabus longis constat, dividi uon potest, nisi <lb/> ita ut prior pars habeat
-						tria tempora, quae continet <lb/> brevem et longam; posterior duo, quæ uni longæ in­
-						<lb/> sunt. IIic autem tertius in eo quidem priori par est, <lb/> quod unam patitur
-						divibionem ; ill eh autem dissimi­ <lb/>
-						<pb n="1105"/> lis, quod cum ille in tria et duo, iste in duo ct tria <lb/> tempora
-						secatur. Nam longa syllaba, quae primam te­ <lb/> uel partem, duobus temporibus tenditur
-						: restat longa <lb/> cl brevis, quod est trium temporum spatium. At vero <lb/> medius
-						qui habet brevem syllabam mediam, gemi­ <lb/> nam potest partitionem pati, quia cadem
-						brevis et <lb/> priori et posteriori parti tribui potest : idcirco aut in <lb/> duo et
-						tria, aut in tria et duo dividitur tempora : <lb/> quamobrem sesquatorum numerorum ratio
-						tres istos <lb/> possidet pedes. M. Omnesne jam trium syllabarum <lb/> pedes
-						consideravimus, an aliquid restat? <hi rend="italic">D.</hi> Unni <lb/> reliquum video,
-						qui ex tribus longis constat. <hi rend="italic">It.</hi> Tra­ <lb/> cta ergo etiam hujus
-						divisionem. D. Una syllaba et <lb/> duæ, aut duae atque una hujus divisio est ; tempora
-						<lb/> scilicet duo et quatuor, aut quatuor et duo : quare <lb/> con plicatorum numerorum
-						ratione istius pedis sibi <lb/> partes conferuntur.</p>
-					<ab>
+						<lb/> des facere ? <hi rend="italic">D.</hi> Possum sane : nam ler sont
+						variatne, <lb/> et tres fecerunt pedes. <hi rend="italic">II.</hi> Quid?
+						isti tres pedes quo­ <lb/> modo sint ordinandi jamnc ipse colligis, an ad
+						hoc <lb/> eliam minutatim es perducendus ? D. Displicet enim <lb/> tibi ordo
+						ille quo ipsam varietatem comperi ? nam <lb/> primo adverti unam longam et
+						duas breves, deinde <lb/> duas breves et unam longam, postremo brevem et
+						<lb/> longam et brevem. <hi rend="italic">M.</hi> Itane vero tibi non
+						displiceat <lb/> qui sic ordinat, ut a primo ad tertium vcniat, a tertio
+						<lb/> ad sccundum ; ac non potius a primo ad secundum, et <lb/> deinde ad
+						tertium? <hi rend="italic">D.</hi> Displicet prorsus : sed quid hic <lb/>
+						tandem tale advertisti, rogo? <hi rend="italic">M.</hi> Cum ideo in hac tri
+						<lb/> partita differentia illum pedem primum posueris, qui <lb/> primo loco
+						habet lOngam, quia sensisti unitatem ipsam <lb/> longæ syllabae principatum
+						tenere ( siquidem ipsa <lb/> ibi una est). et propterea eam debere ordinem
+						gignere, <lb/> ut ille sit primas pes ubi prima ipsa est: simul etiam <lb/>
+						videre debuisti eum esse secundum ubi ipsa secunda <lb/> est, eum tertium
+						ubi eadem tertia est. An adhuc in <lb/> illa sententia manendum putas? <hi
+							rend="italic">D.</hi> Imo eam sine du­ <lb/> bitatione condemno : hunc
+						enim esse meliorem ord:­ <lb/> nem, vel potius hunc esse ordinem, quis non
+						assen­ <lb/> tiatur? M. Nunc ergo dic qua numerorum regula isti <lb/> quoque
+						dividantur pedes, eorumque sibi partes con­ <lb/> ferantur. <hi
+							rend="italic">D.</hi> Primum et postremum æquali regula di­ <lb/> vidi
+						video, quia et ille in longam et duas breves ct <lb/> iste in duas breves et
+						longam dividi potest, ut singula: <lb/> partes habeant bina tempora, et ob
+						hoc sint æquales. <lb/> In secundo autem quoniam mediam habet longnin syl­
+						<lb/> labam, sive priori sive posteriori parti tribuatur, aut <lb/> in tria
+						ei unum, aut in unum et tria tempora dividi­ <lb/> tur : ac per hoc in ejus
+						divisione complicatorum nu­ <lb/> merorum ratio valet.</p>
+					<p>8. M. Volo mihi jam dicas per te ipse si potes, <lb/> post istos qui a nobis
+						tractati sunt, quos pedes ordi­ <lb/> nandos putes. Tractati enim sunt primo
+						binarum syl­ <lb/> labarum quatuor, quorum ordo ductus est a nnmero­ <lb/>
+						rum ordine, ut a brevibus syllabis ordirmnur. Deinde <lb/> jam productiores
+						ternarum syllabarum pedes tractan­ <lb/> dos suscepimus, et quod facilc erat
+						cx superiore ra­ <lb/> tione, a tribus brevibus orsi sumus. Quid deinde se­
+						<lb/> quebatur, nisi ut una longa cum duabus brevibus quot <lb/> fonnas
+						ederct videremus? Visum est; et tres pedes <lb/> post illum primum, iia ut
+						oportebat, ordinati sunt. <lb/> Qui deinceps consequantur nonne per i ipsuiu
+						videre <lb/> jam debes, ne omnia <unclear>minutissimis</unclear>
+						interrogatiunculis <lb/> .eruamus ? D. Recte dicis : nam quis non videat eos
+						<lb/> jam sequi, in quibus una brevis sit, cæteræ lougn;: <lb/> cui brevi,
+						quia una est, cum superiore ratione prin­ <lb/> cipatus tribuatur, primus
+						erit profecto in his ubi <lb/> prima est, secundus ubi secunda, tertius ubi
+						trtia, <lb/> quae etiam ultima est. M. Cernis, ut opinor, quibus <lb/> etiam
+						rationibus dividantur, ut sibi eoram partes con­ <lb/> ferri queant. <hi
+							rend="italic">D.</hi> Ceroo prorsus : nam ijle qui ex una <lb/> brevi et
+						duabus longis constat, dividi uon potest, nisi <lb/> ita ut prior pars
+						habeat tria tempora, quae continet <lb/> brevem et longam; posterior duo,
+						quæ uni longæ in­ <lb/> sunt. IIic autem tertius in eo quidem priori par
+						est, <lb/> quod unam patitur divibionem ; ill eh autem dissimi­ <lb/>
+						<pb n="1105"/> lis, quod cum ille in tria et duo, iste in duo ct tria <lb/>
+						tempora secatur. Nam longa syllaba, quae primam te­ <lb/> uel partem, duobus
+						temporibus tenditur : restat longa <lb/> cl brevis, quod est trium temporum
+						spatium. At vero <lb/> medius qui habet brevem syllabam mediam, gemi­ <lb/>
+						nam potest partitionem pati, quia cadem brevis et <lb/> priori et posteriori
+						parti tribui potest : idcirco aut in <lb/> duo et tria, aut in tria et duo
+						dividitur tempora : <lb/> quamobrem sesquatorum numerorum ratio tres istos
+						<lb/> possidet pedes. M. Omnesne jam trium syllabarum <lb/> pedes
+						consideravimus, an aliquid restat? <hi rend="italic">D.</hi> Unni <lb/>
+						reliquum video, qui ex tribus longis constat. <hi rend="italic">It.</hi>
+						Tra­ <lb/> cta ergo etiam hujus divisionem. D. Una syllaba et <lb/> duæ, aut
+						duae atque una hujus divisio est ; tempora <lb/> scilicet duo et quatuor,
+						aut quatuor et duo : quare <lb/> con plicatorum numerorum ratione istius
+						pedis sibi <lb/> partes conferuntur.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT VI.— <hi rend="italic">Pedes tetrasyllabi.</hi>
 						</title>
 					</ab>
-					<p>9. M. Nunc quaternarum syllabarum pedes con­ <lb/> sequenter atque ordine videamus, ct
-						ipse jam dic <lb/> quem horum primum esse oporteat, addita etiam ra­ <lb/> tione
-						divisionis ejus. <hi rend="italic">D.</hi> Scilicet quatuor brevium, <lb/> qui dividitur
-						in duas binarum syllabarum partes, <lb/> æqualium ratione numerorum duo et duo tempora
-						<lb/> possidentes. M. Tenes 1; jam itaque prge ipso, et <lb/> persequere cætera. Nihil
-						enim opus esse jam puto te <lb/> per singula interrogari, cum sit una ratio dcmendi
-						<lb/> deinceps breves syllabas, ct pro his longas subji­ <lb/> tiendi, donec ad omnes
-						longas veniatur; et cum de­ <lb/> muntur breves, longæque subduntur, quas varietates
-						<lb/> faciant, cl quot pedes gignant, considcrandi; ea sci­ <lb/> licet syllaba
-						principatum ordinis retinente, quæ una <lb/> fuerit inter cæteras vel longa vel brevis:
-						in his euim <lb/> omnibus jam superius es exercitatus. Ubi antem duæ <lb/> breves sunt
-						et duæ longæ, quod in præcedentibus non <lb/> crat, quas censes principatum habere
-						debere? <hi rend="italic">D.</hi> Jani <lb/> hoc qnoque manifestum est de superioribus.
-						Siqui­ <lb/> dem magis tenet unitatem brevis syllaba quæ unum <lb/> habet tempus, quam
-						longa quæ duo. Et propterea in <lb/> omni capite atquc principio eum pedem constituimus
-						<lb/> qui cx brevibus constat.</p>
-					<p>10. <hi rend="italic">M.</hi> Nihil igitur te impedit, quin omnes istos <lb/>
-						perscquaris pedes audiente ac judicante me, non in­ <lb/> terrogante. <hi rend="italic">D.</hi> Faciam si potero : nam primo de qua­ <lb/> tuor brevibus primi pedis, brevis
-						una detrahenda est, <lb/> et pro ca longa ponenda in primo loco propter uuila-, <lb/>
-						tis dignitatem. IIic autem pes dividilur bis : aut in <lb/> longam et tres breves; aut
-						in longam et brevem, et <lb/> duas breves; id est aut in duo et tria; aut in tria, ct
-						<lb/> duo tempora. Secundo autcm loco posita longa facit <lb/> alium pedem, qui uno modo
-						recte dividitur, in tria <lb/> scilicct et duo tempora, ut prior pars teneat brevem
-						<lb/> et longam, posterior duas breves. Porro lcriio loco­ <lb/> consLilula longa facil
-						cum pedem, qui rursus uno <lb/> modo rite dividitur; sed ita ut prior pars habeat duo
-						<lb/> tempora in duabus brevibus syllabis, posterior tria in <lb/> longa ct brevi.
-						Quartum pedem facit longa ultima, qui <note type="footnote">1 lerucr, jutt2 Er, luflg.
-							ven. et Mss. \ n H. M. </note>
-						<lb/> duobus modis dividitur, ut illc ubi prima est : nau, <lb/> vel in duas breves, et
-						brevem ac longam; vel in tres <lb/> breves, etlongam partiri cum licet; in duo scilicet,
-						et <lb/> tria; aut in tria, et duo tempora. Omnesautem iiti <lb/> quatuor pedes, ubi cum
-						tribus brevibus varie longa <lb/> collocatur, sesquatorum numerorum ratione partes <lb/>
-						suas ad se collatas' habent.</p>
-					<p>ii. Sequitur ut de quatuor brevibus duabus de­ <lb/> tractis, pro his duas longas
-						subjiciamus, videamus­ <lb/> que quot formas ac pedes cum breves ac longa. binæ <lb/>
-						sint, possint edere. Primo igitur video duas broves <lb/> et duas longas csse ponendas,
-						quod a brevibus rectius <lb/> exordium sit. Hic autem pes habet a duplicem divisio­
-						<lb/> nem : aut enim in duo at quatn or, ant in quatuor et <lb/> duo dividitur lempora;
-						ut aut duæ breves priorem par­ <lb/> tem lencant, et posteriorem duæ longæ; aut ut
-						prio-. <lb/> rem duæ breves et longa, posteriorem autem longa <lb/> quæ reliqua est. Fit
-						alius pes, cum duæ istæ breves <lb/> quas in capite posueramus, ita ut ordo ipse
-						postulat, <lb/> in medio fuerint collocatæ, et est hujus pedis divisio <lb/> in tria et
-						tria tempora : nam priorem partem occu­ <lb/> pant longa et brevis, posteriorem brevis
-						et longa. <lb/> Cum autem ponuntur in ultimo, nam hoc sequitur, <lb/> faciunt pedcm
-						geminæ divisionis, cnjus aut prior pars <lb/> habeat duo tempora in una longa, posterior
-						quatuor in <lb/> longa et duabus brevibus; aut prior quatuor in dua­ <lb/> bus longis,
-						posterior in duabus brevibus duo. Horum <lb/> autem trium pedum partes, quod ad primum
-						et tertium <lb/> attinet, complicatorum numerorum ratione sibi com­ <lb/> parantur;
-						medius æquales eas babet.</p>
-					<p>12. Jam deinceps istac duæ breves quae conjunctae <lb/> p onebantur, disjunctæ ponendæ
-						sunt : quarnm minima <lb/> disjunctio cst, a qua eliam incipiendum, nt unam syl­ <lb/>
-						labam longam inter se habeant; maxima, ut duas. <lb/> Sed cum una est inter cas, duobus
-						modis fit, et duo <lb/> pedes gignuntur. Priof antem est horum modorum, ut <lb/> in
-						capite brevis sit, -deinde longa ; inde brevis, et longa <lb/> quæ rcliquaest. Alter
-						modus est, ut in secundo et in ulti­ <lb/> mo sint breves , in primo ct tertio loco
-						longae : ita ent <lb/> longa et brevis, cllonga ct brevis. MaXima vero illa dis­ <lb/>
-						junctio est, cum duae longre in medio sunt, brevium <lb/> autem una in primo, altera in
-						extremo loco. Et divi­ <lb/> duntur ii tres pedes, in quibus breves disjunctæ po­ <lb/>
-						nuntur, in tria ct tria tempora, id cst primus horum in <lb/> brevem et longam, et
-						brevem ac longam : secundus in <lb/> longam ac brevem, ct longam ac brevem : tertius in
-						<lb/> brevcm ac longam, ct longam ac brevem. Ita fiunt sex <lb/> pedes duabus brevibus
-						et duabus longis syllabis varie <lb/> inter se, quoad possunt, locatis.</p>
-					<p>13. Restat ut de quatuor brevibus detrahantur tres, <lb/> et pro his tres longæ
-						constituantur : crit una brevis; <lb/> et quia una brevis in capitc, quam tres longæ
-						conse­ <lb/> quentur, facit alium pedem, secundo loco posita secun­ <lb/> dum, tertium
-						tertio, quartum quarto. Quorum qua­ <lb/> tuor, duo primi in tria et quatuor tempora
-						dividuntur, <lb/> duo autem posteriores in quatuor et tria, ct omnes <lb/> sesquatorum
-						ralionc numcrorum partes sibi collatas <note type="footnote">" I collocatos, juxta MS. v
-							ac Edd. omnes AL </note>
+					<p>9. M. Nunc quaternarum syllabarum pedes con­ <lb/> sequenter atque ordine
+						videamus, ct ipse jam dic <lb/> quem horum primum esse oporteat, addita
+						etiam ra­ <lb/> tione divisionis ejus. <hi rend="italic">D.</hi> Scilicet
+						quatuor brevium, <lb/> qui dividitur in duas binarum syllabarum partes,
+						<lb/> æqualium ratione numerorum duo et duo tempora <lb/> possidentes. M.
+						Tenes 1; jam itaque prge ipso, et <lb/> persequere cætera. Nihil enim opus
+						esse jam puto te <lb/> per singula interrogari, cum sit una ratio dcmendi
+						<lb/> deinceps breves syllabas, ct pro his longas subji­ <lb/> tiendi, donec
+						ad omnes longas veniatur; et cum de­ <lb/> muntur breves, longæque
+						subduntur, quas varietates <lb/> faciant, cl quot pedes gignant,
+						considcrandi; ea sci­ <lb/> licet syllaba principatum ordinis retinente, quæ
+						una <lb/> fuerit inter cæteras vel longa vel brevis: in his euim <lb/>
+						omnibus jam superius es exercitatus. Ubi antem duæ <lb/> breves sunt et duæ
+						longæ, quod in præcedentibus non <lb/> crat, quas censes principatum habere
+						debere? <hi rend="italic">D.</hi> Jani <lb/> hoc qnoque manifestum est de
+						superioribus. Siqui­ <lb/> dem magis tenet unitatem brevis syllaba quæ unum
+						<lb/> habet tempus, quam longa quæ duo. Et propterea in <lb/> omni capite
+						atquc principio eum pedem constituimus <lb/> qui cx brevibus constat.</p>
+					</div>
+				<div type="textpart" subtype="dialog"><p>10. <hi rend="italic">M.</hi> Nihil igitur te impedit, quin omnes istos <lb/>
+						perscquaris pedes audiente ac judicante me, non in­ <lb/> terrogante. <hi
+							rend="italic">D.</hi> Faciam si potero : nam primo de qua­ <lb/> tuor
+						brevibus primi pedis, brevis una detrahenda est, <lb/> et pro ca longa
+						ponenda in primo loco propter uuila-, <lb/> tis dignitatem. IIic autem pes
+						dividilur bis : aut in <lb/> longam et tres breves; aut in longam et brevem,
+						et <lb/> duas breves; id est aut in duo et tria; aut in tria, ct <lb/> duo
+						tempora. Secundo autcm loco posita longa facit <lb/> alium pedem, qui uno
+						modo recte dividitur, in tria <lb/> scilicct et duo tempora, ut prior pars
+						teneat brevem <lb/> et longam, posterior duas breves. Porro lcriio loco­
+						<lb/> consLilula longa facil cum pedem, qui rursus uno <lb/> modo rite
+						dividitur; sed ita ut prior pars habeat duo <lb/> tempora in duabus brevibus
+						syllabis, posterior tria in <lb/> longa ct brevi. Quartum pedem facit longa
+						ultima, qui <note type="footnote">1 lerucr, jutt2 Er, luflg. ven. et Mss. \
+							n H. M. </note>
+						<lb/> duobus modis dividitur, ut illc ubi prima est : nau, <lb/> vel in duas
+						breves, et brevem ac longam; vel in tres <lb/> breves, etlongam partiri cum
+						licet; in duo scilicet, et <lb/> tria; aut in tria, et duo tempora.
+						Omnesautem iiti <lb/> quatuor pedes, ubi cum tribus brevibus varie longa
+						<lb/> collocatur, sesquatorum numerorum ratione partes <lb/> suas ad se
+						collatas' habent.</p>
+					<p>ii. Sequitur ut de quatuor brevibus duabus de­ <lb/> tractis, pro his duas
+						longas subjiciamus, videamus­ <lb/> que quot formas ac pedes cum breves ac
+						longa. binæ <lb/> sint, possint edere. Primo igitur video duas broves <lb/>
+						et duas longas csse ponendas, quod a brevibus rectius <lb/> exordium sit.
+						Hic autem pes habet a duplicem divisio­ <lb/> nem : aut enim in duo at quatn
+						or, ant in quatuor et <lb/> duo dividitur lempora; ut aut duæ breves priorem
+						par­ <lb/> tem lencant, et posteriorem duæ longæ; aut ut prio-. <lb/> rem
+						duæ breves et longa, posteriorem autem longa <lb/> quæ reliqua est. Fit
+						alius pes, cum duæ istæ breves <lb/> quas in capite posueramus, ita ut ordo
+						ipse postulat, <lb/> in medio fuerint collocatæ, et est hujus pedis divisio
+						<lb/> in tria et tria tempora : nam priorem partem occu­ <lb/> pant longa et
+						brevis, posteriorem brevis et longa. <lb/> Cum autem ponuntur in ultimo, nam
+						hoc sequitur, <lb/> faciunt pedcm geminæ divisionis, cnjus aut prior pars
+						<lb/> habeat duo tempora in una longa, posterior quatuor in <lb/> longa et
+						duabus brevibus; aut prior quatuor in dua­ <lb/> bus longis, posterior in
+						duabus brevibus duo. Horum <lb/> autem trium pedum partes, quod ad primum et
+						tertium <lb/> attinet, complicatorum numerorum ratione sibi com­ <lb/>
+						parantur; medius æquales eas babet.</p>
+					</div>
+				<div type="textpart" subtype="dialog"><p>12. Jam deinceps istac duæ breves quae conjunctae <lb/> p onebantur,
+						disjunctæ ponendæ sunt : quarnm minima <lb/> disjunctio cst, a qua eliam
+						incipiendum, nt unam syl­ <lb/> labam longam inter se habeant; maxima, ut
+						duas. <lb/> Sed cum una est inter cas, duobus modis fit, et duo <lb/> pedes
+						gignuntur. Priof antem est horum modorum, ut <lb/> in capite brevis sit,
+						-deinde longa ; inde brevis, et longa <lb/> quæ rcliquaest. Alter modus est,
+						ut in secundo et in ulti­ <lb/> mo sint breves , in primo ct tertio loco
+						longae : ita ent <lb/> longa et brevis, cllonga ct brevis. MaXima vero illa
+						dis­ <lb/> junctio est, cum duae longre in medio sunt, brevium <lb/> autem
+						una in primo, altera in extremo loco. Et divi­ <lb/> duntur ii tres pedes,
+						in quibus breves disjunctæ po­ <lb/> nuntur, in tria ct tria tempora, id cst
+						primus horum in <lb/> brevem et longam, et brevem ac longam : secundus in
+						<lb/> longam ac brevem, ct longam ac brevem : tertius in <lb/> brevcm ac
+						longam, ct longam ac brevem. Ita fiunt sex <lb/> pedes duabus brevibus et
+						duabus longis syllabis varie <lb/> inter se, quoad possunt, locatis.</p>
+					</div>
+				<div type="textpart" subtype="dialog"><p>13. Restat ut de quatuor brevibus detrahantur tres, <lb/> et pro his tres
+						longæ constituantur : crit una brevis; <lb/> et quia una brevis in capitc,
+						quam tres longæ conse­ <lb/> quentur, facit alium pedem, secundo loco posita
+						secun­ <lb/> dum, tertium tertio, quartum quarto. Quorum qua­ <lb/> tuor,
+						duo primi in tria et quatuor tempora dividuntur, <lb/> duo autem posteriores
+						in quatuor et tria, ct omnes <lb/> sesquatorum ralionc numcrorum partes sibi
+						collatas <note type="footnote">" I collocatos, juxta MS. v ac Edd. omnes AL </note>
 						<lb/>
-						<pb n="1007"/> habent : nam prior pars primi est brevis et longa, <unclear>te</unclear>-
-						<lb/> Nem tria tempora; posterior duæ longæ in quatuor <lb/> temporibus. Secundi prior
-						pars est longa ei brevis, ergo <lb/> tria lempora; posterior duae longæ, quatuor
-						tempora. <lb/> Tertius priorem pariem habet in duabus longis, qua­ <lb/> tuor
-						temporibus; posteriorem cjus partem brevis et <lb/> longa obtinet, id est tria tempora.
-						Quarti priorem <lb/> partem similiter facium dux longæ, quatuor tempo­ <lb/> rum; et
-						posteriorem longa et brevis, tribus tempori­ <lb/> bus. Reliquus pes est quatuor
-						syllabarum, ubi omnes <lb/> auferuntur breves, ut quatuor longis pes constet. Hic <lb/>
-						in duas et duas longas secundum æquales numeros, <lb/> kl est in quatuor et quatuor
-						videlicet dividitur tempora. <lb/> Habes quod per meipsum explicari voluisti: perge
-						<lb/> jam rogando persequi caetera.</p>
-					<ab>
-						<title type="sub">CAPUT VII. — Versus <hi rend="italic">certo pedum,</hi> ut <hi rend="italic">pes syllabarum</hi> numero <hi rend="italic">constat.</hi>
+						<pb n="1007"/> habent : nam prior pars primi est brevis et longa,
+							<unclear>te</unclear>- <lb/> Nem tria tempora; posterior duæ longæ in
+						quatuor <lb/> temporibus. Secundi prior pars est longa ei brevis, ergo <lb/>
+						tria lempora; posterior duae longæ, quatuor tempora. <lb/> Tertius priorem
+						pariem habet in duabus longis, qua­ <lb/> tuor temporibus; posteriorem cjus
+						partem brevis et <lb/> longa obtinet, id est tria tempora. Quarti priorem
+						<lb/> partem similiter facium dux longæ, quatuor tempo­ <lb/> rum; et
+						posteriorem longa et brevis, tribus tempori­ <lb/> bus. Reliquus pes est
+						quatuor syllabarum, ubi omnes <lb/> auferuntur breves, ut quatuor longis pes
+						constet. Hic <lb/> in duas et duas longas secundum æquales numeros, <lb/> kl
+						est in quatuor et quatuor videlicet dividitur tempora. <lb/> Habes quod per
+						meipsum explicari voluisti: perge <lb/> jam rogando persequi caetera.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT VII. — Versus <hi rend="italic">certo pedum,</hi> ut
+								<hi rend="italic">pes syllabarum</hi> numero <hi rend="italic"
+								>constat.</hi>
 						</title>
 					</ab>
-					<p>14. M Faciam : sed satisne considerasti progres­ <lb/> sionem istam usque ad
-						quaternarium numerum, quæ <lb/> ia ipsis numeria demonstrata est, quantum in his etiam
-						<lb/> pedibus valet! <hi rend="italic">D.</hi> Ita saue in bis ut in illis hanc pro­
-						<lb/> grediendi rationem probo. M. Quid illud! nonne ut <lb/> contextis syllabis pedes
-						facti sunt, ita etiam contextis <lb/> pcdibus aliquid fieri posse existimandum est, quod <unclear/>
+					</div>
+				<div type="textpart" subtype="dialog"><p>14. M Faciam : sed satisne considerasti progres­ <lb/> sionem istam usque ad
+						quaternarium numerum, quæ <lb/> ia ipsis numeria demonstrata est, quantum in
+						his etiam <lb/> pedibus valet! <hi rend="italic">D.</hi> Ita saue in bis ut
+						in illis hanc pro­ <lb/> grediendi rationem probo. M. Quid illud! nonne ut
+						<lb/> contextis syllabis pedes facti sunt, ita etiam contextis <lb/> pcdibus
+						aliquid fieri posse existimandum est, quod <unclear/>
 						<lb/> jam neque syllabae neque pedis nomine censeatur ? <lb/>
-						<hi rend="italic">J)</hi> Omnino existimo. <hi rend="italic">M.</hi> Quid tandem id
-						putas esse! <lb/> D. Versum arbitror. 3/. Quid si perpetuo contexere <lb/> quispiam
-						pedes aliquos velit, ita ut eis modum ac fi­ <lb/> nem non imponat, nisi aut delectus
-						vocis, aut aliquis <lb/> alius casus interpellans, aut temporis ratio ad aliud <lb/>
-						aliquid transeundi ? ctiamne versus a te nominabitur, <lb/> habens vel viginti vel
-						triginta vel centum etiam sive <lb/> amplius pedes, ut voluerit ac potuerit ille qui cos
-						<lb/> quamlibet longa perpetuitate contexit? <hi rend="italic">D.</hi> Non ita <lb/>
-						est: neque enim aut ubi pedes quoslibet quibuslibet <lb/> permixtos animadvertero, aut
-						per infinitam longitudi­ <lb/> nem multos connexos, versum appellabo; sed et se­ <lb/>
-						nus et numerum pedum, id cst qui ct quot pedes vcr­ <lb/> sum conficiant aliqua
-						disciplina consequi, et'ex ea <lb/> judicare potero, utrum versus aurcs meas pepulerit. <lb/>
-						<hi rend="italic">M.</hi> At hæc quæcumque est disciplina, versibus regu­ <lb/> lam et
-						modum non utique ut libitum cst, sed aliqua ra­ <lb/> tione constituit. <hi rend="italic">D.</hi> Non enim aliter, siquidem disci­ <lb/> plina cst, aut oportebat,
-						aut poterat. M. Hanc ergo <lb/> rationem investigemus, et assequamur, si placet: <lb/>
-						nam si auctoritatem solam intueamur, is erit versus, <lb/> quem versum diei voluit
-						Asclepiades nescio qui, aut <lb/> Archilochus, pactæ scilicet veteres, aut Sappho poe­
-						<lb/> tria, et cæteri, quorum etiam nominibus versuum ge­ <lb/> nera vocantur, qu.c
-						primi animadvertentes cecine­ <lb/> runt. Nam et Asclepiadæus versus dicitur, ct
-						Archilu­ <lb/> cuius et Sapphicus, et alia sexcenta auctorum vocabula <lb/> Graeci
-						versibus diversi generis indiderunt. Ex quo non <lb/> absurde cuipiam videri potest,
-						quod si quis ut volet, <lb/> pedes quot volet, et quos volcl ordinaverit, quia nemo
-						<lb/> ante ipsum hunc ordinem ac mensuram pedibus con­ <lb/> stituerit, recte ac jure
-						conditor novi generis versuum <lb/> propagatorque dicctur. Aut si hæc licentia
-						intercludi­ <lb/> tur homini, cum conquestione quærend;un cst quid <lb/> tandem ilii
-						meruerunt, si nullam rationem seculi, <lb/> connexionem pedum quos illis connectere
-						placmt, <lb/>
-						<lb/> versam appellari haberique fecerant. An tibi aliter vi­ <lb/> detur? <hi rend="italic">D.</hi> Ita vero est ut dicis, et prorsus assentior, <lb/> ratione
-						potius quam auctoritate versum esse genera­ <lb/> tum, quam peto jamjamque videamus.</p>
-					<ab>
+						<hi rend="italic">J)</hi> Omnino existimo. <hi rend="italic">M.</hi> Quid
+						tandem id putas esse! <lb/> D. Versum arbitror. 3/. Quid si perpetuo
+						contexere <lb/> quispiam pedes aliquos velit, ita ut eis modum ac fi­ <lb/>
+						nem non imponat, nisi aut delectus vocis, aut aliquis <lb/> alius casus
+						interpellans, aut temporis ratio ad aliud <lb/> aliquid transeundi ? ctiamne
+						versus a te nominabitur, <lb/> habens vel viginti vel triginta vel centum
+						etiam sive <lb/> amplius pedes, ut voluerit ac potuerit ille qui cos <lb/>
+						quamlibet longa perpetuitate contexit? <hi rend="italic">D.</hi> Non ita
+						<lb/> est: neque enim aut ubi pedes quoslibet quibuslibet <lb/> permixtos
+						animadvertero, aut per infinitam longitudi­ <lb/> nem multos connexos,
+						versum appellabo; sed et se­ <lb/> nus et numerum pedum, id cst qui ct quot
+						pedes vcr­ <lb/> sum conficiant aliqua disciplina consequi, et'ex ea <lb/>
+						judicare potero, utrum versus aurcs meas pepulerit. <lb/>
+						<hi rend="italic">M.</hi> At hæc quæcumque est disciplina, versibus regu­
+						<lb/> lam et modum non utique ut libitum cst, sed aliqua ra­ <lb/> tione
+						constituit. <hi rend="italic">D.</hi> Non enim aliter, siquidem disci­ <lb/>
+						plina cst, aut oportebat, aut poterat. M. Hanc ergo <lb/> rationem
+						investigemus, et assequamur, si placet: <lb/> nam si auctoritatem solam
+						intueamur, is erit versus, <lb/> quem versum diei voluit Asclepiades nescio
+						qui, aut <lb/> Archilochus, pactæ scilicet veteres, aut Sappho poe­ <lb/>
+						tria, et cæteri, quorum etiam nominibus versuum ge­ <lb/> nera vocantur,
+						qu.c primi animadvertentes cecine­ <lb/> runt. Nam et Asclepiadæus versus
+						dicitur, ct Archilu­ <lb/> cuius et Sapphicus, et alia sexcenta auctorum
+						vocabula <lb/> Graeci versibus diversi generis indiderunt. Ex quo non <lb/>
+						absurde cuipiam videri potest, quod si quis ut volet, <lb/> pedes quot
+						volet, et quos volcl ordinaverit, quia nemo <lb/> ante ipsum hunc ordinem ac
+						mensuram pedibus con­ <lb/> stituerit, recte ac jure conditor novi generis
+						versuum <lb/> propagatorque dicctur. Aut si hæc licentia intercludi­ <lb/>
+						tur homini, cum conquestione quærend;un cst quid <lb/> tandem ilii
+						meruerunt, si nullam rationem seculi, <lb/> connexionem pedum quos illis
+						connectere placmt, <lb/>
+						<lb/> versam appellari haberique fecerant. An tibi aliter vi­ <lb/> detur?
+							<hi rend="italic">D.</hi> Ita vero est ut dicis, et prorsus assentior,
+						<lb/> ratione potius quam auctoritate versum esse genera­ <lb/> tum, quam
+						peto jamjamque videamus.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT VIII.— <hi rend="italic">Varia pedum nomina.</hi>
 						</title>
 					</ab>
-					<p>15. <hi rend="italic">M.</hi> Videamus ergo qui pedes sibimet copulan­ <lb/> di sint,
-						deinde quid his copulatis liat (non enim ver­ <lb/> sus fit solus); postremo de versus
-						tota ratione tracta­ <lb/> bimus. Sed num censes commode ista nos posse per­ <lb/>
-						sequi, nisi pedum nomina teneamus! Quanquam hac <lb/> ordine a nobis digesti sunt, ut
-						possint ipsius sui or­ <lb/> dinis nominibus nuncupari : dici enim potest, primus, <lb/>
-						secundus, tertius, atque hoc modo cæteri. Sed qnia <lb/> non sunt contemnenda vetusta
-						vocabula, nec facile a <lb/> consuetudine recedendum, nisi quae rationi adversa­ <lb/>
-						tur; utendum est his nominibus pedum quæ Greci in­ <lb/> stituerunt, et nostri jam
-						utuntur pro latinis : quæ <lb/> plane ita usurpemus, ut nou qureramus origines no­ <lb/>
-						minum. Mullum enim habet ista res loquacitatis, nti­ <lb/> litatis parum. Neque euim eo
-						minus utiliter in io­ <lb/> quendo appellas panem, lignum, lapidem, quod nescis <lb/>
-						cur haec ita sint appellata. <hi rend="italic">D.</hi> Ita prorsus, ut dicis , <lb/>
+					</div>
+				<div type="textpart" subtype="dialog"><p>15. <hi rend="italic">M.</hi> Videamus ergo qui pedes sibimet copulan­ <lb/>
+						di sint, deinde quid his copulatis liat (non enim ver­ <lb/> sus fit solus);
+						postremo de versus tota ratione tracta­ <lb/> bimus. Sed num censes commode
+						ista nos posse per­ <lb/> sequi, nisi pedum nomina teneamus! Quanquam hac
+						<lb/> ordine a nobis digesti sunt, ut possint ipsius sui or­ <lb/> dinis
+						nominibus nuncupari : dici enim potest, primus, <lb/> secundus, tertius,
+						atque hoc modo cæteri. Sed qnia <lb/> non sunt contemnenda vetusta vocabula,
+						nec facile a <lb/> consuetudine recedendum, nisi quae rationi adversa­ <lb/>
+						tur; utendum est his nominibus pedum quæ Greci in­ <lb/> stituerunt, et
+						nostri jam utuntur pro latinis : quæ <lb/> plane ita usurpemus, ut nou
+						qureramus origines no­ <lb/> minum. Mullum enim habet ista res loquacitatis,
+						nti­ <lb/> litatis parum. Neque euim eo minus utiliter in io­ <lb/> quendo
+						appellas panem, lignum, lapidem, quod nescis <lb/> cur haec ita sint
+						appellata. <hi rend="italic">D.</hi> Ita prorsus, ut dicis , <lb/>
 						sontio.</p>
-					<p>M. Primus pes vocatur Pyrrhichius, ex duabus brevi­ <lb/> bus, temporum duum, ut <hi rend="italic">fuga.</hi>
+					<p>M. Primus pes vocatur Pyrrhichius, ex duabus brevi­ <lb/> bus, temporum duum,
+						ut <hi rend="italic">fuga.</hi>
 					</p>
-					<p>Secundus, lanibus, ex brevi eL longa, ut <hi rend="italic">parens,</hi> tem­ <lb/>
-						porum trium.</p>
+					<p>Secundus, lanibus, ex brevi eL longa, ut <hi rend="italic">parens,</hi> tem­
+						<lb/> porum trium.</p>
 					<p>Tertius, Trochxus, vtl Chorius, ex longa ct brevi, ut <lb/>
 						<hi rend="italic">meta,</hi> temporum trium.</p>
-					<p>Quartus, Spondeus, ex duabus longis, ut <hi rend="italic">æstas,</hi> tem: <lb/> porum
-						quatuor.</p>
+					<p>Quartus, Spondeus, ex duabus longis, ut <hi rend="italic">æstas,</hi> tem:
+						<lb/> porum quatuor.</p>
 					<p>Quintus, Tribracbus, ex tribus brevibus, ut macula, <lb/> temporum trium.</p>
 					<p>Sextus, Dactylus, ex longa at duabus brevibus, ut <lb/>
 						<hi rend="italic">Mænalus,</hi> temporum quatuor.</p>
-					<p>Septimus, Amphibrachus, ex brevi et longa ct brevi, <lb/> ut <hi rend="italic">carina,</hi> temporum quatuor.</p>
+					<p>Septimus, Amphibrachus, ex brevi et longa ct brevi, <lb/> ut <hi
+							rend="italic">carina,</hi> temporum quatuor.</p>
 					<p>Octavus, Anapaestus, ex duabus brevibus et longa, ut <lb/>
 						<hi rend="italic">Erato,</hi> temporum quatuor.</p>
-					<p>Nonus, Bacchius, ex brevi et duabus longis, ut Acha­ <lb/> tes, temporum quinque.</p>
-					<p>Decimus, Creticus vel Amphimacrus, ex longa ei bre­ <lb/> vi et longa, ut <hi rend="italic">insulæ,</hi> temporum quinque.</p>
+					<p>Nonus, Bacchius, ex brevi et duabus longis, ut Acha­ <lb/> tes, temporum
+						quinque.</p>
+					<p>Decimus, Creticus vel Amphimacrus, ex longa ei bre­ <lb/> vi et longa, ut <hi
+							rend="italic">insulæ,</hi> temporum quinque.</p>
 					<p>Undecimus, Palimbacchius, ex duabus longis et brevi, <lb/>
 						<hi rend="italic">utnatura9</hi> temporum quinque.</p>
 					<p>Duodecimus, Molossus, ex tribus longis, ut <hi rend="italic">Æneas,</hi>
 						<lb/> temporum sex.</p>
-					<p>Decimus tertius, Proceleumaticus, ox quatuor brevi­ <lb/> bus, <hi rend="italic">utavicula,</hi> temporum quatuor.</p>
-					<p>Decimus quartus, Pæon primus, ex prima longa et <lb/> tribus brevibus, ut legitimus,
-						temporum quinque.</p>
-					<p>Decimus quintus, Pæon secundus, ex secunda longa <lb/> et tribus brevibus, m <hi rend="italic">colonia,</hi> temporum quinque.</p>
-					<p>Decimus sextus, Pæon tertius, ex tertia longa et tribus <lb/> brevibus. ut <hi rend="italic">Menedemus,</hi> temporum quinque.</p>
+					<p>Decimus tertius, Proceleumaticus, ox quatuor brevi­ <lb/> bus, <hi
+							rend="italic">utavicula,</hi> temporum quatuor.</p>
+					<p>Decimus quartus, Pæon primus, ex prima longa et <lb/> tribus brevibus, ut
+						legitimus, temporum quinque.</p>
+					<p>Decimus quintus, Pæon secundus, ex secunda longa <lb/> et tribus brevibus, m
+							<hi rend="italic">colonia,</hi> temporum quinque.</p>
+					<p>Decimus sextus, Pæon tertius, ex tertia longa et tribus <lb/> brevibus. ut
+							<hi rend="italic">Menedemus,</hi> temporum quinque.</p>
 					<p>Decimus septimus, Pxon quartus, ex quarta longa <lb/>
-						<pb n="1009"/> et tribus brevibus, ut <hi rend="italic">celeritas,</hi> temporum quln­
-						<lb/> que.</p>
-					<p>Decimus octavus, Ionicus a minore, ex duabus bre­ <lb/> vtbus et duabus longis, ut <hi rend="italic">Diomedea,</hi> temporum <lb/> sex.</p>
-					<p>Decimus nomus, Choriambus, ex longa ct duabus <lb/> brevibus ct longa, ut <hi rend="italic">armipotens,</hi> temporum sex.</p>
-					<p>Vigesimos, lonicus a majore, ex duabus longis et dua­ <lb/> bus brevibus, ut <hi rend="italic">Junonius,</hi> temporum sex.</p>
-					<p>Vigesimus primus, Diiambus, ex brevi ct longa, et <lb/> brevi et longa, ut <hi rend="italic">propinquitas,</hi> temporum sex.</p>
-					<p>Vigesimus sccundus, Dichorius vel Ditrochæus, ex <lb/> longa et brevi, et longa et
-						brevi, ut <hi rend="italic">caniilena</hi> tcm­ <lb/> porum sex.</p>
-					<p>Vigesimus tertius, Antispastus, ex brevi ct duabus <lb/> longis it brevi, ut <hi rend="italic">Saloninus,</hi> temporum sex.</p>
-					<p>Vigesimus quartus, Epitritus primus, ex prima brevi <lb/> et tribus longis, ut
-						sacerdotes, temporum septem.</p>
-					<p>Vigesimus quintus, Epitritus sccundus, ex secunda <lb/> brevi et tribus longis, ut <hi rend="italic">conditores,</hi> temporum sc­ <lb/> ptem.</p>
-					<p>Yigesimus sextus, Epitritus tertius, ex tertia brevi et <lb/> tribus longis, ut <hi rend="italic">Demosthenes,</hi> temporum septem.</p>
-					<p>Vigesimus septimus, Epitritus quartus, cx quarta <lb/> brevi cl tribus longis, ut
-						Fescenninus, temporum se­ <lb/> ptem.</p>
-					<p>Vigesimus octavus, Dispondeus, ex quatuor longis, <lb/> ut <hi rend="italic">oratores,</hi> temporum octo I.</p>
-					<ab>
+						<pb n="1009"/> et tribus brevibus, ut <hi rend="italic">celeritas,</hi>
+						temporum quln­ <lb/> que.</p>
+					<p>Decimus octavus, Ionicus a minore, ex duabus bre­ <lb/> vtbus et duabus
+						longis, ut <hi rend="italic">Diomedea,</hi> temporum <lb/> sex.</p>
+					<p>Decimus nomus, Choriambus, ex longa ct duabus <lb/> brevibus ct longa, ut <hi
+							rend="italic">armipotens,</hi> temporum sex.</p>
+					<p>Vigesimos, lonicus a majore, ex duabus longis et dua­ <lb/> bus brevibus, ut
+							<hi rend="italic">Junonius,</hi> temporum sex.</p>
+					<p>Vigesimus primus, Diiambus, ex brevi ct longa, et <lb/> brevi et longa, ut
+							<hi rend="italic">propinquitas,</hi> temporum sex.</p>
+					<p>Vigesimus sccundus, Dichorius vel Ditrochæus, ex <lb/> longa et brevi, et
+						longa et brevi, ut <hi rend="italic">caniilena</hi> tcm­ <lb/> porum
+						sex.</p>
+					<p>Vigesimus tertius, Antispastus, ex brevi ct duabus <lb/> longis it brevi, ut
+							<hi rend="italic">Saloninus,</hi> temporum sex.</p>
+					<p>Vigesimus quartus, Epitritus primus, ex prima brevi <lb/> et tribus longis,
+						ut sacerdotes, temporum septem.</p>
+					<p>Vigesimus quintus, Epitritus sccundus, ex secunda <lb/> brevi et tribus
+						longis, ut <hi rend="italic">conditores,</hi> temporum sc­ <lb/> ptem.</p>
+					<p>Yigesimus sextus, Epitritus tertius, ex tertia brevi et <lb/> tribus longis,
+						ut <hi rend="italic">Demosthenes,</hi> temporum septem.</p>
+					<p>Vigesimus septimus, Epitritus quartus, cx quarta <lb/> brevi cl tribus
+						longis, ut Fescenninus, temporum se­ <lb/> ptem.</p>
+					<p>Vigesimus octavus, Dispondeus, ex quatuor longis, <lb/> ut <hi rend="italic"
+							>oratores,</hi> temporum octo I.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT IX.— <hi rend="italic">De pedum structura.</hi>
 						</title>
 					</ab>
-					<p><lb/> 16. <hi rend="italic">D.</hi> Habeo ista. Nunc dissere , qui sibi pedes <lb/>
-						copulentur. <hi rend="italic">M.</hi> Judicabis boc facile, si æqualitatem <lb/> ac
-						similitudinem inæqualitati ac dissimilitudini præ­ <lb/> stantiorem esse judicas. D.
-						Ncminem esse arbitror, <lb/> qui non ita judicet. <hi rend="italic">M.</hi> Ilanc ergo
-						prius maxime in <lb/> contexendis pedibus sequi oportet, nec ab ea omnino <lb/>
-						deviandum, nisi cum aliqua causa justissima est. <hi rend="italic">D.</hi>
-						<lb/> Assentior. <hi rend="italic">M.</hi> Non igitur dubitabis pyrrhichios sibimet
-						<lb/> pedes contexere, nec iambos, nec trochaeos qui etiam <lb/> chorii nominantur, nec
-						spondeos; atque ita caeteros <lb/> sui gcneris profecto sibimet sine ulla dubitatione
-						co­ <lb/> pulabis : est enim summa aequalitas cum ejusdem ge­ <lb/> neris et nominis
-						pedes sese consequuntur. An tibi non <lb/> videtur? <hi rend="italic">D.</hi> Nullo modo
-						niihi aliter videri potest. <hi rend="italic">M.</hi>
-						<lb/> Quid ? illud nonne approbas, alios aliis pedes æquali­ <lb/> tate servata esse
-						miscendos ? Quid enim auribus po­ <lb/> test jucundius esse, quam cum et varietate
-						mulcentur, <lb/> nec æqualitate fraudantur? <hi rend="italic">D.</hi> Satis probo. M.
-						Num <lb/> censes alios æquales habendos pedes, nisi qui ejusdem <lb/> mensurx sunt? <hi rend="italic">D.</hi> Ita existimo. M. Quid? ejusdem <lb/> mensuræ putandine sunt,
-						nisi qui temporis tantum­ <lb/> dcm occupant? <hi rend="italic">D.</hi> Verum est. II.
-						Quos crgo invene­ <lb/> ris pedes lolidcm temporum, sine aurium offensione <lb/>
-						contexes. <hi rend="italic">D.</hi> Video esse consequens. <note type="footnote"> I
-							Libri veteres aLsque explicatione et exemplo uno sic <lb/> Ipedes recensent: trtinus
-								<hi rend="italic">pes vocatur Pyrrhichus, seam­<lb/> dns Iambus, Tertius,</hi> etc.,
-							scriptumque constanter praefe­ <lb/> runt <hi rend="italic">spondtus, dispondiusy
-								paan,</hi> pro <hi rend="italic">spondeus, dLpotideiis, <lb/> væon.</hi> Itein i ro
-								<hi rend="italic">tribracltus</hi> ct <hi rend="italic">amphibrachus,</hi> habent
-							aliquo­ <lb/> li05 <hi rend="italic">tribrachijs</hi> et <hi rend="italic">amphibrachys.</hi>
+					</div>
+				<div type="textpart" subtype="dialog"><p><lb/> 16. <hi rend="italic">D.</hi> Habeo ista. Nunc dissere , qui sibi pedes
+						<lb/> copulentur. <hi rend="italic">M.</hi> Judicabis boc facile, si
+						æqualitatem <lb/> ac similitudinem inæqualitati ac dissimilitudini præ­
+						<lb/> stantiorem esse judicas. D. Ncminem esse arbitror, <lb/> qui non ita
+						judicet. <hi rend="italic">M.</hi> Ilanc ergo prius maxime in <lb/>
+						contexendis pedibus sequi oportet, nec ab ea omnino <lb/> deviandum, nisi
+						cum aliqua causa justissima est. <hi rend="italic">D.</hi>
+						<lb/> Assentior. <hi rend="italic">M.</hi> Non igitur dubitabis pyrrhichios
+						sibimet <lb/> pedes contexere, nec iambos, nec trochaeos qui etiam <lb/>
+						chorii nominantur, nec spondeos; atque ita caeteros <lb/> sui gcneris
+						profecto sibimet sine ulla dubitatione co­ <lb/> pulabis : est enim summa
+						aequalitas cum ejusdem ge­ <lb/> neris et nominis pedes sese consequuntur.
+						An tibi non <lb/> videtur? <hi rend="italic">D.</hi> Nullo modo niihi aliter
+						videri potest. <hi rend="italic">M.</hi>
+						<lb/> Quid ? illud nonne approbas, alios aliis pedes æquali­ <lb/> tate
+						servata esse miscendos ? Quid enim auribus po­ <lb/> test jucundius esse,
+						quam cum et varietate mulcentur, <lb/> nec æqualitate fraudantur? <hi
+							rend="italic">D.</hi> Satis probo. M. Num <lb/> censes alios æquales
+						habendos pedes, nisi qui ejusdem <lb/> mensurx sunt? <hi rend="italic"
+							>D.</hi> Ita existimo. M. Quid? ejusdem <lb/> mensuræ putandine sunt,
+						nisi qui temporis tantum­ <lb/> dcm occupant? <hi rend="italic">D.</hi>
+						Verum est. II. Quos crgo invene­ <lb/> ris pedes lolidcm temporum, sine
+						aurium offensione <lb/> contexes. <hi rend="italic">D.</hi> Video esse
+						consequens. <note type="footnote"> I Libri veteres aLsque explicatione et
+							exemplo uno sic <lb/> Ipedes recensent: trtinus <hi rend="italic">pes
+								vocatur Pyrrhichus, seam­<lb/> dns Iambus, Tertius,</hi> etc.,
+							scriptumque constanter praefe­ <lb/> runt <hi rend="italic">spondtus,
+								dispondiusy paan,</hi> pro <hi rend="italic">spondeus, dLpotideiis,
+								<lb/> væon.</hi> Itein i ro <hi rend="italic">tribracltus</hi> ct
+								<hi rend="italic">amphibrachus,</hi> habent aliquo­ <lb/> li05 <hi
+								rend="italic">tribrachijs</hi> et <hi rend="italic"
+								>amphibrachys.</hi>
 						</note>
 					</p>
-					<ab>
-						<title type="sub">CAPUT <hi rend="italic">X.— Amphibrachus nec per</hi> se <hi rend="italic">nee aliis</hi> mixtus <hi rend="italic">versum conficit. De levatione
-								et positione.</hi>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT <hi rend="italic">X.— Amphibrachus nec per</hi> se
+								<hi rend="italic">nee aliis</hi> mixtus <hi rend="italic">versum
+								conficit. De levatione et positione.</hi>
 						</title>
 					</ab>
-					<p>17. M. Recte quidem : sed adhuc nonnihil quæ­ <lb/> stiools rcs habet.Namcum
-						Amphibrachus pes quatuor <lb/> sit temporum, negant eum quidam posse misceri, vel <lb/>
-						dactylis vel anapæstis vcl spondeis vel proceleumati <lb/> cis : nam hi sunt onUs
-						quaternorum temporum pc­ <lb/> des : et non solum istis cum negant posse misceri, <lb/>
-						sed nec ex ipso solo rcpelito et sibimet connexo, rectc <lb/> ct quasi legitime
-						procedcre numerum putant. Quo­ <lb/> rum opinionem considerarc nos oportet, ne quid ha­
-						<lb/> beat rationis, quod scqui ct approbare conveniat. <hi rend="italic">D.</hi>
-						<lb/> Cupio atque aveo prorsus audire quid an'erant. Non <lb/> cnim parum me movet, cum
-						duodetriginta pedes sint, <lb/> quos ratio persecuta cst, hunc solum excludi a conti­
-						<lb/> nualione nunicrorum, cum tantum spatii teneat in <lb/> tempore quantum dactylus et
-						alii quos parcs enume­ <lb/> fasti, quos connectere ncmo prohibetur. M. Atqui <lb/> epus
-						est, ut hoc dispicere valeas, consideraTe cæteros. <lb/> pedes, quemadmodum sihimcl
-						eorum partes conferan­ <lb/> tur : ita enim videbis huic uni quiddam accidere no­ <lb/>
-						vum ac singulare, ut non frustra minime adhibendus <lb/> ad numerus judicatus sit.</p>
-					<p>18. Sed hoc nobis considerantibus, opus est h:rc <lb/> duo nomina mandare memoriæ,
-						levationem et posi­ <lb/> tionem. In plaudendo enim quia levatur et ponitur <lb/> manus,
-						partem pedis sibi levatio vindicat, partem po­ <lb/> sitio. Partes autem pedum dico
-						illas, de quibus supc­ <lb/> rius, cum eos ordine persequeremur, satis dictum est. <lb/>
-						Quocirca si hoc probas, incipe recensere breviter <lb/> mensuras partium in omnibus
-						pedibus, ut quid huic <lb/> uni de quo agitur proprium acciderit, novcris. <hi rend="italic">D.</hi> Vi­ <lb/> deo primum pyrrhichium tantum habere in levatione
+					</div>
+				<div type="textpart" subtype="dialog"><p>17. M. Recte quidem : sed adhuc nonnihil quæ­ <lb/> stiools rcs habet.Namcum
+						Amphibrachus pes quatuor <lb/> sit temporum, negant eum quidam posse
+						misceri, vel <lb/> dactylis vel anapæstis vcl spondeis vel proceleumati
+						<lb/> cis : nam hi sunt onUs quaternorum temporum pc­ <lb/> des : et non
+						solum istis cum negant posse misceri, <lb/> sed nec ex ipso solo rcpelito et
+						sibimet connexo, rectc <lb/> ct quasi legitime procedcre numerum putant.
+						Quo­ <lb/> rum opinionem considerarc nos oportet, ne quid ha­ <lb/> beat
+						rationis, quod scqui ct approbare conveniat. <hi rend="italic">D.</hi>
+						<lb/> Cupio atque aveo prorsus audire quid an'erant. Non <lb/> cnim parum me
+						movet, cum duodetriginta pedes sint, <lb/> quos ratio persecuta cst, hunc
+						solum excludi a conti­ <lb/> nualione nunicrorum, cum tantum spatii teneat
+						in <lb/> tempore quantum dactylus et alii quos parcs enume­ <lb/> fasti,
+						quos connectere ncmo prohibetur. M. Atqui <lb/> epus est, ut hoc dispicere
+						valeas, consideraTe cæteros. <lb/> pedes, quemadmodum sihimcl eorum partes
+						conferan­ <lb/> tur : ita enim videbis huic uni quiddam accidere no­ <lb/>
+						vum ac singulare, ut non frustra minime adhibendus <lb/> ad numerus
+						judicatus sit.</p>
+				</div>
+				<div type="textpart" subtype="dialog"><p>18. Sed hoc nobis considerantibus, opus est h:rc <lb/> duo nomina mandare
+						memoriæ, levationem et posi­ <lb/> tionem. In plaudendo enim quia levatur et
+						ponitur <lb/> manus, partem pedis sibi levatio vindicat, partem po­ <lb/>
+						sitio. Partes autem pedum dico illas, de quibus supc­ <lb/> rius, cum eos
+						ordine persequeremur, satis dictum est. <lb/> Quocirca si hoc probas, incipe
+						recensere breviter <lb/> mensuras partium in omnibus pedibus, ut quid huic
+						<lb/> uni de quo agitur proprium acciderit, novcris. <hi rend="italic"
+							>D.</hi> Vi­ <lb/> deo primum pyrrhichium tantum habere in levatione
 						<lb/> quantum in positione. Spoudeus quoque, dactylus, <lb/> anapaestus,
-						proceleumaticus, choriambus, diiambus, <lb/> dichorius, antispastus, dispondeus, eadem
-						ratione <lb/> dividuntur : nam tantumdem temporis in his ponit <lb/> plausus, quantum
-						levat. Video secundum, iambum <lb/> simpli etdupli habere rationem; quam rationem cerno
-						<lb/> et inchorio et in tribracho et in molosso, et in utro­ <lb/> que ionico. Jam hujus
-						amphibrachi lcvatio ut positio <lb/> (nam ipsa mihi ex ordine occurrit, cui pares
-						cæteros <lb/> quxram), simpli ct tripli ratione constat. Sed nou in <lb/> venio prorsus
-						alium deinceps, cujus sibi partes tanto <lb/> intervallo conferantur. Nam cum cos
-						considero in qui­ <lb/> bus nna brevis est et dux long;c, id cst bacchium, <lb/>
-						creticum et palimbacchium, sesquialteri numeri ra­ <lb/> tionc levationem ac positionem
-						in his fieri vidco. <lb/> Eadem ratio est et in iis quatuor, in quibus nna longa <lb/>
-						est ct tres breves, qui quatuor pxoncs ex ordine no­ <lb/> minantur. Reliqui sunt
-						quatuor epitriti similiter ex <lb/> ordine nuncupati, quorum levationem ac positionem
-						<lb/> sesquitertius numerus continet.</p>
-					<p>19. <hi rend="italic">II.</hi> Num igitur parum libi justa causa videtur <lb/> esse,
-						cur iste pes (a) ad sericIn numerosam vocum <lb/> non admittatur, quod solius partes tam
-						longe a sc dif­ <lb/> fcrant, ut una simpla sii, alia tripla? Vicinitas cuim <note type="footnote">(o) Ami bibrachus. </note>
+						proceleumaticus, choriambus, diiambus, <lb/> dichorius, antispastus,
+						dispondeus, eadem ratione <lb/> dividuntur : nam tantumdem temporis in his
+						ponit <lb/> plausus, quantum levat. Video secundum, iambum <lb/> simpli
+						etdupli habere rationem; quam rationem cerno <lb/> et inchorio et in
+						tribracho et in molosso, et in utro­ <lb/> que ionico. Jam hujus amphibrachi
+						lcvatio ut positio <lb/> (nam ipsa mihi ex ordine occurrit, cui pares
+						cæteros <lb/> quxram), simpli ct tripli ratione constat. Sed nou in <lb/>
+						venio prorsus alium deinceps, cujus sibi partes tanto <lb/> intervallo
+						conferantur. Nam cum cos considero in qui­ <lb/> bus nna brevis est et dux
+						long;c, id cst bacchium, <lb/> creticum et palimbacchium, sesquialteri
+						numeri ra­ <lb/> tionc levationem ac positionem in his fieri vidco. <lb/>
+						Eadem ratio est et in iis quatuor, in quibus nna longa <lb/> est ct tres
+						breves, qui quatuor pxoncs ex ordine no­ <lb/> minantur. Reliqui sunt
+						quatuor epitriti similiter ex <lb/> ordine nuncupati, quorum levationem ac
+						positionem <lb/> sesquitertius numerus continet.</p>
+					<p>19. <hi rend="italic">II.</hi> Num igitur parum libi justa causa videtur
+						<lb/> esse, cur iste pes (a) ad sericIn numerosam vocum <lb/> non
+						admittatur, quod solius partes tam longe a sc dif­ <lb/> fcrant, ut una
+						simpla sii, alia tripla? Vicinitas cuim <note type="footnote">(o) Ami
+							bibrachus. </note>
 						<lb/>
-						<pb n="1111"/> quædam partium tanto est approbatione dignior, <lb/> quanto est proxima
-						æqualitati. Itaque in illa regula 1 <lb/> numerorum CUDI ali uno usque ad quatuor
-						progredi­ <lb/> mur, nihil unicuique est scipso propinquius. Quare <lb/> illud in
-						pritnis approbandum est in pcdibus, cum lan­ <lb/> tudem habent partes ad invicem;
-						deinde copulatio <lb/> simpli et dupli eminet in uno et duobus; sesquialtera <lb/> vcro
-						copulatio in duobus et tribus apparet; jam ses­ <lb/> quitertia, tribus et quatuor.
-						Simplum vero et triplum <lb/> quanquam complicatorum numerorum loge tcneatur, <lb/> non
-						tamen in ordine illo sibimet cohæret : non enim <lb/> post unum tria numeramus, sed ab
-						uno ad ternarium <lb/> numerum binario interposito pervenitur. Haec ratio <lb/> est qua
-						excludendus judicatur amphibrachus pes ab <lb/> ea copulatione dc qua quaerimus 2, quæ
-						si abs te pro­ <lb/> batur, cætera videamus. <hi rend="italic">D.</hi> Probatur sane nam
-						ma­ <lb/> nifestissima atque certissima est.</p>
-					<ab>
-						<title type="sub">CAPUT XI. — <hi rend="italic">Pedum rationalibis</hi> mixlura.</title>
+						<pb n="1111"/> quædam partium tanto est approbatione dignior, <lb/> quanto
+						est proxima æqualitati. Itaque in illa regula 1 <lb/> numerorum CUDI ali uno
+						usque ad quatuor progredi­ <lb/> mur, nihil unicuique est scipso
+						propinquius. Quare <lb/> illud in pritnis approbandum est in pcdibus, cum
+						lan­ <lb/> tudem habent partes ad invicem; deinde copulatio <lb/> simpli et
+						dupli eminet in uno et duobus; sesquialtera <lb/> vcro copulatio in duobus
+						et tribus apparet; jam ses­ <lb/> quitertia, tribus et quatuor. Simplum vero
+						et triplum <lb/> quanquam complicatorum numerorum loge tcneatur, <lb/> non
+						tamen in ordine illo sibimet cohæret : non enim <lb/> post unum tria
+						numeramus, sed ab uno ad ternarium <lb/> numerum binario interposito
+						pervenitur. Haec ratio <lb/> est qua excludendus judicatur amphibrachus pes
+						ab <lb/> ea copulatione dc qua quaerimus 2, quæ si abs te pro­ <lb/> batur,
+						cætera videamus. <hi rend="italic">D.</hi> Probatur sane nam ma­ <lb/>
+						nifestissima atque certissima est.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT XI. — <hi rend="italic">Pedum rationalibis</hi>
+							mixlura.</title>
 					</ab>
-					<p>20. <hi rend="italic">Al.</hi> Cum ergo placcat, quoquo modo se in <lb/> syllabis
-						habeant, tamen si ejusdem spatii sint in tem­ <lb/> pore, recte sibi ct sine detrimento
-						æqualitatis pedes <lb/> posse misceri, cxcepto duntaxat amphibracho; quaeri <lb/> non
-						immerito potest, utrum recte misceantur, qui <lb/> quanquam sint aequales tempore, non
-						eadem tamen <lb/> percussione concordant, quæ levatione ac positionc <lb/> paries pcdis
-						sihimct confert. Nam dactylus et ana­ <lb/> pæstus et spondens non solum æqualium
-						temporum <lb/> sunt, sed etiam percutiuntur aequaliter : in omnibus <lb/> caim tantum
-						Icvatio, quantum positio sibi vindicat. <lb/> Itaque hi sibi miscentur justius qunm
-						quilibet ionicus <lb/> cæteris sex temporum pedibus. Uterque quippe ioni­ <lb/> cus ad
-						simplum et duplum percutitur, duo scilicet <lb/> tempora quatuor temporibus conferens.
-						Ilis molossus <lb/> etiam in hac re congruit. Cæteri vero (a) ad tantum­ <lb/> dem ; nam
-						in his levationi ac positioni terna tempora <lb/> tribuuntur. Ergo tametsi omnes
-						legitime feriantur; <lb/> nam et illi Ires simpli et dupli ratione, et alii quatuor
-						<lb/> æquis partibus feriuntur; tamen quia plausum inaequa­ <lb/> lem facit ista
-						permixtio, haud scio an jure repudietur: <lb/> nisi quid habes ad hæc. D. Proclivior sum
-						in isfam <lb/> sententiam. Nam inæqualis plausus quomodo sensum <lb/> non offendat
-						ignoro : si autem offendit, non utique id <lb/> potest sine vitio hujus permixtionis
-						accidere.</p>
-					<p>it. <hi rend="italic">M.</hi> Atqui scias veteres miscendos judicasse istos <lb/>
-						pedes, et horum mixtione versus compositos condi­ <lb/> disse. Sed ne te auctoritate
-						premere videar, accipe <lb/> aliquid horum versuum, et vide utrum offendat audi­ <lb/>
-						tum. Si cnim non modo non offenderit, sed etiam de­ <lb/> lectaverit, nulla erit ratio
-						hujus mixtionis improbandæ. <lb/> Versus autem ii sunt quos advertas volo : <lb/> At
-						consona quae sunt, nisi voca'ibus aptes, <lb/> Pars diinidium vocis ot us proeret ex se
-						: <lb/> Pars muta soni comprimet ora molientum : <lb/> llUs sonus obscurior
+					<p>20. <hi rend="italic">Al.</hi> Cum ergo placcat, quoquo modo se in <lb/>
+						syllabis habeant, tamen si ejusdem spatii sint in tem­ <lb/> pore, recte
+						sibi ct sine detrimento æqualitatis pedes <lb/> posse misceri, cxcepto
+						duntaxat amphibracho; quaeri <lb/> non immerito potest, utrum recte
+						misceantur, qui <lb/> quanquam sint aequales tempore, non eadem tamen <lb/>
+						percussione concordant, quæ levatione ac positionc <lb/> paries pcdis
+						sihimct confert. Nam dactylus et ana­ <lb/> pæstus et spondens non solum
+						æqualium temporum <lb/> sunt, sed etiam percutiuntur aequaliter : in omnibus
+						<lb/> caim tantum Icvatio, quantum positio sibi vindicat. <lb/> Itaque hi
+						sibi miscentur justius qunm quilibet ionicus <lb/> cæteris sex temporum
+						pedibus. Uterque quippe ioni­ <lb/> cus ad simplum et duplum percutitur, duo
+						scilicet <lb/> tempora quatuor temporibus conferens. Ilis molossus <lb/>
+						etiam in hac re congruit. Cæteri vero (a) ad tantum­ <lb/> dem ; nam in his
+						levationi ac positioni terna tempora <lb/> tribuuntur. Ergo tametsi omnes
+						legitime feriantur; <lb/> nam et illi Ires simpli et dupli ratione, et alii
+						quatuor <lb/> æquis partibus feriuntur; tamen quia plausum inaequa­ <lb/>
+						lem facit ista permixtio, haud scio an jure repudietur: <lb/> nisi quid
+						habes ad hæc. D. Proclivior sum in isfam <lb/> sententiam. Nam inæqualis
+						plausus quomodo sensum <lb/> non offendat ignoro : si autem offendit, non
+						utique id <lb/> potest sine vitio hujus permixtionis accidere.</p>
+					<p>it. <hi rend="italic">M.</hi> Atqui scias veteres miscendos judicasse istos
+						<lb/> pedes, et horum mixtione versus compositos condi­ <lb/> disse. Sed ne
+						te auctoritate premere videar, accipe <lb/> aliquid horum versuum, et vide
+						utrum offendat audi­ <lb/> tum. Si cnim non modo non offenderit, sed etiam
+						de­ <lb/> lectaverit, nulla erit ratio hujus mixtionis improbandæ. <lb/>
+						Versus autem ii sunt quos advertas volo : <lb/> At consona quae sunt, nisi
+						voca'ibus aptes, <lb/> Pars diinidium vocis ot us proeret ex se : <lb/> Pars
+						muta soni comprimet ora molientum : <lb/> llUs sonus obscurior
 						impeditiorque, <lb/> Utrumque tamen promitur ore semicluso. <lb/>
 						<hi rend="italic">(Terentianus.)</hi>
-						<note type="footnote"> I In B. deest vocula in, quam restituimus ex Er. Lugd. <lb/> ven.
-							l.ov. et iks. A et B. Nolaadum loco <hi rend="italic">illa,</hi> quoi habent <lb/>
-							Benedictmi, esse in editis, <hi rend="italic">ista.</hi> M. </note><note type="footnote">' in B., <hi rend="italic">quæsivimus.</hi> F.r, Lugd. ven. Lov. nec
-							non Ms. ** <lb/> A, <hi rend="italic">quwrinm.</hi> M. </note><note type="footnote">
-							(11) cboriamhus, diiaJnhus. dichorius, antispastus. </note>
-						<lb/> S atis esse arbitror ad judicandum id quod volo.Quare <lb/> dic quæso, utrum nihil
-						tuas aurcs numerus iste <lb/> permul-erit. <hi rend="italic">D.</hi> Imo nihil mihi
-						videtur currere ac <lb/> sonare festivius. <hi rend="italic">M.</hi> Considera igitur
-						pedes, inve­ <lb/> nies profecto cum sint quinque versus , duos primos <lb/> solis
-						ionicis currere, tres posteriores habere ad­ <lb/> mixtum dichorium, cum omnes omnino
-						sensum no­ <lb/> strum communi æqualitate delectent. <hi rend="italic">D.</hi> Jam hoc
-						<lb/> animadverti, et facilius te pronuntiante. <hi rend="italic">M.</hi> Quid ergo
-						<lb/> dubitamus consentire veteribus non eorum auctoritate, <lb/> sed ipsa jam ratione
-						victi, qui censent eos pedes qui <lb/> ejusdem temporis sunt rationabiliter posse
-						misceri, <lb/> si habeant legitimam, quamvis diversam percussio­ <lb/> nem? D. Cedo jam
-						prorsus : nam me ille sonus quid­ <lb/> quam Contradicere non sinit.</p>
-					<ab>
-						<title type="sub">CAPUT XII. — <hi rend="italic">Pedes sex</hi> temporuM.</title>
+						<note type="footnote"> I In B. deest vocula in, quam restituimus ex Er.
+							Lugd. <lb/> ven. l.ov. et iks. A et B. Nolaadum loco <hi rend="italic"
+								>illa,</hi> quoi habent <lb/> Benedictmi, esse in editis, <hi
+								rend="italic">ista.</hi> M. </note><note type="footnote">' in B.,
+								<hi rend="italic">quæsivimus.</hi> F.r, Lugd. ven. Lov. nec non Ms.
+							** <lb/> A, <hi rend="italic">quwrinm.</hi> M. </note><note
+							type="footnote"> (11) cboriamhus, diiaJnhus. dichorius, antispastus. </note>
+						<lb/> S atis esse arbitror ad judicandum id quod volo.Quare <lb/> dic quæso,
+						utrum nihil tuas aurcs numerus iste <lb/> permul-erit. <hi rend="italic"
+							>D.</hi> Imo nihil mihi videtur currere ac <lb/> sonare festivius. <hi
+							rend="italic">M.</hi> Considera igitur pedes, inve­ <lb/> nies profecto
+						cum sint quinque versus , duos primos <lb/> solis ionicis currere, tres
+						posteriores habere ad­ <lb/> mixtum dichorium, cum omnes omnino sensum no­
+						<lb/> strum communi æqualitate delectent. <hi rend="italic">D.</hi> Jam hoc
+						<lb/> animadverti, et facilius te pronuntiante. <hi rend="italic">M.</hi>
+						Quid ergo <lb/> dubitamus consentire veteribus non eorum auctoritate, <lb/>
+						sed ipsa jam ratione victi, qui censent eos pedes qui <lb/> ejusdem temporis
+						sunt rationabiliter posse misceri, <lb/> si habeant legitimam, quamvis
+						diversam percussio­ <lb/> nem? D. Cedo jam prorsus : nam me ille sonus quid­
+						<lb/> quam Contradicere non sinit.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT XII. — <hi rend="italic">Pedes sex</hi>
+							temporuM.</title>
 					</ab>
-					<p>22. M. Intende item in istos versus : <lb/> Volo tandem tibi parcas, labor est in
-						chartis, <lb/> Et apertum ire per auras animum permittas. <lb/> Placet hoc nam
-						sapienter, remiuere interdum <lb/> Aciem rebus agendis decenter intentam. <lb/>
-						<hi rend="italic">D.</hi> Etiam hoc satis est. <hi rend="italic">M.</hi> Præsertim cum
-						isti versus <lb/> sint inconditi, quos necessitate ad tempu fabricatus <lb/> sum.
-						Verumtamen et in iis quatuor requiro judicium <lb/> sensus tui. <hi rend="italic">D.</hi> Quid aliud et hic possum dicere, quam <lb/> pulchre illos congruenterque
-						sonuisse? M. S tisme <lb/> etiam duos superiores altero ionico constare qui dici­ <lb/>
-						tar a minore, duos autem posteriores diiambum ha­ <lb/> bere permixtum? <hi rend="italic">D.</hi> Et hoc te pronuntiando insi­ <lb/> nuante persensi. <hi rend="italic">II.</hi> Quid? illud nonne te movet quod <lb/> in illis Terentiani
-						versibus ionico ei qui a majore d:­ <lb/> cilur, dichorius; in iis autcm nostris alteri
-						ionico qui <lb/> a minore nominatur, diiambus mixtus est? an nihil <lb/> interesse
-						arbitraris ? <hi rend="italic">D.</hi> Imo interest, ct videor m.hi <lb/> rationem ipsam
-						videre : nam quoniam ionicus a m i- <lb/> jore a duabus incipit longis, eum sibi potius
-						copulan­ <lb/> dum poscit, ubi longa prima est, id cst dichorium. <lb/> Diiambus vcro
-						quod incipit a brevi, congruentius al­ <lb/> teri miscetur ionico a duabus brevibus
+					<p>22. M. Intende item in istos versus : <lb/> Volo tandem tibi parcas, labor
+						est in chartis, <lb/> Et apertum ire per auras animum permittas. <lb/>
+						Placet hoc nam sapienter, remiuere interdum <lb/> Aciem rebus agendis
+						decenter intentam. <lb/>
+						<hi rend="italic">D.</hi> Etiam hoc satis est. <hi rend="italic">M.</hi>
+						Præsertim cum isti versus <lb/> sint inconditi, quos necessitate ad tempu
+						fabricatus <lb/> sum. Verumtamen et in iis quatuor requiro judicium <lb/>
+						sensus tui. <hi rend="italic">D.</hi> Quid aliud et hic possum dicere, quam
+						<lb/> pulchre illos congruenterque sonuisse? M. S tisme <lb/> etiam duos
+						superiores altero ionico constare qui dici­ <lb/> tar a minore, duos autem
+						posteriores diiambum ha­ <lb/> bere permixtum? <hi rend="italic">D.</hi> Et
+						hoc te pronuntiando insi­ <lb/> nuante persensi. <hi rend="italic">II.</hi>
+						Quid? illud nonne te movet quod <lb/> in illis Terentiani versibus ionico ei
+						qui a majore d:­ <lb/> cilur, dichorius; in iis autcm nostris alteri ionico
+						qui <lb/> a minore nominatur, diiambus mixtus est? an nihil <lb/> interesse
+						arbitraris ? <hi rend="italic">D.</hi> Imo interest, ct videor m.hi <lb/>
+						rationem ipsam videre : nam quoniam ionicus a m i- <lb/> jore a duabus
+						incipit longis, eum sibi potius copulan­ <lb/> dum poscit, ubi longa prima
+						est, id cst dichorium. <lb/> Diiambus vcro quod incipit a brevi,
+						congruentius al­ <lb/> teri miscetur ionico a duabus brevibus
 						incipienti.</p>
-					<p>43. M. Bene intelligis: quare hoc quoque tenendum <lb/> est, istam etiam congruentiam,
-						excepta æqualitate <lb/> temporum, in pedibus miscendis aliquantum valere <lb/> oportere
-						: nou enim plurimum, sed tamen nonnihil <lb/> valet. Nam pro omni pede sex temporum,
-						omnem <lb/> pedem sex temporum poni posse, ita sensu in­ <lb/> terrogato judices licet:
-						primum molossi exemplum <lb/> sit nobis, <hi rend="italic">virtutes</hi> : ionici a
-						minore, moderatas ; <lb/> cboriambi, <hi rend="italic">percipies</hi> : ionici a majore,
-							<hi rend="italic">concedere :</hi>
+					<p>43. M. Bene intelligis: quare hoc quoque tenendum <lb/> est, istam etiam
+						congruentiam, excepta æqualitate <lb/> temporum, in pedibus miscendis
+						aliquantum valere <lb/> oportere : nou enim plurimum, sed tamen nonnihil
+						<lb/> valet. Nam pro omni pede sex temporum, omnem <lb/> pedem sex temporum
+						poni posse, ita sensu in­ <lb/> terrogato judices licet: primum molossi
+						exemplum <lb/> sit nobis, <hi rend="italic">virtutes</hi> : ionici a minore,
+						moderatas ; <lb/> cboriambi, <hi rend="italic">percipies</hi> : ionici a
+						majore, <hi rend="italic">concedere :</hi>
 						<lb/> diiambi, benignitas : dichorii, civitasque : antispasti, <lb/>
-						<hi rend="italic">volet justa. D.</hi> Habeo ista. M. Contexe igitur isti <lb/> omnia
-						atque pronuntia, vel me potius pronuntian e <lb/> accipc, quo ad judicandum liberior
-						sensusvacel. Nam <lb/> ut continuati numeri æqualitatem sine ulla offensi one <lb/>
-						aurium tibi insinuem, hoc totum contextum ter pro <lb/> nuntiabo, quod satis esse non
-						dubitaverim. Virtutes <lb/> moderatas <hi rend="italic">percipies, concedere benignitas
-							civitasque vo­<lb/> let justa. Virtutes moderatas percipies, concedere beni­ <lb/>
-							gnitas civitasque volet justa. Virtutes moderatas perci - <lb/> pies, concedere
-							benignitas civitasque volet juata.</hi> Num <lb/> fortc aliquid in hoc pedum cursu
-						aures tuas æqualitate <lb/>
-						<pb n="1113"/> aut suavitate fraudavit? <hi rend="italic">D.</hi> Nul o modo. <hi rend="italic">M.</hi> Delecta­ <lb/> vine aliquid? quanquam hoc quidem consequens est
-						<lb/> in hoc genere, ut delectet omne quod non offenderit. <lb/>
-						<hi rend="italic">D.</hi> Non possum aliter me dicere affectum, quam vi­ <lb/> dftur
-						tibi. <hi rend="italic">I,.</hi> Probas ergo omnes istos pedes senum <lb/> temporum
-						recte sibi posse copulari atque 1 misceri. <lb/>
+						<hi rend="italic">volet justa. D.</hi> Habeo ista. M. Contexe igitur isti
+						<lb/> omnia atque pronuntia, vel me potius pronuntian e <lb/> accipc, quo ad
+						judicandum liberior sensusvacel. Nam <lb/> ut continuati numeri æqualitatem
+						sine ulla offensi one <lb/> aurium tibi insinuem, hoc totum contextum ter
+						pro <lb/> nuntiabo, quod satis esse non dubitaverim. Virtutes <lb/>
+						moderatas <hi rend="italic">percipies, concedere benignitas civitasque
+							vo­<lb/> let justa. Virtutes moderatas percipies, concedere beni­ <lb/>
+							gnitas civitasque volet justa. Virtutes moderatas perci - <lb/> pies,
+							concedere benignitas civitasque volet juata.</hi> Num <lb/> fortc
+						aliquid in hoc pedum cursu aures tuas æqualitate <lb/>
+						<pb n="1113"/> aut suavitate fraudavit? <hi rend="italic">D.</hi> Nul o
+						modo. <hi rend="italic">M.</hi> Delecta­ <lb/> vine aliquid? quanquam hoc
+						quidem consequens est <lb/> in hoc genere, ut delectet omne quod non
+						offenderit. <lb/>
+						<hi rend="italic">D.</hi> Non possum aliter me dicere affectum, quam vi­
+						<lb/> dftur tibi. <hi rend="italic">I,.</hi> Probas ergo omnes istos pedes
+						senum <lb/> temporum recte sibi posse copulari atque 1 misceri. <lb/>
 						<hi rend="italic">D.</hi> Probo.</p>
-					<ab>
-						<title type="sub">CAPUT XIt. — <hi rend="italic">Ordo pedum</hi> quomodo mutetur <hi rend="italic">concinne.</hi>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT XIII. — <hi rend="italic">Ordo pedum</hi> quomodo
+							mutetur <hi rend="italic">concinne.</hi>
 						</title>
 					</ab>
-					<p>24. <hi rend="italic">M.</hi> Nihilne formidas, ne qni, arbitretur tam <lb/> æqualiter
-						istos pedes hoc ordine collatos sonare <lb/> potuisse ; si autem ordinem permutes, non
-						idem pos­ <lb/> se? <hi rend="italic">D.</hi> Nonnihil quidcm affert, sed experiri non
-						est <lb/> difficile. <hi rend="italic">II.</hi> Istud ergo facito cum vacabit : non
-						aliter <lb/> invenies quam sensum luum multiformi varietate et <lb/> una æqualilate
-						mulceri. <hi rend="italic">D.</hi> Faciam : quanquam hoc <lb/> exmplo nemo est, qui non
-						praevideat necessario id <lb/> eventurum. M. Recte existimas : sed quod ad propo­ <lb/>
-						situm pertinet, ad.noto plausu ista percurram, ut de <lb/> hoc quoque dijudicare possis
-						utrum aliquid, an nihil <lb/> claudicet : atque ut simul aliquid experiaris de com­
-						<lb/> mutatione illius ordinis, quam nihil claudicationis il­ <lb/> laturam esse
-						prædiximus; jam nunc ipsum ordinem <lb/> muta, et ut libitum est, eosdem pedes
-						collocatos ali­ <lb/> tar atque ame coll əcati sunt, personandos mihi plau­ <lb/>
-						dendosque permitte. <hi rend="italic">D.</hi> Primum volo esse ionicum a <lb/> minore,
-						secundum ionicum a majore, tertium cho­ <lb/> riambum, quartum diiambum, quintum
-						antispastum, <lb/> sextum dichorium, septimum molossum. <hi rend="italic">M.</hi>
-						Intende <lb/> ergo ct aurem in sonum, et in plausum oculos : non <lb/> euim audiri, sed
-						videri opus est plaudentem manum, <lb/> (i animadverti acriter quanta temporis mora in
-						leva­ <lb/> tione, quanta in posiLionc sit. <hi rend="italic">D.</hi> Totus istic sum,
-						<lb/> quantum valeo. <hi rend="italic">M.</hi> Accipe igitur collocationem illam <lb/>
-						cum plausu tuam : <hi rend="italic">Moderatas, concedere, per cipies, be­ <lb/>
-							nignitas, volet justa,</hi> civitasque, <hi rend="italic">virtutes. D.</hi> Sentio
-						qui­ <lb/> dem nequəquam plausum istum claudicare, et tantum <lb/> . Icvare quantum
-						ponere; sed vehementer admiror <lb/> quomodo eo percuti potucrint illi pedes, quorum di­
-						<lb/> visio simpli et dupli ratione constat, sicuti sunt ambo <lb/> . ionici et
-						molossus. <hi rend="italic">M.</hi> Quid hic fieri tamen arbitraris, <lb/> cum in his
-						tria leventur tempora, totidemque ponan­ <lb/> tur? <hi rend="italic">D.</hi> Nibil
-						aliud hic prorsus video quam eam lon­ <lb/> gam syllabam, quæ in ionico a majore et in
-						molosso <lb/> secunda, in ionico autem a minore tertia est, plausu <lb/> ipso dividi; ut
-						quoniam duo habet tempora, unum <lb/> inde supcriori parti, alterum posteriori tribuat,
-						atque <lb/> ita terna tempora levatio positioque sortiantur.</p>
-					<p>25. <hi rend="italic">M.</hi> Nihil hie omnino aliud dici aut intelligi po­ <lb/> test.
-						Sed cur non etiam ille amphibrachus, quem ab <lb/> ista numerositate penitus
-						ejiciebamus, hac conditione <lb/> misceatur spondeo, dactylo, et anapaesto, vel per se
-						<lb/> ipse numerosum I aliquid in musica continuatus ef­ <lb/> ficiat? Potest enim
-						simili ratinoe media quoqne pedis <lb/> ejus syllaba, quæ longa est, plausu dividi; ut
-						cum <note type="footnote"> I in B. , <hi rend="italic">aut;</hi> rectiuscum Er.l.u.rd.
-							ven. Lov. et Mss. A., <lb/> aume.M. </note><note type="footnote"> • , Sic Mas.; at
-							Lov. ali3Dciue cditionos hal ent, <hi rend="italic">mmiero­</hi>
+					<p>24. <hi rend="italic">M.</hi> Nihilne formidas, ne qni, arbitretur tam <lb/>
+						æqualiter istos pedes hoc ordine collatos sonare <lb/> potuisse ; si autem
+						ordinem permutes, non idem pos­ <lb/> se? <hi rend="italic">D.</hi> Nonnihil
+						quidcm affert, sed experiri non est <lb/> difficile. <hi rend="italic"
+							>II.</hi> Istud ergo facito cum vacabit : non aliter <lb/> invenies quam
+						sensum luum multiformi varietate et <lb/> una æqualilate mulceri. <hi
+							rend="italic">D.</hi> Faciam : quanquam hoc <lb/> exmplo nemo est, qui
+						non praevideat necessario id <lb/> eventurum. M. Recte existimas : sed quod
+						ad propo­ <lb/> situm pertinet, ad.noto plausu ista percurram, ut de <lb/>
+						hoc quoque dijudicare possis utrum aliquid, an nihil <lb/> claudicet : atque
+						ut simul aliquid experiaris de com­ <lb/> mutatione illius ordinis, quam
+						nihil claudicationis il­ <lb/> laturam esse prædiximus; jam nunc ipsum
+						ordinem <lb/> muta, et ut libitum est, eosdem pedes collocatos ali­ <lb/>
+						tar atque ame coll əcati sunt, personandos mihi plau­ <lb/> dendosque
+						permitte. <hi rend="italic">D.</hi> Primum volo esse ionicum a <lb/> minore,
+						secundum ionicum a majore, tertium cho­ <lb/> riambum, quartum diiambum,
+						quintum antispastum, <lb/> sextum dichorium, septimum molossum. <hi
+							rend="italic">M.</hi> Intende <lb/> ergo ct aurem in sonum, et in
+						plausum oculos : non <lb/> euim audiri, sed videri opus est plaudentem
+						manum, <lb/> (i animadverti acriter quanta temporis mora in leva­ <lb/>
+						tione, quanta in posiLionc sit. <hi rend="italic">D.</hi> Totus istic sum,
+						<lb/> quantum valeo. <hi rend="italic">M.</hi> Accipe igitur collocationem
+						illam <lb/> cum plausu tuam : <hi rend="italic">Moderatas, concedere, per
+							cipies, be­ <lb/> nignitas, volet justa,</hi> civitasque, <hi
+							rend="italic">virtutes. D.</hi> Sentio qui­ <lb/> dem nequəquam plausum
+						istum claudicare, et tantum <lb/> . Icvare quantum ponere; sed vehementer
+						admiror <lb/> quomodo eo percuti potucrint illi pedes, quorum di­ <lb/>
+						visio simpli et dupli ratione constat, sicuti sunt ambo <lb/> . ionici et
+						molossus. <hi rend="italic">M.</hi> Quid hic fieri tamen arbitraris, <lb/>
+						cum in his tria leventur tempora, totidemque ponan­ <lb/> tur? <hi
+							rend="italic">D.</hi> Nibil aliud hic prorsus video quam eam lon­ <lb/>
+						gam syllabam, quæ in ionico a majore et in molosso <lb/> secunda, in ionico
+						autem a minore tertia est, plausu <lb/> ipso dividi; ut quoniam duo habet
+						tempora, unum <lb/> inde supcriori parti, alterum posteriori tribuat, atque
+						<lb/> ita terna tempora levatio positioque sortiantur.</p>
+					<p>25. <hi rend="italic">M.</hi> Nihil hie omnino aliud dici aut intelligi po­
+						<lb/> test. Sed cur non etiam ille amphibrachus, quem ab <lb/> ista
+						numerositate penitus ejiciebamus, hac conditione <lb/> misceatur spondeo,
+						dactylo, et anapaesto, vel per se <lb/> ipse numerosum I aliquid in musica
+						continuatus ef­ <lb/> ficiat? Potest enim simili ratinoe media quoqne pedis
+						<lb/> ejus syllaba, quæ longa est, plausu dividi; ut cum <note
+							type="footnote"> I in B. , <hi rend="italic">aut;</hi> rectiuscum
+							Er.l.u.rd. ven. Lov. et Mss. A., <lb/> aume.M. </note><note
+							type="footnote"> • , Sic Mas.; at Lov. ali3Dciue cditionos hal ent, <hi
+								rend="italic">mmiero­</hi>
 							<lb/> iui </note>
-						<lb/> s ngula tempora singulis lateribus dederit, nan j:un <lb/> unnm et tria, sed bina
-						tempora levatio positioque <lb/> sibi vindicent : nisi habes aliquid quod resistat. <lb/>
-						<hi rend="italic">D.</hi> Nihil sane lubeo qnod dicam, nisi hunc etiam esse <lb/>
-						admittendum. <hi rend="italic">M.</hi> Aliquid ergo plaudamus quaterno­ <lb/> rum
-						temporum pedibus ordinatum atque contextum, <lb/> quibus iste commixtus sit, et eodem
-						modo sensu <lb/> exploremus utnim nibil hnparile offendat. £t ideo at­ <lb/> tende in
-						hunc numerum propter judicandi facilitatem <lb/> cum plausu tertio repetitum. Sumas <hi rend="italic">optima, facias <lb/> honesta. Sumas</hi> optima, <hi rend="italic">facias honesta, Sumas optima, <lb/> facias honesta. D.</hi> Jamjam, obsecro, parce
-						auribus <lb/> micis : nam etiam plausu non admoto, ipse per sc ho­ <lb/> rum pcdum
-						cursus in illo amphibracho vehementissime <lb/> claudicat. <hi rend="italic">M.</hi>
-						Quid igitur putandum est esse causæ, <lb/> ut in Loc fieri non possit quod in molosso et
-						ionicis <lb/> p otuit? an quoniam in illis æqualia sunt medio latera? <lb/> in numero
-						enim pari, ubi sit medium suis æquale la­ <lb/> teribus, primus senarius occurrit. Ergo
-						illi senum <lb/> temporum pedes qnoniam duo temp ora in medio <lb/> possident, et bina
-						in lateribus; libenter quodammodo <lb/> illud medium cccidil in latera , quibus
-						amicissima <lb/> æqualitate conjungitur. Non autum idem fiet in <lb/> amphibracho, ubi
-						sunt imparia medio latera, siquidem <lb/> in illis siogula, in illo duo tempora sunt.
-						Huc accedit <lb/> quod in ionicis ct molosso medio in latera solnto, <lb/> terna fiunt
-						tempora, in quibus rursum medio pari I <lb/> paria Iatera inveniuntur; quod item defit
-						amphi­ <lb/> bracho. <hi rend="italic">D.</hi> Ita res est ut dicis : nec immerito
-						amphi­ <lb/> brachus in illa serie offendit auditum, hi vero etiam <lb/> delectant.</p>
-					<ab>
-						<title type="sub">CAPUT XIV.- <hi rend="italic">Qui pedes quibus misceantur.</hi>
+						<lb/> s ngula tempora singulis lateribus dederit, nan j:un <lb/> unnm et
+						tria, sed bina tempora levatio positioque <lb/> sibi vindicent : nisi habes
+						aliquid quod resistat. <lb/>
+						<hi rend="italic">D.</hi> Nihil sane lubeo qnod dicam, nisi hunc etiam esse
+						<lb/> admittendum. <hi rend="italic">M.</hi> Aliquid ergo plaudamus
+						quaterno­ <lb/> rum temporum pedibus ordinatum atque contextum, <lb/> quibus
+						iste commixtus sit, et eodem modo sensu <lb/> exploremus utnim nibil
+						hnparile offendat. £t ideo at­ <lb/> tende in hunc numerum propter judicandi
+						facilitatem <lb/> cum plausu tertio repetitum. Sumas <hi rend="italic"
+							>optima, facias <lb/> honesta. Sumas</hi> optima, <hi rend="italic"
+							>facias honesta, Sumas optima, <lb/> facias honesta. D.</hi> Jamjam,
+						obsecro, parce auribus <lb/> micis : nam etiam plausu non admoto, ipse per
+						sc ho­ <lb/> rum pcdum cursus in illo amphibracho vehementissime <lb/>
+						claudicat. <hi rend="italic">M.</hi> Quid igitur putandum est esse causæ,
+						<lb/> ut in Loc fieri non possit quod in molosso et ionicis <lb/> p otuit?
+						an quoniam in illis æqualia sunt medio latera? <lb/> in numero enim pari,
+						ubi sit medium suis æquale la­ <lb/> teribus, primus senarius occurrit. Ergo
+						illi senum <lb/> temporum pedes qnoniam duo temp ora in medio <lb/>
+						possident, et bina in lateribus; libenter quodammodo <lb/> illud medium
+						cccidil in latera , quibus amicissima <lb/> æqualitate conjungitur. Non
+						autum idem fiet in <lb/> amphibracho, ubi sunt imparia medio latera,
+						siquidem <lb/> in illis siogula, in illo duo tempora sunt. Huc accedit <lb/>
+						quod in ionicis ct molosso medio in latera solnto, <lb/> terna fiunt
+						tempora, in quibus rursum medio pari I <lb/> paria Iatera inveniuntur; quod
+						item defit amphi­ <lb/> bracho. <hi rend="italic">D.</hi> Ita res est ut
+						dicis : nec immerito amphi­ <lb/> brachus in illa serie offendit auditum, hi
+						vero etiam <lb/> delectant.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT XIV.- <hi rend="italic">Qui pedes quibus
+								misceantur.</hi>
 						</title>
 					</ab>
-					<p>26. <hi rend="italic">M.</hi> Age, nunc tu per tc ab ipso eXOrdire pyr­ <lb/> rhichio,
-						et secundum supra dictas rationes, quos pedes <lb/> qUibus misceri oporteat, quantum
-						potes , breviter <lb/> explica. <hi rend="italic">D.</hi> Nullus pyrrhichio : non enim
-						alias inve­ <lb/> nitur totidem temportum. Iambo posset chorius; sed <lb/> propter
-						inaequalem plausum vitandum est, quod alter <lb/> a simplo, a duplo alter incipit. Ergo
-						tribrachus utri - <lb/> que accommodari potest. Spondeum et dactylum et <lb/> anapæstum,
-						et proceleumaticum amicos inter scatque <lb/> copulabiles video : non enim tantum
-						temporibus, sed <lb/> plausu etiam sibi congruunt. Enimvero exclusus <lb/> amphibrachus,
-						nulla potuit ratione reduci, cui <lb/> parilitas temporum auxiliari quid, divisionc
-						plau­ <lb/> suque discordante, non potuit. Bacchio creticum, <lb/> cl pæoces primum ,
-						secundum et qnartum. Palim­ <lb/> bacchio autem eumdem creticum, (t pxones primum <lb/>
-						ct tertium et qnartum , et I temporibus ct plausu <lb/> concordare manifestum est. Ergo
-						cretico et pæoni­ <lb/> bus primo ct quarto , quoniam et a duobus et a <lb/> tribus
-						temporibus eorum incipere divisio potest, cæ­ <lb/> teri omnes quinum temporum pcdes
-						possunt sine <lb/> ulla claudicatione copulari. Jam illorum qui sex tem­ <lb/> poribus
-						constant, oninium inter se miram quamdam <note type="footnote"> I In prius editis
-							omittitur paii, quam vocem restituimus <lb/> ex Mss., necnon ex iisdem paulo inira ,
-							In <hi rend="italic">rero etutn de­ <lb/> lcetatit;</hi> ut! editi LaV.ent, <hi rend="italic">hic verocti</hi> m <hi rend="italic">dt'lertJ.l.</hi>
-						</note><note type="footnote"> * In n., in tt m;)orilw ; reo tius cum utroqiie Ms., <hi rend="italic">ct. 11.</hi>
+					<p>26. <hi rend="italic">M.</hi> Age, nunc tu per tc ab ipso eXOrdire pyr­ <lb/>
+						rhichio, et secundum supra dictas rationes, quos pedes <lb/> qUibus misceri
+						oporteat, quantum potes , breviter <lb/> explica. <hi rend="italic">D.</hi>
+						Nullus pyrrhichio : non enim alias inve­ <lb/> nitur totidem temportum.
+						Iambo posset chorius; sed <lb/> propter inaequalem plausum vitandum est,
+						quod alter <lb/> a simplo, a duplo alter incipit. Ergo tribrachus utri -
+						<lb/> que accommodari potest. Spondeum et dactylum et <lb/> anapæstum, et
+						proceleumaticum amicos inter scatque <lb/> copulabiles video : non enim
+						tantum temporibus, sed <lb/> plausu etiam sibi congruunt. Enimvero exclusus
+						<lb/> amphibrachus, nulla potuit ratione reduci, cui <lb/> parilitas
+						temporum auxiliari quid, divisionc plau­ <lb/> suque discordante, non
+						potuit. Bacchio creticum, <lb/> cl pæoces primum , secundum et qnartum.
+						Palim­ <lb/> bacchio autem eumdem creticum, (t pxones primum <lb/> ct
+						tertium et qnartum , et I temporibus ct plausu <lb/> concordare manifestum
+						est. Ergo cretico et pæoni­ <lb/> bus primo ct quarto , quoniam et a duobus
+						et a <lb/> tribus temporibus eorum incipere divisio potest, cæ­ <lb/> teri
+						omnes quinum temporum pcdes possunt sine <lb/> ulla claudicatione copulari.
+						Jam illorum qui sex tem­ <lb/> poribus constant, oninium inter se miram
+						quamdam <note type="footnote"> I In prius editis omittitur paii, quam vocem
+							restituimus <lb/> ex Mss., necnon ex iisdem paulo inira , In <hi
+								rend="italic">rero etutn de­ <lb/> lcetatit;</hi> ut! editi LaV.ent,
+								<hi rend="italic">hic verocti</hi> m <hi rend="italic"
+								>dt'lertJ.l.</hi>
+						</note><note type="footnote"> * In n., in tt m;)orilw ; reo tius cum
+							utroqiie Ms., <hi rend="italic">ct. 11.</hi>
 						</note>
 						<lb/>
-						<pb n="1115"/> esse concordiam, satis disputatum est. Quandoqnidcm <lb/> Illi quoque ab
-						aliis in plaudendo non dissonant, quos <lb/> aliter dividi engil conditio syllabarum :
-						tantam vim <lb/> habet cum medio laterum aequalitas. Porro septenum <lb/> temporum pedes
-						cum sint quatuor, qni epitriti no­ <lb/> minantur, primum et secundum invenio sibi posse
-						<lb/> copulari : amborum enim divisio incipit a tribus tem­ <lb/> poribus, idcirco nec
-						spatio temporis nee plausu dis. <lb/> sident. Rursus libenter sibi junguntur terlius et
-						quar­ <lb/> tus, quia uterque in dividendo incipit a quatuor tem­ <lb/> poribus, quare
-						et metiuntur et plauduntur æqualiter. <lb/> Restat octo temporum pes qui dispondeus
-						vocamur , <lb/> cui sicut pyrrhichio par nullus est. Habes a me quod <lb/> poposcisti et
-						facere potui. Perge ad reliqua. M. Fa <lb/> ciam : sed post tam longum sermonem
-						respiremus <lb/> aliquantulum; et illorum versuum meminerimus , <lb/> quos mibi
-						extemporalcs paulo aute ipsa lassitudo sug <lb/> gessit. ' <lb/> volo tandem tilii
-						parcas, labor est in cbartis, <lb/> Et apertum ire per auras animum permittas. <lb/>
-						Placet hoc nam sapienter, remittere interdum <lb/> Aciem rehus agendis decenter
-						intentam. <lb/>
+						<pb n="1115"/> esse concordiam, satis disputatum est. Quandoqnidcm <lb/>
+						Illi quoque ab aliis in plaudendo non dissonant, quos <lb/> aliter dividi
+						engil conditio syllabarum : tantam vim <lb/> habet cum medio laterum
+						aequalitas. Porro septenum <lb/> temporum pedes cum sint quatuor, qni
+						epitriti no­ <lb/> minantur, primum et secundum invenio sibi posse <lb/>
+						copulari : amborum enim divisio incipit a tribus tem­ <lb/> poribus, idcirco
+						nec spatio temporis nee plausu dis. <lb/> sident. Rursus libenter sibi
+						junguntur terlius et quar­ <lb/> tus, quia uterque in dividendo incipit a
+						quatuor tem­ <lb/> poribus, quare et metiuntur et plauduntur æqualiter.
+						<lb/> Restat octo temporum pes qui dispondeus vocamur , <lb/> cui sicut
+						pyrrhichio par nullus est. Habes a me quod <lb/> poposcisti et facere potui.
+						Perge ad reliqua. M. Fa <lb/> ciam : sed post tam longum sermonem respiremus
+						<lb/> aliquantulum; et illorum versuum meminerimus , <lb/> quos mibi
+						extemporalcs paulo aute ipsa lassitudo sug <lb/> gessit. ' <lb/> volo tandem
+						tilii parcas, labor est in cbartis, <lb/> Et apertum ire per auras animum
+						permittas. <lb/> Placet hoc nam sapienter, remittere interdum <lb/> Aciem
+						rehus agendis decenter intentam. <lb/>
 						<hi rend="italic">D.</hi> Placet sane, ac libenetr obtempero.</p>
 				</div>
-				<div type="textpart" subtype="chapter">
+				<div type="textpart" subtype="book">
 					<head>
 						<title type="main">
 							<hi rend="italic">LIBER TERTIUS.</hi>
 						</title>
 					</head>
 					<ab>
-						<title type="sub">la quo cxponitur quid intersit discriminis inter rhythmum, metrum et
-							versum; tum agitur seorsim de rhythmo ; ac deinde tractatio de metro inchoatur.
-							*</title>
+						<title type="sub">la quo cxponitur quid intersit discriminis inter rhythmum,
+							metrum et versum; tum agitur seorsim de rhythmo ; ac deinde tractatio de
+							metro inchoatur. *</title>
 					</ab>
-					<ab>
-						<title type="sub">CAPUT PRIMUM. — <hi rend="italic">Rhythmus ac metrum quid.</hi>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT PRIMUM. — <hi rend="italic">Rhythmus ac metrum
+								quid.</hi>
 						</title>
 					</ab>
 					<p>i. M. Tertius hic sermo postulat, ut quoniam de <lb/> pedum amicitia quadam
-						concordiaque satis dictum <lb/> est , vidcamus quid ex bis contextis continuatisque
-						<lb/> gignatur. Quare primum cx te quæro, utrum possint <lb/> copulati sibi pedes, quos
-						copulari oportet, perpetuum <lb/> quemdam numerum creare, ubi nullus finis certus <lb/>
-						appareat: velut cum symphoniaci scahella et cymbala <lb/> pedibus feriunt, certis quidcm
-						numeris ct his qui sibi <lb/> cum aurium voluptate junguntur; sed tamen tenore <lb/>
-						perpetuo, ita ut si tibias non audias, nullo modo ibi <lb/> notare possis quonsque
-						procurrat connexio pedum, et <lb/> nude rursus ad caput redeatur. Velut si tu velis cen­
-						<lb/> ium vcl amplius, quousque libitum est, pyrrhichios vel <lb/> alios qui inter se
-						amici sunt pedes, continua con­ <lb/> ncxionc decurrerc. <hi rend="italic">D.</hi> Jam
-						intelligo, et fieri posse <lb/> concedo quamdam pedum connexioncm, in qua cer­ <lb/> tum
-						est usque ad quot pedes progrediendum sil , <lb/> atquc inde redeundum. M. Num hujus
-						generis esse <lb/> dubitas 1, cum certam facicndorum versuum discipli­ <lb/> nam esse
-						non neges, et qui versus te semper cum <lb/> voluptate audisse confessus sis? <hi rend="italic">D.</hi> Manifestum est ct <lb/> hoc esse, ct ab illo superiore genere
-						distare.</p>
-					<p>i. M. Ergo quoniam oportet distingui ctiam voca­ <lb/> bulis ea quæ re ab se distincta
-						sunt, scias illud su­ <lb/> perius gcnus copulationis, rhythmum a Græcis; hoc <lb/>
-						autem alterum, metrum vocali : latine autcm dici <lb/> possent, illud numerus, hoc
-						mensio vet mensura. <lb/> Scd qnonianl hæc apud nos nomina late patent, et <lb/>
-						cavendum est no ainbigue loquamur, commodius <lb/> utimur græcis. Yidcs tamen, ut
-						opinor, quam recte <lb/> utrumque nomen sit his rebus impositum. Nam quo­ <lb/> niam
-						illud pedibus certis provolvitur, peccAturque in <lb/> co si pedes dissoni misceantur,
-						recte appelatus est <lb/> rhythmus, id est .numerus : seu quia ipsa provolutio <lb/> mu
-						habet modum, nec statutum est in quoto pedo <lb/> finis aliquis emineat; propter nullam
-						mensuram con­ <lb/> tinuationis non debuit metrum vocari. Hoc autem <note type="footnote"> 1 Lov.: Num certum <hi rend="italic">esse cluiJitas;</hi> at <hi rend="italic">MSS., num hujus generis <lb/> esae dubita*;</hi> Cluontooo clintn
-							editiones Ani. et. Er. qnæ <lb/> atWuni, <hi rend="italic">ct hoc tib illo
-								superiore</hi> iHsiare conocuis. — in Ms. A <lb/> tkest <hi rend="italic">IUljus
-								grneris,</hi>
-							<unclear>fertque</unclear> simpliciicr, <hi rend="italic">nvm rSSe dic­ <lb/>
-								pltas</hi> M. </note>
-						<lb/> utrumque habet ; nam ei certis pedibus currit 1, et <lb/> certo terminatur modo.
-						Itaquc non solum metrum <lb/> propter insignem finem, sed ctiam rhythmus est, <lb/>
-						propter pedum rationabilem connexionem. Quocirca <lb/> omne metrum rhythmus, non omnis
-						rhythmus etiam <lb/> metrum est. Rhythmi enim nomen in musica usque <lb/> adeo late
-						patet, lit hæc tota pars ejus quæ ad diu et <lb/> non diu pertinet, rhythmus nominata
-						sit. Sed de no­ <lb/> mine, cum res appareat, non esse satagendam, et <lb/> doctis et
-						sapientibus placuit. An aliquid contradicen­ <lb/> dum ant dubitandum putas dc his quiB
-						a me dicta <lb/> sunt? <hi rend="italic">D.</hi> Imo prorsus assentior.</p>
-					<ab>
-						<title type="sub">CAPUТ II. - <hi rend="italic">Quid intersit infer versum et
-								metrum.</hi>
+						concordiaque satis dictum <lb/> est , vidcamus quid ex bis contextis
+						continuatisque <lb/> gignatur. Quare primum cx te quæro, utrum possint <lb/>
+						copulati sibi pedes, quos copulari oportet, perpetuum <lb/> quemdam numerum
+						creare, ubi nullus finis certus <lb/> appareat: velut cum symphoniaci
+						scahella et cymbala <lb/> pedibus feriunt, certis quidcm numeris ct his qui
+						sibi <lb/> cum aurium voluptate junguntur; sed tamen tenore <lb/> perpetuo,
+						ita ut si tibias non audias, nullo modo ibi <lb/> notare possis quonsque
+						procurrat connexio pedum, et <lb/> nude rursus ad caput redeatur. Velut si
+						tu velis cen­ <lb/> ium vcl amplius, quousque libitum est, pyrrhichios vel
+						<lb/> alios qui inter se amici sunt pedes, continua con­ <lb/> ncxionc
+						decurrerc. <hi rend="italic">D.</hi> Jam intelligo, et fieri posse <lb/>
+						concedo quamdam pedum connexioncm, in qua cer­ <lb/> tum est usque ad quot
+						pedes progrediendum sil , <lb/> atquc inde redeundum. M. Num hujus generis
+						esse <lb/> dubitas 1, cum certam facicndorum versuum discipli­ <lb/> nam
+						esse non neges, et qui versus te semper cum <lb/> voluptate audisse
+						confessus sis? <hi rend="italic">D.</hi> Manifestum est ct <lb/> hoc esse,
+						ct ab illo superiore genere distare.</p>
+					<p>i. M. Ergo quoniam oportet distingui ctiam voca­ <lb/> bulis ea quæ re ab se
+						distincta sunt, scias illud su­ <lb/> perius gcnus copulationis, rhythmum a
+						Græcis; hoc <lb/> autem alterum, metrum vocali : latine autcm dici <lb/>
+						possent, illud numerus, hoc mensio vet mensura. <lb/> Scd qnonianl hæc apud
+						nos nomina late patent, et <lb/> cavendum est no ainbigue loquamur,
+						commodius <lb/> utimur græcis. Yidcs tamen, ut opinor, quam recte <lb/>
+						utrumque nomen sit his rebus impositum. Nam quo­ <lb/> niam illud pedibus
+						certis provolvitur, peccAturque in <lb/> co si pedes dissoni misceantur,
+						recte appelatus est <lb/> rhythmus, id est .numerus : seu quia ipsa
+						provolutio <lb/> mu habet modum, nec statutum est in quoto pedo <lb/> finis
+						aliquis emineat; propter nullam mensuram con­ <lb/> tinuationis non debuit
+						metrum vocari. Hoc autem <note type="footnote"> 1 Lov.: Num certum <hi
+								rend="italic">esse cluiJitas;</hi> at <hi rend="italic">MSS., num
+								hujus generis <lb/> esae dubita*;</hi> Cluontooo clintn editiones
+							Ani. et. Er. qnæ <lb/> atWuni, <hi rend="italic">ct hoc tib illo
+								superiore</hi> iHsiare conocuis. — in Ms. A <lb/> tkest <hi
+								rend="italic">IUljus grneris,</hi>
+							<unclear>fertque</unclear> simpliciicr, <hi rend="italic">nvm rSSe dic­
+								<lb/> pltas</hi> M. </note>
+						<lb/> utrumque habet ; nam ei certis pedibus currit 1, et <lb/> certo
+						terminatur modo. Itaquc non solum metrum <lb/> propter insignem finem, sed
+						ctiam rhythmus est, <lb/> propter pedum rationabilem connexionem. Quocirca
+						<lb/> omne metrum rhythmus, non omnis rhythmus etiam <lb/> metrum est.
+						Rhythmi enim nomen in musica usque <lb/> adeo late patet, lit hæc tota pars
+						ejus quæ ad diu et <lb/> non diu pertinet, rhythmus nominata sit. Sed de no­
+						<lb/> mine, cum res appareat, non esse satagendam, et <lb/> doctis et
+						sapientibus placuit. An aliquid contradicen­ <lb/> dum ant dubitandum putas
+						dc his quiB a me dicta <lb/> sunt? <hi rend="italic">D.</hi> Imo prorsus
+						assentior.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUТ II. - <hi rend="italic">Quid intersit infer versum
+								et metrum.</hi>
 						</title>
 					</ab>
-					<p>3. <hi rend="italic">II.</hi> Nunc ergo mecum illud considera, utrum sic­ <lb/> ut
-						omnis versus mettum cst, iui omne metrum ctiani <lb/> versus sit. D. Considero quidem,
-						sed quid respondeam <lb/> non invenio. M. Uude id tibi censes accidisse? an quia <lb/>
-						de vocabulis quaestio est? Non enim ut de rebus ad <lb/> disciplinam pertinentibus, ita
-						de nominibus possumus <lb/> respondere interrogati : propterea quia res omniuln <lb/>
-						mentibus communiter sunt insito; nominavero, ut <lb/> cuique placuit, imposita, quorum
-						vis auctoritate asque <lb/> consuctudine maxime nititur : unde etiam esse lin­ <lb/>
-						gnarum divcesitas potest, rerumautem in ipsa veritate <lb/> constitutarum profecto non
-						potest. A me igitur accipe <lb/> quod ipse nullo pacto respondere posses : non versum
-						<lb/> solum, metrum veteres vocavere. Itaque quod ad te <lb/> attinet, ,-ide atque
-						responde, non enim jam cic nom!­ <lb/> nibusagitur, utrum inter hæc duo aliquid distet,
-						<lb/> quod quidam numerus pedum iia certo fine claudatur, <lb/> ut nihil ad rem
-						pertineat t, ubi fiat quidam articulus <lb/> autcquam veniatur ad finem; alius autem non
-						solum <lb/> certo fine claudatur, sed etiam ante finem I certo quo­ <lb/> dam loco
-						quædam ejus partitio emineat, ut quasi <lb/> membris conficiatur duobus. D Non
-						intelligo. <hi rend="italic">II.</hi> At­ <lb/> tende ergo in hæc exempla : <lb/> Ite
-						igitur, <unclear>Camænæ</unclear>
-						<lb/> Fonticolæ <unclear>puellæ</unclear>, <lb/> Quæ canitis sub antris <lb/> Mellifluos
-						s nores, <lb/> Quæ lavilis ca, illum <note type="footnote">1 In B., <unclear/><hi rend="italic">currtur.</hi> Ex t 1i. et vis.A, <hi rend="italic">run it.</hi> vi.
-							</note><note type="footnote"> I Hiic rcvocavimus ex Vias. istli* c verba, <hi rend="italic">imie finem,</hi> l'lna <lb/> in hactenus editis desunt. — Non desunt
-							iu ':.:ic, 14. </note>
+					<p>3. <hi rend="italic">II.</hi> Nunc ergo mecum illud considera, utrum sic­
+						<lb/> ut omnis versus mettum cst, iui omne metrum ctiani <lb/> versus sit.
+						D. Considero quidem, sed quid respondeam <lb/> non invenio. M. Uude id tibi
+						censes accidisse? an quia <lb/> de vocabulis quaestio est? Non enim ut de
+						rebus ad <lb/> disciplinam pertinentibus, ita de nominibus possumus <lb/>
+						respondere interrogati : propterea quia res omniuln <lb/> mentibus
+						communiter sunt insito; nominavero, ut <lb/> cuique placuit, imposita,
+						quorum vis auctoritate asque <lb/> consuctudine maxime nititur : unde etiam
+						esse lin­ <lb/> gnarum divcesitas potest, rerumautem in ipsa veritate <lb/>
+						constitutarum profecto non potest. A me igitur accipe <lb/> quod ipse nullo
+						pacto respondere posses : non versum <lb/> solum, metrum veteres vocavere.
+						Itaque quod ad te <lb/> attinet, ,-ide atque responde, non enim jam cic
+						nom!­ <lb/> nibusagitur, utrum inter hæc duo aliquid distet, <lb/> quod
+						quidam numerus pedum iia certo fine claudatur, <lb/> ut nihil ad rem
+						pertineat t, ubi fiat quidam articulus <lb/> autcquam veniatur ad finem;
+						alius autem non solum <lb/> certo fine claudatur, sed etiam ante finem I
+						certo quo­ <lb/> dam loco quædam ejus partitio emineat, ut quasi <lb/>
+						membris conficiatur duobus. D Non intelligo. <hi rend="italic">II.</hi> At­
+						<lb/> tende ergo in hæc exempla : <lb/> Ite igitur,
+							<unclear>Camænæ</unclear>
+						<lb/> Fonticolæ <unclear>puellæ</unclear>, <lb/> Quæ canitis sub antris
+						<lb/> Mellifluos s nores, <lb/> Quæ lavilis ca, illum <note type="footnote"
+							>1 In B., <unclear/><hi rend="italic">currtur.</hi> Ex t 1i. et vis.A,
+								<hi rend="italic">run it.</hi> vi. </note><note type="footnote"> I
+							Hiic rcvocavimus ex Vias. istli* c verba, <hi rend="italic">imie
+								finem,</hi> l'lna <lb/> in hactenus editis desunt. — Non desunt iu
+							':.:ic, 14. </note>
 						<lb/>
 						<pb n="1117"/> Purpureum <unclear>Hypocrene</unclear>
-						<lb/> Fonte, ubi fusus olim <lb/> Spumea lavit almus <lb/> Ora juhis aquosis <lb/>
-						Pegasus, in nitentem <lb/> Pervolaturus æthram. <lb/> Cernis profecto quinque superiores
-						versiculos eodem <lb/> loco partem orationis habere terminatam, id est in <lb/>
-						choriambo pede, cui subjungitur bacchius, ut versi­ <lb/> culum compleat (namque hi
-						undecim, choriambo et <lb/> bacchio pcdibus constant); caeteros vero excepto uno, <lb/>
-						scilicet <hi rend="italic">Ora jubis</hi> aquosis, non eodem loco habere <lb/>
-						terminatam partem orationis. <hi rend="italic">D.</hi> Cerno istud quidem, <lb/> sed quo
-						pertineat non video. M. Eo scilicet ut intel­ <lb/> ligas, hoc nictrum non quasi
-						legitimum locum habere, <lb/> ubi antc finem versus finiatur pars orationis : nam si
-						<lb/> ita esset, omnes eodem loco hunc haberent articulum, <lb/> aut certe rarissime in
-						his inveniretur qui non habe­ <lb/> ret : nunc vcro cnm sint undecim, sex ita suut,
-						quin­ <lb/> que non ita. <hi rend="italic">D.</hi> Et hoc accipio, et adhuc quo ratio
-						<lb/> tendat exspecto. <hi rend="italic">M.</hi> Attende ergo etiam in ista per­ <lb/>
-						vulgatissima : <hi rend="italic">Arma</hi> virumque <hi rend="italic">cano, Trojce</hi>
-						qui <hi rend="italic">primus <lb/> nb</hi> oria. Et ne longum faciamus, quia carmen
-						notissi­ <lb/> mim est, ab hoc versu usque ad quem volueris ex­ <lb/> plora singulos ;
-						invenieS finilain partem orationis in <lb/> quinto semipede, id est, in duobus pcdibus
-						et semis­ <lb/> se : nam hi versus constant pedibus quaternorum <lb/> temporum : quare
-						iste finis de quo agitur partis ora­ <lb/> tionis, quasi legitimus in decimo tcinporc
-						est. <hi rend="italic">D.</hi> Ma­ <lb/> nifestum ct.</p>
-					<p><hi rend="italic">A. M.</hi> Jain crgo intelligis inter illa duo genera quae <lb/> ante
-						ista exempla proposueram, nonnihil distare : <lb/> quod aliud scilicct metrum antequam
-						claadatur, non <lb/> habet certum et statutum aliquem articulum, sicut in <lb/> illis
-						undecim versiculis exploravimus : aliud vero <lb/> habet, sicut in hcroico metro quintus
-						semipes satis <lb/> indicat. D. Jam liquet quod dicis. <hi rend="italic">M.</hi> Atqui
-						scias <lb/> opertet, a veteribus doctis, in quibus magna est au­ <lb/> ctoritas, illud
-						superius genus non esse versum appel­ <lb/> latum ; sed hunc definitum et vocatum esse
-						versum, <lb/> qui duobus quasi membris constaret, certa mensura <lb/> ct ratione
-						conjunctis. Sed tu non multum labores de <lb/> nomine, quod nisi a me vel a quolibet
-						alio tibi indi- <lb/> caretur, nullo modo cle hoc interrogatus respondere <lb/> posses.
-						Sed qnod rnlio docet, in id præcipue et maxi­ <lb/> mc animum intende, velut hoc ipsum
-						quod nunc agi­ <lb/> mus : ratio enin docct inter hæc duo genera distare <lb/> aliquid,
-						quibuslibet vocabulis nuncupentur : itaque <lb/> hoc bene interrogatus posses dicere
-						ipsa veritate <lb/> confisus; illud autem nisi auctoritatem secutus, non <lb/> posses.
-							<hi rend="italic">D.</hi> Apertissime jam ista cognovi, et quanti <lb/> pendas hoc, de
-						quo me tam crebro admones, jam <lb/> existimo. <hi rend="italic">M.</hi> Hæc ergo tria
-						nomina, quibus disse­ <lb/> rendi causa necessario usuri sumus, memoriae mandes <lb/>
-						velint : rhythmum, metrum, versum. Quæ sic distin­ <lb/> guuntur, ut omne metrum etiam
-						rhythmus sit, non <lb/> omnis rhythmus etiam metrum. Item omnis versus <lb/> etiam
-						metrum sit, non omne metrum etiam versus. <lb/> Ergo omnis versus est rhythmus et
-						metrum: nam hoc, <lb/> ut arbitror, esse consequens vides. <hi rend="italic">D.</hi>
-						Video sanc : <lb/> nam est luce clarius.</p>
-					<ab>
-						<title type="sub">CAPUT III. — <hi rend="italic">Rhythmi ex</hi> pyrrhichiis.</title>
+						<lb/> Fonte, ubi fusus olim <lb/> Spumea lavit almus <lb/> Ora juhis aquosis
+						<lb/> Pegasus, in nitentem <lb/> Pervolaturus æthram. <lb/> Cernis profecto
+						quinque superiores versiculos eodem <lb/> loco partem orationis habere
+						terminatam, id est in <lb/> choriambo pede, cui subjungitur bacchius, ut
+						versi­ <lb/> culum compleat (namque hi undecim, choriambo et <lb/> bacchio
+						pcdibus constant); caeteros vero excepto uno, <lb/> scilicet <hi
+							rend="italic">Ora jubis</hi> aquosis, non eodem loco habere <lb/>
+						terminatam partem orationis. <hi rend="italic">D.</hi> Cerno istud quidem,
+						<lb/> sed quo pertineat non video. M. Eo scilicet ut intel­ <lb/> ligas, hoc
+						nictrum non quasi legitimum locum habere, <lb/> ubi antc finem versus
+						finiatur pars orationis : nam si <lb/> ita esset, omnes eodem loco hunc
+						haberent articulum, <lb/> aut certe rarissime in his inveniretur qui non
+						habe­ <lb/> ret : nunc vcro cnm sint undecim, sex ita suut, quin­ <lb/> que
+						non ita. <hi rend="italic">D.</hi> Et hoc accipio, et adhuc quo ratio <lb/>
+						tendat exspecto. <hi rend="italic">M.</hi> Attende ergo etiam in ista per­
+						<lb/> vulgatissima : <hi rend="italic">Arma</hi> virumque <hi rend="italic"
+							>cano, Trojce</hi> qui <hi rend="italic">primus <lb/> nb</hi> oria. Et
+						ne longum faciamus, quia carmen notissi­ <lb/> mim est, ab hoc versu usque
+						ad quem volueris ex­ <lb/> plora singulos ; invenieS finilain partem
+						orationis in <lb/> quinto semipede, id est, in duobus pcdibus et semis­
+						<lb/> se : nam hi versus constant pedibus quaternorum <lb/> temporum : quare
+						iste finis de quo agitur partis ora­ <lb/> tionis, quasi legitimus in decimo
+						tcinporc est. <hi rend="italic">D.</hi> Ma­ <lb/> nifestum ct.</p>
+					<p><hi rend="italic">A. M.</hi> Jain crgo intelligis inter illa duo genera quae
+						<lb/> ante ista exempla proposueram, nonnihil distare : <lb/> quod aliud
+						scilicct metrum antequam claadatur, non <lb/> habet certum et statutum
+						aliquem articulum, sicut in <lb/> illis undecim versiculis exploravimus :
+						aliud vero <lb/> habet, sicut in hcroico metro quintus semipes satis <lb/>
+						indicat. D. Jam liquet quod dicis. <hi rend="italic">M.</hi> Atqui scias
+						<lb/> opertet, a veteribus doctis, in quibus magna est au­ <lb/> ctoritas,
+						illud superius genus non esse versum appel­ <lb/> latum ; sed hunc definitum
+						et vocatum esse versum, <lb/> qui duobus quasi membris constaret, certa
+						mensura <lb/> ct ratione conjunctis. Sed tu non multum labores de <lb/>
+						nomine, quod nisi a me vel a quolibet alio tibi indi- <lb/> caretur, nullo
+						modo cle hoc interrogatus respondere <lb/> posses. Sed qnod rnlio docet, in
+						id præcipue et maxi­ <lb/> mc animum intende, velut hoc ipsum quod nunc agi­
+						<lb/> mus : ratio enin docct inter hæc duo genera distare <lb/> aliquid,
+						quibuslibet vocabulis nuncupentur : itaque <lb/> hoc bene interrogatus
+						posses dicere ipsa veritate <lb/> confisus; illud autem nisi auctoritatem
+						secutus, non <lb/> posses. <hi rend="italic">D.</hi> Apertissime jam ista
+						cognovi, et quanti <lb/> pendas hoc, de quo me tam crebro admones, jam <lb/>
+						existimo. <hi rend="italic">M.</hi> Hæc ergo tria nomina, quibus disse­
+						<lb/> rendi causa necessario usuri sumus, memoriae mandes <lb/> velint :
+						rhythmum, metrum, versum. Quæ sic distin­ <lb/> guuntur, ut omne metrum
+						etiam rhythmus sit, non <lb/> omnis rhythmus etiam metrum. Item omnis versus
+						<lb/> etiam metrum sit, non omne metrum etiam versus. <lb/> Ergo omnis
+						versus est rhythmus et metrum: nam hoc, <lb/> ut arbitror, esse consequens
+						vides. <hi rend="italic">D.</hi> Video sanc : <lb/> nam est luce
+						clarius.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT III. — <hi rend="italic">Rhythmi ex</hi>
+							pyrrhichiis.</title>
 					</ab>
-					<p>5. <hi rend="italic">M.</hi> Prius igitur, si placet, de rhythmo In quo <lb/> nullum
-						metrum est, deinde cic metro ubi versus non <lb/> est, postremo de ipso versu, quantum
-						possumus, dis­ <lb/> seramus. <hi rend="italic">D.</hi> Placet vcro. <hi rend="italic">M.</hi> Sume ergo tibi ab ipso. <lb/> capite pedes pyrrhichios, et de his rhythmum
-						con­ <lb/> lcxe. <hi rend="italic">D.</hi> Etiam si id possim facere, qui modus erit? <lb/>
-						<hi rend="italic">M.</hi> Satis est, ut cum tendas (exempli enim gratia id <lb/>
-						facilnus) usque ad decem pedes: nam usque ad hunc <lb/> pedum numerum non progreditur
-						versus, quod suo <lb/> loco diligenter tractabitur. <hi rend="italic">D.</hi> Bene
-						quidem tu non <lb/> multos pedcs milii proposuisti copulandos ; sed vide­ <lb/> ris mihi
-						non recordari, jam te satis discrevisse, quid <lb/> .inter grammaticum et musicum
-						intersit, cnm cgo tibi <lb/> respondissem, syllabarum longarum et brevium cogni­ <lb/>
-						tionem me non habere, quæ a grammaticis traditur : <lb/> nist forte permittis, ut non
-						verbis, sed aliquo plausu <lb/> rhythmum istum exhibeam : nam judicium aurium ad <lb/>
-						temporum momenta moderanda me posse habere non <lb/> nego; quoe vero syllaba producenda
-						vel corripicnda <lb/> sit, quod in auctoritate situm cst, omnino nescio. <hi rend="italic">II.</hi>
-						<lb/> Fateor nos ita, ut dicis, grammaticum a musico dis­ <lb/> crevisse, et in hoc te
-						genere inscitiam luam esse con­ <lb/> fessum. Quare a me accipe hoc exempli gcnus : <hi rend="italic">Ago</hi>
-						<lb/> celeriter <hi rend="italic">agile quod ago libi quod anima velit. D.</hi> Habeo
-						<lb/> istuc.</p>
-					<p>6. M. Hoc ergo quoties libet rcpetendo, efficies. <lb/> rhythmi hujus longitudinem
-						quantam volcs, quan­ <lb/> quam hi decem pedes ad exemplum sufficiant. Sed <lb/> illud
-						quæro, si tibi quispiam dicai, non pyrrhichiis , <lb/> sed proceleumaticis pcdihus hunc
-						rhythmum constare, <lb/> quid respondebis? <hi rend="italic">D,</hi> Prorsus ignoro :
-						nam ubi de­ <lb/> cem pyrrhichii sunt, quin'lue proceleumaticos mctior; <lb/> et eo
-						major dubitatio est, quod de rhythmo consuli­ <lb/> mur, qai scilicet perpetuo fluit.
-						Undecim enim pyr­ <lb/> rhichii vel tredecim, et quolibet impari numero, non <lb/>
-						possunt habere integrum proceleumaticorum nuine­ <lb/> rum. Si ergo esset certus finis
-						in hoc de quo agiiur <lb/> rhythmo, ibi saltem diccre possemus pyrrhichio po­ <lb/> tius
-						quam proceleumatico cum currere, ubi omnes <lb/> integri proceleumatici non invenirentur
-						: nunc vero <lb/> et ipsum infinitum nobis conturbat judicium, ct si <lb/> quando
-						numerati quidem pedes, sed pari numero no­ <lb/> bis proponuntur, sicut isti sunt decem.
-						M. Atqui nec <lb/> de ipso impari numero pyrrhichiorum, quod tibi vi­ <lb/> sum est,
-						liquido visum est. Quid enim si undecim pro­ <lb/> positis pedibus pyrrhichiis dicatur
-						rhythmus quinque <lb/> babere proceleumaticos et semipcdem ? numquid re­ <lb/> sisti
-						potest, cum multos inveniamus versus claudi se­ <lb/> mipede? <hi rend="italic">D.</hi>
-						Jam dixi me nescire quid de hac re dici <lb/> possit. <hi rend="italic">II.</hi> Num
-						ctiam illud nescis, proceleumatico <lb/> priorem esse pyrrhichium ? siquidem duobus
-						pyrrbi­ <lb/> chiis proceleumaticus confit; sicut prius est unum <lb/> qnam duo, et duo
-						quam quatuor, ita proceleumatico <lb/> prior cst pyrrhichius. D. Verissimum est. <hi rend="italic">II.</hi> Cum <lb/> ergO in hanc ambiguitatem incidimus, ut possit in
-						<lb/> rhythmo ct pyrrhichius mctiri ct proceleumaticus , <lb/> cui principatum daturi
-						sumus? priori, ex quo iste <lb/> constat; an posteriori, t'X quo ille non constat? <hi rend="italic">D :</hi>
+					<p>5. <hi rend="italic">M.</hi> Prius igitur, si placet, de rhythmo In quo <lb/>
+						nullum metrum est, deinde cic metro ubi versus non <lb/> est, postremo de
+						ipso versu, quantum possumus, dis­ <lb/> seramus. <hi rend="italic">D.</hi>
+						Placet vcro. <hi rend="italic">M.</hi> Sume ergo tibi ab ipso. <lb/> capite
+						pedes pyrrhichios, et de his rhythmum con­ <lb/> lcxe. <hi rend="italic"
+							>D.</hi> Etiam si id possim facere, qui modus erit? <lb/>
+						<hi rend="italic">M.</hi> Satis est, ut cum tendas (exempli enim gratia id
+						<lb/> facilnus) usque ad decem pedes: nam usque ad hunc <lb/> pedum numerum
+						non progreditur versus, quod suo <lb/> loco diligenter tractabitur. <hi
+							rend="italic">D.</hi> Bene quidem tu non <lb/> multos pedcs milii
+						proposuisti copulandos ; sed vide­ <lb/> ris mihi non recordari, jam te
+						satis discrevisse, quid <lb/> .inter grammaticum et musicum intersit, cnm
+						cgo tibi <lb/> respondissem, syllabarum longarum et brevium cogni­ <lb/>
+						tionem me non habere, quæ a grammaticis traditur : <lb/> nist forte
+						permittis, ut non verbis, sed aliquo plausu <lb/> rhythmum istum exhibeam :
+						nam judicium aurium ad <lb/> temporum momenta moderanda me posse habere non
+						<lb/> nego; quoe vero syllaba producenda vel corripicnda <lb/> sit, quod in
+						auctoritate situm cst, omnino nescio. <hi rend="italic">II.</hi>
+						<lb/> Fateor nos ita, ut dicis, grammaticum a musico dis­ <lb/> crevisse, et
+						in hoc te genere inscitiam luam esse con­ <lb/> fessum. Quare a me accipe
+						hoc exempli gcnus : <hi rend="italic">Ago</hi>
+						<lb/> celeriter <hi rend="italic">agile quod ago libi quod anima velit.
+							D.</hi> Habeo <lb/> istuc.</p>
+					<p>6. M. Hoc ergo quoties libet rcpetendo, efficies. <lb/> rhythmi hujus
+						longitudinem quantam volcs, quan­ <lb/> quam hi decem pedes ad exemplum
+						sufficiant. Sed <lb/> illud quæro, si tibi quispiam dicai, non pyrrhichiis ,
+						<lb/> sed proceleumaticis pcdihus hunc rhythmum constare, <lb/> quid
+						respondebis? <hi rend="italic">D,</hi> Prorsus ignoro : nam ubi de­ <lb/>
+						cem pyrrhichii sunt, quin'lue proceleumaticos mctior; <lb/> et eo major
+						dubitatio est, quod de rhythmo consuli­ <lb/> mur, qai scilicet perpetuo
+						fluit. Undecim enim pyr­ <lb/> rhichii vel tredecim, et quolibet impari
+						numero, non <lb/> possunt habere integrum proceleumaticorum nuine­ <lb/>
+						rum. Si ergo esset certus finis in hoc de quo agiiur <lb/> rhythmo, ibi
+						saltem diccre possemus pyrrhichio po­ <lb/> tius quam proceleumatico cum
+						currere, ubi omnes <lb/> integri proceleumatici non invenirentur : nunc vero
+						<lb/> et ipsum infinitum nobis conturbat judicium, ct si <lb/> quando
+						numerati quidem pedes, sed pari numero no­ <lb/> bis proponuntur, sicut isti
+						sunt decem. M. Atqui nec <lb/> de ipso impari numero pyrrhichiorum, quod
+						tibi vi­ <lb/> sum est, liquido visum est. Quid enim si undecim pro­ <lb/>
+						positis pedibus pyrrhichiis dicatur rhythmus quinque <lb/> babere
+						proceleumaticos et semipcdem ? numquid re­ <lb/> sisti potest, cum multos
+						inveniamus versus claudi se­ <lb/> mipede? <hi rend="italic">D.</hi> Jam
+						dixi me nescire quid de hac re dici <lb/> possit. <hi rend="italic">II.</hi>
+						Num ctiam illud nescis, proceleumatico <lb/> priorem esse pyrrhichium ?
+						siquidem duobus pyrrbi­ <lb/> chiis proceleumaticus confit; sicut prius est
+						unum <lb/> qnam duo, et duo quam quatuor, ita proceleumatico <lb/> prior cst
+						pyrrhichius. D. Verissimum est. <hi rend="italic">II.</hi> Cum <lb/> ergO in
+						hanc ambiguitatem incidimus, ut possit in <lb/> rhythmo ct pyrrhichius
+						mctiri ct proceleumaticus , <lb/> cui principatum daturi sumus? priori, ex
+						quo iste <lb/> constat; an posteriori, t'X quo ille non constat? <hi
+							rend="italic">D :</hi>
 						<lb/>
-						<pb n="1119"/> Nemo dubitabit priori esse dandum. <hi rend="italic">M.</hi> Quid ergo
-						<lb/> dubitas de bac re consultis respondere, pyrrhichium <lb/> potius quam
-						proceleumaticum istum rhythmum csse <lb/> nuncupandum? <hi rend="italic">D.</hi> Jam
-						omnino non dubito ; pudel <lb/> tam manifestam rationem non me cito animadver­ <lb/>
-						tisse.</p>
-					<ab>
-						<title type="sub">CAPUT IV. — <hi rend="italic">Rhythmus</hi> continuus.</title>
+						<pb n="1119"/> Nemo dubitabit priori esse dandum. <hi rend="italic">M.</hi>
+						Quid ergo <lb/> dubitas de bac re consultis respondere, pyrrhichium <lb/>
+						potius quam proceleumaticum istum rhythmum csse <lb/> nuncupandum? <hi
+							rend="italic">D.</hi> Jam omnino non dubito ; pudel <lb/> tam manifestam
+						rationem non me cito animadver­ <lb/> tisse.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT IV. — <hi rend="italic">Rhythmus</hi>
+							continuus.</title>
 					</ab>
-					<p>7. <hi rend="italic">M.</hi> Videsne illud etiam ista ratione cogi, ut qui­ <lb/> dam
-						pedes sint, qui rhythmum continuare non pos­ <lb/> sinl? Nam quod de proceleumatico
-						inventum est, cui <lb/> tollit pyrrhichius principatum, hoc et do diiambo et <lb/> dc
-						dichorio et de dispondeo inventum puto : nisi tibi <lb/> aliud videtur. <hi rend="italic">D.</hi> Quid mihi aliud videri potest, cum <lb/> probata illa rationc
-						hoc quod sequitur improbare non <lb/> possim ? M. Vide etiam ista, et compara ac judica.
-						<lb/> Nam videtur, cum tale incertum evenit, plausu potius <lb/> dcberc discerni 1 quo
-						pede curratur : ut si pyrrhichio <lb/> velrs currere, unum tibi tempus levandum, uuum
-						<lb/> ponendum sit; si proceleumatico, duo ct duo : ita et <lb/> pes apparebit, et
-						nullus pedum erit a rhythmi conti­ <lb/> nuatione seclusus. <hi rend="italic">D.</hi>
-						Huic magis favco sententiæ, <lb/> quæ nullum pedem ab hac contextione esse immunem <lb/>
-						sinit. <hi rend="italic">M.</hi> Recte facis, et quo magis hoc approbcs , <lb/>
-						considera de tribracho pede quid respondere possimus, <lb/> si nihilominus quisque
-						contendat non pyrrhichio aut <lb/> proccleumalico istum rhythmum, sed tribracho cur­
-						<lb/> rcre. <hi rend="italic">D.</hi> Vico judicium ad plausum illum esse revo­ <lb/>
-						c.tndum, ut si unum tempus cst ill levalione, duo in <lb/> positione, id est, una ct duæ
-						syllabæ ; aut contra duæ <lb/> in levatione, una in posilione; tribrachus rhythmus <lb/>
-						esse dicatur.</p>
-					<p>8. <hi rend="italic">M.</hi> Recte intelligis. Quamobrem jam dic mihi <lb/> utrum
-						spondeus pes pyrrhichio rhythmo possit ad­ <lb/> jungi. <hi rend="italic">D.</hi> Nullo
-						modo : non cnim continuabitur plau­ <lb/> sus a qualis ; cum levatio ct positio in
-						pyrrhichio sin­ <lb/> gula, in Spondeo vero bina tempora lencanL. <hi rend="italic">M.</hi> Potest <lb/> ergo proceleumatico adjungi. <hi rend="italic">D.</hi> Potest.
-							<hi rend="italic">M.</hi> Quid cum <lb/> ei ndjungitur? interrogati uirum rhythmus
-						prooe­ <lb/> leumaticus an spondiacus sit, quid respondebimus? <lb/>
-						<hi rend="italic">D.</hi> Quid censes, nisi spondeo dandunt esse principa­ <lb/> lum?
-						Cum enim plausu ista controversia noh dijudi­ <lb/> cetur, nam in utroque bina levamus
-						ac ponimus tem­ <lb/> pora ; quid aliud restat, nisi ut i te regnet qui in ipso <lb/>
-						pedum ordine prior est? <hi rend="italic">M.</hi> Rationem tc secutum esse <lb/> satis
-						approbo; et vidcs, ut arbitror, quid sequatur. <lb/> D Quid tandem? <hi rend="italic">M.</hi> Quid putas, nisi proceleumatico <lb/> rhythmo 2 nullum alium pedem posse
-						misceri? quoniam <lb/> quisquis miscebitur totidem temporum , non cnim <lb/> aliter
-						potest misceri, in cum rhythmi nomen transfe­ <lb/> ratur necesse esl. Omnes enim
-						priores illo sunt, qui <lb/> totidem temporibus constant. Et. quoniam iis qui prio­
-						<lb/> ics inventi fucrint, cogit nos ralio, quam vidisti <lb/> principatum dare, id est,
-						cx eo rhythmum nuncupare ; <lb/> non crit jam proceleumaticus rhythmus, aliquo alio
-							<note type="footnote">
-							<hi rend="italic">I nccemu</hi> juxta Ms. A. M. </note><note type="footnote"> ! tn B.:
-								<hi rend="italic">Quid putas,</hi> ttM&lt; tam <hi rend="italic">proceleumatico
-								quarn pyrrhicllio<lb/> rhythmo</hi> : corrupte pro'ecto; nam cum |yrrbicliius omnes
-							<lb/> alios | ru cedat JKXICS, ei male accommodaretur ratio ahAu­ <lb/> gustino
-							subjecta, quur ia p ro doumaiicu.ii convenientissime <unclear/><lb/> ineldit. M. </note>
-						<lb/> quatuor temporum mixto, sed spondiacus aut dacty­ <lb/> licus aut anapæsticus.
-						Amphibracbum enim ab isto­ <lb/> rum copulatione numerorum recte remotum esse <lb/>
-						convenit. <hi rend="italic">D.</hi> Fateor ita esse.</p>
-					<p>9. M. Nunc ergo ex ordine considera iambicum <lb/> rhythmum, quoniam pyrrhichium et
-						proceleumati­ <lb/> cum, qui duplicato pyrrbicbio gignitur, satis discus­ <lb/> simus.
-						Quare dicas velim huic quem censes admi­ <lb/> scendum pedem, ut iambicus rhythmus suum
-						nomen <lb/> obtineat. <hi rend="italic">D.</hi> Quem, nisi tribrachum, qui et temporibus
-						<lb/> et plausu congruit; et quia posterior cst, regio pol <lb/> lcre non potest? Nam
-						chorius cst quidem posterior, <lb/> et totidem temporum, sed non eodem modo plaudi­
-						<lb/> tur. M. Age, jam vide rhythmum trochaicum, et ad <lb/> eadem de hoc quoque
-						respoude. <hi rend="italic">D.</hi> Idem respoudco : <lb/> nam potest et huic non solum
-						spatio temporis, s d <lb/> plausu etiam concinere tribrachus. Cavendum autem <lb/>
-						iambum quis non videat? qui eliam si æqualiter plau­ <lb/> docetur, principatum tamen
-						mixtus auferret. <hi rend="italic">M.</hi> Quid ? <lb/> spondiaco rhythmo quem taudem
-						copulabimus pe­ <lb/> dem? D. Sane in hoc largissima copia cst : nani et da­ <lb/>
-						ctylum et anapæstum et proceleumaticum nulla im­ <lb/> parilitate temporum, nulla
-						claudicatione plausus, <lb/> nulla principatus ademptione impediente, huic video <lb/>
-						misceri posse.</p>
-					<p>10. M. Vidoo jam te facile posse cætera ordiuc <lb/> persequi : quocirca remota
-						interrogatione mea, vel <lb/> potius tanquam de omnibus interrogatus responde <lb/>
-						breviter, dilucidcque quantum |otcs, quomodo siu <lb/> guli qui restant pedes, aliis
-						legitime immixtis, obti­ <lb/> neant suum nomen in rhythmo. <hi rend="italic">D.</hi>
-						Faciam : neque <lb/> enim ullius negotii est, tanta rationum luce præmissa. <lb/> Nam
-						tribracho nullus miscebitur ; omnes enim prio­ <lb/> res sunt, qui ei sunt u;mporibus
-						pares. Dactylo ana­ <lb/> pæstus potest; nam ct cst posterior, et I tempore ac <lb/>
-						plausu currit aequaliter : ulriquc autem proceleuma­ <lb/> ticus eadem scilicet ratione
-						copulatur. Jam bacchio <lb/> creticus, et de paconibus primus, sccundus ct qua.-. <lb/>
-						tus misceri possunt. Porro ipsi cretico, omues qui <lb/> post illum sunt quinque
-						temporum pedes jure miscen <lb/> tur, sed non omnes eadem divisione. Alii namque ad
-						<lb/> duo et tria, alii ad tria et duo tempora dividuntur. <lb/> Iste autem creticus
-						ulroquc modo dividi pOtest, quia <lb/> media brevis cuilibet parti tribuitur.
-						Palimbacchius <lb/> autcm , quia ejus divisio a duobus temporibus inci­ <lb/> piena, in
-						tria desinit, cougruos ct copulabiles habet <lb/> pæones omnes, præter secundum.
-						Molossus de tri­ <lb/> syllabis restat, a quo prino incipiunt sex temporum <lb/> pedes,
-						qui omnes eidem conjungi possunt, partim <lb/> propter simpli duplique rationcm; partim
-						propter <lb/> illam quam nobis plausus ostendit, partitionem longæ <lb/> syllabæ, quæ
-						singula tempora parti utrique concedit, <lb/> quia in senario numero par lateribus
-						medium est. <lb/> Ob quam causam et molossus, et ambo ionici non so­ <lb/> lum in
-						simplum et duplum, sed ctiam in æquas par­ <lb/> tes per terna tempora feriuntur. Hinc
-						efficitur ut dcin­ <lb/> ceps omnibus sci temporum pedibus, omnes totidem <note type="footnote">1 In B. et omnibus editis, <hi rend="italic">posterior tempore,</hi>
-							omissa I ar­ <lb/> licula c(,quain fert Ms. A, et sine qua oratio claudicat. M. </note>
+					<p>7. <hi rend="italic">M.</hi> Videsne illud etiam ista ratione cogi, ut qui­
+						<lb/> dam pedes sint, qui rhythmum continuare non pos­ <lb/> sinl? Nam quod
+						de proceleumatico inventum est, cui <lb/> tollit pyrrhichius principatum,
+						hoc et do diiambo et <lb/> dc dichorio et de dispondeo inventum puto : nisi
+						tibi <lb/> aliud videtur. <hi rend="italic">D.</hi> Quid mihi aliud videri
+						potest, cum <lb/> probata illa rationc hoc quod sequitur improbare non <lb/>
+						possim ? M. Vide etiam ista, et compara ac judica. <lb/> Nam videtur, cum
+						tale incertum evenit, plausu potius <lb/> dcberc discerni 1 quo pede
+						curratur : ut si pyrrhichio <lb/> velrs currere, unum tibi tempus levandum,
+						uuum <lb/> ponendum sit; si proceleumatico, duo ct duo : ita et <lb/> pes
+						apparebit, et nullus pedum erit a rhythmi conti­ <lb/> nuatione seclusus.
+							<hi rend="italic">D.</hi> Huic magis favco sententiæ, <lb/> quæ nullum
+						pedem ab hac contextione esse immunem <lb/> sinit. <hi rend="italic">M.</hi>
+						Recte facis, et quo magis hoc approbcs , <lb/> considera de tribracho pede
+						quid respondere possimus, <lb/> si nihilominus quisque contendat non
+						pyrrhichio aut <lb/> proccleumalico istum rhythmum, sed tribracho cur­ <lb/>
+						rcre. <hi rend="italic">D.</hi> Vico judicium ad plausum illum esse revo­
+						<lb/> c.tndum, ut si unum tempus cst ill levalione, duo in <lb/> positione,
+						id est, una ct duæ syllabæ ; aut contra duæ <lb/> in levatione, una in
+						posilione; tribrachus rhythmus <lb/> esse dicatur.</p>
+					<p>8. <hi rend="italic">M.</hi> Recte intelligis. Quamobrem jam dic mihi <lb/>
+						utrum spondeus pes pyrrhichio rhythmo possit ad­ <lb/> jungi. <hi
+							rend="italic">D.</hi> Nullo modo : non cnim continuabitur plau­ <lb/>
+						sus a qualis ; cum levatio ct positio in pyrrhichio sin­ <lb/> gula, in
+						Spondeo vero bina tempora lencanL. <hi rend="italic">M.</hi> Potest <lb/>
+						ergo proceleumatico adjungi. <hi rend="italic">D.</hi> Potest. <hi
+							rend="italic">M.</hi> Quid cum <lb/> ei ndjungitur? interrogati uirum
+						rhythmus prooe­ <lb/> leumaticus an spondiacus sit, quid respondebimus? <lb/>
+						<hi rend="italic">D.</hi> Quid censes, nisi spondeo dandunt esse principa­
+						<lb/> lum? Cum enim plausu ista controversia noh dijudi­ <lb/> cetur, nam in
+						utroque bina levamus ac ponimus tem­ <lb/> pora ; quid aliud restat, nisi ut
+						i te regnet qui in ipso <lb/> pedum ordine prior est? <hi rend="italic"
+							>M.</hi> Rationem tc secutum esse <lb/> satis approbo; et vidcs, ut
+						arbitror, quid sequatur. <lb/> D Quid tandem? <hi rend="italic">M.</hi> Quid
+						putas, nisi proceleumatico <lb/> rhythmo 2 nullum alium pedem posse misceri?
+						quoniam <lb/> quisquis miscebitur totidem temporum , non cnim <lb/> aliter
+						potest misceri, in cum rhythmi nomen transfe­ <lb/> ratur necesse esl. Omnes
+						enim priores illo sunt, qui <lb/> totidem temporibus constant. Et. quoniam
+						iis qui prio­ <lb/> ics inventi fucrint, cogit nos ralio, quam vidisti <lb/>
+						principatum dare, id est, cx eo rhythmum nuncupare ; <lb/> non crit jam
+						proceleumaticus rhythmus, aliquo alio <note type="footnote">
+							<hi rend="italic">I nccemu</hi> juxta Ms. A. M. </note><note
+							type="footnote"> ! tn B.: <hi rend="italic">Quid putas,</hi> ttM&lt; tam
+								<hi rend="italic">proceleumatico quarn pyrrhicllio<lb/> rhythmo</hi>
+							: corrupte pro'ecto; nam cum |yrrbicliius omnes <lb/> alios | ru cedat
+							JKXICS, ei male accommodaretur ratio ahAu­ <lb/> gustino subjecta, quur
+							ia p ro doumaiicu.ii convenientissime <unclear/><lb/> ineldit. M. </note>
+						<lb/> quatuor temporum mixto, sed spondiacus aut dacty­ <lb/> licus aut
+						anapæsticus. Amphibracbum enim ab isto­ <lb/> rum copulatione numerorum
+						recte remotum esse <lb/> convenit. <hi rend="italic">D.</hi> Fateor ita
+						esse.</p>
+					<p>9. M. Nunc ergo ex ordine considera iambicum <lb/> rhythmum, quoniam
+						pyrrhichium et proceleumati­ <lb/> cum, qui duplicato pyrrbicbio gignitur,
+						satis discus­ <lb/> simus. Quare dicas velim huic quem censes admi­ <lb/>
+						scendum pedem, ut iambicus rhythmus suum nomen <lb/> obtineat. <hi
+							rend="italic">D.</hi> Quem, nisi tribrachum, qui et temporibus <lb/> et
+						plausu congruit; et quia posterior cst, regio pol <lb/> lcre non potest? Nam
+						chorius cst quidem posterior, <lb/> et totidem temporum, sed non eodem modo
+						plaudi­ <lb/> tur. M. Age, jam vide rhythmum trochaicum, et ad <lb/> eadem
+						de hoc quoque respoude. <hi rend="italic">D.</hi> Idem respoudco : <lb/> nam
+						potest et huic non solum spatio temporis, s d <lb/> plausu etiam concinere
+						tribrachus. Cavendum autem <lb/> iambum quis non videat? qui eliam si
+						æqualiter plau­ <lb/> docetur, principatum tamen mixtus auferret. <hi
+							rend="italic">M.</hi> Quid ? <lb/> spondiaco rhythmo quem taudem
+						copulabimus pe­ <lb/> dem? D. Sane in hoc largissima copia cst : nani et da­
+						<lb/> ctylum et anapæstum et proceleumaticum nulla im­ <lb/> parilitate
+						temporum, nulla claudicatione plausus, <lb/> nulla principatus ademptione
+						impediente, huic video <lb/> misceri posse.</p>
+					</div>
+				<div type="textpart" subtype="dialog"><p>10. M. Vidoo jam te facile posse cætera ordiuc <lb/> persequi : quocirca
+						remota interrogatione mea, vel <lb/> potius tanquam de omnibus interrogatus
+						responde <lb/> breviter, dilucidcque quantum |otcs, quomodo siu <lb/> guli
+						qui restant pedes, aliis legitime immixtis, obti­ <lb/> neant suum nomen in
+						rhythmo. <hi rend="italic">D.</hi> Faciam : neque <lb/> enim ullius negotii
+						est, tanta rationum luce præmissa. <lb/> Nam tribracho nullus miscebitur ;
+						omnes enim prio­ <lb/> res sunt, qui ei sunt u;mporibus pares. Dactylo ana­
+						<lb/> pæstus potest; nam ct cst posterior, et I tempore ac <lb/> plausu
+						currit aequaliter : ulriquc autem proceleuma­ <lb/> ticus eadem scilicet
+						ratione copulatur. Jam bacchio <lb/> creticus, et de paconibus primus,
+						sccundus ct qua.-. <lb/> tus misceri possunt. Porro ipsi cretico, omues qui
+						<lb/> post illum sunt quinque temporum pedes jure miscen <lb/> tur, sed non
+						omnes eadem divisione. Alii namque ad <lb/> duo et tria, alii ad tria et duo
+						tempora dividuntur. <lb/> Iste autem creticus ulroquc modo dividi pOtest,
+						quia <lb/> media brevis cuilibet parti tribuitur. Palimbacchius <lb/> autcm
+						, quia ejus divisio a duobus temporibus inci­ <lb/> piena, in tria desinit,
+						cougruos ct copulabiles habet <lb/> pæones omnes, præter secundum. Molossus
+						de tri­ <lb/> syllabis restat, a quo prino incipiunt sex temporum <lb/>
+						pedes, qui omnes eidem conjungi possunt, partim <lb/> propter simpli
+						duplique rationcm; partim propter <lb/> illam quam nobis plausus ostendit,
+						partitionem longæ <lb/> syllabæ, quæ singula tempora parti utrique concedit,
+						<lb/> quia in senario numero par lateribus medium est. <lb/> Ob quam causam
+						et molossus, et ambo ionici non so­ <lb/> lum in simplum et duplum, sed
+						ctiam in æquas par­ <lb/> tes per terna tempora feriuntur. Hinc efficitur ut
+						dcin­ <lb/> ceps omnibus sci temporum pedibus, omnes totidem <note
+							type="footnote">1 In B. et omnibus editis, <hi rend="italic">posterior
+								tempore,</hi> omissa I ar­ <lb/> licula c(,quain fert Ms. A, et sine
+							qua oratio claudicat. M. </note>
 						<lb/>
-						<pb n="1121"/> temporum posteriores copulari queant ; solusque an­ <lb/> tispastus, qui
-						nullum sibi velit misceri, remaneat. <lb/> Hos consequuntur quatuor epitriti, quorum
-						primus <lb/> admittit secundum, secundus nullum, tertius quar­ <lb/> tum, quartus
-						nullum. Restat dispondeus, rhythmum <lb/> solus cnam ipse facturus, quia nec posteriorem
-						quem­ <lb/> quam invenit, nec æqualem. Itaque omnium pedum <lb/> octo sunt !, qui nullo
-						alio mixto rhythmum faciunt : <lb/> pyrrhichius, tribrachus, proccleusmaticus,paeonquar­
-						<lb/> tus, aniispastus, epitritus secundus, et quartus, et <lb/> dispondeus : rcliqui
-						eos, qui se posteriores sunt, co­ <lb/> pulari sibi patiuntur, ita ut rhythmi nomen
-						obti­ <lb/> neant, etiamsi pauciores in ea serie numerentur. <lb/> Huc cst, ut opinor,
-						satis a me quod voluisti, expli­ <lb/> catum atque digestum : tuum cst jam videre quod
-						<lb/> restat.</p>
-					<ab>
+						<pb n="1121"/> temporum posteriores copulari queant ; solusque an­ <lb/>
+						tispastus, qui nullum sibi velit misceri, remaneat. <lb/> Hos consequuntur
+						quatuor epitriti, quorum primus <lb/> admittit secundum, secundus nullum,
+						tertius quar­ <lb/> tum, quartus nullum. Restat dispondeus, rhythmum <lb/>
+						solus cnam ipse facturus, quia nec posteriorem quem­ <lb/> quam invenit, nec
+						æqualem. Itaque omnium pedum <lb/> octo sunt !, qui nullo alio mixto
+						rhythmum faciunt : <lb/> pyrrhichius, tribrachus,
+						proccleusmaticus,paeonquar­ <lb/> tus, aniispastus, epitritus secundus, et
+						quartus, et <lb/> dispondeus : rcliqui eos, qui se posteriores sunt, co­
+						<lb/> pulari sibi patiuntur, ita ut rhythmi nomen obti­ <lb/> neant, etiamsi
+						pauciores in ea serie numerentur. <lb/> Huc cst, ut opinor, satis a me quod
+						voluisti, expli­ <lb/> catum atque digestum : tuum cst jam videre quod <lb/>
+						restat.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT V. — <hi rend="italic">An sint pedes supra syllabas
 								quatuor.</hi>
 						</title>
 					</ab>
-					<p>it. <hi rend="italic">M.</hi> Imo mecum etiam tuum * : ambo enin <lb/> quarimus. Sed
-						quid tandem restare arbitraris, quod <lb/> ad rhythmum attinet? Nonne illud
-						considerandum est <lb/> utrum aliqua dimensio pedis, quamvis octo tempora <lb/> non
-						excedat, quæ dispondeus obtinet, excedat tamen <lb/> numerum quatuor syllabarum ? <hi rend="italic">D.</hi> Quare , quæso? <lb/>
-						<hi rend="italic">M.</hi> Imo In , quare mc potius quam teipsum rogas? <lb/> An tibi non
-						videtur sine ulla fraude vel offensione au­ <lb/> rium, sive quod a ad plausum ac
-						divisionem pedum, <lb/> sivc quod ad spatium temporis pertinet, pro una <lb/> longa
-						syllaba duas posse poni breves? <hi rend="italic">D.</hi> Quis hoc <lb/> negaverit? M.
-						Hinc ergo est, qnod pro iambo velcho­ <lb/> ria tribrachum ponimus, ct pro spondeo
-						dactylum vel <lb/> anapæstum vcl proceleusmaticum, cum vel pro se­ <lb/> cunda ejus, vel
-						pro prima duas breves ponimus, vcl <lb/> quatuor pro utraque. <hi rend="italic">D.</hi>
-						Assentior. <hi rend="italic">M.</hi> Fac igitur boc <lb/> idcm in ionico quolibct, vel
-						alio quopiam quadrisyl­ <lb/> labo sex tem; orum pede, ct pro una cjus quacumque <lb/>
-						longa duas breves constitue 4. Num quidquam meu­ <lb/> suræ deperit, aut plausui
-						resistit ? <hi rend="italic">D.</hi> Nihil omnino. <lb/> M. Considera ergo quot syllaba
-						fiunt. <hi rend="italic">D.</hi> Quinque <lb/> fieri video. M. Vides certe posse quatuor
-						syllabarum <lb/> numerum excedi. <hi rend="italic">D.</hi> Video sane. <hi rend="italic">M.</hi> Quid, si pro <lb/> duabus, quæ ibi sunt longæ, quatuor breves posuc­ <lb/>
-						ris? nonne in uno pede sex syllabas neces e cst mc- <note type="footnote">1 in It. Am.
-							Er. ell.ov,: <hi rend="italic">omnium pedum nm'e?1' suni, <lb/> Qui nullo clio
-								muxU)</hi> rhylkuvm <hi rend="italic">fuciunl : pyrrhichius, tri­</hi>
-							<lb/> brachus, <hi rend="italic">procclevwnalicus, pceon secundus, paron</hi> quar­ <lb/>
-							<hi rend="italic">tus,</hi> etc. Ha?c addit nota edit. Bened.: <hi rend="italic">Mss.
-								otnnes quos per <lb/> nos inspicere licuit, habent,</hi> octo sunt, <hi rend="italic">et mox in horum <lb/> , pedum recemione</hi> omittunt, prcon secundus;
-								<hi rend="italic">qui tamen pes<lb/> videtur haud posse ex lege hic præscripta
-								rhythmum alio<lb/> admixto pede facere</hi> : quippe <hi rend="italic">cum
-								posteriores totidem tem­ <lb/> porurn pedes misceri illi prohibeat</hi> plausus <hi rend="italic">disparitas; prw--<lb/> res vero</hi> st <hi rend="italic">illi
-								nmcetitur, rhythmum sibi vindicent, suum­ <lb/> que ipsi nomen</hi> iMponant. <hi rend="italic">Quapropter lectionem</hi> retinuimus <lb/>
-							<hi rend="italic">editionum :m. Er. et Lov.</hi> Falsa supj ositione nititur illud ar­
-							<lb/> gumentum, scilicet paeonem secundumcumnulloaliofede <lb/> posse misceri. nam
-							paeon quartus, ut testatur lihr. 2, n. 10, <lb/> dividi jiotest <hi rend="italic">aut</hi> in <hi rend="italic">auo et tiia, alll ill tria et duo tempora :</hi>
-							<lb/> quæ divisio eum jaconi secundo maritat sine plausus dIs- <lb/> I a: iiale. M.
-							</note><note type="footnote"> 3 <hi rend="italic">,IlW meum etiam Ill,</hi> juxta Er.
-							I.ugd. ven. <hi rend="italic">imomeum, <lb/> ne etiam tuum9</hi> juxta Ms. A. <hi rend="italic">II1W mew1t est (jiuim luunt,</hi>
-							<lb/> juxta als. B. M. </note><note type="footnote"> 3 Hic et I aulo post, quod, juxta
-							vatic. M. </note><note type="footnote"> 4 fr. Lugd. Ven. ct Lov., <hi rend="italic">et
-								pro</hi> rma <hi rend="italic">ejus... constituas.</hi>
-							<lb/> iLss. A et ti., <hi rend="italic">ut</hi> pro <hi rend="italic">ima ejus
-								quacumque hnga duas</hi> b TM3 <lb/>
+					<p>it. <hi rend="italic">M.</hi> Imo mecum etiam tuum * : ambo enin <lb/>
+						quarimus. Sed quid tandem restare arbitraris, quod <lb/> ad rhythmum
+						attinet? Nonne illud considerandum est <lb/> utrum aliqua dimensio pedis,
+						quamvis octo tempora <lb/> non excedat, quæ dispondeus obtinet, excedat
+						tamen <lb/> numerum quatuor syllabarum ? <hi rend="italic">D.</hi> Quare ,
+						quæso? <lb/>
+						<hi rend="italic">M.</hi> Imo In , quare mc potius quam teipsum rogas? <lb/>
+						An tibi non videtur sine ulla fraude vel offensione au­ <lb/> rium, sive
+						quod a ad plausum ac divisionem pedum, <lb/> sivc quod ad spatium temporis
+						pertinet, pro una <lb/> longa syllaba duas posse poni breves? <hi
+							rend="italic">D.</hi> Quis hoc <lb/> negaverit? M. Hinc ergo est, qnod
+						pro iambo velcho­ <lb/> ria tribrachum ponimus, ct pro spondeo dactylum vel
+						<lb/> anapæstum vcl proceleusmaticum, cum vel pro se­ <lb/> cunda ejus, vel
+						pro prima duas breves ponimus, vcl <lb/> quatuor pro utraque. <hi
+							rend="italic">D.</hi> Assentior. <hi rend="italic">M.</hi> Fac igitur
+						boc <lb/> idcm in ionico quolibct, vel alio quopiam quadrisyl­ <lb/> labo
+						sex tem; orum pede, ct pro una cjus quacumque <lb/> longa duas breves
+						constitue 4. Num quidquam meu­ <lb/> suræ deperit, aut plausui resistit ?
+							<hi rend="italic">D.</hi> Nihil omnino. <lb/> M. Considera ergo quot
+						syllaba fiunt. <hi rend="italic">D.</hi> Quinque <lb/> fieri video. M. Vides
+						certe posse quatuor syllabarum <lb/> numerum excedi. <hi rend="italic"
+							>D.</hi> Video sane. <hi rend="italic">M.</hi> Quid, si pro <lb/>
+						duabus, quæ ibi sunt longæ, quatuor breves posuc­ <lb/> ris? nonne in uno
+						pede sex syllabas neces e cst mc- <note type="footnote">1 in It. Am. Er.
+							ell.ov,: <hi rend="italic">omnium pedum nm'e?1' suni, <lb/> Qui nullo
+								clio muxU)</hi> rhylkuvm <hi rend="italic">fuciunl : pyrrhichius,
+								tri­</hi>
+							<lb/> brachus, <hi rend="italic">procclevwnalicus, pceon secundus,
+								paron</hi> quar­ <lb/>
+							<hi rend="italic">tus,</hi> etc. Ha?c addit nota edit. Bened.: <hi
+								rend="italic">Mss. otnnes quos per <lb/> nos inspicere licuit,
+								habent,</hi> octo sunt, <hi rend="italic">et mox in horum <lb/> ,
+								pedum recemione</hi> omittunt, prcon secundus; <hi rend="italic">qui
+								tamen pes<lb/> videtur haud posse ex lege hic præscripta rhythmum
+								alio<lb/> admixto pede facere</hi> : quippe <hi rend="italic">cum
+								posteriores totidem tem­ <lb/> porurn pedes misceri illi
+								prohibeat</hi> plausus <hi rend="italic">disparitas; prw--<lb/> res
+								vero</hi> st <hi rend="italic">illi nmcetitur, rhythmum sibi
+								vindicent, suum­ <lb/> que ipsi nomen</hi> iMponant. <hi
+								rend="italic">Quapropter lectionem</hi> retinuimus <lb/>
+							<hi rend="italic">editionum :m. Er. et Lov.</hi> Falsa supj ositione
+							nititur illud ar­ <lb/> gumentum, scilicet paeonem
+							secundumcumnulloaliofede <lb/> posse misceri. nam paeon quartus, ut
+							testatur lihr. 2, n. 10, <lb/> dividi jiotest <hi rend="italic">aut</hi>
+							in <hi rend="italic">auo et tiia, alll ill tria et duo tempora :</hi>
+							<lb/> quæ divisio eum jaconi secundo maritat sine plausus dIs- <lb/> I
+							a: iiale. M. </note><note type="footnote"> 3 <hi rend="italic">,IlW meum
+								etiam Ill,</hi> juxta Er. I.ugd. ven. <hi rend="italic">imomeum,
+								<lb/> ne etiam tuum9</hi> juxta Ms. A. <hi rend="italic">II1W mew1t
+								est (jiuim luunt,</hi>
+							<lb/> juxta als. B. M. </note><note type="footnote"> 3 Hic et I aulo
+							post, quod, juxta vatic. M. </note><note type="footnote"> 4 fr. Lugd.
+							Ven. ct Lov., <hi rend="italic">et pro</hi> rma <hi rend="italic"
+								>ejus... constituas.</hi>
+							<lb/> iLss. A et ti., <hi rend="italic">ut</hi> pro <hi rend="italic"
+								>ima ejus quacumque hnga duas</hi> b TM3 <lb/>
 							<hi rend="italic">comtilKus.</hi> M. </note>
-						<lb/> tiri? <hi rend="italic">D.</hi> Ita est. <hi rend="italic">M.</hi> Quid, si
-						cujuslibet epitriti omnes <lb/> longas solvas in breves? num eliam de septem sylla­
-						<lb/> bisdubitandum est? D. Nullomodo. <hi rend="italic">M.</hi> Quid ipse dis­ <lb/>
-						pondeus? nonne octo efficit, cum pro omnibus lon­ <lb/> gis binas breves locamus? <hi rend="italic">D.</hi> Verissimum est.</p>
-					<p>12. <hi rend="italic">M.</hi> Quæ igitur ratio est, qua cogimur et tam <lb/> multarum
-						syllabarum metiri pedes, et pedem qui <lb/> adhibetur ad numeros, non excedere quatuor
-						sylla­ <lb/> bas, ante tractatis rationibus confitemur? nonne libi <lb/> videntur inter
-						se ista pugnare? <hi rend="italic">D.</hi> Imo maxime, et <lb/> quomodo istud pacari
-						possit, ignoro. <hi rend="italic">M.</hi> Etiam hoc <lb/> facile est, si te ipsum rursum
-						interroges, utrum ra­ <lb/> tionabiliter inter nos paulo anle constiterit, ideo pyr­
-						<lb/> rhichium,et proceleusmaticum plausu debere dijudi­ <lb/> cari atque discerni, ne
-						sit ullus pes legitimæ divisio­ <lb/> nis, qni rhythmum non faciat, id cst, ut ex eo
-						<lb/> rhythmus nominetur. <hi rend="italic">D.</hi> Hoc vero memini, et non <lb/>
-						invenio cur mihi placuisse poeniteat : sed quorsum <lb/> ista ? <hi rend="italic">M.</hi> Quia scilicet hi omnes pedes quaternarum <lb/> syllabarum, excepto
-						amphibracho, rhythmum faciunt, <lb/> id est, principatum in rhythmo tenent, eumque usu
-						<lb/> et nomine efficiunt : illi vero qui plures quam qua­ <lb/> tuor syllabas habent,
-						multi quidem pro his poni pos­ <lb/> sunt t; sed ipsi per se rhythmum facere, ac rhythmi
-						<lb/> nomen obtinere non possunt : el ideo ne pedes qui­ <lb/> dem istos appellandos
-						putaverim Quamobrem repu­ <lb/> gnantia illa quæ nos movebat, jam, ut opinor, conpo­
-						<lb/> sita est et sopita, quandoquidem licet ct plures <lb/> syllabas quam quatuor pro
-						aliquo pede ponere, et <lb/> pedem tamen non appellare, nisi eum quo rhythmus <lb/>
-						efficiatur. Oportebat cnim jedi constitui aliquem nio­ <lb/> dum progressionis in
-						syllabis. Is aulcm modus con­ <lb/> stitui optime potuit, qui de ipsa numerorum ratione
-						<lb/> translatus in quaternario constitit. Itaque longarum <lb/> syllabarum quatuor pes
-						esse potuit. Cum autcm pro <lb/> eo breves octo constituimus, quoniam tautum spatii
-						<lb/> habent in tempore, pro altero poni possunt. Quia <lb/> vero legitimam
-						progressionem, id est quaternarium <lb/> numerum cxcedunt, pro ac ipsi poui, ac rhythmum
-						<lb/> gignere non sensu aurium, sea disciplinae lege prohi­ <lb/> bentur. Nisi
-						contradicere aliquid paras.</p>
-					<p>13. <hi rend="italic">D.</hi> Paro sanc, et jam faciam. Nam quid impe­ <lb/> diebat
-						usque ad octonarium numerum syllabarum <lb/> progredi pedum, cum cumdem numerum ad rhy­
-						<lb/> thmum admitti posse videamus? n'eque enim me mo­ <lb/> vet, quod pro alio dicis
-						admitti : imo hoc me magis <lb/> admonet quærere. vel potius queri, quod non etiam <lb/>
-						suo nomine admittitur qui pro alio potest. <hi rend="italic">M.</hi> Non <lb/> mirum
-						est, quod hic falleris; sed facilis explicatio <lb/> veri est. Nam ut omittam tanta quæ
-						pro qnaternario <lb/> numero jam ante disputata sunt, cur usquc ad illum <lb/> fieri
-						debeat progressio sylhharmn; fac me jam ces­ <lb/> sisse libi et consensisse usque in
-						octo syllabas pedis <lb/> debere longitudinem porrigi : num resistere poteris <lb/> esse
-						jam posse octo longarum syllabarum pcdem ? <lb/> Certe enim ad quem numerum syllabarum
-						pervenit <lb/> pes, non solus ad cum pervenit qui brevibus, sed <note type="footnote"> 1
-							vatie.: <hi rend="italic">:'lli vero qvi</hi> pturc* <hi rend="italic">nuam quatuor
-								sijlLibns ha­ <lb/> bent, pro aliis poni possunt, zcd</hi> ilnl. M. </note>
+						<lb/> tiri? <hi rend="italic">D.</hi> Ita est. <hi rend="italic">M.</hi>
+						Quid, si cujuslibet epitriti omnes <lb/> longas solvas in breves? num eliam
+						de septem sylla­ <lb/> bisdubitandum est? D. Nullomodo. <hi rend="italic"
+							>M.</hi> Quid ipse dis­ <lb/> pondeus? nonne octo efficit, cum pro
+						omnibus lon­ <lb/> gis binas breves locamus? <hi rend="italic">D.</hi>
+						Verissimum est.</p>
+					</div>
+				<div type="textpart" subtype="dialog"><p>12. <hi rend="italic">M.</hi> Quæ igitur ratio est, qua cogimur et tam <lb/>
+						multarum syllabarum metiri pedes, et pedem qui <lb/> adhibetur ad numeros,
+						non excedere quatuor sylla­ <lb/> bas, ante tractatis rationibus confitemur?
+						nonne libi <lb/> videntur inter se ista pugnare? <hi rend="italic">D.</hi>
+						Imo maxime, et <lb/> quomodo istud pacari possit, ignoro. <hi rend="italic"
+							>M.</hi> Etiam hoc <lb/> facile est, si te ipsum rursum interroges,
+						utrum ra­ <lb/> tionabiliter inter nos paulo anle constiterit, ideo pyr­
+						<lb/> rhichium,et proceleusmaticum plausu debere dijudi­ <lb/> cari atque
+						discerni, ne sit ullus pes legitimæ divisio­ <lb/> nis, qni rhythmum non
+						faciat, id cst, ut ex eo <lb/> rhythmus nominetur. <hi rend="italic">D.</hi>
+						Hoc vero memini, et non <lb/> invenio cur mihi placuisse poeniteat : sed
+						quorsum <lb/> ista ? <hi rend="italic">M.</hi> Quia scilicet hi omnes pedes
+						quaternarum <lb/> syllabarum, excepto amphibracho, rhythmum faciunt, <lb/>
+						id est, principatum in rhythmo tenent, eumque usu <lb/> et nomine efficiunt
+						: illi vero qui plures quam qua­ <lb/> tuor syllabas habent, multi quidem
+						pro his poni pos­ <lb/> sunt t; sed ipsi per se rhythmum facere, ac rhythmi
+						<lb/> nomen obtinere non possunt : el ideo ne pedes qui­ <lb/> dem istos
+						appellandos putaverim Quamobrem repu­ <lb/> gnantia illa quæ nos movebat,
+						jam, ut opinor, conpo­ <lb/> sita est et sopita, quandoquidem licet ct
+						plures <lb/> syllabas quam quatuor pro aliquo pede ponere, et <lb/> pedem
+						tamen non appellare, nisi eum quo rhythmus <lb/> efficiatur. Oportebat cnim
+						jedi constitui aliquem nio­ <lb/> dum progressionis in syllabis. Is aulcm
+						modus con­ <lb/> stitui optime potuit, qui de ipsa numerorum ratione <lb/>
+						translatus in quaternario constitit. Itaque longarum <lb/> syllabarum
+						quatuor pes esse potuit. Cum autcm pro <lb/> eo breves octo constituimus,
+						quoniam tautum spatii <lb/> habent in tempore, pro altero poni possunt. Quia
+						<lb/> vero legitimam progressionem, id est quaternarium <lb/> numerum
+						cxcedunt, pro ac ipsi poui, ac rhythmum <lb/> gignere non sensu aurium, sea
+						disciplinae lege prohi­ <lb/> bentur. Nisi contradicere aliquid paras.</p>
+					</div>
+				<div type="textpart" subtype="dialog"><p>13. <hi rend="italic">D.</hi> Paro sanc, et jam faciam. Nam quid impe­ <lb/>
+						diebat usque ad octonarium numerum syllabarum <lb/> progredi pedum, cum
+						cumdem numerum ad rhy­ <lb/> thmum admitti posse videamus? n'eque enim me
+						mo­ <lb/> vet, quod pro alio dicis admitti : imo hoc me magis <lb/> admonet
+						quærere. vel potius queri, quod non etiam <lb/> suo nomine admittitur qui
+						pro alio potest. <hi rend="italic">M.</hi> Non <lb/> mirum est, quod hic
+						falleris; sed facilis explicatio <lb/> veri est. Nam ut omittam tanta quæ
+						pro qnaternario <lb/> numero jam ante disputata sunt, cur usquc ad illum
+						<lb/> fieri debeat progressio sylhharmn; fac me jam ces­ <lb/> sisse libi et
+						consensisse usque in octo syllabas pedis <lb/> debere longitudinem porrigi :
+						num resistere poteris <lb/> esse jam posse octo longarum syllabarum pcdem ?
+						<lb/> Certe enim ad quem numerum syllabarum pervenit <lb/> pes, non solus ad
+						cum pervenit qui brevibus, sed <note type="footnote"> 1 vatie.: <hi
+								rend="italic">:'lli vero qvi</hi> pturc* <hi rend="italic">nuam
+								quatuor sijlLibns ha­ <lb/> bent, pro aliis poni possunt, zcd</hi>
+							ilnl. M. </note>
 						<lb/>
-						<pb n="1123"/> etiam qni longis syllabis constat. Quo fit ut adhibita <lb/> rursus ea
-						lege, quæ abrogari non potest, qua duas <lb/> breves pro una longa poni licet, ad
-						sexdecim sylla­ <lb/> bas pertendamus. Ubi si rursus pedis incrementum <lb/> statuero
-						volueris, in triginta duas breves proficisci­ <lb/> mur : huc qnoque ratio tua pedem te
-						compellit addu­ <lb/> cere, at rursus lex illa duplum numerum brevium <lb/> pro longis
-						locare : atque ita nullus constituetur mo­ <lb/> dus. <hi rend="italic">D.</hi> Jam cedo
-						rationi, qua usque ad quaterna- <lb/> Tium syllabarum numerum promovemus pedem. Pro
-						<lb/> bis autem legitimis pedibus poni oportere pedes plu­ <lb/> rium syllabarum, dum
-						breves duae unius longæ locum <lb/> occupant non recuso.</p>
-					<ab>
-						<title type="sub">CAPUT VI. — <hi rend="italic">Pedes quatuor syllabis longiores</hi>
-							rhy­ thmum <hi rend="italic">suo nomine facere</hi> nequeunt.</title>
+						<pb n="1123"/> etiam qni longis syllabis constat. Quo fit ut adhibita <lb/>
+						rursus ea lege, quæ abrogari non potest, qua duas <lb/> breves pro una longa
+						poni licet, ad sexdecim sylla­ <lb/> bas pertendamus. Ubi si rursus pedis
+						incrementum <lb/> statuero volueris, in triginta duas breves proficisci­
+						<lb/> mur : huc qnoque ratio tua pedem te compellit addu­ <lb/> cere, at
+						rursus lex illa duplum numerum brevium <lb/> pro longis locare : atque ita
+						nullus constituetur mo­ <lb/> dus. <hi rend="italic">D.</hi> Jam cedo
+						rationi, qua usque ad quaterna- <lb/> Tium syllabarum numerum promovemus
+						pedem. Pro <lb/> bis autem legitimis pedibus poni oportere pedes plu­ <lb/>
+						rium syllabarum, dum breves duae unius longæ locum <lb/> occupant non
+						recuso.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT VI. — <hi rend="italic">Pedes quatuor syllabis
+								longiores</hi> rhy­ thmum <hi rend="italic">suo nomine facere</hi>
+							nequeunt.</title>
 					</ab>
-					<p>14. M. Facile est ergo te etiam illud videre atque <lb/> concedere, alios pedes esse
-						pro his, penes quos rhy­ <lb/> thmi est principatns, alios qui cum his collocantur.
-						<lb/> Nam ubi pro longis singulis geminantur breves, pro <lb/> eo qui rhythmum obtinet,
-						alium locamus; velut pro <lb/> iambo vel trochæo tribrachum, aut pro spondeo da­ <lb/>
-						ctylum aut anapæstum aut proceleusmaticum. Ubi <lb/> vero non idem fit, non pro co, sed
-						cum eo ponitur <lb/> quisquis miscetur inferiorum; ut cum dactylo anapae­ <lb/> atus ,
-						cum ionico vero utrolibet diiambus vel dicho­ <lb/> rius: et reliqui similiter san jure
-						cum cæteris. An pa­ <lb/> rum tibi dilucidum, vel falsum videtur <unclear>3</unclear> D.
-						Jam intel­ <lb/> iigo. <hi rend="italic">M.</hi> Responde ergo utrum illi qui pro aliis
-						<lb/> ponuntur, possint eliam ipsi pcr se facere rhythmum. <lb/> D. Possunt. M. Omnesne?
-							<hi rend="italic">D.</hi> Omnes. <hi rend="italic">M.</hi> Ergo et <lb/> quinque
-						syllabarum pes potest suonomine rhythmum <lb/> facere, quia pro bacchio vel cretico vel
-						quolibet <lb/> pæone poni potest. <hi rend="italic">D.</hi> Non potest quidem; sed jam
-						<lb/> istum non vocamus pedem, si progressionis illius us­ <lb/> que ad quaternarium
-						numerum satis memini t. Ego <lb/> autem cum omnes posse respondi, pedes utiquc <lb/>
-						posse respondi. M. Laudo etiam in nomine reti­ <lb/> nendo diligentiam et vigilantiam
-						tuam. Sed scias <lb/> multis visum esse etiam senarum syllabarum pedes <lb/> nun
-						cupandos ; sed amplius, quod sciam, nemini pla­ <lb/> cuit. Et illi quibus hoc placuit,
-						negaverunt ad rhy­ <lb/> thmum, aut ad metrum per se gignendum tam longos <lb/> pedes
-						adhiberi oportere. Itaque ne nomina quidcm <lb/> his indiderunt. Quocirca verissimus est
-						ille progres­ <lb/> sionis modus, qui usquead quatuor syllabas pervenit; <lb/>
-						quandoquidem hi omnes pedes, quibus divisis dno <lb/> 'Heri non possont, conjuncti pedem
-						facere potuerunt: <lb/> et ita qui in Mesiam syllabam usque progreesi sunt, <lb/> nomen
-						tantum pedis in eos, qui quaitam excesserunt, <lb/> transferre ausi sunt; ad principatum
-						vero , qui est <lb/> in rhythmis et metris, nuHo modo eos aspirare sive­ <lb/> runt. Sed
-						cum pro longis breves duplicantur, etiam <lb/> ad septimam atque octavam, ut jam
-						ostendit ratio, <lb/> syllabam pervenitur : ad quem numerum nemo te­ <lb/> tendit pedem.
-						Sed quoniam video constare inter nos <lb/> quemlibet plurium quam quatuor syllabarum,
-						cum pro <note type="footnote"> * sic Mss. A et ai B; at in B. legitur <hi rend="italic">sed jam istum non<lb/> vecart pedem, progressio tllius ultra qttaternarium nu­
-								<lb/> merum transeat, satis memini.</hi> Er. Lugd. Vea., si <hi rend="italic">progres</hi>sione etc.M. </note><lb/> longa duas breves ponimus, non cum his
-						legitimis <lb/> pedibus, sed pro hi, posse poni, neque per seipsos <lb/> rhythmum
-						creare, ne in infinitum eat quod ratione <lb/> finiendum est, satisque jam inter nos de
-						rhythmo exi. <lb/> sumo disputatum ; transeamus ad mItra, si placet. <lb/>
+					</div>
+				<div type="textpart" subtype="dialog"><p>14. M. Facile est ergo te etiam illud videre atque <lb/> concedere, alios
+						pedes esse pro his, penes quos rhy­ <lb/> thmi est principatns, alios qui
+						cum his collocantur. <lb/> Nam ubi pro longis singulis geminantur breves,
+						pro <lb/> eo qui rhythmum obtinet, alium locamus; velut pro <lb/> iambo vel
+						trochæo tribrachum, aut pro spondeo da­ <lb/> ctylum aut anapæstum aut
+						proceleusmaticum. Ubi <lb/> vero non idem fit, non pro co, sed cum eo
+						ponitur <lb/> quisquis miscetur inferiorum; ut cum dactylo anapae­ <lb/>
+						atus , cum ionico vero utrolibet diiambus vel dicho­ <lb/> rius: et reliqui
+						similiter san jure cum cæteris. An pa­ <lb/> rum tibi dilucidum, vel falsum
+						videtur <unclear>3</unclear> D. Jam intel­ <lb/> iigo. <hi rend="italic"
+							>M.</hi> Responde ergo utrum illi qui pro aliis <lb/> ponuntur, possint
+						eliam ipsi pcr se facere rhythmum. <lb/> D. Possunt. M. Omnesne? <hi
+							rend="italic">D.</hi> Omnes. <hi rend="italic">M.</hi> Ergo et <lb/>
+						quinque syllabarum pes potest suonomine rhythmum <lb/> facere, quia pro
+						bacchio vel cretico vel quolibet <lb/> pæone poni potest. <hi rend="italic"
+							>D.</hi> Non potest quidem; sed jam <lb/> istum non vocamus pedem, si
+						progressionis illius us­ <lb/> que ad quaternarium numerum satis memini t.
+						Ego <lb/> autem cum omnes posse respondi, pedes utiquc <lb/> posse respondi.
+						M. Laudo etiam in nomine reti­ <lb/> nendo diligentiam et vigilantiam tuam.
+						Sed scias <lb/> multis visum esse etiam senarum syllabarum pedes <lb/> nun
+						cupandos ; sed amplius, quod sciam, nemini pla­ <lb/> cuit. Et illi quibus
+						hoc placuit, negaverunt ad rhy­ <lb/> thmum, aut ad metrum per se gignendum
+						tam longos <lb/> pedes adhiberi oportere. Itaque ne nomina quidcm <lb/> his
+						indiderunt. Quocirca verissimus est ille progres­ <lb/> sionis modus, qui
+						usquead quatuor syllabas pervenit; <lb/> quandoquidem hi omnes pedes, quibus
+						divisis dno <lb/> 'Heri non possont, conjuncti pedem facere potuerunt: <lb/>
+						et ita qui in Mesiam syllabam usque progreesi sunt, <lb/> nomen tantum pedis
+						in eos, qui quaitam excesserunt, <lb/> transferre ausi sunt; ad principatum
+						vero , qui est <lb/> in rhythmis et metris, nuHo modo eos aspirare sive­
+						<lb/> runt. Sed cum pro longis breves duplicantur, etiam <lb/> ad septimam
+						atque octavam, ut jam ostendit ratio, <lb/> syllabam pervenitur : ad quem
+						numerum nemo te­ <lb/> tendit pedem. Sed quoniam video constare inter nos
+						<lb/> quemlibet plurium quam quatuor syllabarum, cum pro <note
+							type="footnote"> * sic Mss. A et ai B; at in B. legitur <hi
+								rend="italic">sed jam istum non<lb/> vecart pedem, progressio tllius
+								ultra qttaternarium nu­ <lb/> merum transeat, satis memini.</hi> Er.
+							Lugd. Vea., si <hi rend="italic">progres</hi>sione etc.M. </note><lb/>
+						longa duas breves ponimus, non cum his legitimis <lb/> pedibus, sed pro hi,
+						posse poni, neque per seipsos <lb/> rhythmum creare, ne in infinitum eat
+						quod ratione <lb/> finiendum est, satisque jam inter nos de rhythmo exi.
+						<lb/> sumo disputatum ; transeamus ad mItra, si placet. <lb/>
 						<hi rend="italic">D.</hi> Placet vero.</p>
-					<ab>
-						<title type="sub">-CAPUT VII. — <hi rend="italic">De</hi> metro <hi rend="italic">quibus
-								et quot</hi> minimum <hi rend="italic">constituatur pedibus.</hi>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">-CAPUT VII. — <hi rend="italic">De</hi> metro <hi
+								rend="italic">quibus et quot</hi> minimum <hi rend="italic"
+								>constituatur pedibus.</hi>
 						</title>
 					</ab>
-					<p>15. M. Dic igitur, metrumne arbitreris pedibusfleri, <lb/> an pedes metro. <hi rend="italic">D.</hi> Non intelligo. <hi rend="italic">M.</hi> Pedesne con­ <lb/>
-						juncti metrum creant, an metris conjunctis pedes cre­ <lb/> antur ? D. Scio jam quid
-						dicas, et conjunctis pedibus <lb/> metrum fieri pato. X. Cur tandem id putas! D. Quia
-						<lb/> inter rhythmum et metrum hoe interesse dixisti, quod <lb/> in rhythmo contextio
-						pedum nullum certum babet fi­ <lb/> Dem, in metro vero habet : ita ista pedum contextio
-						<lb/> et rhythmi et metri esse intelligitur ; sed ibi infinita, <lb/> hic autem finita
-						constat. <hi rend="italic">M.</hi> Ergo unus pes metrum <lb/> non est. <hi rend="italic">D.</hi> Non utique. H. Quid unus pes et semipes? <lb/>
-						<hi rend="italic">D.</hi> Ne hoc quidem. <hi rend="italic">II.</hi> Quare? an quia
-						metrum pedi­ <lb/> bus confit, nec utique possunt dici pedes, ubi minus <lb/> quam duo
-						sunt ? <hi rend="italic">D.</hi> Ita est. <hi rend="italic">M.</hi> Inspiciamus igitur
-						me­ <lb/> tra illa quæ a me paulo ante commemorata sunt, et <lb/> videamus quibus
-						pcdibus constent: non enim te in hoc <lb/> generc animadvertendo rudem esse adhuc decet.
-						Ea <lb/> sunt autem : <lb/> Ite igitur, Camœnæ <lb/> Fonticolx puellae, <lb/> Quae
-						canitis sub antris <lb/> Mellifluos sonores. <lb/> Satis hæc esse ad id quod intendimus
-						puto : tu jam <lb/> metire ista, et quos habeant pedes renuntia. D.Omni­ <lb/> no non
-						possum : eos enim metiendos puto, qui sibi le­ <lb/> gitime copulari queunt; nec valeo
-						me hinc expedire. <lb/> Si enim primum chorium fecero, sequitur iambus, qui <lb/>
-						temporibus par est, sed non similiter plauditur: si da­ <lb/> ctylum, non sequitur alius
-						qui ei saltem temporibus <lb/> coæquetur : si choriambum, eadem difficultas est; <lb/>
-						quod enim restat, nec temporibus cum eo, nec plausu <lb/> convenit. Quare aut hoc metrum
-						non est, aut falsum <lb/> est quod inter nos de pedum copulatione dissertum <lb/> est:
-						nam quid aliud dicam non invenio.</p>
-					<p>16. <hi rend="italic">M.</hi> Metrum quidem esse et eo quod plus es! <lb/> quam pes,
-						certumque finem habet, et ipsarum aurium <lb/> judicio convincitur 1 Non enim tam suavi
-						sonaret <lb/> æqualitate, aut motu tam concinno plaudcretur, si non <lb/> inesset in
-						illo numerositas, quoe profecto esse nisi iD <lb/> hac parte musicæ non potest. Falsa
-						vero esse, quæ <lb/> ioter nos constiterunt, miror quod existimes : non <lb/> enim aut
-						numcris quidquam est certius, aut illa pcdum <lb/> commemoratione et collocatione
-						ordinatius. Nain ex <lb/> ipsa numeroruin ratione, quæ nullo modo fallit, ei­ <lb/>
-						pressum est quidquid in cis et ad mulcendas aures, ct <lb/> ad obtinendum in rhythmo
-						principatum t valere pcr­ <lb/> speximus : sed vide potius cum sæpe repeto, <hi rend="italic">Que</hi> ca­ <lb/>
-						<hi rend="italic">nitis sub antris,</hi> dcmulccoque ista numerositate sen­ <lb/> sum
-						tuum; quid distat inter hoc, et si adderem ad <lb/> finem hujus brevem aliquam syllabam,
-						et item istud <lb/> eodem modo repeterem, <hi rend="italic">Qum canitis sub</hi>
-						antrisve? <hi rend="italic">D.</hi>
+					</div>
+				<div type="textpart" subtype="dialog"><p>15. M. Dic igitur, metrumne arbitreris pedibusfleri, <lb/> an pedes metro.
+							<hi rend="italic">D.</hi> Non intelligo. <hi rend="italic">M.</hi>
+						Pedesne con­ <lb/> juncti metrum creant, an metris conjunctis pedes cre­
+						<lb/> antur ? D. Scio jam quid dicas, et conjunctis pedibus <lb/> metrum
+						fieri pato. X. Cur tandem id putas! D. Quia <lb/> inter rhythmum et metrum
+						hoe interesse dixisti, quod <lb/> in rhythmo contextio pedum nullum certum
+						babet fi­ <lb/> Dem, in metro vero habet : ita ista pedum contextio <lb/> et
+						rhythmi et metri esse intelligitur ; sed ibi infinita, <lb/> hic autem
+						finita constat. <hi rend="italic">M.</hi> Ergo unus pes metrum <lb/> non
+						est. <hi rend="italic">D.</hi> Non utique. H. Quid unus pes et semipes? <lb/>
+						<hi rend="italic">D.</hi> Ne hoc quidem. <hi rend="italic">II.</hi> Quare?
+						an quia metrum pedi­ <lb/> bus confit, nec utique possunt dici pedes, ubi
+						minus <lb/> quam duo sunt ? <hi rend="italic">D.</hi> Ita est. <hi
+							rend="italic">M.</hi> Inspiciamus igitur me­ <lb/> tra illa quæ a me
+						paulo ante commemorata sunt, et <lb/> videamus quibus pcdibus constent: non
+						enim te in hoc <lb/> generc animadvertendo rudem esse adhuc decet. Ea <lb/>
+						sunt autem : <lb/> Ite igitur, Camœnæ <lb/> Fonticolx puellae, <lb/> Quae
+						canitis sub antris <lb/> Mellifluos sonores. <lb/> Satis hæc esse ad id quod
+						intendimus puto : tu jam <lb/> metire ista, et quos habeant pedes renuntia.
+						D.Omni­ <lb/> no non possum : eos enim metiendos puto, qui sibi le­ <lb/>
+						gitime copulari queunt; nec valeo me hinc expedire. <lb/> Si enim primum
+						chorium fecero, sequitur iambus, qui <lb/> temporibus par est, sed non
+						similiter plauditur: si da­ <lb/> ctylum, non sequitur alius qui ei saltem
+						temporibus <lb/> coæquetur : si choriambum, eadem difficultas est; <lb/>
+						quod enim restat, nec temporibus cum eo, nec plausu <lb/> convenit. Quare
+						aut hoc metrum non est, aut falsum <lb/> est quod inter nos de pedum
+						copulatione dissertum <lb/> est: nam quid aliud dicam non invenio.</p>
+					</div>
+				<div type="textpart" subtype="dialog"><p>16. <hi rend="italic">M.</hi> Metrum quidem esse et eo quod plus es! <lb/>
+						quam pes, certumque finem habet, et ipsarum aurium <lb/> judicio convincitur
+						1 Non enim tam suavi sonaret <lb/> æqualitate, aut motu tam concinno
+						plaudcretur, si non <lb/> inesset in illo numerositas, quoe profecto esse
+						nisi iD <lb/> hac parte musicæ non potest. Falsa vero esse, quæ <lb/> ioter
+						nos constiterunt, miror quod existimes : non <lb/> enim aut numcris quidquam
+						est certius, aut illa pcdum <lb/> commemoratione et collocatione ordinatius.
+						Nain ex <lb/> ipsa numeroruin ratione, quæ nullo modo fallit, ei­ <lb/>
+						pressum est quidquid in cis et ad mulcendas aures, ct <lb/> ad obtinendum in
+						rhythmo principatum t valere pcr­ <lb/> speximus : sed vide potius cum sæpe
+						repeto, <hi rend="italic">Que</hi> ca­ <lb/>
+						<hi rend="italic">nitis sub antris,</hi> dcmulccoque ista numerositate sen­
+						<lb/> sum tuum; quid distat inter hoc, et si adderem ad <lb/> finem hujus
+						brevem aliquam syllabam, et item istud <lb/> eodem modo repeterem, <hi
+							rend="italic">Qum canitis sub</hi> antrisve? <hi rend="italic">D.</hi>
 						<note type="footnote"> 1 CGiivetmwtr, jUXt: Er. et Mss. A ct B. M. </note>
 						<lb/>
-						<pb n="1125"/> Utrumque mihi jucunde illabitur auribus : hoc tamen <lb/> posterius, cui
-						syllab::m addidisti brevem, plus tenere <lb/> spatii ac temporis, siquidem longius
-						factum est, cogor <lb/> fateri. <hi rend="italic">M.</hi> Quid cum illud superius, <hi rend="italic">Qu</hi>æ <hi rend="italic">canitis</hi> sub <hi rend="italic">an­<lb/>
-							tris,</hi> ita repeto, ut post Onem nihil sileam ? eademne <lb/> ad te jucunditas
-						pervenit ? <hi rend="italic">D.</hi> Imo nescio quid clau­ <lb/> dum me offendit, nisi
-						torte illam uUimam plus quam <lb/> Cæteras longas produxeris. M. Ergo sive idipsum am­
-						<lb/> plius quod producitur, sive quod siletur, censesne in <lb/> tempore babere aliquid
-						spatii ? <hi rend="italic">D.</hi> Qui aliter potest?</p>
-					<ab>
-						<title type="sub">CAPUT VIII — Silentia in metris quanta <hi rend="italic">adhiberi
-								oportet. Metrum quod dicatur.</hi>
+						<pb n="1125"/> Utrumque mihi jucunde illabitur auribus : hoc tamen <lb/>
+						posterius, cui syllab::m addidisti brevem, plus tenere <lb/> spatii ac
+						temporis, siquidem longius factum est, cogor <lb/> fateri. <hi rend="italic"
+							>M.</hi> Quid cum illud superius, <hi rend="italic">Qu</hi>æ <hi
+							rend="italic">canitis</hi> sub <hi rend="italic">an­<lb/> tris,</hi> ita
+						repeto, ut post Onem nihil sileam ? eademne <lb/> ad te jucunditas pervenit
+						? <hi rend="italic">D.</hi> Imo nescio quid clau­ <lb/> dum me offendit,
+						nisi torte illam uUimam plus quam <lb/> Cæteras longas produxeris. M. Ergo
+						sive idipsum am­ <lb/> plius quod producitur, sive quod siletur, censesne in
+						<lb/> tempore babere aliquid spatii ? <hi rend="italic">D.</hi> Qui aliter
+						potest?</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT VIII — Silentia in metris quanta <hi rend="italic"
+								>adhiberi oportet. Metrum quod dicatur.</hi>
 						</title>
 					</ab>
-					<p>17. M. Recte censes. Sed dic mibi etiam quantum <lb/> spatium putas esse? <hi rend="italic">D.</hi> Metiri hoc omnino difficile est. <lb/> It. Vcrum dicis : sed
-						nonne tibi videtur brevis illa syl­ <lb/> laba id metiri, quam cum addidimus, neque
-						longæ <lb/> ultimae ultra solitum productionem, neque ullam si­ <lb/> lentium in ejus
-						metri repetitionc sensus desideravit? D. <lb/> Omnino assentior : nam et te illud
-						superius pronun­ <lb/> tiante atque repetente, hoc posterius ego apud me ipse <lb/>
-						repetebam pariter tecum : ita sensi idem spatium tem­ <lb/> poris ambobus occurrere, cum
-						silentio tuo brevis mea <lb/> ultima conveniret. M. Teneas Igitur oportet hæc si­ <lb/>
-						lentiorum spatia certa in metris esse. Quare cum <lb/> in veneris aliquid deesse pedi
-						legitimo, considerare <lb/> te oportebit, utrum dimenso 1 atque annumerato si­ <lb/>
-						lentio compensetur. <hi rend="italic">D.</hi> Teneo jam istud, persequcre <lb/>
-						cætera.</p>
-					<p>18. II. Video jam nos quærere debere ipsius si­ <lb/> lentii modum : namque in hoc
-						metro, ubi post cho­ <lb/> riambum bacchium comperimus , quia unum tempus <lb/> dees! ut
-						sex temporum esset sicut choriambus, fa­ <lb/> cillime id aures senserunt, et in
-						repetitione tanti <lb/> spatii silentium interponere coegerunt, quantum syl­ <lb/> laba
-						occuparet brevis : at si post choriambum lo­ <lb/> cetur spondeus, duo nobis tempora cum
-						2 silentio <lb/> peragenda sunt ad caput redeuntibus, veluti hoc est, <lb/>
-						<hi rend="italic">Quoe</hi> canitis <hi rend="italic">fontem.</hi> Nam te sentire jam
-						credo si­ <lb/> lendum esse. ut cum redimus ad caput, plausus non <lb/> claudicet. Sed
-						ut experiri queas quanta sihntii hujus <lb/> mensura sit, adde unam syllabam longam, ut
-						Gat, <hi rend="italic">Quce<lb/> canitis fontem</hi> vos ; atque hoc cam plausu repete :
-						vi­ <lb/> bubis tantum occupare temporis plausum, quantum in <lb/> dpperiore occupabat,
-						cum ibi duæ longæ post choriam 0 <lb/> sum, hic tres sint locatæ. Unde apparet duum iLi
-						<lb/> temporum interponi silentium. At si post choriambum <lb/> iambus locetur, sicut
-						hoc est, <hi rend="italic">Quas canitis locos,</hi> tria <lb/> tempora silere cogimur:
-						quod ut exploretur, adduntur <lb/> sive per alterunt iambum, sive per choriom, sive per
-						<lb/> tribrachum ut sit ita : <hi rend="italic">Qua</hi> canitis <hi rend="italic">locos
-							bonos:</hi> aut, <lb/>
-						<hi rend="italic">Qu</hi>æ <hi rend="italic">canitis locos monte</hi> : aut, <hi rend="italic">Qum</hi> canis locos <hi rend="italic">nemore.</hi>
-						<lb/> II 5 caina additis, cum sine silentio jucunda et æquabi- <lb/> Ii... repetitio
-						movet, et plausu adhibito tantum spatii <lb/> hiic tria singula tenere inveniuntur,
-						quantum illud in <lb/> quo silebamus, manifestum fit trium temporum ibi esse <note type="footnote"> * juxta <unclear>atie</unclear>., <hi rend="italic">in menso atque
+					</div>
+				<div type="textpart" subtype="dialog"><p>17. M. Recte censes. Sed dic mibi etiam quantum <lb/> spatium putas esse? <hi
+							rend="italic">D.</hi> Metiri hoc omnino difficile est. <lb/> It. Vcrum
+						dicis : sed nonne tibi videtur brevis illa syl­ <lb/> laba id metiri, quam
+						cum addidimus, neque longæ <lb/> ultimae ultra solitum productionem, neque
+						ullam si­ <lb/> lentium in ejus metri repetitionc sensus desideravit? D.
+						<lb/> Omnino assentior : nam et te illud superius pronun­ <lb/> tiante atque
+						repetente, hoc posterius ego apud me ipse <lb/> repetebam pariter tecum :
+						ita sensi idem spatium tem­ <lb/> poris ambobus occurrere, cum silentio tuo
+						brevis mea <lb/> ultima conveniret. M. Teneas Igitur oportet hæc si­ <lb/>
+						lentiorum spatia certa in metris esse. Quare cum <lb/> in veneris aliquid
+						deesse pedi legitimo, considerare <lb/> te oportebit, utrum dimenso 1 atque
+						annumerato si­ <lb/> lentio compensetur. <hi rend="italic">D.</hi> Teneo jam
+						istud, persequcre <lb/> cætera.</p>
+					</div>
+				<div type="textpart" subtype="dialog"><p>18. II. Video jam nos quærere debere ipsius si­ <lb/> lentii modum : namque
+						in hoc metro, ubi post cho­ <lb/> riambum bacchium comperimus , quia unum
+						tempus <lb/> dees! ut sex temporum esset sicut choriambus, fa­ <lb/> cillime
+						id aures senserunt, et in repetitione tanti <lb/> spatii silentium
+						interponere coegerunt, quantum syl­ <lb/> laba occuparet brevis : at si post
+						choriambum lo­ <lb/> cetur spondeus, duo nobis tempora cum 2 silentio <lb/>
+						peragenda sunt ad caput redeuntibus, veluti hoc est, <lb/>
+						<hi rend="italic">Quoe</hi> canitis <hi rend="italic">fontem.</hi> Nam te
+						sentire jam credo si­ <lb/> lendum esse. ut cum redimus ad caput, plausus
+						non <lb/> claudicet. Sed ut experiri queas quanta sihntii hujus <lb/>
+						mensura sit, adde unam syllabam longam, ut Gat, <hi rend="italic">Quce<lb/>
+							canitis fontem</hi> vos ; atque hoc cam plausu repete : vi­ <lb/> bubis
+						tantum occupare temporis plausum, quantum in <lb/> dpperiore occupabat, cum
+						ibi duæ longæ post choriam 0 <lb/> sum, hic tres sint locatæ. Unde apparet
+						duum iLi <lb/> temporum interponi silentium. At si post choriambum <lb/>
+						iambus locetur, sicut hoc est, <hi rend="italic">Quas canitis locos,</hi>
+						tria <lb/> tempora silere cogimur: quod ut exploretur, adduntur <lb/> sive
+						per alterunt iambum, sive per choriom, sive per <lb/> tribrachum ut sit ita
+						: <hi rend="italic">Qua</hi> canitis <hi rend="italic">locos bonos:</hi>
+						aut, <lb/>
+						<hi rend="italic">Qu</hi>æ <hi rend="italic">canitis locos monte</hi> : aut,
+							<hi rend="italic">Qum</hi> canis locos <hi rend="italic">nemore.</hi>
+						<lb/> II 5 caina additis, cum sine silentio jucunda et æquabi- <lb/> Ii...
+						repetitio movet, et plausu adhibito tantum spatii <lb/> hiic tria singula
+						tenere inveniuntur, quantum illud in <lb/> quo silebamus, manifestum fit
+						trium temporum ibi esse <note type="footnote"> * juxta
+								<unclear>atie</unclear>., <hi rend="italic">in menso atque
 								annumerato silentio</hi> com­ <lb/>
 							<hi rend="italic">pensetur. M.</hi>
-						</note><note type="footnote"> 17 <hi rend="italic">empora silentio,</hi> juxta vatic..
-							omisa pnepoaitione, . <lb/> cum. M </note>
-						<lb/> silentium. Potest post cborianjbum una syllaba longa <lb/> constitui, ut quatuor
-						tempora sileantur. Nam etiam sic <lb/> choriambus dividi potest, ut simplo ct duplo
-						levatio <lb/> sibi positioque conveniant. Hujus metri exemplum est, <lb/> Qum cantia <hi rend="italic">rea.</hi> Cui si addas vel duas lungas, vel lon­ <lb/> gam et duas
-						breves, vel brevem et longam et brevem, <lb/> vel duas breves ct longam, vel quatuor
-						breves, imple­ <lb/> bis sex temporum pedem, ut nullo desiderato silentio <lb/>
-						repetatur. Talia sunt, <hi rend="italic">Qu</hi>æ <hi rend="italic">canitis rea
+						</note><note type="footnote"> 17 <hi rend="italic">empora silentio,</hi>
+							juxta vatic.. omisa pnepoaitione, . <lb/> cum. M </note>
+						<lb/> silentium. Potest post cborianjbum una syllaba longa <lb/> constitui,
+						ut quatuor tempora sileantur. Nam etiam sic <lb/> choriambus dividi potest,
+						ut simplo ct duplo levatio <lb/> sibi positioque conveniant. Hujus metri
+						exemplum est, <lb/> Qum cantia <hi rend="italic">rea.</hi> Cui si addas vel
+						duas lungas, vel lon­ <lb/> gam et duas breves, vel brevem et longam et
+						brevem, <lb/> vel duas breves ct longam, vel quatuor breves, imple­ <lb/>
+						bis sex temporum pedem, ut nullo desiderato silentio <lb/> repetatur. Talia
+						sunt, <hi rend="italic">Qu</hi>æ <hi rend="italic">canitis rea
 							pulchras,</hi> Qum <lb/>
-						<hi rend="italic">canitis rea in bona,</hi> Qum <hi rend="italic">canitis res bonumve,
-							Quas ca</hi> .niti, <lb/>
-						<hi rend="italic">nilis rea teneras , Qu</hi>æ <hi rend="italic">canitis rea modo
-							bene.</hi> Quibus <lb/> cognitis atque concessis, credo tibi jam satis apparere, <lb/>
-						nec minus uno tempore sileri posse, nec plus quatuor <lb/> temporibus sileri oportere.
-						Nam et ipsa est illa, de qua <lb/> jam multa dicta sunt, moderata progressio; et in
-						<lb/> omnibus pedibus nulla levatio aut positio amplius quam <lb/> quatuor occupat
-						tempora.</p>
-					<p>19. Itaque cnm aliquid canitur sive pronuntiatur <lb/> quod habeat certum finem, et
-						plus habeat quam ununt <lb/> pedem, et naturali motu ante considerationem nume­ <lb/>
-						rorum sensum quadam aequabilitate demulceat1, jam <lb/> me:rum est. Quanquam enim minus
-						habeat quam duos <lb/> pedes, tamen quia excedit unum et silere cogit, non <lb/> sine
-						mensura , sed I quantum implendis temporibus <lb/> satis est quae alteri debentur pedi;
-						pro duobuspedibus <lb/> auditus accipit •, quod duorum pedum occupat tempera <lb/> donec
-						ad caput redeatur, dum annumeratur sono etinm <lb/> certum atque dimensum intervalli
-						silentium. Sed jain <lb/> mihi dicas velim , utrum his quæ dicta sunt cognitis <lb/>
-						assentiaris. <hi rend="italic">D.</hi> Cognovi et assentior. <hi rend="italic">M.</hi>
-						Mihine cre­ <lb/> dens, an per te ipse vera esse perspiciens ? <hi rend="italic">D.</hi>
-						Per me <lb/> ipse sanc, quamvis dicente te vera hac esse cognosco.</p>
-					<ab>
-						<title type="sub">CAPUT IX — <hi rend="italic">Quot ad summum temporibus ac pedibul
-								metrum constare possit.</hi>
+						<hi rend="italic">canitis rea in bona,</hi> Qum <hi rend="italic">canitis
+							res bonumve, Quas ca</hi> .niti, <lb/>
+						<hi rend="italic">nilis rea teneras , Qu</hi>æ <hi rend="italic">canitis rea
+							modo bene.</hi> Quibus <lb/> cognitis atque concessis, credo tibi jam
+						satis apparere, <lb/> nec minus uno tempore sileri posse, nec plus quatuor
+						<lb/> temporibus sileri oportere. Nam et ipsa est illa, de qua <lb/> jam
+						multa dicta sunt, moderata progressio; et in <lb/> omnibus pedibus nulla
+						levatio aut positio amplius quam <lb/> quatuor occupat tempora.</p>
+					<p>19. Itaque cnm aliquid canitur sive pronuntiatur <lb/> quod habeat certum
+						finem, et plus habeat quam ununt <lb/> pedem, et naturali motu ante
+						considerationem nume­ <lb/> rorum sensum quadam aequabilitate demulceat1,
+						jam <lb/> me:rum est. Quanquam enim minus habeat quam duos <lb/> pedes,
+						tamen quia excedit unum et silere cogit, non <lb/> sine mensura , sed I
+						quantum implendis temporibus <lb/> satis est quae alteri debentur pedi; pro
+						duobuspedibus <lb/> auditus accipit •, quod duorum pedum occupat tempera
+						<lb/> donec ad caput redeatur, dum annumeratur sono etinm <lb/> certum atque
+						dimensum intervalli silentium. Sed jain <lb/> mihi dicas velim , utrum his
+						quæ dicta sunt cognitis <lb/> assentiaris. <hi rend="italic">D.</hi> Cognovi
+						et assentior. <hi rend="italic">M.</hi> Mihine cre­ <lb/> dens, an per te
+						ipse vera esse perspiciens ? <hi rend="italic">D.</hi> Per me <lb/> ipse
+						sanc, quamvis dicente te vera hac esse cognosco.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT IX — <hi rend="italic">Quot ad summum temporibus ac
+								pedibul metrum constare possit.</hi>
 						</title>
 					</ab>
-					<p>20. <hi rend="italic">II.</hi> Age ergo nunc quoniam invenimus unde <lb/> metrum esse
-						incipiat, inveniamus etiam quousque pro­ <lb/> cedat. Nam metrum incipit a duobus
-						pedibus, sive ipso <lb/> sono plenis, sive ad implendum quod deest annume­ <lb/> rato
-						silentio. Quare oportet te jam respiccre ad illam <lb/> quaternariam progressionem,
-						mihique renuntiare us­ <lb/> que ad quot pedes metrum tendere debeamus. <hi rend="italic">D.</hi> Fa­ <lb/> cHe istud quidcm est. Nam octo pedes esse ratio salis
-						<lb/> ducet. <hi rend="italic">3f.</hi> Quid? illud recordarisne, dixisse nos eum <lb/>
-						versum a doctis appellatum, qui duobus membris certa <lb/> ratione dimensis copulatisque
-						constaret? <hi rend="italic">D.</hi> Bene me­ <lb/> mini. M. Cum ergo non sit dictum
-						duobus pcdibus, <lb/> sed duobns membris constare versum, cumque mani­ <lb/> festam sit
-						versum non unum pedem habere, sed plures; <lb/> nonne Ipsa res indicat longius membrum
-						esse quam <lb/> pedem ? <hi rend="italic">D.</hi> Ita vero. <hi rend="italic">M.</hi> At
-						si membra æqualia sint iti <lb/> versu, nonne præposterari poterit, ut prima pars sine
-						<lb/> discrimine ultima, et ultima prima fiat? D. Intelligo <lb/>
-						<hi rend="italic">M. Ergo ut hoc</hi> non accidat 4, satisque appareat discer­ <lb/>
-						naturque in versu aliud esse membrum quo incipit, <lb/> aliud quo desinit ; non possumus
-						recusare inæqualia <note type="footnote">s <hi rend="italic">Aqualtiate,</hi> iuxta
-							vatlc. ct blS. A. M. </note><note type="footnote"> t <hi rend="italic">Et,</hi> jutta
-							vatic. at. </note><note type="footnote"> • <hi rend="italic">fccepit,</hi> juxta
-							eumdem. SI. </note><note type="footnote"> a Er., <hi rend="italic">ne accidat.</hi>
-							ven. 1.0 v , Ms. A, <hi rend="italic">hoc n* accidct,</hi> Sic <lb/> euani LUt;tJ.,
-							<unclear/> S4'1't.a laiijvu vocc, <hi rend="italic">hoc</hi> M. </note>
+					<p>20. <hi rend="italic">II.</hi> Age ergo nunc quoniam invenimus unde <lb/>
+						metrum esse incipiat, inveniamus etiam quousque pro­ <lb/> cedat. Nam metrum
+						incipit a duobus pedibus, sive ipso <lb/> sono plenis, sive ad implendum
+						quod deest annume­ <lb/> rato silentio. Quare oportet te jam respiccre ad
+						illam <lb/> quaternariam progressionem, mihique renuntiare us­ <lb/> que ad
+						quot pedes metrum tendere debeamus. <hi rend="italic">D.</hi> Fa­ <lb/> cHe
+						istud quidcm est. Nam octo pedes esse ratio salis <lb/> ducet. <hi
+							rend="italic">3f.</hi> Quid? illud recordarisne, dixisse nos eum <lb/>
+						versum a doctis appellatum, qui duobus membris certa <lb/> ratione dimensis
+						copulatisque constaret? <hi rend="italic">D.</hi> Bene me­ <lb/> mini. M.
+						Cum ergo non sit dictum duobus pcdibus, <lb/> sed duobns membris constare
+						versum, cumque mani­ <lb/> festam sit versum non unum pedem habere, sed
+						plures; <lb/> nonne Ipsa res indicat longius membrum esse quam <lb/> pedem ?
+							<hi rend="italic">D.</hi> Ita vero. <hi rend="italic">M.</hi> At si
+						membra æqualia sint iti <lb/> versu, nonne præposterari poterit, ut prima
+						pars sine <lb/> discrimine ultima, et ultima prima fiat? D. Intelligo <lb/>
+						<hi rend="italic">M. Ergo ut hoc</hi> non accidat 4, satisque appareat
+						discer­ <lb/> naturque in versu aliud esse membrum quo incipit, <lb/> aliud
+						quo desinit ; non possumus recusare inæqualia <note type="footnote">s <hi
+								rend="italic">Aqualtiate,</hi> iuxta vatlc. ct blS. A. M.
+							</note><note type="footnote"> t <hi rend="italic">Et,</hi> jutta vatic.
+							at. </note><note type="footnote"> • <hi rend="italic">fccepit,</hi>
+							juxta eumdem. SI. </note><note type="footnote"> a Er., <hi rend="italic"
+								>ne accidat.</hi> ven. 1.0 v , Ms. A, <hi rend="italic">hoc n*
+								accidct,</hi> Sic <lb/> euani LUt;tJ., <unclear/> S4'1't.a laiijvu
+							vocc, <hi rend="italic">hoc</hi> M. </note>
 						<lb/>
-						<pb n="1127"/> membra esse oportere. <hi rend="italic">D.</hi> Nullo modo. <hi rend="italic">M.</hi> Id ergo <lb/> prius in pyrrhichio consideremus, si placet, inquo
-						jam <lb/> credo videri libi minus tribus temporibus membrum <lb/> esse non posse,
-						quoniam id primum est plus quam pes. <lb/> D. Assentior. M. Ergo minimus versus quot
-						tempora <lb/> possidebit? <hi rend="italic">D.</hi> Dicerem sex, nisi me illa
-						praeposteratio <lb/> revocaret. Septem ergo hahebit : quia minus quam tria <lb/> membrum
-						babere non potest; plus autem habere, non­ <lb/> dum prohibitum est. <hi rend="italic">M.</hi> Recte intelligis. Sed dic quot <lb/> pedes pyrrhichios habeant septem
-						tempora. <hi rend="italic">D.</hi> Tres <lb/> et semis. <hi rend="italic">M.</hi>
-						Debetur ergo unius temporis silentium; <lb/> dum ad principium reditur, ut spatium pedis
-						possit im­ <lb/> pleri. <hi rend="italic">D.</hi> Debetur sane. <hi rend="italic">M.</hi> Hoc annumeratoquot tem. <lb/> pora erunt? D. Octo. <hi rend="italic">M.</hi>
-						Ut ergo minimus, qui etiam <lb/> primus est pes , minus quam duo; ita minimus qui <lb/>
-						primus est versus, minus habere quam octo tempora <lb/> non potest. <hi rend="italic">D.</hi> Ita est. <hi rend="italic">M.</hi> Quid maximus versus, quo <lb/> ampliorem
-						esse non oporteat? quot tandem temporum <lb/> esse debet ? Nonne statim videbis, si ad
-						illam progres­ <lb/> sionem retulerimus animum, de qua toties tam multa <lb/> dicta sunt
-						? <hi rend="italic">D.</hi> Jam intelligo ampliorem quam triginta <lb/> duum temporum
-						versum osse non posse.</p>
-					<p>21. <hi rend="italic">M.</hi> Quid de metri longitudine? censesne am­ <lb/> pliorem
-						esse dcberc qnam versus1, cum metrum id <lb/> quod est minimum, tam minus sit quam
-						minimus ver- <note type="footnote">1 In B., <hi rend="italic">versum.</hi> Melius cum
-							Ms. A, <hi rend="italic">versus.</hi> M. </note>
-						<lb/> sus? <hi rend="italic">D.</hi> Non censeo. <hi rend="italic">M.</hi> Cum ergo
-						metrum incipiat <lb/> a duobus pcdihus, versus a quatuor; aut illud ab spa­ <lb/> tio
-						duorum pedum, hoc a quatuor annumerato silen­ <lb/> tio; metrum autcm octo pedes non
-						excedat: nonne <lb/> cnm et versus metrum sit, necesse est eum pedes <lb/> totidem non
-						excedere ? <hi rend="italic">D.</hi> Ita est. M. Rursus cum <lb/> versus non sit longior
-						quam triginta duum temporum, <lb/> et metrum sit etiam longitudo versus, si conjunctio­
-						<lb/> nem duorum membrorum talem non habeat qualis in <lb/> versu præcipitur, sed
-						tantum1 certo fine claudatur, <lb/> neque debeat longius esse quam versus : nonne ma­
-						<lb/> nifestum est ut versum pedes octo, ita metrum tri­ <lb/> ginta duo tempora
-						excedere non oportere? D. Assen­ <lb/> tior. M. Erit ergo idem spatium temporis, et idem
-						<lb/> numcrus pedum et metro et versui, communisque <lb/> quidam terminus, ultra quem
-						progredi utrumque <lb/> non debeat : quamvis metrum quadruplicatis pedi­ <lb/> bus, a
-						quibus esse incipit; versus autem quadrupli­ <lb/> catis temporibus, a quibus et ipse
-						esse incipit, finia­ <lb/> tur : ut crescendi scilicet modum quaternaria illa <lb/>
-						ratione servata metrum cum versu communicaverit <lb/> in pcdibus, versus cum metro in
-						temporibus. <hi rend="italic">D.</hi> In­ <lb/> telligo, et probo; atque ita se habere
-						istam concur­ <lb/> diam consensionemquc delector. <note type="footnote"> 4 <hi rend="italic">Tamen,</hi> juxta vatic. M. </note><note type="footnote"> I Ita legit
-							vatic. : <hi rend="italic">it idem mmierus pedum;</hi> et <hi rend="italic">quidam
-								<lb/> tcrimnus metro et versui communi, ultra quem.</hi> M. </note>
+						<pb n="1127"/> membra esse oportere. <hi rend="italic">D.</hi> Nullo modo.
+							<hi rend="italic">M.</hi> Id ergo <lb/> prius in pyrrhichio
+						consideremus, si placet, inquo jam <lb/> credo videri libi minus tribus
+						temporibus membrum <lb/> esse non posse, quoniam id primum est plus quam
+						pes. <lb/> D. Assentior. M. Ergo minimus versus quot tempora <lb/>
+						possidebit? <hi rend="italic">D.</hi> Dicerem sex, nisi me illa
+						praeposteratio <lb/> revocaret. Septem ergo hahebit : quia minus quam tria
+						<lb/> membrum babere non potest; plus autem habere, non­ <lb/> dum
+						prohibitum est. <hi rend="italic">M.</hi> Recte intelligis. Sed dic quot
+						<lb/> pedes pyrrhichios habeant septem tempora. <hi rend="italic">D.</hi>
+						Tres <lb/> et semis. <hi rend="italic">M.</hi> Debetur ergo unius temporis
+						silentium; <lb/> dum ad principium reditur, ut spatium pedis possit im­
+						<lb/> pleri. <hi rend="italic">D.</hi> Debetur sane. <hi rend="italic"
+							>M.</hi> Hoc annumeratoquot tem. <lb/> pora erunt? D. Octo. <hi
+							rend="italic">M.</hi> Ut ergo minimus, qui etiam <lb/> primus est pes ,
+						minus quam duo; ita minimus qui <lb/> primus est versus, minus habere quam
+						octo tempora <lb/> non potest. <hi rend="italic">D.</hi> Ita est. <hi
+							rend="italic">M.</hi> Quid maximus versus, quo <lb/> ampliorem esse non
+						oporteat? quot tandem temporum <lb/> esse debet ? Nonne statim videbis, si
+						ad illam progres­ <lb/> sionem retulerimus animum, de qua toties tam multa
+						<lb/> dicta sunt ? <hi rend="italic">D.</hi> Jam intelligo ampliorem quam
+						triginta <lb/> duum temporum versum osse non posse.</p>
+					<p>21. <hi rend="italic">M.</hi> Quid de metri longitudine? censesne am­ <lb/>
+						pliorem esse dcberc qnam versus1, cum metrum id <lb/> quod est minimum, tam
+						minus sit quam minimus ver- <note type="footnote">1 In B., <hi rend="italic"
+								>versum.</hi> Melius cum Ms. A, <hi rend="italic">versus.</hi> M. </note>
+						<lb/> sus? <hi rend="italic">D.</hi> Non censeo. <hi rend="italic">M.</hi>
+						Cum ergo metrum incipiat <lb/> a duobus pcdihus, versus a quatuor; aut illud
+						ab spa­ <lb/> tio duorum pedum, hoc a quatuor annumerato silen­ <lb/> tio;
+						metrum autcm octo pedes non excedat: nonne <lb/> cnm et versus metrum sit,
+						necesse est eum pedes <lb/> totidem non excedere ? <hi rend="italic">D.</hi>
+						Ita est. M. Rursus cum <lb/> versus non sit longior quam triginta duum
+						temporum, <lb/> et metrum sit etiam longitudo versus, si conjunctio­ <lb/>
+						nem duorum membrorum talem non habeat qualis in <lb/> versu præcipitur, sed
+						tantum1 certo fine claudatur, <lb/> neque debeat longius esse quam versus :
+						nonne ma­ <lb/> nifestum est ut versum pedes octo, ita metrum tri­ <lb/>
+						ginta duo tempora excedere non oportere? D. Assen­ <lb/> tior. M. Erit ergo
+						idem spatium temporis, et idem <lb/> numcrus pedum et metro et versui,
+						communisque <lb/> quidam terminus, ultra quem progredi utrumque <lb/> non
+						debeat : quamvis metrum quadruplicatis pedi­ <lb/> bus, a quibus esse
+						incipit; versus autem quadrupli­ <lb/> catis temporibus, a quibus et ipse
+						esse incipit, finia­ <lb/> tur : ut crescendi scilicet modum quaternaria
+						illa <lb/> ratione servata metrum cum versu communicaverit <lb/> in pcdibus,
+						versus cum metro in temporibus. <hi rend="italic">D.</hi> In­ <lb/> telligo,
+						et probo; atque ita se habere istam concur­ <lb/> diam consensionemquc
+						delector. <note type="footnote"> 4 <hi rend="italic">Tamen,</hi> juxta
+							vatic. M. </note><note type="footnote"> I Ita legit vatic. : <hi
+								rend="italic">it idem mmierus pedum;</hi> et <hi rend="italic"
+								>quidam <lb/> tcrimnus metro et versui communi, ultra quem.</hi> M.
+						</note>
 					</p>
 				</div>
-				<div type="textpart" subtype="chapter">
+				<div type="textpart" subtype="book">
 					<head>
-						<title type="main"><hi rend="italic">LIBER QUARTUS.</hi> Continuatur tractatio de
-							metro.</title>
+						<title type="main"><hi rend="italic">LIBER QUARTUS.</hi> Continuatur
+							tractatio de metro.</title>
 					</head>
-					<ab>
-						<title type="sub">CAPUT PRIMUM. — <hi rend="italic">Ultima syllaba quare indifferens in
-								metro.</hi>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT PRIMUM. — <hi rend="italic">Ultima syllaba quare
+								indifferens in metro.</hi>
 						</title>
 					</ab>
-					<p><hi rend="italic">1. M.</hi> Redeamus ergo ad metri considerationem, pro­ <lb/> pter
-						cujus progressum ac longitudinem de versu te­ <lb/> cum aliquid agere coactus sum, cujus
-						tractandi postea <lb/> nobis est conslilulus locus. Sed primo illud quærO, <lb/> utrum
-						non repudies, quod ultimam syllabam, quæ <lb/> metrum terminat, seu longa seu brevis
-						sit, poeLc at­ <lb/> que horum judices grammatici nihil ad rem pertinere <lb/> arbitrati
-						sunt. <hi rend="italic">D.</hi> Omnino repudio : non cnim mihi <lb/> vidctur esse
-						rationis. M. Dic mihi, obsecro, quod me­ <lb/> trum sit in pyrrhichio minimum. <hi rend="italic">D.</hi> Tres breves. <hi rend="italic">II.</hi>
-						<lb/> Quantum ergo silendum est, dum repetitur? <hi rend="italic">D.</hi> Unum <lb/>
-						tempus, quod cst unius brevis syllabae spatium. <hi rend="italic">M.</hi>
+					<p><hi rend="italic">1. M.</hi> Redeamus ergo ad metri considerationem, pro­
+						<lb/> pter cujus progressum ac longitudinem de versu te­ <lb/> cum aliquid
+						agere coactus sum, cujus tractandi postea <lb/> nobis est conslilulus locus.
+						Sed primo illud quærO, <lb/> utrum non repudies, quod ultimam syllabam, quæ
+						<lb/> metrum terminat, seu longa seu brevis sit, poeLc at­ <lb/> que horum
+						judices grammatici nihil ad rem pertinere <lb/> arbitrati sunt. <hi
+							rend="italic">D.</hi> Omnino repudio : non cnim mihi <lb/> vidctur esse
+						rationis. M. Dic mihi, obsecro, quod me­ <lb/> trum sit in pyrrhichio
+						minimum. <hi rend="italic">D.</hi> Tres breves. <hi rend="italic">II.</hi>
+						<lb/> Quantum ergo silendum est, dum repetitur? <hi rend="italic">D.</hi>
+						Unum <lb/> tempus, quod cst unius brevis syllabae spatium. <hi rend="italic"
+							>M.</hi>
 						<lb/> Age, jam perente hoc metrum, non voce, sed plausu. <lb/>
-						<hi rend="italic">D.</hi> Feci. <hi rend="italic">M.</hi> Percute etiam hoc modo
-						anapæstum. <hi rend="italic">D.</hi>
-						<lb/> Ei hoc feci. <hi rend="italic">M.</hi> Quid libi visum cst interesse? <hi rend="italic">D.</hi>
-						<lb/> Prorsus nihil. <hi rend="italic">M.</hi> Quid? causam, cur ita sit, potesne <lb/>
-						dicere? D. Videtur mihi satis apparere : nam quod in <lb/> illo ad silentium, hoc in
-						isto ad productionem ultimae <lb/> syllabae refertur; nam codem modo ibi brevis ultima,
-						<lb/> ut hic long:., percutitur; et post tantumdem interval­ <lb/> lum rcditur ad caput.
-						Sed ibi quiescitur donec spa­ <lb/> tium pyrrhichii pedis, hic donec longæ syllabae im­
-						<lb/> pleatur. Ita in utroque par mora cst, qua inlerposlLa <lb/> remeamns. <hi rend="italic">M.</hi> Non igitur absurde illi ultimam sylla­ <lb/> bam metri, seu
-						longa scu brevis sii. nihil ad rem per­ <lb/> tinere voluerunt : ubi enim finis cst,
-						silentium sequi­ <lb/> tur, quantum ad ipsum metrum attinet quod finitur. <lb/> An eos
-						in bac causa repe itioncm ullam vel reditum <lb/> ad caput considerare debuisse
-						existimas, ac non tan­ <lb/> tummodo quia finitur, quasi deinceps uihil dicendum <lb/>
-						sit? <hi rend="italic">D.</hi> Jam assentior, ultimam syllabam indifferenter <lb/> esse
-						accipiendam. M. Recte. Sed si hoc propter silen­ <lb/> tium fit, quoniam ita
-						consideratus est finis, quasi <lb/> deinceps nihil soniturus1 sit qui fmicrit, et ob hoc
-						<lb/> spatium temporis in ipsa quiete largissimum niliil di­ <lb/> stat quoe ibi syllaba
-						locetur; nonne illud est conse­ <lb/> quens, ut ipsa ultimae syllabæ indifferentia, quae
-						pro­ <lb/> pter largum spatium conceditur, ad id proficiat, ut <lb/> sive ibi brevis
-						syllaba sive longa sit, cam sibi aures <lb/> pro longa vindicent ? <hi rend="italic">D.</hi> Video plane esse consequens.</p>
-					<ab>
-						<title type="sub">CAPUT II. — <hi rend="italic">Quoi syllabis minimum constituatur</hi>
-							pyr­ rhichium <hi rend="italic">metrum : quamdiu quoqne silendum.</hi>
+						<hi rend="italic">D.</hi> Feci. <hi rend="italic">M.</hi> Percute etiam hoc
+						modo anapæstum. <hi rend="italic">D.</hi>
+						<lb/> Ei hoc feci. <hi rend="italic">M.</hi> Quid libi visum cst interesse?
+							<hi rend="italic">D.</hi>
+						<lb/> Prorsus nihil. <hi rend="italic">M.</hi> Quid? causam, cur ita sit,
+						potesne <lb/> dicere? D. Videtur mihi satis apparere : nam quod in <lb/>
+						illo ad silentium, hoc in isto ad productionem ultimae <lb/> syllabae
+						refertur; nam codem modo ibi brevis ultima, <lb/> ut hic long:., percutitur;
+						et post tantumdem interval­ <lb/> lum rcditur ad caput. Sed ibi quiescitur
+						donec spa­ <lb/> tium pyrrhichii pedis, hic donec longæ syllabae im­ <lb/>
+						pleatur. Ita in utroque par mora cst, qua inlerposlLa <lb/> remeamns. <hi
+							rend="italic">M.</hi> Non igitur absurde illi ultimam sylla­ <lb/> bam
+						metri, seu longa scu brevis sii. nihil ad rem per­ <lb/> tinere voluerunt :
+						ubi enim finis cst, silentium sequi­ <lb/> tur, quantum ad ipsum metrum
+						attinet quod finitur. <lb/> An eos in bac causa repe itioncm ullam vel
+						reditum <lb/> ad caput considerare debuisse existimas, ac non tan­ <lb/>
+						tummodo quia finitur, quasi deinceps uihil dicendum <lb/> sit? <hi
+							rend="italic">D.</hi> Jam assentior, ultimam syllabam indifferenter
+						<lb/> esse accipiendam. M. Recte. Sed si hoc propter silen­ <lb/> tium fit,
+						quoniam ita consideratus est finis, quasi <lb/> deinceps nihil soniturus1
+						sit qui fmicrit, et ob hoc <lb/> spatium temporis in ipsa quiete largissimum
+						niliil di­ <lb/> stat quoe ibi syllaba locetur; nonne illud est conse­ <lb/>
+						quens, ut ipsa ultimae syllabæ indifferentia, quae pro­ <lb/> pter largum
+						spatium conceditur, ad id proficiat, ut <lb/> sive ibi brevis syllaba sive
+						longa sit, cam sibi aures <lb/> pro longa vindicent ? <hi rend="italic"
+							>D.</hi> Video plane esse consequens.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT II. — <hi rend="italic">Quoi syllabis minimum
+								constituatur</hi> pyr­ rhichium <hi rend="italic">metrum : quamdiu
+								quoqne silendum.</hi>
 						</title>
 					</ab>
-					<p>i. <hi rend="italic">M.</hi> Videsne etiam illud, cum dicimUs minimum <lb/> metrum esse
-						pyrrhichium tres breves syllabas, ut <lb/> unius brevis spatio sileatur, dum ad initium
-						reverti­ <lb/> mur; nihil interesse, utrum hoc metrum, an pedes <lb/> anapæstos
-						repetamus? <hi rend="italic">D.</hi> Jain hoc quidem paulo ante <lb/> illa percussione
-						percepi. M. Nonne irgo quidquid hic <lb/> est conf..sum, distinguendum aliqua ratione
-						arbitra­ <lb/> ris? <hi rend="italic">D.</hi> Omnino arbitror. <hi rend="italic">M.</hi>
-						Dic utrum aliam videas <note type="footnote"> I sonaturus, juxta vatic. et Ms. A. v </note>
+					<p>i. <hi rend="italic">M.</hi> Videsne etiam illud, cum dicimUs minimum <lb/>
+						metrum esse pyrrhichium tres breves syllabas, ut <lb/> unius brevis spatio
+						sileatur, dum ad initium reverti­ <lb/> mur; nihil interesse, utrum hoc
+						metrum, an pedes <lb/> anapæstos repetamus? <hi rend="italic">D.</hi> Jain
+						hoc quidem paulo ante <lb/> illa percussione percepi. M. Nonne irgo quidquid
+						hic <lb/> est conf..sum, distinguendum aliqua ratione arbitra­ <lb/> ris?
+							<hi rend="italic">D.</hi> Omnino arbitror. <hi rend="italic">M.</hi> Dic
+						utrum aliam videas <note type="footnote"> I sonaturus, juxta vatic. et Ms.
+							A. v </note>
 						<lb/>
-						<pb n="1129"/> esse rationem, quae ista distinguat, nisi ut metrum <lb/> pyrrhichium non
-						illud sit minimum, quod tibi videba­ <lb/> tur in tribus brevibus, sed in quinque. Post
-						unum <lb/> enim pedem ac semipedem silere mora semipedis <lb/> ejus qui debetur implendo
-						pedi, atque ila rcdire ad <lb/> initium, et hoc minimum metrum in pyrrhichio con­ <lb/>
-						stituere non nos sinit anapæsti parilitas, ut jam de­ <lb/> monstratum est: quare post
-						duos pedes et semipedem <lb/> silendum est illud unum tempus, si confusione carere <lb/>
-						volumus. <hi rend="italic">D.</hi> Cur enim non duo pyrrhichii sunt mini­ <lb/> mum
-						metrum in pyrrhichio, et quatuor syllabæ breves <lb/> potius, post quas silere opus non
-						sit, quam quinque <lb/> post quas opus sit? <hi rend="italic">M.</hi> Vigilanter quidem,
-						sed non <lb/> caves ne ab hoc te ita proceleusmaticus, ut ab illo ana­ <lb/> pæstus
-						excludat. <hi rend="italic">D.</hi> V crum dicis. <hi rend="italic">II.</hi> Placet ergo
-						hic <lb/> modus in quinque brevibus, et silentio unius tempo­ <lb/> . ris? <hi rend="italic">D.</hi> Placet vero. <hi rend="italic">II.</hi> Videtur mihi oblitum
-						esse te, <lb/> quomadmodum in rhythmo dixerimus posse discerni <lb/> utruni pyrrhichio
-						an proceleusmatico curreretur. <hi rend="italic">D.</hi>
-						<lb/> Bene admones : nam plausu istos numcros ab invicem <lb/> distinguendos comperimus
-						: quare jam neque hic <lb/> isium proceleusmaticum metuo, quem plausu adhibito <lb/> a
-						pyrrbichio discernere potero. <hi rend="italic">M.</hi> Cur igitur non <lb/> eumdem
-						plausum adhibendum vidisti, ut ab illis tri­ <lb/> bus brevibus, id est jyrrhichio et
-						scmipcde, post <lb/> quem oporteret unum tempus silere, discerneretur <lb/> anapcestus?
-							<hi rend="italic">D.</hi> Jam intelligo, et in viam redeo, me­ <lb/> trumque in
-						pyrrhichio minimum tres syllabas breves, <lb/> quae, annumerato silentio, duorum
-						pyrrhichiorum <lb/> tempus occupant, esse confirmo. <hi rend="italic">M.</hi> Probant
-						ergo <lb/> aures tuæ hoc genus numeri: <hi rend="italic">Si aliqua, Bene vis, Bene<lb/>
-							dic, Bene fac, Animus,</hi> Si ali;uid, <hi rend="italic">Male</hi> vis, <hi rend="italic">Male dir, <lb/> Maie fac, Animus, Medium est. D.</hi> Satis probant,
-						<lb/> præsertim cum jam rccordalus sim quemadmodum <lb/> eas plaudi oporteat, ne cnm
-						metro pyrrhicliio ana­ <lb/> paesti confundantur pedes.</p>
-					<p>3. <hi rend="italic">M.</hi> Vide et ista : Si <hi rend="italic">aliquid</hi> es , <hi rend="italic">Age bene, Male <lb/> quiayit, Nihil agit,</hi> Et <hi rend="italic">ideo, Miser erit. D.</hi> Suaviter <lb/> etiam ista se insinuant, nisi uno loco, uhi
-						finis tertii <lb/> cum initio quarti copulatur. M. Idipsum omnino est, <lb/> quod a tuis
-						auribus desideravi. Non enim frustra sen­ <lb/> sus offenditur, cum omnium syllabarum
-						nullo inter­ <lb/> posito silentio tempora singula exspectat : quam ex­ <lb/>
-						spectationem profecto fraudat concursus duarum <lb/> consonauLium, t el II, quæ
-						præcedentem vocalem <lb/> longam esse cogunt, et in duo tempora extendunt; <lb/> quod
-						genus grammatici positione longam syllabam <lb/> vocant. Sed propter illam ultimae
-						syllabæ indilferen­ <lb/> tiam , nemo criminatur hoc metrum , cum id since­ <lb/> ras
-						atque severæ aures ctiam sine accusatore conde­ <lb/> mnent. Nam vide, quæso, quantum
-						interest, si pro <lb/> eo quod est, <lb/> Male qui agit, Nihil agit : <lb/> Male qui
+						<pb n="1129"/> esse rationem, quae ista distinguat, nisi ut metrum <lb/>
+						pyrrhichium non illud sit minimum, quod tibi videba­ <lb/> tur in tribus
+						brevibus, sed in quinque. Post unum <lb/> enim pedem ac semipedem silere
+						mora semipedis <lb/> ejus qui debetur implendo pedi, atque ila rcdire ad
+						<lb/> initium, et hoc minimum metrum in pyrrhichio con­ <lb/> stituere non
+						nos sinit anapæsti parilitas, ut jam de­ <lb/> monstratum est: quare post
+						duos pedes et semipedem <lb/> silendum est illud unum tempus, si confusione
+						carere <lb/> volumus. <hi rend="italic">D.</hi> Cur enim non duo pyrrhichii
+						sunt mini­ <lb/> mum metrum in pyrrhichio, et quatuor syllabæ breves <lb/>
+						potius, post quas silere opus non sit, quam quinque <lb/> post quas opus
+						sit? <hi rend="italic">M.</hi> Vigilanter quidem, sed non <lb/> caves ne ab
+						hoc te ita proceleusmaticus, ut ab illo ana­ <lb/> pæstus excludat. <hi
+							rend="italic">D.</hi> V crum dicis. <hi rend="italic">II.</hi> Placet
+						ergo hic <lb/> modus in quinque brevibus, et silentio unius tempo­ <lb/> .
+						ris? <hi rend="italic">D.</hi> Placet vero. <hi rend="italic">II.</hi>
+						Videtur mihi oblitum esse te, <lb/> quomadmodum in rhythmo dixerimus posse
+						discerni <lb/> utruni pyrrhichio an proceleusmatico curreretur. <hi
+							rend="italic">D.</hi>
+						<lb/> Bene admones : nam plausu istos numcros ab invicem <lb/> distinguendos
+						comperimus : quare jam neque hic <lb/> isium proceleusmaticum metuo, quem
+						plausu adhibito <lb/> a pyrrbichio discernere potero. <hi rend="italic"
+							>M.</hi> Cur igitur non <lb/> eumdem plausum adhibendum vidisti, ut ab
+						illis tri­ <lb/> bus brevibus, id est jyrrhichio et scmipcde, post <lb/>
+						quem oporteret unum tempus silere, discerneretur <lb/> anapcestus? <hi
+							rend="italic">D.</hi> Jam intelligo, et in viam redeo, me­ <lb/> trumque
+						in pyrrhichio minimum tres syllabas breves, <lb/> quae, annumerato silentio,
+						duorum pyrrhichiorum <lb/> tempus occupant, esse confirmo. <hi rend="italic"
+							>M.</hi> Probant ergo <lb/> aures tuæ hoc genus numeri: <hi
+							rend="italic">Si aliqua, Bene vis, Bene<lb/> dic, Bene fac, Animus,</hi>
+						Si ali;uid, <hi rend="italic">Male</hi> vis, <hi rend="italic">Male dir,
+							<lb/> Maie fac, Animus, Medium est. D.</hi> Satis probant, <lb/>
+						præsertim cum jam rccordalus sim quemadmodum <lb/> eas plaudi oporteat, ne
+						cnm metro pyrrhicliio ana­ <lb/> paesti confundantur pedes.</p>
+					<p>3. <hi rend="italic">M.</hi> Vide et ista : Si <hi rend="italic">aliquid</hi>
+						es , <hi rend="italic">Age bene, Male <lb/> quiayit, Nihil agit,</hi> Et <hi
+							rend="italic">ideo, Miser erit. D.</hi> Suaviter <lb/> etiam ista se
+						insinuant, nisi uno loco, uhi finis tertii <lb/> cum initio quarti
+						copulatur. M. Idipsum omnino est, <lb/> quod a tuis auribus desideravi. Non
+						enim frustra sen­ <lb/> sus offenditur, cum omnium syllabarum nullo inter­
+						<lb/> posito silentio tempora singula exspectat : quam ex­ <lb/>
+						spectationem profecto fraudat concursus duarum <lb/> consonauLium, t el II,
+						quæ præcedentem vocalem <lb/> longam esse cogunt, et in duo tempora
+						extendunt; <lb/> quod genus grammatici positione longam syllabam <lb/>
+						vocant. Sed propter illam ultimae syllabæ indilferen­ <lb/> tiam , nemo
+						criminatur hoc metrum , cum id since­ <lb/> ras atque severæ aures ctiam
+						sine accusatore conde­ <lb/> mnent. Nam vide, quæso, quantum interest, si
+						pro <lb/> eo quod est, <lb/> Male qui agit, Nihil agit : <lb/> Male qui
 						agit, Homo perit. dicatur, <lb/>
-						<hi rend="italic">D.</hi> Hoc sane liquidum atque integrum est. M. noc <lb/> ergo nos
-						observemus propter musicaE sinceritatem , <lb/> quod poetæ non observant propter
-						facilitatem canen­ <lb/> di : ut quoties, exempli causa , nobis necesse est ali. <lb/>
-						qua metra interponere, in qufbus nihil debetur pedi <lb/> quod silentio compensetur, eas
-						ponamus ultimas syl- <lb/> labas quas lex ejusdem numeri flagital : ne eum ali­ <lb/>
-						qua offensione aurium et falsitate mensuræ, a fine <lb/> ad initium redeamus;
-						concedentes tamen illis ut ita <lb/> metra talia finiant, quasi deinceps nihil dicturi,
-						et <lb/> idco extremam syllabam seu longam seu brevem im­ <lb/> pune constituant : nam
-						in continuatione metrorum <lb/> apertissime convincuntur aurium judicio, non se <lb/>
-						debere poncre ultimam, nisi quae ipsius metri jure <lb/> atque ratione ponenda est. Hæc
-						autem continuatio <lb/> iit, cum pedi nihil debetur propter quod silere co­ <lb/> gamur.
-						D. Intelligo, et gratum habeo quod talia pol­ <lb/> liceris exempta , quibus nullam
-						patiatur sensus in­ <lb/> jurialn.</p>
-					<ab>
-						<title type="sub">CAPUT III. — <hi rend="italic">Pyrrhichiorum</hi> metrorum <hi rend="italic">ordo et</hi> numerus.</title>
+						<hi rend="italic">D.</hi> Hoc sane liquidum atque integrum est. M. noc <lb/>
+						ergo nos observemus propter musicaE sinceritatem , <lb/> quod poetæ non
+						observant propter facilitatem canen­ <lb/> di : ut quoties, exempli causa ,
+						nobis necesse est ali. <lb/> qua metra interponere, in qufbus nihil debetur
+						pedi <lb/> quod silentio compensetur, eas ponamus ultimas syl- <lb/> labas
+						quas lex ejusdem numeri flagital : ne eum ali­ <lb/> qua offensione aurium
+						et falsitate mensuræ, a fine <lb/> ad initium redeamus; concedentes tamen
+						illis ut ita <lb/> metra talia finiant, quasi deinceps nihil dicturi, et
+						<lb/> idco extremam syllabam seu longam seu brevem im­ <lb/> pune
+						constituant : nam in continuatione metrorum <lb/> apertissime convincuntur
+						aurium judicio, non se <lb/> debere poncre ultimam, nisi quae ipsius metri
+						jure <lb/> atque ratione ponenda est. Hæc autem continuatio <lb/> iit, cum
+						pedi nihil debetur propter quod silere co­ <lb/> gamur. D. Intelligo, et
+						gratum habeo quod talia pol­ <lb/> liceris exempta , quibus nullam patiatur
+						sensus in­ <lb/> jurialn.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT III. — <hi rend="italic">Pyrrhichiorum</hi> metrorum
+								<hi rend="italic">ordo et</hi> numerus.</title>
 					</ab>
-					<p>d. M. Age, nunc ordine de his quoque renuntia <lb/> pyrrhichiis : <lb/> Quid erit homo
-						<lb/> Qui amat hominem, <lb/> si amet in eo <lb/> Fragile quod est? <lb/> Amet igitur
-						<lb/> Animum hominis, <lb/> £t erit homo <lb/> Aliquid amans. <lb/> Quid haec videntur ?
-							<hi rend="italic">D.</hi> Quid nisi suavissime atque <lb/> integerrime currere ? M.
-						Quid ista ? <lb/> x Bonus erit amor, <lb/> Anima bona sit: <lb/> Amor inhabitat, <lb/>
-						Et anima domus. <lb/> lea bene habitat, <lb/> Ubi bona domus; <lb/> Ubi mala, male. <lb/>
-						<hi rend="italic">D.</hi> Eliam ista continuata suavissime aedpio. M. <lb/> Nunc tres
-						semis pedes, vide : <lb/> Animus bominis eat <lb/> Mala bonave agitans. <lb/> Bona
-						voluit, habet; <lb/> Mala voluit, habet. <lb/>
-						<hi rend="italic">D.</hi> Hæc quoqne interposito unius temporis silentio, <lb/> jucunda
-						sunt. <hi rend="italic">M.</hi> Sequuntur quatuor pleni pyrrlii­ <lb/> chii; hos accipe,
-						et judica: <lb/> - Animus hominis agit <lb/> Ut habeat ea bona, <lb/> Quibus inhabitet
-						homo, <lb/> Nihil ibi metuitur. <lb/>
-						<hi rend="italic">D.</hi> In his quoque certa et jucunda mensura est. <lb/> M. Auli jam
-						nunc novem syllabas breves ; audi et <lb/> judica: <lb/> Homo malus amat et eget; <lb/>
-						Malus etenim ea bona amat, <lb/> Mihil ubi satiat eum. <lb/>
-						<hi rend="italic">D.</hi> Prome nunc qniAquc pyrrhichios. <hi rend="italic">M.</hi>
+					<p>d. M. Age, nunc ordine de his quoque renuntia <lb/> pyrrhichiis : <lb/> Quid
+						erit homo <lb/> Qui amat hominem, <lb/> si amet in eo <lb/> Fragile quod
+						est? <lb/> Amet igitur <lb/> Animum hominis, <lb/> £t erit homo <lb/>
+						Aliquid amans. <lb/> Quid haec videntur ? <hi rend="italic">D.</hi> Quid
+						nisi suavissime atque <lb/> integerrime currere ? M. Quid ista ? <lb/> x
+						Bonus erit amor, <lb/> Anima bona sit: <lb/> Amor inhabitat, <lb/> Et anima
+						domus. <lb/> lea bene habitat, <lb/> Ubi bona domus; <lb/> Ubi mala, male. <lb/>
+						<hi rend="italic">D.</hi> Eliam ista continuata suavissime aedpio. M. <lb/>
+						Nunc tres semis pedes, vide : <lb/> Animus bominis eat <lb/> Mala bonave
+						agitans. <lb/> Bona voluit, habet; <lb/> Mala voluit, habet. <lb/>
+						<hi rend="italic">D.</hi> Hæc quoqne interposito unius temporis silentio,
+						<lb/> jucunda sunt. <hi rend="italic">M.</hi> Sequuntur quatuor pleni
+						pyrrlii­ <lb/> chii; hos accipe, et judica: <lb/> - Animus hominis agit
+						<lb/> Ut habeat ea bona, <lb/> Quibus inhabitet homo, <lb/> Nihil ibi
+						metuitur. <lb/>
+						<hi rend="italic">D.</hi> In his quoque certa et jucunda mensura est. <lb/>
+						M. Auli jam nunc novem syllabas breves ; audi et <lb/> judica: <lb/> Homo
+						malus amat et eget; <lb/> Malus etenim ea bona amat, <lb/> Mihil ubi satiat
+						eum. <lb/>
+						<hi rend="italic">D.</hi> Prome nunc qniAquc pyrrhichios. <hi rend="italic"
+							>M.</hi>
 						<lb/> Levicula fragilia bona, <lb/> Qui amat homo, similiterhabet. <lb/>
-						<hi rend="italic">D.</hi> Jam hoc sat est, et probo; nunc adde semi­ <lb/> pedem. M.
-						Faciam : <lb/> vaga levia fragilia bona, <lb/> Qui amat homo, similis erit eis. <lb/>
+						<hi rend="italic">D.</hi> Jam hoc sat est, et probo; nunc adde semi­ <lb/>
+						pedem. M. Faciam : <lb/> vaga levia fragilia bona, <lb/> Qui amat homo,
+						similis erit eis. <lb/>
 						<hi rend="italic">D.</hi> Bene prorsus ; ci sex jam exspecto pyrrhicmos. <lb/>
-						<hi rend="italic">M.</hi> Et bos audi : <lb/> Vaga levicula fragQia booa, . <lb/> Qui
-						adamat homo, similis erit eis. <lb/>
-						<hi rend="italic">D.</hi> Satis est; adde semipcdem. M. <lb/> Fluida levicula fragilia
-						bona <lb/> Quæ adamat anima, similis erit <unclear/>
+						<hi rend="italic">M.</hi> Et bos audi : <lb/> Vaga levicula fragQia booa, .
+						<lb/> Qui adamat homo, similis erit eis. <lb/>
+						<hi rend="italic">D.</hi> Satis est; adde semipcdem. M. <lb/> Fluida
+						levicula fragilia bona <lb/> Quæ adamat anima, similis erit <unclear/>
 						<note type="footnote">PATROL. XXXII.</note>
 						<note type="footnote"><hi rend="italic">(Trente-six.)</hi></note>
 						<lb/>
-						<pb n="1131"/> D Sat est, et bene est; da jam septem pyrrhi­ <lb/> chios. M. <lb/>
-						Levicula fragilia gracilia bona, <lb/> Quæ adamai animula, similis erit eis. <lb/> D.
-						Accedat his semipes; nam hoc eleganter se <lb/> habeL. <hi rend="italic">Al.</hi>
-						<lb/> vaga fluida levicula fragilia bona, <lb/> Qux adamat animula, fit ea similis cis.
-						<lb/> D. Octo pedes jam restare video, ut jam istas mi­ <lb/> nutias evadamus. Quanquam
-						enim approbent aures <lb/> naturali quadam dimensione quod sonas, nolim te <lb/> tamen
-						tot breves syllabas quærere; quas, ni fallor, <lb/> contoxtas invenire in conjunctione
-						verborum diffici­ <lb/> lius est, quam si eis miscere longas liceret. <hi rend="italic">M.</hi> Ni­ <lb/> hil te fallit, et ul tibi probem gratulationem meam, <lb/> quod
-						hinc aliquando transire permittimur, metrum <lb/> quod restat hujus generis sententia
-						feliciore compo­ <lb/> uam I : <lb/> solida bona bonus amat, et ea qui amat habet. <lb/>
-						Itaque nec eget amor, et ea bona Deus est. <lb/>
-						<hi rend="italic">D.</hi> Habeo cumulatissime perlecta metra pyrrhichii. <lb/> Sequuntur
-						iambica, de quibus mihi singulis bina <lb/> exempla sufficiunt, quæ nulla
-						interpellatione audire <lb/> delectat.</p>
-					<ab>
-						<title type="sub">CAPUT <hi rend="italic">IV. - De m</hi> tro <hi rend="italic">iambico.</hi>
+						<pb n="1131"/> D Sat est, et bene est; da jam septem pyrrhi­ <lb/> chios. M.
+						<lb/> Levicula fragilia gracilia bona, <lb/> Quæ adamai animula, similis
+						erit eis. <lb/> D. Accedat his semipes; nam hoc eleganter se <lb/> habeL.
+							<hi rend="italic">Al.</hi>
+						<lb/> vaga fluida levicula fragilia bona, <lb/> Qux adamat animula, fit ea
+						similis cis. <lb/> D. Octo pedes jam restare video, ut jam istas mi­ <lb/>
+						nutias evadamus. Quanquam enim approbent aures <lb/> naturali quadam
+						dimensione quod sonas, nolim te <lb/> tamen tot breves syllabas quærere;
+						quas, ni fallor, <lb/> contoxtas invenire in conjunctione verborum diffici­
+						<lb/> lius est, quam si eis miscere longas liceret. <hi rend="italic"
+							>M.</hi> Ni­ <lb/> hil te fallit, et ul tibi probem gratulationem meam,
+						<lb/> quod hinc aliquando transire permittimur, metrum <lb/> quod restat
+						hujus generis sententia feliciore compo­ <lb/> uam I : <lb/> solida bona
+						bonus amat, et ea qui amat habet. <lb/> Itaque nec eget amor, et ea bona
+						Deus est. <lb/>
+						<hi rend="italic">D.</hi> Habeo cumulatissime perlecta metra pyrrhichii.
+						<lb/> Sequuntur iambica, de quibus mihi singulis bina <lb/> exempla
+						sufficiunt, quæ nulla interpellatione audire <lb/> delectat.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT <hi rend="italic">IV. - De m</hi> tro <hi
+								rend="italic">iambico.</hi>
 						</title>
 					</ab>
-					<p>5. <hi rend="italic">M.</hi> Geram tibi morem. Sed ista quæ jam per­ <lb/> egimus quot
-						sunt? <hi rend="italic">D.</hi> Quatuordecim. <hi rend="italic">M.</hi> Quot etiam <lb/>
-						iambica fore credis? <hi rend="italic">D.</hi> Æque quatuordecim. <hi rend="italic">M.</hi>
-						<lb/> Quid, si in eis velim pro iambo tribrachum ponere , <lb/> nonne multiformior
-						varietas erit? D. Manifestum est <lb/> quidem : sed ego exempla ista in solis iambis
-						audire <lb/> cupio , ne longum faciamus : pro quavis enim longa <lb/> syllaba duas
-						breves posse poni , facilis disciplina est. <lb/>
-						<hi rend="italic">II.</hi> Faciam quod vis, gratumque habeo quod intelli­ <lb/> gentia
-						sequaci minuis laborem meum : sed aurcm ad <lb/> iambicum præbe. D. Istic sum, incipe.
-							<hi rend="italic">M.</hi>
+					<p>5. <hi rend="italic">M.</hi> Geram tibi morem. Sed ista quæ jam per­ <lb/>
+						egimus quot sunt? <hi rend="italic">D.</hi> Quatuordecim. <hi rend="italic"
+							>M.</hi> Quot etiam <lb/> iambica fore credis? <hi rend="italic">D.</hi>
+						Æque quatuordecim. <hi rend="italic">M.</hi>
+						<lb/> Quid, si in eis velim pro iambo tribrachum ponere , <lb/> nonne
+						multiformior varietas erit? D. Manifestum est <lb/> quidem : sed ego exempla
+						ista in solis iambis audire <lb/> cupio , ne longum faciamus : pro quavis
+						enim longa <lb/> syllaba duas breves posse poni , facilis disciplina est. <lb/>
+						<hi rend="italic">II.</hi> Faciam quod vis, gratumque habeo quod intelli­
+						<lb/> gentia sequaci minuis laborem meum : sed aurcm ad <lb/> iambicum
+						præbe. D. Istic sum, incipe. <hi rend="italic">M.</hi>
 						<figure type="illustration">
-							<graphic url="PL32_fig7.jpg"/></figure></p>
-					<ab>
+							<graphic url="PL32_fig7.jpg"/>
+						</figure></p>
+					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT V. <hi rend="italic">- De metro trochaico.</hi>
 						</title>
 					</ab>
-					<p>6. <hi rend="italic">D</hi> 'trochæus sequitur, prome trochaica : nam <lb/> ista se
-						haben' optime. <hi rend="italic">M.</hi> Faciam, et codem modo <lb/> QUO iambica :
-							<figure type="illustration">
-							<graphic url="PL32_fig8.jpg"/></figure><note type="footnote"> ' III B., <hi rend="italic">jaciaore.</hi> lIcliua cum Мss. A et B, <hi rend="italic">felictore.</hi> U. </note>
+					<p>6. <hi rend="italic">D</hi> 'trochæus sequitur, prome trochaica : nam <lb/>
+						ista se haben' optime. <hi rend="italic">M.</hi> Faciam, et codem modo <lb/>
+						QUO iambica : <figure type="illustration">
+							<graphic url="PL32_fig8.jpg"/>
+						</figure><note type="footnote"> ' III B., <hi rend="italic">jaciaore.</hi>
+							lIcliua cum Мss. A et B, <hi rend="italic">felictore.</hi> U. </note>
 						<figure type="illustration">
-							<graphic url="PL32_fig9.jpg"/></figure></p>
-					<ab>
+							<graphic url="PL32_fig9.jpg"/>
+						</figure></p>
+					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT VI. <hi rend="italic">- De metro sponduico.</hi>
 						</title>
 					</ab>
-					<p>7. <hi rend="italic">D.</hi> Spondeum sequi video : nam et trochæus <lb/> satis auribus
-						fecit. <hi rend="italic">M.</hi> Hæc sunt metra spondei : <figure type="illustration">
-							<graphic url="PL32_fig10.jpg"/></figure></p>
-					<ab>
-						<title type="sub">CAPUT VII. — <hi rend="italic">Tribrachi metra quot sint.</hi>
+					<p>7. <hi rend="italic">D.</hi> Spondeum sequi video : nam et trochæus <lb/>
+						satis auribus fecit. <hi rend="italic">M.</hi> Hæc sunt metra spondei :
+							<figure type="illustration">
+							<graphic url="PL32_fig10.jpg"/>
+						</figure></p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT VII. — <hi rend="italic">Tribrachi metra quot
+								sint.</hi>
 						</title>
 					</ab>
-					<p>8. <hi rend="italic">D.</hi> Nec de spondeo habeo quod requiram , ve <lb/> uiamus ad
-						tribrachum. <hi rend="italic">M.</hi> Ita vero. Sed cum omnes <lb/> quatuor superiores
-						pedes, de quibus dictum est, qua- <lb/> tuordena metra pepererint, quæ fiunt simul sex
-						ci <lb/> quinquaginta, plura sunt exspectanda de tribracho. <lb/> In illis enim cum
-						spatium semipedis in silentio est. <lb/> plus una syllaba non siletur: in hoc autem cum
-						sile­ <lb/> mus, num censes unius brevis syllabæ spatio tantum­ <lb/> modo siler i
-						oportere , an et duarum brevium mora <lb/> silentio contineri potest? quandoquidem nemo
-						dubi­ <lb/> taverit duplicem hujus esse divisionem : itamque aut <lb/> ab una incipit,
-						et finitur ad duas, aut centra iuci­ <lb/> piens a duabus, una terminatur. Quare Imnc
-						ne­ <lb/> cessc est viginti et unum metra procreare. <hi rend="italic">D.</hi> Veris.-
-						<lb/> simum est. Nam incipiunt a quatuor brevibus, ut duo <lb/> tempora sileamus: deinde
-						quinque sunt, ubi unum <lb/> silemus : tertio sex , ubi nihil silendum est: quarto <lb/>
-						septem, ubi rursus duo tempora silenda sunt : inde <lb/> octo, ubi unum : sexto novem,
-						ubi nullum. Atque <lb/> ita cum singuLe adduntur, donec ad viginti quatuor <lb/>
-						syllabas veniatur, qui octo suut tribrachi, viginti <lb/> unum omnino metra complentur.
-							<hi rend="italic">M.</hi> Expeditissime <lb/> rationem secutus es : sed censesne
-						ubique a nobis <lb/> exempla esse promenda; an ea quæ illis quatuur <lb/> primis pedibus
-						subjecimus, satis putandum cst lumi­ <lb/> nis cæteiis esse præbitura? <hi rend="italic">D.</hi> Meo quidem judicio <lb/> satis. <hi rend="italic">M.</hi> Nec ego nunc aliud
-						requiro quam tuum. Ve­ <lb/> rumtamen quoniam jam optime scis in pyrrhichiis <lb/>
-						metris muLato plausu posse tribrachos percuti; quæro, <lb/>
-						<pb n="1133"/> utrum pyrrhichii primuin metrum possil etiam tribra­ <lb/> chi metrum
-						habere. <hi rend="italic">D.</hi> Non potest : majus enim me­ <lb/> trum oportet esse
-						quam pedem. M. Quid, secundum? <lb/>
-						<hi rend="italic">D.</hi> Potest: nam breves quatuor pyrrhichii duo sunt, <lb/>
-						tribrachus unus et semipes, ita ut ibi nullum , hic <lb/> duo tempora sileamus. <hi rend="italic">I,.</hi> Mutato igitur plausu habcs <lb/> in pyrrhichiis etiam trihrachi
-						exempla usque ad sex­ <lb/> decim syllabas, id est usque ad quinque tribrachos <lb/> et
-						semipedem , quihus debes esse contentus : cætera <lb/> enim potes vel voce vel aliquo
-						plausu per tc ipso <lb/> contexere. Si tamen adhuc aurit:m sensu explorandos <lb/>
-						hujuscemodi numeros arbitraris. <hi rend="italic">D.</hi> Faciam equidem <lb/> quod
+					<p>8. <hi rend="italic">D.</hi> Nec de spondeo habeo quod requiram , ve <lb/>
+						uiamus ad tribrachum. <hi rend="italic">M.</hi> Ita vero. Sed cum omnes
+						<lb/> quatuor superiores pedes, de quibus dictum est, qua- <lb/> tuordena
+						metra pepererint, quæ fiunt simul sex ci <lb/> quinquaginta, plura sunt
+						exspectanda de tribracho. <lb/> In illis enim cum spatium semipedis in
+						silentio est. <lb/> plus una syllaba non siletur: in hoc autem cum sile­
+						<lb/> mus, num censes unius brevis syllabæ spatio tantum­ <lb/> modo siler i
+						oportere , an et duarum brevium mora <lb/> silentio contineri potest?
+						quandoquidem nemo dubi­ <lb/> taverit duplicem hujus esse divisionem :
+						itamque aut <lb/> ab una incipit, et finitur ad duas, aut centra iuci­ <lb/>
+						piens a duabus, una terminatur. Quare Imnc ne­ <lb/> cessc est viginti et
+						unum metra procreare. <hi rend="italic">D.</hi> Veris.- <lb/> simum est. Nam
+						incipiunt a quatuor brevibus, ut duo <lb/> tempora sileamus: deinde quinque
+						sunt, ubi unum <lb/> silemus : tertio sex , ubi nihil silendum est: quarto
+						<lb/> septem, ubi rursus duo tempora silenda sunt : inde <lb/> octo, ubi
+						unum : sexto novem, ubi nullum. Atque <lb/> ita cum singuLe adduntur, donec
+						ad viginti quatuor <lb/> syllabas veniatur, qui octo suut tribrachi, viginti
+						<lb/> unum omnino metra complentur. <hi rend="italic">M.</hi> Expeditissime
+						<lb/> rationem secutus es : sed censesne ubique a nobis <lb/> exempla esse
+						promenda; an ea quæ illis quatuur <lb/> primis pedibus subjecimus, satis
+						putandum cst lumi­ <lb/> nis cæteiis esse præbitura? <hi rend="italic"
+							>D.</hi> Meo quidem judicio <lb/> satis. <hi rend="italic">M.</hi> Nec
+						ego nunc aliud requiro quam tuum. Ve­ <lb/> rumtamen quoniam jam optime scis
+						in pyrrhichiis <lb/> metris muLato plausu posse tribrachos percuti; quæro, <lb/>
+						<pb n="1133"/> utrum pyrrhichii primuin metrum possil etiam tribra­ <lb/>
+						chi metrum habere. <hi rend="italic">D.</hi> Non potest : majus enim me­
+						<lb/> trum oportet esse quam pedem. M. Quid, secundum? <lb/>
+						<hi rend="italic">D.</hi> Potest: nam breves quatuor pyrrhichii duo sunt,
+						<lb/> tribrachus unus et semipes, ita ut ibi nullum , hic <lb/> duo tempora
+						sileamus. <hi rend="italic">I,.</hi> Mutato igitur plausu habcs <lb/> in
+						pyrrhichiis etiam trihrachi exempla usque ad sex­ <lb/> decim syllabas, id
+						est usque ad quinque tribrachos <lb/> et semipedem , quihus debes esse
+						contentus : cætera <lb/> enim potes vel voce vel aliquo plausu per tc ipso
+						<lb/> contexere. Si tamen adhuc aurit:m sensu explorandos <lb/> hujuscemodi
+						numeros arbitraris. <hi rend="italic">D.</hi> Faciam equidem <lb/> quod
 						videbitur : videamus quæ restant.</p>
-					<ab>
+					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT VIII. — <hi rend="italic">De dactylo.</hi>
 						</title>
 					</ab>
-					<p>9. <hi rend="italic">M.</hi> Dactylus sequitur, qui semel dividi potest. <lb/> An
-						aliter putes 7 D. Imo ita cst. 31. Quota ergo ejus <lb/> pars potest esso in silentio ?
-							<hi rend="italic">D.</hi> Dimidia scilicet. <hi rend="italic">M.</hi>
-						<lb/> Quid, si post dactylum trochæo constituto, vclil <lb/> quispiam silere uuum
-						tempus, quod in brevi syllaha <lb/> dactylo debetur implendo? quid respondebimus? Non
-						<lb/> enim possumus dicer e minus quam spatium scmipc­ <lb/> dis sileri non oportere.
-						natio enim superius tractata <lb/> non minus, sed amplus quam semipedis tempus si­ <lb/>
-						lendum nou esse persuaserat. Nam utique minus quam <lb/> semipes siletur in choriambo,
-						ubi pon ipsum chor­ <lb/> iambum bacchius collocilur, cujus exemplum est, <lb/>
-						<hi rend="italic">Fonticolæ</hi> puellæ. Unius cnim brevis syllabæ spatio <lb/> hic nos
-						silere cognoscis, quod sex temporibus debc­ <lb/> lur implendis. <hi rend="italic">D.</hi> Verum dicis. <hi rend="italic">M.</hi> Constituto ergo <lb/> trochæo post
-						dactylum, licebitne eliam unum tempus <lb/> silere ? <hi rend="italic">D.</hi> Ita cogor
-						fater i. <hi rend="italic">M.</hi> Quis te tandem coge­ <lb/> ret, si meminisses
-						superiorum ? Hoc cnim libi acci- - <lb/> dii, quod de indifferentia ullimx syllabæ, et
-						quomodo <lb/> sibi ultimam longam vindicent aurcs, ubi restat spa­ <lb/> lium quo
-						ponigatur, etiamsi brevis sit, quid demon­ <lb/> stratum fuerit oblitus es. D. Jam
-						intelligo : nam uti­ <lb/> que si ultimam syllabam brevem, quando restat si­ <lb/>
-						lentium, longam aurcs accipiunt, sicut superiore <lb/> ratione exemplisque cognovimus;
-						nihil intererit utrum <lb/> post dactylum trochxus, an spondeus locetur. Quam­ <lb/>
-						obrem cum repetitio distinguenda silentio est, unam <lb/> longam syllabam oportet post
-						dactylum ponere , ut <lb/> duorum temporum spatio sileamus. <hi rend="italic">M.</hi>
+					<p>9. <hi rend="italic">M.</hi> Dactylus sequitur, qui semel dividi potest.
+						<lb/> An aliter putes 7 D. Imo ita cst. 31. Quota ergo ejus <lb/> pars
+						potest esso in silentio ? <hi rend="italic">D.</hi> Dimidia scilicet. <hi
+							rend="italic">M.</hi>
+						<lb/> Quid, si post dactylum trochæo constituto, vclil <lb/> quispiam silere
+						uuum tempus, quod in brevi syllaha <lb/> dactylo debetur implendo? quid
+						respondebimus? Non <lb/> enim possumus dicer e minus quam spatium scmipc­
+						<lb/> dis sileri non oportere. natio enim superius tractata <lb/> non minus,
+						sed amplus quam semipedis tempus si­ <lb/> lendum nou esse persuaserat. Nam
+						utique minus quam <lb/> semipes siletur in choriambo, ubi pon ipsum chor­
+						<lb/> iambum bacchius collocilur, cujus exemplum est, <lb/>
+						<hi rend="italic">Fonticolæ</hi> puellæ. Unius cnim brevis syllabæ spatio
+						<lb/> hic nos silere cognoscis, quod sex temporibus debc­ <lb/> lur
+						implendis. <hi rend="italic">D.</hi> Verum dicis. <hi rend="italic">M.</hi>
+						Constituto ergo <lb/> trochæo post dactylum, licebitne eliam unum tempus
+						<lb/> silere ? <hi rend="italic">D.</hi> Ita cogor fater i. <hi
+							rend="italic">M.</hi> Quis te tandem coge­ <lb/> ret, si meminisses
+						superiorum ? Hoc cnim libi acci- - <lb/> dii, quod de indifferentia ullimx
+						syllabæ, et quomodo <lb/> sibi ultimam longam vindicent aurcs, ubi restat
+						spa­ <lb/> lium quo ponigatur, etiamsi brevis sit, quid demon­ <lb/> stratum
+						fuerit oblitus es. D. Jam intelligo : nam uti­ <lb/> que si ultimam syllabam
+						brevem, quando restat si­ <lb/> lentium, longam aurcs accipiunt, sicut
+						superiore <lb/> ratione exemplisque cognovimus; nihil intererit utrum <lb/>
+						post dactylum trochxus, an spondeus locetur. Quam­ <lb/> obrem cum repetitio
+						distinguenda silentio est, unam <lb/> longam syllabam oportet post dactylum
+						ponere , ut <lb/> duorum temporum spatio sileamus. <hi rend="italic">M.</hi>
 						Quid si pyr­ <lb/> rhichius ponatur post dactyluin , rectene fieri putas ? <lb/>
-						<hi rend="italic">D.</hi> Non recte : nam utrum idem sit, an iambus, , ni­ <lb/> hil
-						interest : siquidem pro iambo eum necesse est ac­ <lb/> cipi propter ultimam, quam
-						longum cxigunt aures, <lb/> quia restat silentium. Iambum autem non oportere <lb/> poni
-						post dactylum, propterdiversitatem levationis et <lb/> positionis, quarum neutram
-						oportet in dactylo habcre <lb/> tria tempora, quis non intelligat?</p>
-					<ab>
+						<hi rend="italic">D.</hi> Non recte : nam utrum idem sit, an iambus, , ni­
+						<lb/> hil interest : siquidem pro iambo eum necesse est ac­ <lb/> cipi
+						propter ultimam, quam longum cxigunt aures, <lb/> quia restat silentium.
+						Iambum autem non oportere <lb/> poni post dactylum, propterdiversitatem
+						levationis et <lb/> positionis, quarum neutram oportet in dactylo habcre
+						<lb/> tria tempora, quis non intelligat?</p>
+					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT IX. — <hi rend="italic">De bacchio.</hi>
 						</title>
 					</ab>
-					<p>10. M. Optime omnino atque sequacitcr. Sed quid <lb/> tibi tandem videtur de anapæsto?
-						an eadem ratio est? <lb/> . <hi rend="italic">D.</hi> Prorsus eadem. <hi rend="italic">M.</hi> Jam ergo bacchium conside­ <lb/> remus, si placet, et dic mihi quod primum
-						ejus ine­ <lb/> trum est. <hi rend="italic">D.</hi> Quatuor syllabas puto esse, unam
-						bre­ <lb/> vem, et tres longas, quarum duæ ad bacchium per­ <lb/> tinent, una vero
-						ultima ad inchoationem ejus pedis <lb/> qui cum bacchio poni potest; ut id quod ei
-						debetur, <lb/> sit in silentio : in aliquo tamen exemplo vellem ! oc <lb/> auribus
-						explorare. <hi rend="italic">II.</hi> Facile quidem tst exempla <lb/> subjicere, quibus
-						tamen non te arbitror ita ut supe­ <lb/> rioribus posse delectari: nam isti quinum
-						temporum <lb/> pedes, ut etiam septenum, non tam suaviter currunt, <lb/> quam ii qui aut
-						in æquas partes dividuntur, aut in <lb/> simplam et duplant, vel in duplam el simplam;
-						tan­ <lb/> tum interest inter sesquatos motus ct æquales aut <lb/> complicatos, dequibus
-						satis in primo illo nostro ser­ <lb/> mone tractavimus. Itaque hos pedes, quinque ac se­
-						<lb/> ptem scilicet temporum, uti aspernantins poetac, ita <lb/> soluta libentius
-						assumit oratio : qnod videri facilius <lb/> in exemplis quæ postulasti, potest : nam
-						ista sunt, <lb/>
-						<hi rend="italic">Laborat magister docens</hi> tardos. Hoc revolve interpo­ <lb/> sito
-						trium temporum silcmio , quod ut sentires faci­ <lb/> lius, ideo post tres pedes longam
-						syllabam posui, <lb/> quod est initium cretici , qui cum bacchio poni po­ <lb/> test.
-						Nee ad primum metrum exemplum dedi quod <lb/> est quatuor syllabarum, ne unus pes non
-						esset sa­ <lb/> tis ad commonendum sensum tuum, quantum post <lb/> illum a1que unam
-						longam silere deberes. Quod ecce <lb/> nanc edam, atque ipse repetam , ut in meo
-						silentio <lb/> tria tempora sentias : <hi rend="italic">Labor nullus, Amor magnus.
+						<div type="textpart" subtype="dialog"><p>10. M. Optime omnino atque sequacitcr. Sed quid <lb/> tibi tandem videtur de
+						anapæsto? an eadem ratio est? <lb/> . <hi rend="italic">D.</hi> Prorsus
+						eadem. <hi rend="italic">M.</hi> Jam ergo bacchium conside­ <lb/> remus, si
+						placet, et dic mihi quod primum ejus ine­ <lb/> trum est. <hi rend="italic"
+							>D.</hi> Quatuor syllabas puto esse, unam bre­ <lb/> vem, et tres
+						longas, quarum duæ ad bacchium per­ <lb/> tinent, una vero ultima ad
+						inchoationem ejus pedis <lb/> qui cum bacchio poni potest; ut id quod ei
+						debetur, <lb/> sit in silentio : in aliquo tamen exemplo vellem ! oc <lb/>
+						auribus explorare. <hi rend="italic">II.</hi> Facile quidem tst exempla
+						<lb/> subjicere, quibus tamen non te arbitror ita ut supe­ <lb/> rioribus
+						posse delectari: nam isti quinum temporum <lb/> pedes, ut etiam septenum,
+						non tam suaviter currunt, <lb/> quam ii qui aut in æquas partes dividuntur,
+						aut in <lb/> simplam et duplant, vel in duplam el simplam; tan­ <lb/> tum
+						interest inter sesquatos motus ct æquales aut <lb/> complicatos, dequibus
+						satis in primo illo nostro ser­ <lb/> mone tractavimus. Itaque hos pedes,
+						quinque ac se­ <lb/> ptem scilicet temporum, uti aspernantins poetac, ita
+						<lb/> soluta libentius assumit oratio : qnod videri facilius <lb/> in
+						exemplis quæ postulasti, potest : nam ista sunt, <lb/>
+						<hi rend="italic">Laborat magister docens</hi> tardos. Hoc revolve interpo­
+						<lb/> sito trium temporum silcmio , quod ut sentires faci­ <lb/> lius, ideo
+						post tres pedes longam syllabam posui, <lb/> quod est initium cretici , qui
+						cum bacchio poni po­ <lb/> test. Nee ad primum metrum exemplum dedi quod
+						<lb/> est quatuor syllabarum, ne unus pes non esset sa­ <lb/> tis ad
+						commonendum sensum tuum, quantum post <lb/> illum a1que unam longam silere
+						deberes. Quod ecce <lb/> nanc edam, atque ipse repetam , ut in meo silentio
+						<lb/> tria tempora sentias : <hi rend="italic">Labor nullus, Amor magnus.
 							D.</hi>
-						<lb/> Satis apparet solutæ orationi hos esse congruentiores <lb/> pedes, et nihil opus
-						est exemplis cætera excurrere. <lb/>
-						<hi rend="italic">II.</hi> Verum dicis : sed num libi cum silendum est, <lb/> una tantum
-						longa videtur pom posse post bacchium? <lb/> D. Non sane ; sed etiam brevis ct longa,
-						qui ejus­ <lb/> dem bacchii semipes primus est: nam si nobis in­ <lb/> choare creticum
-						licuit, quia cum eodem baccbio poni <lb/> potest; quanto magis id de ipso bacchio facere
-						lice­ <lb/> bit, cum præscrtim non totum de cretico posueri­ <lb/> mus quod primæ parti
-						bacchii sit æquale temporibus'</p>
-					<ab>
+						<lb/> Satis apparet solutæ orationi hos esse congruentiores <lb/> pedes, et
+						nihil opus est exemplis cætera excurrere. <lb/>
+						<hi rend="italic">II.</hi> Verum dicis : sed num libi cum silendum est,
+						<lb/> una tantum longa videtur pom posse post bacchium? <lb/> D. Non sane ;
+						sed etiam brevis ct longa, qui ejus­ <lb/> dem bacchii semipes primus est:
+						nam si nobis in­ <lb/> choare creticum licuit, quia cum eodem baccbio poni
+						<lb/> potest; quanto magis id de ipso bacchio facere lice­ <lb/> bit, cum
+						præscrtim non totum de cretico posueri­ <lb/> mus quod primæ parti bacchii
+						sit æquale temporibus'</p>
+					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT X. — <hi rend="italic">Pleno pedi quid addatur ante
 								silentium.</hi>
 						</title>
 					</ab>
-					<p>ii. M. Jam ergo, si placet, mc audiente atque ju­ <lb/> dicante, tu ipse per catcra
-						excurre, et quid ponatur <lb/> post plenum pedcm, quando silentio reliquum iut­ <lb/>
-						pletur in omnibus pedibus qui restant, exsequcrc. <lb/>
-						<hi rend="italic">D.</hi> Brevissimum jam, opinor , atque facillimum est <lb/> quod
-						rcquiris : nam quod de bacchio dictum est, id <lb/> etiam de secundo pæone dici potest.
-						Post creticum au­ <lb/> tcm cl unam longam syllabam licet ponere, et iam­ <lb/> bum, ct
-						spondeum ; iLa ut aut ti ia tempora, aul duo, <lb/> aut unum silcalur. Quod autem de hoc
-						dictum est, <lb/> id et in primum et in ultimum pæonem cadit '. Jam <lb/> post
-						palimbacchium vel unam longam vcl spondcuna <lb/> collocari decet, quocirca et in hoc
-						metro aut tria <lb/> tempora, aut unum silebitur. Eadem conditio est <lb/> pæonis
-						tertii. Sanc ubicumque spondeus, ibi et ana­ <lb/> pæstus jure ponatur. Post molossum
-						vero, quod ad <lb/> ejus attinet divisionem, aut unam longam ut quatuor, <lb/> aut duas
-						ponimus ut duo tempora sileamus. Sed quo­ <lb/> niam et censu et ratione exploratum est,
-						ordinari <note type="footnote"> I Er. Lugd. habent: <hi rend="italic">Sec ad</hi> prinii
-								<hi rend="italic">metri</hi> exemplum <hi rend="italic">dedt;</hi>
-							<lb/> et in margine <hi rend="italic">adeo,</hi> j ro <hi rend="italic">ad;</hi> Lov.,
-								<hi rend="italic">nec adeo primi</hi> nwtri. <lb/> MS. A, <hi rend="italic">nec</hi>
-							pritni <hi rend="italic">melrt;</hi> at Ms. B legit ui Benedictini. vcu. <lb/> textum
-							Er. ct l ugd. sequitur. II. </note><note type="footnote">t Adjiciuntur a *:s. A tirc
-							verba : <hi rend="italic">Propter</hi> duas <hi rend="italic">divi­</hi>
+					<p>ii. M. Jam ergo, si placet, mc audiente atque ju­ <lb/> dicante, tu ipse per
+						catcra excurre, et quid ponatur <lb/> post plenum pedcm, quando silentio
+						reliquum iut­ <lb/> pletur in omnibus pedibus qui restant, exsequcrc. <lb/>
+						<hi rend="italic">D.</hi> Brevissimum jam, opinor , atque facillimum est
+						<lb/> quod rcquiris : nam quod de bacchio dictum est, id <lb/> etiam de
+						secundo pæone dici potest. Post creticum au­ <lb/> tcm cl unam longam
+						syllabam licet ponere, et iam­ <lb/> bum, ct spondeum ; iLa ut aut ti ia
+						tempora, aul duo, <lb/> aut unum silcalur. Quod autem de hoc dictum est,
+						<lb/> id et in primum et in ultimum pæonem cadit '. Jam <lb/> post
+						palimbacchium vel unam longam vcl spondcuna <lb/> collocari decet, quocirca
+						et in hoc metro aut tria <lb/> tempora, aut unum silebitur. Eadem conditio
+						est <lb/> pæonis tertii. Sanc ubicumque spondeus, ibi et ana­ <lb/> pæstus
+						jure ponatur. Post molossum vero, quod ad <lb/> ejus attinet divisionem, aut
+						unam longam ut quatuor, <lb/> aut duas ponimus ut duo tempora sileamus. Sed
+						quo­ <lb/> niam et censu et ratione exploratum est, ordinari <note
+							type="footnote"> I Er. Lugd. habent: <hi rend="italic">Sec ad</hi>
+							prinii <hi rend="italic">metri</hi> exemplum <hi rend="italic"
+								>dedt;</hi>
+							<lb/> et in margine <hi rend="italic">adeo,</hi> j ro <hi rend="italic"
+								>ad;</hi> Lov., <hi rend="italic">nec adeo primi</hi> nwtri. <lb/>
+							MS. A, <hi rend="italic">nec</hi> pritni <hi rend="italic">melrt;</hi>
+							at Ms. B legit ui Benedictini. vcu. <lb/> textum Er. ct l ugd. sequitur.
+							II. </note><note type="footnote">t Adjiciuntur a *:s. A tirc verba : <hi
+								rend="italic">Propter</hi> duas <hi rend="italic">divi­</hi>
 							<lb/> siones. ii. </note>
 						<lb/>
-						<pb n="1135"/> cum eo posse omnes senum temporum pedes, erit <lb/> post cum locus et
-						iambo, et tria tempora silenda re­ <lb/> manebant; erit et cretico , et unum tacebitur;
-						hac <lb/> conditione erit et bacchio. At si in duas breves pri­ <lb/> mam cretici, et
-						secundam bacchii solverimus, ent et <lb/> pæoni quarto. Quod autem de molosso, id etiam
-						de <lb/> cjeleris sex temporum pedibus dixerim. Jam procc­ <lb/> leusmaticum arbitror ad
-						cæteros qui quatuor tempo­ <lb/> ribus constant, esse referendum, nisi cum tres bre­
-						<lb/> res post cum locamus. Quod ita est ac si anapræstum <lb/> locemus, propter
-						ultiinam syllabam quæ cum silentio <lb/> longa accipi solet. Primo vero cpitrito iambus
-						recte <lb/> subjungitur, et bacchius ct creticus et pxon quar­ <lb/> tus. Hoc dctum sil
-						et de secundo, ut tempora si- <lb/> Icantur aut quatuor, aul duo. Duos autem reliqnos
-						<lb/> epitritos recte possunt consequi spondcus ct molos­ <lb/> sus : ita ut primam s;
-						ondei, et primam vel sccun­ <lb/> dam molossi in duas breves solvere liceat. Ergo in
-						<lb/> his metris aut tria tempora, aut unum tacebitur. <lb/> Dispondeus restat, post
-						quem si posuerimus spon­ <lb/> deum, quatuor tempora silenda erunt; si molossum , <lb/>
-						duo, manente licentia solvendi longam in duas bre­ <lb/> ves , vel in spondeo, vet in
-						molosso, excepta ul­ <lb/> tima. Habes quod me excurrere voluisti. Nisi aliquid <lb/>
-						forte emendabis.</p>
-					<ab>
-						<title type="sub">. CAPUT X I. — <hi rend="italic">Iambus post</hi> dichorium <hi rend="italic">male ponitur.</hi>
+						<pb n="1135"/> cum eo posse omnes senum temporum pedes, erit <lb/> post cum
+						locus et iambo, et tria tempora silenda re­ <lb/> manebant; erit et cretico
+						, et unum tacebitur; hac <lb/> conditione erit et bacchio. At si in duas
+						breves pri­ <lb/> mam cretici, et secundam bacchii solverimus, ent et <lb/>
+						pæoni quarto. Quod autem de molosso, id etiam de <lb/> cjeleris sex temporum
+						pedibus dixerim. Jam procc­ <lb/> leusmaticum arbitror ad cæteros qui
+						quatuor tempo­ <lb/> ribus constant, esse referendum, nisi cum tres bre­
+						<lb/> res post cum locamus. Quod ita est ac si anapræstum <lb/> locemus,
+						propter ultiinam syllabam quæ cum silentio <lb/> longa accipi solet. Primo
+						vero cpitrito iambus recte <lb/> subjungitur, et bacchius ct creticus et
+						pxon quar­ <lb/> tus. Hoc dctum sil et de secundo, ut tempora si- <lb/>
+						Icantur aut quatuor, aul duo. Duos autem reliqnos <lb/> epitritos recte
+						possunt consequi spondcus ct molos­ <lb/> sus : ita ut primam s; ondei, et
+						primam vel sccun­ <lb/> dam molossi in duas breves solvere liceat. Ergo in
+						<lb/> his metris aut tria tempora, aut unum tacebitur. <lb/> Dispondeus
+						restat, post quem si posuerimus spon­ <lb/> deum, quatuor tempora silenda
+						erunt; si molossum , <lb/> duo, manente licentia solvendi longam in duas
+						bre­ <lb/> ves , vel in spondeo, vet in molosso, excepta ul­ <lb/> tima.
+						Habes quod me excurrere voluisti. Nisi aliquid <lb/> forte emendabis.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">. CAPUT X I. — <hi rend="italic">Iambus post</hi>
+							dichorium <hi rend="italic">male ponitur.</hi>
 						</title>
 					</ab>
-					<p>ii. <hi rend="italic">M.</hi> lino non ego, sed tu, cum aurem ad judi­ <lb/> candum
-						adhibueris : nam quæro a te, utrum cum di­ <lb/> co et plaudo istud metrum, <hi rend="italic">Verus optimus; et hoc,<lb/> Verus optimorum;</hi> et boc, <hi rend="italic">Veritatis inops</hi> : tam jucun­ <lb/> de hoc tertium quam illa
-						superiora tuus sensus acci­ <lb/> piat; quod ea repetendo, et cum debilis silentiis
-						plau­ <lb/> dendo facile judicabit. <hi rend="italic">D.</hi> Manifestum est quod jucun­
-						<lb/> de illa, hoc injucunde accipiat1. <hi rend="italic">M.</hi> Non ergo recte <lb/>
-						post dichorium iambus ponitur. <hi rend="italic">D.</hi> Ita est. <hi rend="italic">37.</hi> Recte <lb/> autcm poni posse post cæteros assentitur quisquis <lb/> hæc
-						metra cum disciplina interponendoram silentio­ <lb/> rum repetierit. <lb/> Fallacem
-						cave. <lb/> Malo castum cave. <lb/> Mutiloquum cave. <lb/> Fallaciam cave. <lb/> Et
-						invidum cave. <lb/> Et infirmum cave. <lb/> D. Sentio quod dicis, ct approbo. <hi rend="italic">M.</hi> Vide etiam <lb/> utrum te nihil offendat, cum interposito duorum
-						tem­ <lb/> porum silentio, hoc metrum npetitum inæquale per­ <lb/> git I. Num enin, ita
-						senet nt ista ? <lb/> Veraces regnant. <lb/> sapientes regnant. <lb/> Veriloqui regnant.
-						<lb/> Prudentia regnat. <lb/> Boni in bonis regnant. <lb/> Pura eunc1a regnant. <lb/> D.
-						Imo hæc æqualiter ct suaviter, illud autem ab­ <lb/> surde. <hi rend="italic">M.</hi>
-						Hoc ergo tenebimus in metris scx tempo­ <lb/> rum pedum, dichorium iambo, antispastum
+					<p>ii. <hi rend="italic">M.</hi> lino non ego, sed tu, cum aurem ad judi­ <lb/>
+						candum adhibueris : nam quæro a te, utrum cum di­ <lb/> co et plaudo istud
+						metrum, <hi rend="italic">Verus optimus; et hoc,<lb/> Verus optimorum;</hi>
+						et boc, <hi rend="italic">Veritatis inops</hi> : tam jucun­ <lb/> de hoc
+						tertium quam illa superiora tuus sensus acci­ <lb/> piat; quod ea repetendo,
+						et cum debilis silentiis plau­ <lb/> dendo facile judicabit. <hi
+							rend="italic">D.</hi> Manifestum est quod jucun­ <lb/> de illa, hoc
+						injucunde accipiat1. <hi rend="italic">M.</hi> Non ergo recte <lb/> post
+						dichorium iambus ponitur. <hi rend="italic">D.</hi> Ita est. <hi
+							rend="italic">37.</hi> Recte <lb/> autcm poni posse post cæteros
+						assentitur quisquis <lb/> hæc metra cum disciplina interponendoram silentio­
+						<lb/> rum repetierit. <lb/> Fallacem cave. <lb/> Malo castum cave. <lb/>
+						Mutiloquum cave. <lb/> Fallaciam cave. <lb/> Et invidum cave. <lb/> Et
+						infirmum cave. <lb/> D. Sentio quod dicis, ct approbo. <hi rend="italic"
+							>M.</hi> Vide etiam <lb/> utrum te nihil offendat, cum interposito
+						duorum tem­ <lb/> porum silentio, hoc metrum npetitum inæquale per­ <lb/>
+						git I. Num enin, ita senet nt ista ? <lb/> Veraces regnant. <lb/> sapientes
+						regnant. <lb/> Veriloqui regnant. <lb/> Prudentia regnat. <lb/> Boni in
+						bonis regnant. <lb/> Pura eunc1a regnant. <lb/> D. Imo hæc æqualiter ct
+						suaviter, illud autem ab­ <lb/> surde. <hi rend="italic">M.</hi> Hoc ergo
+						tenebimus in metris scx tempo­ <lb/> rum pedum, dichorium iambo, antispastum
 						spondeo <lb/> male claudi. <hi rend="italic">D.</hi> Tenebimus sanc.</p>
-					<p>43. M. Quid ? causam cur ita sit nonne approbabis, <note type="footnote"> I Mss. A et B
-							ferum : <hi rend="italic">Manifestum eat juetmde illa, hoc <lb/> injucunde</hi>
-							accipi. M. </note><note type="footnote"> I <hi rend="italic">Inæqualiter,</hi> juxta
-							Ms. A et omnes editos. Ks. B legit <lb/> uti Benedictini, inæquale. M. </note>
-						<lb/> si animadverteris levatione ac positronc in duas partes <lb/> dividi pedem, ita ut
-						si qua in eo syllaba media est, <lb/> vel una vol duae, aut uni parti attribuantur
-						priori vel <lb/> posteriori, aut in utramque partiantur? <hi rend="italic">D.</hi> Novi
-						qni­ <lb/> dem istuc, et vcrum est: sed quid ad rcm? M. Ho c <lb/> quoque attende quod
-						dicam, tum videbis facilius quod <lb/> requiris. Nam manifestum tibi esse arbitror,
-						alios <lb/> esse sine mediis syllabis pedes, tri pyrrhichius, et <lb/> cæteri binarum
-						syllabarum; alios in quibus medium <lb/> aut primae parti, aut extremæ, aut utrique, aut
-						neu­ <lb/> ti i, spatio conveniat; primæ, ut in anapæsto, vel in <lb/> palimbacchio, vel
-						in pæone primo : extremae, ut in <lb/> dactylo vel in bacchio, vcl in pæone quarto:
-						utrique, <lb/> ut in tribracho, sive in molosso, sive in choriambo, <lb/> sive in
-						quolibet ionico : neutri, ut in cretico, sive in <lb/> paeonibus secundo et tertio, sive
-						in diiambo, dicho­ <lb/> rio, antispasto. Nam qui pedes in tres acquales par­ <lb/> les
-						dividi possunt, media pars in his convenit cum <lb/> prima et extrema; qui autem. non
-						possunt, aut cum <lb/> prima tantum, aut cum extrema, aut cum neutra. <hi rend="italic">D.</hi>
-						<lb/> Et hoc aeque scio, et quo tendat exspecto. M. Quo tan­ <lb/> dem putas, nisi ut
-						videas iambum post dichorium ideo <lb/> male poni cum silentio, quia medium ejus est,
-						nec <lb/> primae parti æquale nec extremae, et idcirco a leva­ <lb/> tione ac positione
-						discordat ? Hoc etiam de spondeo <lb/> intelligitur, qui similiter post antispastumcum
-						silen­ <lb/> tio nou amat poni. An quidquam tibi adversum ista <lb/> dicendum est? D.
-						Mihi vero nihil ? nisi quod ista offen­ <lb/> sio quae fit auribus, cum ita hi pedes
-						collocantur, in <lb/> comparatione fit ejus suavitatis, quæ oblectat audi­ <lb/> tum,
-						cum post caeteros senum temporum hi cum si­ <lb/> lentio ponuntur pedes. Nam si aliis
-						tacitis me consu­ <lb/> leres quemadmodum sonarent, exemplis subjectis, <lb/> aut post
-						dichorium iambus, aut post antispastum spon­ <lb/> deus, cum silentio positi; dicam quod
-						sentio, for­ <lb/> tasse approbarem et laudarcm. <hi rend="italic">M.</hi> Non equidem
-						<lb/> resisto tibi. Satis est mihi tamen, quod hæc collocatio <lb/> in comparatione
-						lIlium numerorum, sed melius so­ <lb/> nantium, sicut dicis, offendit: co enim est
-						impro­ <lb/> banda, quod cum ejusdem generis etiam illi sint pe­ <lb/> des, quos his
-						semipedibus clausos labi jucundius con­ <lb/> fitemur, ab iis discrepare non dcbuit. Sed
-						nonne tibi <lb/> vidctur secundum istam rationem, nec post epitritum <lb/> secundum
-						iambum cum silentio poni oportere! Nam <lb/> et in hoc pede iambus ita medium locum
-						tenet, ut <lb/> nec prioris nec posterioris partis temporibus sequetur <lb/>
+					<p>43. M. Quid ? causam cur ita sit nonne approbabis, <note type="footnote"> I
+							Mss. A et B ferum : <hi rend="italic">Manifestum eat juetmde illa, hoc
+								<lb/> injucunde</hi> accipi. M. </note><note type="footnote"> I <hi
+								rend="italic">Inæqualiter,</hi> juxta Ms. A et omnes editos. Ks. B
+							legit <lb/> uti Benedictini, inæquale. M. </note>
+						<lb/> si animadverteris levatione ac positronc in duas partes <lb/> dividi
+						pedem, ita ut si qua in eo syllaba media est, <lb/> vel una vol duae, aut
+						uni parti attribuantur priori vel <lb/> posteriori, aut in utramque
+						partiantur? <hi rend="italic">D.</hi> Novi qni­ <lb/> dem istuc, et vcrum
+						est: sed quid ad rcm? M. Ho c <lb/> quoque attende quod dicam, tum videbis
+						facilius quod <lb/> requiris. Nam manifestum tibi esse arbitror, alios <lb/>
+						esse sine mediis syllabis pedes, tri pyrrhichius, et <lb/> cæteri binarum
+						syllabarum; alios in quibus medium <lb/> aut primae parti, aut extremæ, aut
+						utrique, aut neu­ <lb/> ti i, spatio conveniat; primæ, ut in anapæsto, vel
+						in <lb/> palimbacchio, vel in pæone primo : extremae, ut in <lb/> dactylo
+						vel in bacchio, vcl in pæone quarto: utrique, <lb/> ut in tribracho, sive in
+						molosso, sive in choriambo, <lb/> sive in quolibet ionico : neutri, ut in
+						cretico, sive in <lb/> paeonibus secundo et tertio, sive in diiambo, dicho­
+						<lb/> rio, antispasto. Nam qui pedes in tres acquales par­ <lb/> les dividi
+						possunt, media pars in his convenit cum <lb/> prima et extrema; qui autem.
+						non possunt, aut cum <lb/> prima tantum, aut cum extrema, aut cum neutra.
+							<hi rend="italic">D.</hi>
+						<lb/> Et hoc aeque scio, et quo tendat exspecto. M. Quo tan­ <lb/> dem
+						putas, nisi ut videas iambum post dichorium ideo <lb/> male poni cum
+						silentio, quia medium ejus est, nec <lb/> primae parti æquale nec extremae,
+						et idcirco a leva­ <lb/> tione ac positione discordat ? Hoc etiam de spondeo
+						<lb/> intelligitur, qui similiter post antispastumcum silen­ <lb/> tio nou
+						amat poni. An quidquam tibi adversum ista <lb/> dicendum est? D. Mihi vero
+						nihil ? nisi quod ista offen­ <lb/> sio quae fit auribus, cum ita hi pedes
+						collocantur, in <lb/> comparatione fit ejus suavitatis, quæ oblectat audi­
+						<lb/> tum, cum post caeteros senum temporum hi cum si­ <lb/> lentio ponuntur
+						pedes. Nam si aliis tacitis me consu­ <lb/> leres quemadmodum sonarent,
+						exemplis subjectis, <lb/> aut post dichorium iambus, aut post antispastum
+						spon­ <lb/> deus, cum silentio positi; dicam quod sentio, for­ <lb/> tasse
+						approbarem et laudarcm. <hi rend="italic">M.</hi> Non equidem <lb/> resisto
+						tibi. Satis est mihi tamen, quod hæc collocatio <lb/> in comparatione lIlium
+						numerorum, sed melius so­ <lb/> nantium, sicut dicis, offendit: co enim est
+						impro­ <lb/> banda, quod cum ejusdem generis etiam illi sint pe­ <lb/> des,
+						quos his semipedibus clausos labi jucundius con­ <lb/> fitemur, ab iis
+						discrepare non dcbuit. Sed nonne tibi <lb/> vidctur secundum istam rationem,
+						nec post epitritum <lb/> secundum iambum cum silentio poni oportere! Nam
+						<lb/> et in hoc pede iambus ita medium locum tenet, ut <lb/> nec prioris nec
+						posterioris partis temporibus sequetur <lb/>
 						<hi rend="italic">D.</hi> Cogii me superior ratio concedere.</p>
-					<ab>
-						<title type="sub">CAPUT XII. — <hi rend="italic">Summa</hi> omnium <hi rend="italic">metrorum.</hi>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT XII. — <hi rend="italic">Summa</hi> omnium <hi
+								rend="italic">metrorum.</hi>
 						</title>
 					</ab>
-					<p>14. <hi rend="italic">M.</hi> . Age ,nunc, reddc mihi omnium metrorum <lb/> numerum, si
-						placet, quæ jam tractavimus; id est eo­ <lb/> rum quæ a suis plenis pedibus incipiunt,
-						clauduntur <lb/> antem aut suis pcdibus plenis. ila ut silentium, cum <lb/> ad caput
-						reditur, non interponamus ; aut non plenis <lb/> pedibus cum silentio, quos tamen cis
-						congruere ratio <lb/> docuit; incipiente humero a duobus non plenis usque <lb/> ad octo
-						plenos, ita tamen ut triginta duo tempora non <lb/> excedantur. <hi rend="italic">D.</hi> Operosum quidem est quod imponis, <lb/> est tamen opcrae pretium. Sed memini
-						nos paulo an­ <lb/> te jam pervenisse ad septuaginta septem metra a <lb/>
-						<pb n="1137"/> pyrrhichio usque ad tribrachum, cum illi binarum <lb/> syllabarum pedes
-						quatuordecim singuli crearent, qu:o <lb/> fiunt simul quinquaginta ct sex. Tribrachus
-						autem <lb/> viginti et unum, propter geminam divisioncm. His <lb/> igitur septuaginta ct
-						septem addimus quatuordecim <lb/> dactyli, et anapaesti totidem : pleni enim si locentur
-						<lb/> nullo silentio, incipicnte metro a duobus usque ad <lb/> octo pedes, septena
-						pariunt; additis vero semipedi­ <lb/> bus cum silentio, incipiente metro ab uno pede, et
-						<lb/> semipede perveniente ad septem et sontis, alia sopte­ <lb/> na. Et fiunt jam omnia
-						centum ct quinque, Bacchius <lb/> vcro non potest metrum suum ad octo pedes perdu­ <lb/>
-						ecre, ne triginta duo tompora transeat, neqne quis­ <lb/> quam quinum temporum pes; scd
-						possunt isti usque <lb/> ad sex pervenire. Bacchius ergo et qui ei par est, nun <lb/>
-						modo temporibus, scil etiam divisione pæon secun­ <lb/> dus, a duobus pedibus usque ad
-						sex procedentes cum <lb/> integri ordinantur sine silentio, quina metra pariunt ; <lb/>
-						cum silentio autem incipientes ab uno semipcde, et <lb/> ad quinque semipedes
-						pervenientes, niia quina cum <lb/> una longa post cos ponitur, ct item quina cum bre -
-						<lb/> via et longa : quindena igitur creant, quæ in summam <lb/> redacta triginta sunt.
-						Et fiunt jam metra omnia cen­ <lb/> tum et triginta quin'luc, Creticus vero, et qni
-						pariter <lb/> dividuntur, pxoncs primus et quartus, quoniam post <lb/> illos et unam
-						longam, ct iambum, et spondeum, ct <lb/> anapæstum licet ponere, ad septuaginta quinque
-						pcr­ <lb/> veniunt : cum enim tres sint pedes, qnina crcant sine <lb/> silentio, cum
-						silentio autem viginti, quæ simul, ut <lb/> dictum est, fiunt quinque et septuaginta,
-						quibus addi­ <lb/> tis superiori summæ, decem et ducenta complentur. <lb/> Palimbacchius
-						et qui ei divisione concordat tertius <lb/> paeon, quina pariunt integri sine silentio :
-						cum silen­ <lb/> tio autem quina cum una longa, quina cum spondeo, <lb/> quina cum
-						anapæsto. Hæc addimus ad majorem sum­ <lb/> mam, ct habemus metra omnia ducenta quinqua­
-						<lb/> ginta.</p>
-					<p>i5. Molossus et cæteri sex temporum pe.lcs, qui <lb/> cum illo simnl septem fiunt,
-						quaterna crcanl integri : <lb/> cum silentio autem quoniam et una longa post unum­ <lb/>
-						quemque eorum locari potest, et iambus, et spondeus, <lb/> et anapæstus, et bacchius, et
-						creticus, et pæon qunr­ <lb/> rus; vicena et octona complent, quae simul fiunt cen­
-						<lb/> tum nonaginta sex, quæ ducta cum illis quaternis du­ <lb/> centa viginti quatuor
-						complentur : sed hinc octo dc­ <lb/> ducendi sunt, quia post dichorium iambus, ct post
-						<lb/> antispastum spondcus male ordinantur. Reliqua sunt <lb/> ducenta sexdecim, qune
-						addita majori summae, fa­ <lb/> ciunt metra omuia quadringenta sexaginta sex. Proce­
-						<lb/> leumatici ratio hab eri non potuit cum his pedibus qui­ <lb/> hus congruit,
-						propter semipedes qui post hunc plures <lb/> ponuntur. Nam ct una syllaba longa post eum
-						poni <lb/> potest cum si'entio, sicut post dactylum et rjus con­ <lb/> sortes ut duo, cl
-						tres breves ut unum tempus silea­ <lb/> tur; quo efficitur ut ultima brevis pro longa
-						accipia­ <lb/> tur. Epitriti metra gignunt terna integri, incipiente <lb/> metro a
-						duobus pedibus, perveniente ad quatuor : si <lb/> cniin addas quintum, triginta duo
-						tempora, quod uon <lb/> oportet, excedes. Cum silentio vero primus et secun­ <lb/> dus
-						epitritus terna post locato i mbo, terna bacchio, <lb/> terna cretico, terna pæone
-						quarto; quae fiuut cum <lb/> illis ternis quæ sunt sine silentio, triginta. Tet tius ve­
-						<lb/> ro et quartus epitriti tres ante silentium gignunt, cum <lb/> spondeo terna, ct
-						terna cum anapæsto, lerna cum <lb/> molosso, terna cum ionico minore, terna cum chor­
-						<lb/> iambo; quæ fiunt simul cum illis ternis, quæ sine <lb/> silentio genuerunt,
-						triginta et sev. Ergo epitriti orn­ <lb/> lies sexaginta et sex metra pariunt. : quæ cum
-						viginti <lb/> ct uno proceleumatici, superiori summæ addta, fa­ <lb/> ciunt quingenta
-						quinquaginta tria. Dispondeus restat <lb/> gignens et ipse liia integer; adhibito autem
-						silemio <lb/> cum spondeo tria, et tria cum anapæsto, tria cum mo­ <lb/> losso, tria cum
-						ionico a miaore, tria cum choriambo: <lb/> quæ in summam ducta cum illis tribus quæ
-						creat in­ <lb/> teger, fiunt decem et octo. Ita erum metra omma <lb/> quingenta
-						septuaginta et unum.</p>
-					<ab>
-						<title type="sub">CAPUT XIII. - <hi rend="italic">Ratio metietidi metra et silentia
-								interponendi.</hi>
+					</div>
+				<div type="textpart" subtype="dialog"><p>14. <hi rend="italic">M.</hi> . Age ,nunc, reddc mihi omnium metrorum <lb/>
+						numerum, si placet, quæ jam tractavimus; id est eo­ <lb/> rum quæ a suis
+						plenis pedibus incipiunt, clauduntur <lb/> antem aut suis pcdibus plenis.
+						ila ut silentium, cum <lb/> ad caput reditur, non interponamus ; aut non
+						plenis <lb/> pedibus cum silentio, quos tamen cis congruere ratio <lb/>
+						docuit; incipiente humero a duobus non plenis usque <lb/> ad octo plenos,
+						ita tamen ut triginta duo tempora non <lb/> excedantur. <hi rend="italic"
+							>D.</hi> Operosum quidem est quod imponis, <lb/> est tamen opcrae
+						pretium. Sed memini nos paulo an­ <lb/> te jam pervenisse ad septuaginta
+						septem metra a <lb/>
+						<pb n="1137"/> pyrrhichio usque ad tribrachum, cum illi binarum <lb/>
+						syllabarum pedes quatuordecim singuli crearent, qu:o <lb/> fiunt simul
+						quinquaginta ct sex. Tribrachus autem <lb/> viginti et unum, propter geminam
+						divisioncm. His <lb/> igitur septuaginta ct septem addimus quatuordecim
+						<lb/> dactyli, et anapaesti totidem : pleni enim si locentur <lb/> nullo
+						silentio, incipicnte metro a duobus usque ad <lb/> octo pedes, septena
+						pariunt; additis vero semipedi­ <lb/> bus cum silentio, incipiente metro ab
+						uno pede, et <lb/> semipede perveniente ad septem et sontis, alia sopte­
+						<lb/> na. Et fiunt jam omnia centum ct quinque, Bacchius <lb/> vcro non
+						potest metrum suum ad octo pedes perdu­ <lb/> ecre, ne triginta duo tompora
+						transeat, neqne quis­ <lb/> quam quinum temporum pes; scd possunt isti usque
+						<lb/> ad sex pervenire. Bacchius ergo et qui ei par est, nun <lb/> modo
+						temporibus, scil etiam divisione pæon secun­ <lb/> dus, a duobus pedibus
+						usque ad sex procedentes cum <lb/> integri ordinantur sine silentio, quina
+						metra pariunt ; <lb/> cum silentio autem incipientes ab uno semipcde, et
+						<lb/> ad quinque semipedes pervenientes, niia quina cum <lb/> una longa post
+						cos ponitur, ct item quina cum bre - <lb/> via et longa : quindena igitur
+						creant, quæ in summam <lb/> redacta triginta sunt. Et fiunt jam metra omnia
+						cen­ <lb/> tum et triginta quin'luc, Creticus vero, et qni pariter <lb/>
+						dividuntur, pxoncs primus et quartus, quoniam post <lb/> illos et unam
+						longam, ct iambum, et spondeum, ct <lb/> anapæstum licet ponere, ad
+						septuaginta quinque pcr­ <lb/> veniunt : cum enim tres sint pedes, qnina
+						crcant sine <lb/> silentio, cum silentio autem viginti, quæ simul, ut <lb/>
+						dictum est, fiunt quinque et septuaginta, quibus addi­ <lb/> tis superiori
+						summæ, decem et ducenta complentur. <lb/> Palimbacchius et qui ei divisione
+						concordat tertius <lb/> paeon, quina pariunt integri sine silentio : cum
+						silen­ <lb/> tio autem quina cum una longa, quina cum spondeo, <lb/> quina
+						cum anapæsto. Hæc addimus ad majorem sum­ <lb/> mam, ct habemus metra omnia
+						ducenta quinqua­ <lb/> ginta.</p>
+					<p>i5. Molossus et cæteri sex temporum pe.lcs, qui <lb/> cum illo simnl septem
+						fiunt, quaterna crcanl integri : <lb/> cum silentio autem quoniam et una
+						longa post unum­ <lb/> quemque eorum locari potest, et iambus, et spondeus,
+						<lb/> et anapæstus, et bacchius, et creticus, et pæon qunr­ <lb/> rus;
+						vicena et octona complent, quae simul fiunt cen­ <lb/> tum nonaginta sex,
+						quæ ducta cum illis quaternis du­ <lb/> centa viginti quatuor complentur :
+						sed hinc octo dc­ <lb/> ducendi sunt, quia post dichorium iambus, ct post
+						<lb/> antispastum spondcus male ordinantur. Reliqua sunt <lb/> ducenta
+						sexdecim, qune addita majori summae, fa­ <lb/> ciunt metra omuia
+						quadringenta sexaginta sex. Proce­ <lb/> leumatici ratio hab eri non potuit
+						cum his pedibus qui­ <lb/> hus congruit, propter semipedes qui post hunc
+						plures <lb/> ponuntur. Nam ct una syllaba longa post eum poni <lb/> potest
+						cum si'entio, sicut post dactylum et rjus con­ <lb/> sortes ut duo, cl tres
+						breves ut unum tempus silea­ <lb/> tur; quo efficitur ut ultima brevis pro
+						longa accipia­ <lb/> tur. Epitriti metra gignunt terna integri, incipiente
+						<lb/> metro a duobus pedibus, perveniente ad quatuor : si <lb/> cniin addas
+						quintum, triginta duo tempora, quod uon <lb/> oportet, excedes. Cum silentio
+						vero primus et secun­ <lb/> dus epitritus terna post locato i mbo, terna
+						bacchio, <lb/> terna cretico, terna pæone quarto; quae fiuut cum <lb/> illis
+						ternis quæ sunt sine silentio, triginta. Tet tius ve­ <lb/> ro et quartus
+						epitriti tres ante silentium gignunt, cum <lb/> spondeo terna, ct terna cum
+						anapæsto, lerna cum <lb/> molosso, terna cum ionico minore, terna cum chor­
+						<lb/> iambo; quæ fiunt simul cum illis ternis, quæ sine <lb/> silentio
+						genuerunt, triginta et sev. Ergo epitriti orn­ <lb/> lies sexaginta et sex
+						metra pariunt. : quæ cum viginti <lb/> ct uno proceleumatici, superiori
+						summæ addta, fa­ <lb/> ciunt quingenta quinquaginta tria. Dispondeus restat
+						<lb/> gignens et ipse liia integer; adhibito autem silemio <lb/> cum spondeo
+						tria, et tria cum anapæsto, tria cum mo­ <lb/> losso, tria cum ionico a
+						miaore, tria cum choriambo: <lb/> quæ in summam ducta cum illis tribus quæ
+						creat in­ <lb/> teger, fiunt decem et octo. Ita erum metra omma <lb/>
+						quingenta septuaginta et unum.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT XIII. - <hi rend="italic">Ratio metietidi metra et
+								silentia interponendi.</hi>
 						</title>
 					</ab>
-					<p>46. M. Essent quidcm, nisi tria detrabenda essent, . <lb/> quia post secundum epitritum
-						dictum est iainbum ara­ <lb/> le poni. Sed hoc quidem bene se habet: quare jant <lb/>
-						dic mihi, quomodo libi aurem tangat metrum hoe, <lb/>
-						<hi rend="italic">Triplici vides, ut ortu Triviæ rotetur ignis. D.</hi> Persua­ <lb/>
-						viter. <hi rend="italic">M.</hi> Potesne dicere quibus pedibus constet? <hi rend="italic">D.</hi>
-						<lb/> Non possum : neque enim invenio quomodo sibi con­ <lb/> gruantquos melior : sive
-						cniui pyrrhichium a capite <lb/> constituam, sive anapæstum, sive pæonem tertium, <lb/>
-						non his conveniunt qui. sequuntur ct invenio bic qui­ <lb/> dem creticum post tertium
-						pæonem, ut reliqua sit <lb/> longa syllaba, quam creticus post se non respuit col­ <lb/>
-						locari; sed his pedibus hoc metrum constare recte <lb/> non posset, nisi interposito
-						silentio trium temporum : <lb/> nunc vero nihil siletur, cum hoe repetendo permulcet
-						<lb/> auditum. M. Vide igitur, utrum hicipere debeat a pyr­ <lb/> rhichio, deinde
-						mctiamur dichorium, tum spondeum, <lb/> qui complet tempora, quorum duo sunt in
-						principio : <lb/> potest item caput tenere anapæstus, deinde diiambus <lb/> metiri, ut
-						extrema longa collocata cum' quatuor tem­ <lb/> poribus anapæsti perficiat sex timpora,
-						quae cum di­ <lb/> iambo conveniunt, ex quo intelligas licct, partes pe­ <lb/> dum non
-						solum in fine poni, sed etiam in capite me­ <lb/> trorum. <hi rend="italic">D.</hi> Jam
+					<p>46. M. Essent quidcm, nisi tria detrabenda essent, . <lb/> quia post secundum
+						epitritum dictum est iainbum ara­ <lb/> le poni. Sed hoc quidem bene se
+						habet: quare jant <lb/> dic mihi, quomodo libi aurem tangat metrum hoe, <lb/>
+						<hi rend="italic">Triplici vides, ut ortu Triviæ rotetur ignis. D.</hi>
+						Persua­ <lb/> viter. <hi rend="italic">M.</hi> Potesne dicere quibus pedibus
+						constet? <hi rend="italic">D.</hi>
+						<lb/> Non possum : neque enim invenio quomodo sibi con­ <lb/> gruantquos
+						melior : sive cniui pyrrhichium a capite <lb/> constituam, sive anapæstum,
+						sive pæonem tertium, <lb/> non his conveniunt qui. sequuntur ct invenio bic
+						qui­ <lb/> dem creticum post tertium pæonem, ut reliqua sit <lb/> longa
+						syllaba, quam creticus post se non respuit col­ <lb/> locari; sed his
+						pedibus hoc metrum constare recte <lb/> non posset, nisi interposito
+						silentio trium temporum : <lb/> nunc vero nihil siletur, cum hoe repetendo
+						permulcet <lb/> auditum. M. Vide igitur, utrum hicipere debeat a pyr­ <lb/>
+						rhichio, deinde mctiamur dichorium, tum spondeum, <lb/> qui complet tempora,
+						quorum duo sunt in principio : <lb/> potest item caput tenere anapæstus,
+						deinde diiambus <lb/> metiri, ut extrema longa collocata cum' quatuor tem­
+						<lb/> poribus anapæsti perficiat sex timpora, quae cum di­ <lb/> iambo
+						conveniunt, ex quo intelligas licct, partes pe­ <lb/> dum non solum in fine
+						poni, sed etiam in capite me­ <lb/> trorum. <hi rend="italic">D.</hi> Jam
 						intelligo.</p>
-					<p>17. <hi rend="italic">M</hi> Quid, si demam unam ultimam rongam, ut <lb/> tale sil
-						metrum, <hi rend="italic">Segetes</hi> meus <hi rend="italic">labor :</hi> nonne
-						aninlad­ <lb/> vertis cum silentio duorum temporum repeti i Ex quo <lb/> manifestum est,
-						et aliquam partem pedis posse in <lb/> principio metri poni, et aliquam in fine, et
-						aliquam <lb/> in silentio. <hi rend="italic">D.</hi> Et hoc manifestum est. <hi rend="italic">M.</hi> Sed hoe <lb/> fieri si dichorium metiaris integrum in hoc metro;
-						<lb/> nam si diiambum, et a capite anapæstus ponatur, <lb/> cernis partem pedis in
-						principio positam, quai habet <lb/> jam quatuor tempora : duo autcm quæ debentur, si­
-						<lb/> lentur in fine. Ex quo discimus, posse metrum inci­ <lb/> pere a parte pedis, et
-						desinere ad plenum pedem, <lb/> sed nunquam siue silentio. <hi rend="italic">D.</hi> Et
-						hoc perspicuum <lb/> est. <note type="footnote"> 1 In B, <hi rend="italic">coliocata
-								quatllO",</hi> ooussa præpositione <hi rend="italic">""PL,</hi>
+					</div>
+				<div type="textpart" subtype="dialog"><p>17. <hi rend="italic">M</hi> Quid, si demam unam ultimam rongam, ut <lb/>
+						tale sil metrum, <hi rend="italic">Segetes</hi> meus <hi rend="italic">labor
+							:</hi> nonne aninlad­ <lb/> vertis cum silentio duorum temporum repeti i
+						Ex quo <lb/> manifestum est, et aliquam partem pedis posse in <lb/>
+						principio metri poni, et aliquam in fine, et aliquam <lb/> in silentio. <hi
+							rend="italic">D.</hi> Et hoc manifestum est. <hi rend="italic">M.</hi>
+						Sed hoe <lb/> fieri si dichorium metiaris integrum in hoc metro; <lb/> nam
+						si diiambum, et a capite anapæstus ponatur, <lb/> cernis partem pedis in
+						principio positam, quai habet <lb/> jam quatuor tempora : duo autcm quæ
+						debentur, si­ <lb/> lentur in fine. Ex quo discimus, posse metrum inci­
+						<lb/> pere a parte pedis, et desinere ad plenum pedem, <lb/> sed nunquam
+						siue silentio. <hi rend="italic">D.</hi> Et hoc perspicuum <lb/> est. <note
+							type="footnote"> 1 In B, <hi rend="italic">coliocata quatllO",</hi>
+							ooussa præpositione <hi rend="italic">""PL,</hi>
 							<lb/> quam in Ms. A reperimus. </note>
 						<pb n="1139"/>
-					</p>
-					<p>18. <hi rend="italic">M.</hi> Quid ? hoc metrum potesne metiri et dicere <lb/> quibas
-						pcdibus constet ? <lb/> jam satis terris nivis, atque dire <lb/> Grandinis misit Pater,
-						et rubente <lb/> Dextera sacras jaculatus arces. <lb/>
-						<hi rend="italic">(Horat. lib.</hi> i <hi rend="italic">carminum, ode</hi> 2.; <lb/>
-						<hi rend="italic">D.</hi> Possum constituere in capite creticum , et duos <lb/> metiri
-						reliquos senum temporum pedes, unum ioni­ <lb/> cum a majori, alterum dichorium, et
-						silcre unum <lb/> tempus quod adjungitur cretico ut sex tempora com­ <lb/> pleantur. <hi rend="italic">M.</hi> Nonnihil dcfuit considerationi tusc : <lb/> nam cum dichorius
-						est in line, restante silentio , ul­ <lb/> lima ejus quæ brevis est, pro longa
-						accipitur. An hoc <lb/> negabis? <hi rend="italic">D.</hi> Imo fateor. <hi rend="italic">M.</hi> Non ergo constitui dccet <lb/> in fine dichorium, nisi nullo in repetitione
-						consequente <lb/> silenlio , ne non jam dichorius, sed epitritus secun­ <lb/> dus
-						semiatur. D. Manifestum est. Quomodo ergo me­ <lb/> tiemur hoc metruin ? <hi rend="italic">D.</hi> Nescio.</p>
-					<ab>
-						<title type="sub">CAPUT XIV. — <hi rend="italic">Persequitur rationem adhibendi</hi>
-							silen­ <hi rend="italic">tia</hi> in metiendis metris.</title>
+					</p></div>
+				<div type="textpart" subtype="dialog">
+					<p>18. <hi rend="italic">M.</hi> Quid ? hoc metrum potesne metiri et dicere
+						<lb/> quibas pcdibus constet ? <lb/> jam satis terris nivis, atque dire
+						<lb/> Grandinis misit Pater, et rubente <lb/> Dextera sacras jaculatus
+						arces. <lb/>
+						<hi rend="italic">(Horat. lib.</hi> i <hi rend="italic">carminum, ode</hi>
+						2.; <lb/>
+						<hi rend="italic">D.</hi> Possum constituere in capite creticum , et duos
+						<lb/> metiri reliquos senum temporum pedes, unum ioni­ <lb/> cum a majori,
+						alterum dichorium, et silcre unum <lb/> tempus quod adjungitur cretico ut
+						sex tempora com­ <lb/> pleantur. <hi rend="italic">M.</hi> Nonnihil dcfuit
+						considerationi tusc : <lb/> nam cum dichorius est in line, restante silentio
+						, ul­ <lb/> lima ejus quæ brevis est, pro longa accipitur. An hoc <lb/>
+						negabis? <hi rend="italic">D.</hi> Imo fateor. <hi rend="italic">M.</hi> Non
+						ergo constitui dccet <lb/> in fine dichorium, nisi nullo in repetitione
+						consequente <lb/> silenlio , ne non jam dichorius, sed epitritus secun­
+						<lb/> dus semiatur. D. Manifestum est. Quomodo ergo me­ <lb/> tiemur hoc
+						metruin ? <hi rend="italic">D.</hi> Nescio.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT XIV. — <hi rend="italic">Persequitur rationem
+								adhibendi</hi> silen­ <hi rend="italic">tia</hi> in metiendis
+							metris.</title>
 					</ab>
-					<p>M. Attende ergo utrum bene sonet, cnm ila pro­ <lb/> nuntio, ut post tres primas
-						syllabas unum tempus si­ <lb/> leam : ita enim in fine nihil debebitur , ut decenter
-						<lb/> ibi possit esse dichorius. <hi rend="italic">D.</hi> Jucundissime sonat.</p>
-					<p>49. <hi rend="italic">M.</hi> Hoc qnoque igitur adjungamus arti, ut non <lb/> solum in
-						fine , sed et ante tinem cum oportet silea­ <lb/> mus. Tunc autem oportet, cnm id quod
-						debetur im­ <lb/> plendis temporibus pedum , ant indecenter siletur in <lb/> line
-						propter ultimam brevem, ut in hoc quod dictum <lb/> est ; aut cum duo constitnuntur non
-						pleni pedes, <lb/> unus in capite, alter in fine, qualis iste est, <lb/> Gentiles
-						nostros inter oberrat equos. <lb/> Sensisti enim, ut opinor, me post quinque syllabas
-						<lb/> longas , moram duorum temporum siluisse , et tan - <lb/> tumdem in fine silendum
-						est, dum reditur ad caput. <lb/> Si enim hoc metrum ad legem sex temporum metii­ <lb/>
-						ris; erit tibi primus spondeus, secundus molossus, <lb/> tertius choriambus, quartus
-						anapaestus. Spondeo igi­ <lb/> tur debentur duo tempora ut sex temporum pedcm <lb/>
-						impleat, et anapæsto : itaque duo silentur post mo­ <lb/> lossum ante finem, et duo post
-						anapæstum in fine. Si <lb/> amem ad legem temporum quatuor; una longa erit <lb/> in
-						capite, deinde duos metimur spondeos, dcinde <lb/> duos dactylos, et post una longa
-						concludet1. Sile­ <lb/> mus itaque duo tempora post geminum spondeum <lb/> ante finem,
-						et duo in fine, ut ambo pedes implean­ <lb/> tur, quorum dimidias partes in capite atque
-						in extre­ <lb/> mo posuimus.</p>
-					<p>20. Nonnunquam tamen qnod duobus non plenis <lb/> pedibus debetur in principio ac fine
-						collocatis, finali <lb/> tantum silentio redditur2; si tantum sit ut dimidii <lb/>
-						spatium pedis non excedat, qualia hæc duo sunt: <lb/> silvæ laborantes, geluque <lb/>
-						Flumina constiterint acuto. <lb/> Horum enim prius incipit a palimbacchio, inde excur­
-						<lb/> rit in molossum, et bacchio terminatur : silentur ergo <lb/> duo tempora ; quorum
-						unum bacchio, alterum pa­ <lb/> limbacchio cum reddideris, sena ubique tempora in,.. <lb/>
-						<note type="footnote">1 III B., concludetur. concludet, juxta Mss. A et B. M.
-							</note><note type="footnote"> ' in prius excusis, <hi rend="italic">finaii tamcn
-								silentio redditur.</hi> At iD <lb/> AUS , <hi rend="italic">nnali tantum.</hi>
+					<p>M. Attende ergo utrum bene sonet, cnm ila pro­ <lb/> nuntio, ut post tres
+						primas syllabas unum tempus si­ <lb/> leam : ita enim in fine nihil
+						debebitur , ut decenter <lb/> ibi possit esse dichorius. <hi rend="italic"
+							>D.</hi> Jucundissime sonat.</p>
+					<p>49. <hi rend="italic">M.</hi> Hoc qnoque igitur adjungamus arti, ut non <lb/>
+						solum in fine , sed et ante tinem cum oportet silea­ <lb/> mus. Tunc autem
+						oportet, cnm id quod debetur im­ <lb/> plendis temporibus pedum , ant
+						indecenter siletur in <lb/> line propter ultimam brevem, ut in hoc quod
+						dictum <lb/> est ; aut cum duo constitnuntur non pleni pedes, <lb/> unus in
+						capite, alter in fine, qualis iste est, <lb/> Gentiles nostros inter oberrat
+						equos. <lb/> Sensisti enim, ut opinor, me post quinque syllabas <lb/> longas
+						, moram duorum temporum siluisse , et tan - <lb/> tumdem in fine silendum
+						est, dum reditur ad caput. <lb/> Si enim hoc metrum ad legem sex temporum
+						metii­ <lb/> ris; erit tibi primus spondeus, secundus molossus, <lb/>
+						tertius choriambus, quartus anapaestus. Spondeo igi­ <lb/> tur debentur duo
+						tempora ut sex temporum pedcm <lb/> impleat, et anapæsto : itaque duo
+						silentur post mo­ <lb/> lossum ante finem, et duo post anapæstum in fine. Si
+						<lb/> amem ad legem temporum quatuor; una longa erit <lb/> in capite, deinde
+						duos metimur spondeos, dcinde <lb/> duos dactylos, et post una longa
+						concludet1. Sile­ <lb/> mus itaque duo tempora post geminum spondeum <lb/>
+						ante finem, et duo in fine, ut ambo pedes implean­ <lb/> tur, quorum
+						dimidias partes in capite atque in extre­ <lb/> mo posuimus.</p>
+					<p>20. Nonnunquam tamen qnod duobus non plenis <lb/> pedibus debetur in
+						principio ac fine collocatis, finali <lb/> tantum silentio redditur2; si
+						tantum sit ut dimidii <lb/> spatium pedis non excedat, qualia hæc duo sunt:
+						<lb/> silvæ laborantes, geluque <lb/> Flumina constiterint acuto. <lb/>
+						Horum enim prius incipit a palimbacchio, inde excur­ <lb/> rit in molossum,
+						et bacchio terminatur : silentur ergo <lb/> duo tempora ; quorum unum
+						bacchio, alterum pa­ <lb/> limbacchio cum reddideris, sena ubique tempora
+						in,.. <lb/>
+						<note type="footnote">1 III B., concludetur. concludet, juxta Mss. A et B.
+							M. </note><note type="footnote"> ' in prius excusis, <hi rend="italic"
+								>finaii tamcn silentio redditur.</hi> At iD <lb/> AUS , <hi
+								rend="italic">nnali tantum.</hi>
 						</note>
-						<lb/> plebuntur. Mcc autem posterius dactylo inchoatur , <lb/> indc pergit in
-						choriambum, clauditur bacchio : tria <lb/> igitur tempora silere oportebit; hinc unum
-						bacchio , <lb/> dno dactylo redhibebimus, ut in omnibus sint sena <lb/> tempora.,</p>
-					<p>24. Prins autem redditur quod debetur implendo <lb/> extremo pedi, quam in principio
-						constituto. Nec ali­ <lb/> tcr omnino fieri aures sinunt. Nec mirum : id enim <lb/> cum
-						repetimus, adjungitur capiti quod prorsus extre­ <lb/> mum est. Itaque in hoc metro quod
-						dictum est, Flu­ <lb/>
-						<hi rend="italic">mina constiterint acuto :</hi> cum tria tempora scnis utique <lb/>
-						implendis dcbeantur, si ea non silentio velis, sed <lb/> voce reddere, possintque reddi
-						et per ianibum , et <lb/> per chorium , et per tribrachum , quia omnes tern <lb/>
-						tempora possident; nullo modo ca per chorium reddi <lb/> sensus ipse permittit, in quo
-						prior cst longa syllaba, <lb/> brevis posterior : id enim prius sonare debet, quod <lb/>
-						bacchio debetur extremo, id est brevis syllaba; non <lb/> longa, quae dactylo primo.
-						Licet hoc explorare his <lb/> exemplis : <lb/> Flumina consUtcrint acuto gelu. <lb/>
-						Flumina constiterint acute gelida. <lb/> Flumina constiterint in alta nocte. <lb/> Gui
-						dubium cst, duo illa suaviter repeti, hoc autem <lb/> tertium nullo modo ?</p>
-					<p>22. Item cum singula tempora singulis debentur <lb/> pedibus minus plenis, si ea voce
-						reddere velis, non <lb/> sinit sensus in unam syllabam coarctari; mira omnino <lb/>
-						justitia. Non enim convenit, quod separatim redden­ <lb/> dum est, non etiam constitui
-						separatim. Quocirca iD <lb/> illo metro, <hi rend="italic">Silvce laborantes,
-							geluquc,</hi> si unam longam <lb/> pro silentio fini addas, sicuti est, <hi rend="italic">Silvæ laborantes <lb/> gelu duro,</hi> non probant aures; sicut probant
-						cum di­ <lb/> cimus , <hi rend="italic">Silvæ laborantes gelu et frigore.</hi> Quod
-						satiatis­ <lb/> simc sentis, cum singula repetis.</p>
-					<p>25. Item non oportet cum duo minus pleni pedes <lb/> ponuntur, majorem in principio
-						quam in fine poni; <lb/> nam et hoc condemnat auditus, tanquam si dicas, <lb/>
-						<hi rend="italic">Optimum tempus adest tandem,</hi> ut primus pos sit cre- <lb/> Licus,
-						secundus choriambus, tertius spondeus; ut tria <lb/> tempora sileamus, quorum duo
-						debentur ultimo spon­ <lb/> deo ad sena implenda, et unum primo cretico. At si <lb/> ita
-						dicalur, <hi rend="italic">Tandem tempus adest optimum,</hi> eadem <lb/> interposita
-						trium temporum mora in silentio, quis <lb/> non sentiat jucundissime repeti ? Quare aut
-						tanti spa­ <lb/> tii decet esse in fine minus plenum pedem, quanti est <lb/> in
-						principio, ut illud, <hi rend="italic">Silvæ laborantes , geluque</hi> : aut <lb/>
-						minorem in principio, et in fine majorem, veluti est, <lb/> Flumina <hi rend="italic">constiterint acuto.</hi> Ncque injuria, quia ubi <lb/> est aequalitas, nulla
-						discordia : uhi autem dispar est <lb/> numerus, si a minore ad majorem veniamus, ul
-						<lb/> in numerando solet , facit rursus ipse ordo concor­ <lb/> diam.</p>
-					<p>24. Ex quo illud est etiam consequens, ut cum ii <lb/> de quibus agitur, minus pleni
-						ponuntur pedes, si duo­ <lb/> bus locis interponitur silentium, id est ante finem et in
-						<lb/> fine; tantum ante finem sileatur quantum debcturex­ <lb/> tremo, tantum autem in
-						fine quantum scilicet primo I : <lb/> quia medium tendit ad finem; a fine vero ad
-						princi­ <note type="footnote">i Am. Er. l.ov. sic habent <hi rend="italic">Qtumtum
+						<lb/> plebuntur. Mcc autem posterius dactylo inchoatur , <lb/> indc pergit
+						in choriambum, clauditur bacchio : tria <lb/> igitur tempora silere
+						oportebit; hinc unum bacchio , <lb/> dno dactylo redhibebimus, ut in omnibus
+						sint sena <lb/> tempora.,</p>
+					<p>24. Prins autem redditur quod debetur implendo <lb/> extremo pedi, quam in
+						principio constituto. Nec ali­ <lb/> tcr omnino fieri aures sinunt. Nec
+						mirum : id enim <lb/> cum repetimus, adjungitur capiti quod prorsus extre­
+						<lb/> mum est. Itaque in hoc metro quod dictum est, Flu­ <lb/>
+						<hi rend="italic">mina constiterint acuto :</hi> cum tria tempora scnis
+						utique <lb/> implendis dcbeantur, si ea non silentio velis, sed <lb/> voce
+						reddere, possintque reddi et per ianibum , et <lb/> per chorium , et per
+						tribrachum , quia omnes tern <lb/> tempora possident; nullo modo ca per
+						chorium reddi <lb/> sensus ipse permittit, in quo prior cst longa syllaba,
+						<lb/> brevis posterior : id enim prius sonare debet, quod <lb/> bacchio
+						debetur extremo, id est brevis syllaba; non <lb/> longa, quae dactylo primo.
+						Licet hoc explorare his <lb/> exemplis : <lb/> Flumina consUtcrint acuto
+						gelu. <lb/> Flumina constiterint acute gelida. <lb/> Flumina constiterint in
+						alta nocte. <lb/> Gui dubium cst, duo illa suaviter repeti, hoc autem <lb/>
+						tertium nullo modo ?</p>
+					<p>22. Item cum singula tempora singulis debentur <lb/> pedibus minus plenis, si
+						ea voce reddere velis, non <lb/> sinit sensus in unam syllabam coarctari;
+						mira omnino <lb/> justitia. Non enim convenit, quod separatim redden­ <lb/>
+						dum est, non etiam constitui separatim. Quocirca iD <lb/> illo metro, <hi
+							rend="italic">Silvce laborantes, geluquc,</hi> si unam longam <lb/> pro
+						silentio fini addas, sicuti est, <hi rend="italic">Silvæ laborantes <lb/>
+							gelu duro,</hi> non probant aures; sicut probant cum di­ <lb/> cimus ,
+							<hi rend="italic">Silvæ laborantes gelu et frigore.</hi> Quod satiatis­
+						<lb/> simc sentis, cum singula repetis.</p>
+					<p>25. Item non oportet cum duo minus pleni pedes <lb/> ponuntur, majorem in
+						principio quam in fine poni; <lb/> nam et hoc condemnat auditus, tanquam si
+						dicas, <lb/>
+						<hi rend="italic">Optimum tempus adest tandem,</hi> ut primus pos sit cre-
+						<lb/> Licus, secundus choriambus, tertius spondeus; ut tria <lb/> tempora
+						sileamus, quorum duo debentur ultimo spon­ <lb/> deo ad sena implenda, et
+						unum primo cretico. At si <lb/> ita dicalur, <hi rend="italic">Tandem tempus
+							adest optimum,</hi> eadem <lb/> interposita trium temporum mora in
+						silentio, quis <lb/> non sentiat jucundissime repeti ? Quare aut tanti spa­
+						<lb/> tii decet esse in fine minus plenum pedem, quanti est <lb/> in
+						principio, ut illud, <hi rend="italic">Silvæ laborantes , geluque</hi> : aut
+						<lb/> minorem in principio, et in fine majorem, veluti est, <lb/> Flumina
+							<hi rend="italic">constiterint acuto.</hi> Ncque injuria, quia ubi <lb/>
+						est aequalitas, nulla discordia : uhi autem dispar est <lb/> numerus, si a
+						minore ad majorem veniamus, ul <lb/> in numerando solet , facit rursus ipse
+						ordo concor­ <lb/> diam.</p>
+					<p>24. Ex quo illud est etiam consequens, ut cum ii <lb/> de quibus agitur,
+						minus pleni ponuntur pedes, si duo­ <lb/> bus locis interponitur silentium,
+						id est ante finem et in <lb/> fine; tantum ante finem sileatur quantum
+						debcturex­ <lb/> tremo, tantum autem in fine quantum scilicet primo I :
+						<lb/> quia medium tendit ad finem; a fine vero ad princi­ <note
+							type="footnote">i Am. Er. l.ov. sic habent <hi rend="italic">Qtumtum
 								scilictl</hi> prvicipto;</note>
 						<lb/>
-						<pb n="1141"/> pium redeundum est. Si antem utrique tantumdem de­ <lb/> betur, nulla
-						controversia est quin tantum ante finem <lb/> quantum in fine silendum sit. Sileri autem
-						oportet non <lb/> nisi ubi terminatur pars orationis. In iis antem numeris <lb/> qui non
-						verbis fiunt1, sed aliquo pulsu vel flatu, vel <lb/> ipsa etiam lingua, nullum in hac re
-						discrimen est, post <lb/> quam vocem percussionemve sileatur; modo ut legiti­ <lb/> mum
-						secundum supradictas rationes intercedat silen­ <lb/> tium. Quamobrem et a duobus potest
-						minus plenis <lb/> pedibus metrum incipere, si tamen utriusque con­ <lb/> junctum
-						spatium minus non -sil, quam posset esse <lb/> unius cl dilnidii pedis; nam supra
-						diximus, tum recte <lb/> poni duos minus plenos pedes, cum id quod debetur <lb/>
-						ambobus, non transit spatio pedem dimidium : exem­ <lb/> plum est, <hi rend="italic">Montes acuti;</hi> ut aut in fine tria tempora <lb/> sileamus, aut unum tempus post
-						spondeum, et duo in <lb/> fine. Aliter enim hoc metrum convenienter metiri <lb/> non
+						<pb n="1141"/> pium redeundum est. Si antem utrique tantumdem de­ <lb/>
+						betur, nulla controversia est quin tantum ante finem <lb/> quantum in fine
+						silendum sit. Sileri autem oportet non <lb/> nisi ubi terminatur pars
+						orationis. In iis antem numeris <lb/> qui non verbis fiunt1, sed aliquo
+						pulsu vel flatu, vel <lb/> ipsa etiam lingua, nullum in hac re discrimen
+						est, post <lb/> quam vocem percussionemve sileatur; modo ut legiti­ <lb/>
+						mum secundum supradictas rationes intercedat silen­ <lb/> tium. Quamobrem et
+						a duobus potest minus plenis <lb/> pedibus metrum incipere, si tamen
+						utriusque con­ <lb/> junctum spatium minus non -sil, quam posset esse <lb/>
+						unius cl dilnidii pedis; nam supra diximus, tum recte <lb/> poni duos minus
+						plenos pedes, cum id quod debetur <lb/> ambobus, non transit spatio pedem
+						dimidium : exem­ <lb/> plum est, <hi rend="italic">Montes acuti;</hi> ut aut
+						in fine tria tempora <lb/> sileamus, aut unum tempus post spondeum, et duo
+						in <lb/> fine. Aliter enim hoc metrum convenienter metiri <lb/> non
 						potest.</p>
-					<ab>
-						<title type="sub">CAPUT XV. — <hi rend="italic">Item de silentio in metris</hi>
-							interponendo.</title>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT XV. — <hi rend="italic">Item de silentio in
+								metris</hi> interponendo.</title>
 					</ab>
-					<p>25. Sit hoc etiam in disciplina , ut cum ante finem <lb/> silemus, non ibi pars
-						orationis brevi syllaba termino­ <lb/> tur, ne secundum illam sæpe commemoratam rcgu­
-						<lb/> lam, pro longa eam sensus accipiat, sequente silentio. <lb/> Itaque in hoc metro ,
-							<hi rend="italic">Montibu, acutis,</hi> non possumus <lb/> silere post dactylum tempus
-						unum, quod post spon­ <lb/> deum in superiore potcramus; ne non jam dactylus, <lb/> sed
-						creticus sentiatur : atque ita non duobus minus <lb/> plenis pedibus, quod nunc
-						demonstramus, sed pleno <lb/> dichorio et ultimo spondco metrum constare videatur, <lb/>
-						duum temporum silentio in fine reddendo.</p>
-					<p>2G. Sed illud notandum est, in principio posito mi­ <lb/> nus pleno pedi, aut ibidem
-						reddi debitum per silen­ <lb/> tiu:n, sicuti est, <hi rend="italic">Jam satis
-							terris</hi> nivis <hi rend="italic">atque diræ :</hi> ant <lb/> in fine, velut, <hi rend="italic">Segetes nieus labor.</hi> Minus autem pleno <lb/> pedi qui in fine
-						ponitur, aut ibidem restitui silentio, <lb/> quod debetur, ut in illo, <hi rend="italic">Ite</hi> 'fitur Camænce : aut in <lb/> aliquo de mediis loco, vcluii in hoc, <hi rend="italic">I'a blandum vi­ <lb/> gel arvis, adest hospes hirundo.</hi> Unum enim
-						tempus <lb/> qnod debetur ultimo bacchio, vel post totum nume­ <lb/> nim sileri potest,
-						vel post primam ejus numeri pedem <lb/> molossum, vcl sccundum ionicum a minore. Quod
-						<lb/> vcro mediis forte ninus plenis pedibus dcbiti est, non <lb/> nisi ibidem reddi
-						potest : ut est, <lb/> Tuba terribilem sonitum dedit acre curvo. <lb/> Si enim sic
-						mutianum. hoc metrum , ut primum fa­ <lb/> ciamus anapæstum, secundum ioniculn qucmlibct
-						ill <lb/> syllabis quinque, soluta scilicet longa vel prima vel <lb/> ultima in duas
-						breves, tertium choriambum, ultimum <lb/> bacchium : tria eruut tempora in debito, unum
-						ex­ <lb/> tremo bacchio reddendum, et duo anapæsto primo, ut <lb/> sena compleantur. Sed
-						hoc totum spatium trium tem­ <lb/> porum in fine sileri potest. At si ab integro pede
-						in­ <lb/> cipias, quiuque syllabas primas pro quolibet ionico <note type="footnote">quia
-								<hi rend="italic">medium tendU ad</hi> finem, si xmam longam pro <hi rend="italic">silentio fim<lb/> addas, sicuti</hi> Silvae lal)orantes gelu duro. <hi rend="italic">A fine vero,</hi> etc. <lb/> Plerique autem MSS., <hi rend="italic">quantumsciiicet</hi> pritno : supple, minus <lb/> pleno pedi debetur. Postea carent
-							hisce verbis, si <hi rend="italic">unam<lb/> ongam;</hi> Quae exigente sensu
-							removimus. </note><note type="footnote"> I ita Mss. AL editi babent, finiimtur. </note>
-						<lb/> metitus, sequitur choriambus r inde jam pedem inte­ <lb/> grum non invenies :
-						quocirca unius longæ spatio silere <lb/> oportebit: qno annumerato, choriambus alter
-						impte­ <lb/> bitur; bacchio reliquo metrum clausuro, cui tempus <lb/> unum debitum
-						silebis in fine.</p>
-					<p>27. Unde janfesse opinor perspicuum, cum in me­ <lb/> diis siletur locis, aut ea
-						restitui tempora quoe in fine <lb/> debentur, aut ea quoo ibi debentur ubi siletur. Sed
-						ali­ <lb/> quando non est necesse ut sileatur in medii,. cum <lb/> potest alitcr metrum
-						mctiri, ut in eo quod paulo ante <lb/> posuimus. Aliquando autcm necesse cst, ut in hoc, <lb/>
-						<hi rend="italic">Vernat temperies,</hi> auræ tepent, sunt <hi rend="italic">deliciæ</hi> : nam ma­ <lb/> nifeslum est istum numeruin, aut quaternorum tem­ <lb/>
-						porum, aut senorum pedibus currere. Si quaternorum; <lb/> silenduln est unum tempus post
-						syllabam octavum, et <lb/> in fine duo; metiatur primo spondeus, secundo da. <lb/>
-						ctylus, tertio spondeus, quarto dactylus annumerato <lb/> post longam silentio, quia
-						post brevem non oportet, <lb/> quinto spondcus, sexto dactylus, ultima longa qua <lb/>
-						numerus clauditur, cui duo tempora debita silentur in <lb/> fine. Si autem scnurum
-						temporum hie metimur pe­ <lb/> des , primus erit molossus, secundos ionicus a mi­ <lb/>
-						nore, tertius creticus qui fit dichorius adjuncto silen­ <lb/> tio unius temporis,
-						quartus ionicus a majore et longa <lb/> ultima, post quam quatu r tempora silebuntur.
-						Posset <lb/> alitcr, ut una longa in principio locaretur, quam se- <lb/> queretur
-						ionicus a majore, deinde molossus, deinde <lb/> bacchius, qui fieret antispastus
-						adjuncto silentio unius <lb/> temporis; ultimus choriambus meti um clauderet, ita <lb/>
-						ut quatuor temporum in fine silentium redderetur uni <lb/> longae in principio
-						constitutæ. Sed aures istam di­ <lb/> mensionem repudiant; quia pars pedis in principio
-						<lb/> collocata, nisi major quam dimidia fuerit, non recte <lb/> illi post plenum pedem
-						finali silentio redditur ubi de-. <lb/> betur : sed aliis interpositis pedibus, scimus
-						quidem <lb/> quantum debeatur; sed uon comprehenditur sensu, <lb/> ut tanto spatio
-						sileatur, nisi minus debentur in silen­ <lb/> tio quam positum est in sono : quia cum
-						mojorem <lb/> partem pedis vox peregerit, minor quae reliqua est, <lb/> ubicumque facile
-						occurrit.</p>
-					<p>28. Quamobrem metri quod sub hoc exemplo po­ <lb/> suimus, <hi rend="italic">Vernat
-							temperies, aura lepenl,</hi> sunt <hi rend="italic">deliciæ:</hi>
-						<lb/> cum sit una necessaria, quam diximus, dimensio, si <lb/> post decimam ejus
-						syllabam tempus unum silentur, eI <lb/> quatuor in fine; est alia voluntaria, si quis
-						post <lb/> sextam syllabam velit silere duo tempora, et unum <lb/> post undecimam , et
-						duo in fine: ut sii in principio <lb/> spondeas, sequatur hunc choriambus, tertio
-						spondeo <lb/> silentium duum temporum annumeretur, ut vd mo­ <lb/> loSSUs vel a minore
-						ionicus fiat, quartus bacchius <lb/> adjuncto itidem silentio unius temporis fiat
-						antispa­ <lb/> stus, quinto choriambo numcrus torminetur in voce, <lb/> duobus
-						temporibus in fine per silentium redditis in <lb/> principio locato spondeo. Est item
-						alia. Si enim velis, <lb/> post sextam syllabam unum tempus silcbis, ct post <lb/>
-						decimam unum, post undecimam tantumdem, et doc <lb/> in fine : ut sil primus spondeus,
-						secundus cboriam­ <lb/> bus, tertius palimbacchius fiat antispastas uno silentii <lb/>
-						tempore annumerato, quartus spondeus fiat dit borius <lb/>
-						<pb n="1143"/> unius temporis interjecto, et unius temporis conse­ <lb/> queote
-						silentio, choriambos ultimus numerum clau­ <lb/> dat, ita ut sileamus duo tempora in
-						fine, quæ primo <lb/> debentur spondeo. Est et tertia dimensio, si post pri­ <lb/> mum
-						spondeum tempus unum sileatur, et reliqua quæ <lb/> In proximo superiore serventur; nisi
-						quod in hujus <lb/> fine unum tempus silebitur, quia spondeus ille qui so­ <lb/> let in
-						principio locari, consequente unius temporis <lb/> silentio factus est palimbacchius, ut
-						plus uno tempore <lb/> nihil ei debeatur, quod in fine silendum est, Unde jam <lb/>
-						perspicis metris interponi silentia, quædam necessa­ <lb/> ria , quaedam voluntaria : et
-						necessaria qnidem , cum <lb/> aliquid pedibus dcbetur implendis; voluntaria vero, <lb/>
-						cum pleni sunt pedes atque integri.</p>
-					<p>29.'Quod autem superius dictam est, amplius qua­ <lb/> tuor temporibus silendum non
-						esse, de necessariis <lb/> silentiis dictum est, ubi debita tempora explentur. <lb/> Nam
-						in iis qu:c voluntaria silentia nominavimus, licet <lb/> etiam pedem sonare, et pedem
-						silere : quod si pari­ <lb/> bus intervallis fecerimus, non erit metrum, sed rhy­ <lb/>
-						thmus, nullo certo fine apparente unde redeatur ad <lb/> caput. Quamobrem si exempli
-						gratia silentiis velis <lb/> distinguere, ut post primum pedem alterius pedis <lb/>
-						tempora sileas, non hoc perpetuo servandum est. Li­ <lb/> cet autem varietate qualibet
-						connumeratis silentiis <lb/> usque ad legitima tempora metrum producere, velut <lb/> in
-						boe, <hi rend="italic">Nobis</hi> verum <hi rend="italic">in promptu est , tu</hi> si
-						verum <hi rend="italic">dicis.</hi>
-						<lb/> Licet hic post primum spondeum quatuor tempora si- <lb/> Jere, et alia quatuor
-						post sequentes duos : post tres <lb/> autem finales nihil silebitur; jam cnim triginta
-						duo <lb/> tempora terminata sunt. Sed multo est aptius, et quo­ <lb/> dammodo justius,
-						ut vel in fine tantum , vel etiam <lb/> in medio et One sileatur t, quod subtracto uno
-						pede <lb/> leri potest, ut ita sit : <hi rend="italic">Nobis verum in promptu est,</hi>
-						<lb/> tu <hi rend="italic">dic</hi> verum. Hoc et in metris caeterorum pedum <lb/>
-						tenendum est, scilicet necessariis silentiis, sive <lb/> finalibus sive mediis reddi
-						debita, ut pedes implean­ <lb/> tur : non autem sileri2 oportere amplius qnam pedis
-						<lb/> partem, quam levatio positiove occupant. Voluntariis <lb/> antem silentiis et
-						partes pedum et integros pedes si­ <lb/> fere conceditur, sicut exemplis supra editis1
-						monstra­ <lb/> vimus. Sed hactenus interponendorum silentiorum <lb/> ratio tractata
-						sit.</p>
-					<ab>
-						<title type="sub">CAPUT X VI. — <hi rend="italic">De pedum commixtione, et de</hi> me­
-							trorum <hi rend="italic">copulatione.</hi>
+					<p>25. Sit hoc etiam in disciplina , ut cum ante finem <lb/> silemus, non ibi
+						pars orationis brevi syllaba termino­ <lb/> tur, ne secundum illam sæpe
+						commemoratam rcgu­ <lb/> lam, pro longa eam sensus accipiat, sequente
+						silentio. <lb/> Itaque in hoc metro , <hi rend="italic">Montibu,
+							acutis,</hi> non possumus <lb/> silere post dactylum tempus unum, quod
+						post spon­ <lb/> deum in superiore potcramus; ne non jam dactylus, <lb/> sed
+						creticus sentiatur : atque ita non duobus minus <lb/> plenis pedibus, quod
+						nunc demonstramus, sed pleno <lb/> dichorio et ultimo spondco metrum
+						constare videatur, <lb/> duum temporum silentio in fine reddendo.</p>
+					<p>2G. Sed illud notandum est, in principio posito mi­ <lb/> nus pleno pedi, aut
+						ibidem reddi debitum per silen­ <lb/> tiu:n, sicuti est, <hi rend="italic"
+							>Jam satis terris</hi> nivis <hi rend="italic">atque diræ :</hi> ant
+						<lb/> in fine, velut, <hi rend="italic">Segetes nieus labor.</hi> Minus
+						autem pleno <lb/> pedi qui in fine ponitur, aut ibidem restitui silentio,
+						<lb/> quod debetur, ut in illo, <hi rend="italic">Ite</hi> 'fitur Camænce :
+						aut in <lb/> aliquo de mediis loco, vcluii in hoc, <hi rend="italic">I'a
+							blandum vi­ <lb/> gel arvis, adest hospes hirundo.</hi> Unum enim tempus
+						<lb/> qnod debetur ultimo bacchio, vel post totum nume­ <lb/> nim sileri
+						potest, vel post primam ejus numeri pedem <lb/> molossum, vcl sccundum
+						ionicum a minore. Quod <lb/> vcro mediis forte ninus plenis pedibus dcbiti
+						est, non <lb/> nisi ibidem reddi potest : ut est, <lb/> Tuba terribilem
+						sonitum dedit acre curvo. <lb/> Si enim sic mutianum. hoc metrum , ut primum
+						fa­ <lb/> ciamus anapæstum, secundum ioniculn qucmlibct ill <lb/> syllabis
+						quinque, soluta scilicet longa vel prima vel <lb/> ultima in duas breves,
+						tertium choriambum, ultimum <lb/> bacchium : tria eruut tempora in debito,
+						unum ex­ <lb/> tremo bacchio reddendum, et duo anapæsto primo, ut <lb/> sena
+						compleantur. Sed hoc totum spatium trium tem­ <lb/> porum in fine sileri
+						potest. At si ab integro pede in­ <lb/> cipias, quiuque syllabas primas pro
+						quolibet ionico <note type="footnote">quia <hi rend="italic">medium tendU
+								ad</hi> finem, si xmam longam pro <hi rend="italic">silentio
+								fim<lb/> addas, sicuti</hi> Silvae lal)orantes gelu duro. <hi
+								rend="italic">A fine vero,</hi> etc. <lb/> Plerique autem MSS., <hi
+								rend="italic">quantumsciiicet</hi> pritno : supple, minus <lb/>
+							pleno pedi debetur. Postea carent hisce verbis, si <hi rend="italic"
+								>unam<lb/> ongam;</hi> Quae exigente sensu removimus. </note><note
+							type="footnote"> I ita Mss. AL editi babent, finiimtur. </note>
+						<lb/> metitus, sequitur choriambus r inde jam pedem inte­ <lb/> grum non
+						invenies : quocirca unius longæ spatio silere <lb/> oportebit: qno
+						annumerato, choriambus alter impte­ <lb/> bitur; bacchio reliquo metrum
+						clausuro, cui tempus <lb/> unum debitum silebis in fine.</p>
+					<p>27. Unde janfesse opinor perspicuum, cum in me­ <lb/> diis siletur locis, aut
+						ea restitui tempora quoe in fine <lb/> debentur, aut ea quoo ibi debentur
+						ubi siletur. Sed ali­ <lb/> quando non est necesse ut sileatur in medii,.
+						cum <lb/> potest alitcr metrum mctiri, ut in eo quod paulo ante <lb/>
+						posuimus. Aliquando autcm necesse cst, ut in hoc, <lb/>
+						<hi rend="italic">Vernat temperies,</hi> auræ tepent, sunt <hi rend="italic"
+							>deliciæ</hi> : nam ma­ <lb/> nifeslum est istum numeruin, aut
+						quaternorum tem­ <lb/> porum, aut senorum pedibus currere. Si quaternorum;
+						<lb/> silenduln est unum tempus post syllabam octavum, et <lb/> in fine duo;
+						metiatur primo spondeus, secundo da. <lb/> ctylus, tertio spondeus, quarto
+						dactylus annumerato <lb/> post longam silentio, quia post brevem non
+						oportet, <lb/> quinto spondcus, sexto dactylus, ultima longa qua <lb/>
+						numerus clauditur, cui duo tempora debita silentur in <lb/> fine. Si autem
+						scnurum temporum hie metimur pe­ <lb/> des , primus erit molossus, secundos
+						ionicus a mi­ <lb/> nore, tertius creticus qui fit dichorius adjuncto silen­
+						<lb/> tio unius temporis, quartus ionicus a majore et longa <lb/> ultima,
+						post quam quatu r tempora silebuntur. Posset <lb/> alitcr, ut una longa in
+						principio locaretur, quam se- <lb/> queretur ionicus a majore, deinde
+						molossus, deinde <lb/> bacchius, qui fieret antispastus adjuncto silentio
+						unius <lb/> temporis; ultimus choriambus meti um clauderet, ita <lb/> ut
+						quatuor temporum in fine silentium redderetur uni <lb/> longae in principio
+						constitutæ. Sed aures istam di­ <lb/> mensionem repudiant; quia pars pedis
+						in principio <lb/> collocata, nisi major quam dimidia fuerit, non recte
+						<lb/> illi post plenum pedem finali silentio redditur ubi de-. <lb/> betur :
+						sed aliis interpositis pedibus, scimus quidem <lb/> quantum debeatur; sed
+						uon comprehenditur sensu, <lb/> ut tanto spatio sileatur, nisi minus
+						debentur in silen­ <lb/> tio quam positum est in sono : quia cum mojorem
+						<lb/> partem pedis vox peregerit, minor quae reliqua est, <lb/> ubicumque
+						facile occurrit.</p>
+					<p>28. Quamobrem metri quod sub hoc exemplo po­ <lb/> suimus, <hi rend="italic"
+							>Vernat temperies, aura lepenl,</hi> sunt <hi rend="italic"
+							>deliciæ:</hi>
+						<lb/> cum sit una necessaria, quam diximus, dimensio, si <lb/> post decimam
+						ejus syllabam tempus unum silentur, eI <lb/> quatuor in fine; est alia
+						voluntaria, si quis post <lb/> sextam syllabam velit silere duo tempora, et
+						unum <lb/> post undecimam , et duo in fine: ut sii in principio <lb/>
+						spondeas, sequatur hunc choriambus, tertio spondeo <lb/> silentium duum
+						temporum annumeretur, ut vd mo­ <lb/> loSSUs vel a minore ionicus fiat,
+						quartus bacchius <lb/> adjuncto itidem silentio unius temporis fiat antispa­
+						<lb/> stus, quinto choriambo numcrus torminetur in voce, <lb/> duobus
+						temporibus in fine per silentium redditis in <lb/> principio locato spondeo.
+						Est item alia. Si enim velis, <lb/> post sextam syllabam unum tempus
+						silcbis, ct post <lb/> decimam unum, post undecimam tantumdem, et doc <lb/>
+						in fine : ut sil primus spondeus, secundus cboriam­ <lb/> bus, tertius
+						palimbacchius fiat antispastas uno silentii <lb/> tempore annumerato,
+						quartus spondeus fiat dit borius <lb/>
+						<pb n="1143"/> unius temporis interjecto, et unius temporis conse­ <lb/>
+						queote silentio, choriambos ultimus numerum clau­ <lb/> dat, ita ut sileamus
+						duo tempora in fine, quæ primo <lb/> debentur spondeo. Est et tertia
+						dimensio, si post pri­ <lb/> mum spondeum tempus unum sileatur, et reliqua
+						quæ <lb/> In proximo superiore serventur; nisi quod in hujus <lb/> fine unum
+						tempus silebitur, quia spondeus ille qui so­ <lb/> let in principio locari,
+						consequente unius temporis <lb/> silentio factus est palimbacchius, ut plus
+						uno tempore <lb/> nihil ei debeatur, quod in fine silendum est, Unde jam
+						<lb/> perspicis metris interponi silentia, quædam necessa­ <lb/> ria ,
+						quaedam voluntaria : et necessaria qnidem , cum <lb/> aliquid pedibus
+						dcbetur implendis; voluntaria vero, <lb/> cum pleni sunt pedes atque
+						integri.</p>
+					<p>29.'Quod autem superius dictam est, amplius qua­ <lb/> tuor temporibus
+						silendum non esse, de necessariis <lb/> silentiis dictum est, ubi debita
+						tempora explentur. <lb/> Nam in iis qu:c voluntaria silentia nominavimus,
+						licet <lb/> etiam pedem sonare, et pedem silere : quod si pari­ <lb/> bus
+						intervallis fecerimus, non erit metrum, sed rhy­ <lb/> thmus, nullo certo
+						fine apparente unde redeatur ad <lb/> caput. Quamobrem si exempli gratia
+						silentiis velis <lb/> distinguere, ut post primum pedem alterius pedis <lb/>
+						tempora sileas, non hoc perpetuo servandum est. Li­ <lb/> cet autem
+						varietate qualibet connumeratis silentiis <lb/> usque ad legitima tempora
+						metrum producere, velut <lb/> in boe, <hi rend="italic">Nobis</hi> verum <hi
+							rend="italic">in promptu est , tu</hi> si verum <hi rend="italic"
+							>dicis.</hi>
+						<lb/> Licet hic post primum spondeum quatuor tempora si- <lb/> Jere, et alia
+						quatuor post sequentes duos : post tres <lb/> autem finales nihil silebitur;
+						jam cnim triginta duo <lb/> tempora terminata sunt. Sed multo est aptius, et
+						quo­ <lb/> dammodo justius, ut vel in fine tantum , vel etiam <lb/> in medio
+						et One sileatur t, quod subtracto uno pede <lb/> leri potest, ut ita sit :
+							<hi rend="italic">Nobis verum in promptu est,</hi>
+						<lb/> tu <hi rend="italic">dic</hi> verum. Hoc et in metris caeterorum pedum
+						<lb/> tenendum est, scilicet necessariis silentiis, sive <lb/> finalibus
+						sive mediis reddi debita, ut pedes implean­ <lb/> tur : non autem sileri2
+						oportere amplius qnam pedis <lb/> partem, quam levatio positiove occupant.
+						Voluntariis <lb/> antem silentiis et partes pedum et integros pedes si­
+						<lb/> fere conceditur, sicut exemplis supra editis1 monstra­ <lb/> vimus.
+						Sed hactenus interponendorum silentiorum <lb/> ratio tractata sit.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT X VI. — <hi rend="italic">De pedum commixtione, et
+								de</hi> me­ trorum <hi rend="italic">copulatione.</hi>
 						</title>
 					</ab>
-					<p>30. Nunc de pedum commixtione, et de ipsorum <lb/> metrorum copulatione pauca dicamus :
-						quoniam jam <lb/> multa dicta sunt cum quaereremus, quos sibimet opor­ <lb/> teat
-						misceri pedes; et quod ad metrorum attinet co­ <lb/> puJationem, nonnulla dicenda sunt
-						cum de versibus <lb/> disserere coeperimus : junguntur enim sibi pedes <lb/> atque
-						miscentur secundum regulas, quas in secundo <lb/> sermone aperuimus. In hoc autcm illud
-						sciendum est, <lb/> Metri quæque genera quæ a poetis jam celebrata sunt, <lb/> habuisse
-						auctores et inventores suos, a quibus quas­ <lb/> dam certas leges positas convellere
-						prohibemur; non <note type="footnote">I Apud toY. omittitur, in <hi rend="italic">medio
-								et,</hi> quod restituimus ex <lb/> Mss. At .pad Er. legitur, <hi rend="italic">vei
-								etiamante finem sUealur.</hi>
-						</note><note type="footnote"> I Mss. cum Ain. Labent, <hi rend="italic">deberi.</hi>
-						</note><note type="footnote"> • in B., supradictis. Mss. A et <hi rend="italic">B,
-								supracditis,</hi> correctius. M. </note>
-						<lb/> enim oportet, cum illi eas ratione fixcrint aliquid ibi <lb/> mutare quamvis
-						secundum rationem sine aurium of. <lb/> fensione possimus t. Cujus rei cognilio non
-						arte, sed <lb/> historia traditur; unde creditur potius quam cognosci­ <lb/> tur. Neque
-						enim si Phaliscus, nescio qui, metra 2 ita <lb/> composuit, ut hæc sonant, <lb/> Quando
-						flagella ligas, ita liga, <lb/> vitis et ulmus uti simul eant; <lb/> scire hoc possumus
-						; sed tantummodo credere au. <lb/> diendo ct legendo. Illud cst disciplinæ. quod ad nos
-						<lb/> pertinet; videre utrum hoc tribus dactylis constet et <lb/> pyrrhichio ultimo, ul
-						plerique musicae imperiti autu­ <lb/> mant ; non enim sentiunt pyrrhichium poni non
-						posse <lb/> post dactylum : an ut ratio docet, primus pes sit in <lb/> hoc metro
-						choriambus, secundus ionicus longa syl­ <lb/> laba in duas soluta breves, ultimus
-						iambus, post quem <lb/> tria tempora silebuntur : quod semidocti homines <lb/> sentire
-						possent, si a docto secundum utramque legein <lb/> pronuntiaretur et pJauderetur. Ita
-						enim nalurali ct <lb/> communi sensu judicarent, quid disciplinæ norma <lb/>
+					<p>30. Nunc de pedum commixtione, et de ipsorum <lb/> metrorum copulatione pauca
+						dicamus : quoniam jam <lb/> multa dicta sunt cum quaereremus, quos sibimet
+						opor­ <lb/> teat misceri pedes; et quod ad metrorum attinet co­ <lb/>
+						puJationem, nonnulla dicenda sunt cum de versibus <lb/> disserere coeperimus
+						: junguntur enim sibi pedes <lb/> atque miscentur secundum regulas, quas in
+						secundo <lb/> sermone aperuimus. In hoc autcm illud sciendum est, <lb/>
+						Metri quæque genera quæ a poetis jam celebrata sunt, <lb/> habuisse auctores
+						et inventores suos, a quibus quas­ <lb/> dam certas leges positas convellere
+						prohibemur; non <note type="footnote">I Apud toY. omittitur, in <hi
+								rend="italic">medio et,</hi> quod restituimus ex <lb/> Mss. At .pad
+							Er. legitur, <hi rend="italic">vei etiamante finem sUealur.</hi>
+						</note><note type="footnote"> I Mss. cum Ain. Labent, <hi rend="italic"
+								>deberi.</hi>
+						</note><note type="footnote"> • in B., supradictis. Mss. A et <hi
+								rend="italic">B, supracditis,</hi> correctius. M. </note>
+						<lb/> enim oportet, cum illi eas ratione fixcrint aliquid ibi <lb/> mutare
+						quamvis secundum rationem sine aurium of. <lb/> fensione possimus t. Cujus
+						rei cognilio non arte, sed <lb/> historia traditur; unde creditur potius
+						quam cognosci­ <lb/> tur. Neque enim si Phaliscus, nescio qui, metra 2 ita
+						<lb/> composuit, ut hæc sonant, <lb/> Quando flagella ligas, ita liga, <lb/>
+						vitis et ulmus uti simul eant; <lb/> scire hoc possumus ; sed tantummodo
+						credere au. <lb/> diendo ct legendo. Illud cst disciplinæ. quod ad nos <lb/>
+						pertinet; videre utrum hoc tribus dactylis constet et <lb/> pyrrhichio
+						ultimo, ul plerique musicae imperiti autu­ <lb/> mant ; non enim sentiunt
+						pyrrhichium poni non posse <lb/> post dactylum : an ut ratio docet, primus
+						pes sit in <lb/> hoc metro choriambus, secundus ionicus longa syl­ <lb/>
+						laba in duas soluta breves, ultimus iambus, post quem <lb/> tria tempora
+						silebuntur : quod semidocti homines <lb/> sentire possent, si a docto
+						secundum utramque legein <lb/> pronuntiaretur et pJauderetur. Ita enim
+						nalurali ct <lb/> communi sensu judicarent, quid disciplinæ norma <lb/>
 						præscriberet.</p>
-					<p>3i. Verumtamen quod poeta illc hos numeros im­ <lb/> . mobilcsesse voluit, cum hoc
-						metro utimur, custo­ <lb/> diendum est: non enim fraudat auditum ; quanquam <lb/> æque
-						nihil fraudarct, si vel pro choriambo diiambum, <lb/> vel ipsum ionicum nulla in breves
-						facta solutione <lb/> poneremus, et quidqnid aliud congruisset. In hoc igi­ <lb/> tar
-						metro nihil mulabitur; non ea ratione qua in­ <lb/> æqualitatem vitamus, sed ca qua
-						observamus auctori- <lb/> talem. Docet sane ratio, alia institui metra immobilia, <lb/>
-						id est in quibus mutari nihil oportet, ut hoc ipsum <lb/> cst de quo salis locuti sumus
-						; alia mobilia, in quibus <lb/> locare pedes alios pro aliis licct, sicuti est ; <hi rend="italic">Trojæ qui <lb/> primus ab oris, arma virumque cano.</hi> Nani hic pro
-						<lb/> spondco anapæstum quolibet loco licct ponere. Alia <lb/> nec tota immobilia, nec
-						tota mobilia, ut est: <lb/> Pendeat ex humeris dulcis chelys, <lb/> Et numcros edat
-						varios, quibus <lb/> Assonel onme virens late nemus, <lb/> Et tortis errans qui
-						flexibus. <lb/> ( <hi rend="italic">Terentianus</hi> ex rompomo.) <lb/> Vides hic enim
-						ubique et spondeos et dactylos poni <lb/> posse, præter ultimum pedem, quem metri auctor
-						<lb/> semper esse dactylum voluit. Etin iis quidem generi­ <lb/> bus tribus nonnihil
-						valere auctoritatem vidcs.</p>
-					<p>32. Quod autem in pedum commixtione ad ratio­ <lb/> nem solam pertinet de iis rebus quæ
-						sentiuntur judi­ <lb/> cantem; sciendum est cas partes pedum, qu:c post <lb/> certos
-						pedes silentio restante suaviter locantur, ut <lb/> iambos post dichorium atque secundum
-						epitritum, et <lb/> spondeus post antispastum, etiam post alios pedes <lb/> male locarit
-						quibus isti permixti fuerint : nam mani­ <lb/> festum est iambum post molossum bene
-						poni, sicut <lb/> hoc exemplum indicat sæpe repetitum cum silentio in <lb/> fine
-						temporum trium, <hi rend="italic">Ver blandum viret floribus :</hi> at <lb/> si pro
+					<p>3i. Verumtamen quod poeta illc hos numeros im­ <lb/> . mobilcsesse voluit,
+						cum hoc metro utimur, custo­ <lb/> diendum est: non enim fraudat auditum ;
+						quanquam <lb/> æque nihil fraudarct, si vel pro choriambo diiambum, <lb/>
+						vel ipsum ionicum nulla in breves facta solutione <lb/> poneremus, et
+						quidqnid aliud congruisset. In hoc igi­ <lb/> tar metro nihil mulabitur; non
+						ea ratione qua in­ <lb/> æqualitatem vitamus, sed ca qua observamus auctori-
+						<lb/> talem. Docet sane ratio, alia institui metra immobilia, <lb/> id est
+						in quibus mutari nihil oportet, ut hoc ipsum <lb/> cst de quo salis locuti
+						sumus ; alia mobilia, in quibus <lb/> locare pedes alios pro aliis licct,
+						sicuti est ; <hi rend="italic">Trojæ qui <lb/> primus ab oris, arma virumque
+							cano.</hi> Nani hic pro <lb/> spondco anapæstum quolibet loco licct
+						ponere. Alia <lb/> nec tota immobilia, nec tota mobilia, ut est: <lb/>
+						Pendeat ex humeris dulcis chelys, <lb/> Et numcros edat varios, quibus <lb/>
+						Assonel onme virens late nemus, <lb/> Et tortis errans qui flexibus. <lb/> (
+							<hi rend="italic">Terentianus</hi> ex rompomo.) <lb/> Vides hic enim
+						ubique et spondeos et dactylos poni <lb/> posse, præter ultimum pedem, quem
+						metri auctor <lb/> semper esse dactylum voluit. Etin iis quidem generi­
+						<lb/> bus tribus nonnihil valere auctoritatem vidcs.</p>
+					<p>32. Quod autem in pedum commixtione ad ratio­ <lb/> nem solam pertinet de iis
+						rebus quæ sentiuntur judi­ <lb/> cantem; sciendum est cas partes pedum, qu:c
+						post <lb/> certos pedes silentio restante suaviter locantur, ut <lb/> iambos
+						post dichorium atque secundum epitritum, et <lb/> spondeus post antispastum,
+						etiam post alios pedes <lb/> male locarit quibus isti permixti fuerint : nam
+						mani­ <lb/> festum est iambum post molossum bene poni, sicut <lb/> hoc
+						exemplum indicat sæpe repetitum cum silentio in <lb/> fine temporum trium,
+							<hi rend="italic">Ver blandum viret floribus :</hi> at <lb/> si pro
 						molosso primum dichorium constituas, ut cst, <lb/>
-						<hi rend="italic">Vere terra viret floribus,</hi> respuit hoc auditus atque con - <note type="footnote"> I Mss. A et B concordant in lectionem hanc : Non ewfrn <lb/>
-							<hi rend="italic">oportet, non illi eas ratione fixcrint : quanuis ibi aliquid <lb/>
-								secundum rationem nittt:l1"e une aMrt:w! offensione possifiius</hi>
-							<lb/> Er. Lugd. ven. legiuit. <hi rend="italic">finxerint.</hi> M. </note><note type="footnote">
-							<hi rend="italic">9 Jiictrum,</hi> juxta ix. I ugd. vcn. Lov. et )!s. A. M. </note>
+						<hi rend="italic">Vere terra viret floribus,</hi> respuit hoc auditus atque
+						con - <note type="footnote"> I Mss. A et B concordant in lectionem hanc :
+							Non ewfrn <lb/>
+							<hi rend="italic">oportet, non illi eas ratione fixcrint : quanuis ibi
+								aliquid <lb/> secundum rationem nittt:l1"e une aMrt:w! offensione
+								possifiius</hi>
+							<lb/> Er. Lugd. ven. legiuit. <hi rend="italic">finxerint.</hi> M.
+							</note><note type="footnote">
+							<hi rend="italic">9 Jiictrum,</hi> juxta ix. I ugd. vcn. Lov. et )!s. A.
+							M. </note>
 						<lb/>
-						<pb n="1145"/> demnat. Id eliam in cadem sensu explorante facile <lb/> est experiri.
-						Ratio namque certissima cst, cum sibi <lb/> copulantur qui inter se sunt copulabiles
-						pedes, eas <lb/> partes debere in fine subjungi quæ omnibus conve­ <lb/> niunt in illa
-						serie collocatis, ne inter socios quodam­ <lb/> modo discordiae aliquid oriatur.</p>
-					<p>33. Illud magis mirandum est, quod cum spondeus <lb/> et diiambum et dichorium suaviter
-						claudat, tamen cum <lb/> hi duo pedes sive soli, sive cum aliis copulabilibus <lb/>
-						quoquo modo mixtis in una serie fuerint, spondeus in <lb/> fine, approbante sensu, poni
-						non potest. Quis enun <lb/> dubitet aures libenter accipere ista singula repetita, <lb/>
-						<hi rend="italic">Timenda</hi> res <hi rend="italic">non eat :</hi> et item separatim,
-							<hi rend="italic">Jam timcre<lb/> noli?</hi> At si ita jungas, Timenda <hi rend="italic">rea, jam</hi> timere <hi rend="italic">noli ;</hi>
-						<lb/> nisi in soluta oratione audire nolim. Nec absurdum <lb/> minus est, si quolibet
-						loco alium connectas, veluti <lb/> molossum hoc modo : <hi rend="italic">Vir fortia,
-							timenda res, jam</hi> ti­ <lb/>
-						<hi rend="italic">mere noli.</hi> Vel ita : <hi rend="italic">Timenda</hi> res, <hi rend="italic">vir fortis, jam timere<lb/> voli.</hi> Vel etiam ita : <hi rend="italic">Timenda res, jam timere vir fortis</hi>
-						<lb/> noli. Cujus absurditatis causa est, qnod pes diiambus <lb/> etiam ad duplum et
-						simp'um plaudi potest, ut ad sim­ <lb/> plum et duplum dichorius : spondens autem duplre
-						<lb/> parti corum sequalis est; sed cum eum ille trabit ad <lb/> primam, hic ad
-						extremam, existit nonnulla discordia; <lb/> et ita ratio tollit admirationcm.</p>
-					<p>34. Nec minus miraculum edit antispastus, cui si <lb/> nullus alius pedum, aut certe
-						solus diiambus miscea­ <lb/> tur, pntitur iambo metrum claudi, cum aliis autem po­ <lb/>
-						situs nullo modo; et cum dichorio quidem propter <lb/> ipsum dichorium; itaque hoc
-						minime miror. Cum <lb/> cæteris vero senum temporum pedibus, cur memo­ <lb/> ratum trium
-						temporum pedem in fine repudiet, nescio <lb/> quæ est causa secretior fortasse quam ut a
-						nobis erui <lb/> atque ostendi queat : sed hoc ita esse bis exemplis <lb/> proto. Nam
-						ista duo metra, <hi rend="italic">Potestate placet, potestate <lb/> potentium
-							placet,</hi> nemo ambigit suaviter singula repcu <lb/> cum silentio trium temporum in
-						fine. At ista insuavi­ <lb/> ter cum eodem silentia : <hi rend="italic">Potestate
-							præclara placet.</hi> Po­ <lb/> testate <hi rend="italic">tibi multum placet.
-							Potestate jam tibi sic placet.</hi>
-						<lb/> 'Potestate <hi rend="italic">multum tibi placet. Potestatis magnitudo pla­<lb/>
-							cet.</hi> Quod ad sensum attinet, peregit officium suum in <lb/> hac quæstione, et
-						quid acceperit, et quid exploserit <lb/> indicavit: sed de causa cur ita sit, ratio
-						consulenda <lb/> est. Ac mea 1 quidem in tanta obscuri:atc nihil aliud <lb/> videl, nisi
-						cum diiambo anlispastum dimidiam par­ <lb/> tem priorem babere communem : nam uterque a
-						<lb/> brevi et longa incipit; posteriorem autem cum dicho­ <lb/> rio • longa cnim et
-						brev i ambo finiuntur. Itaque anti­ <lb/> spastus vul solus tanquam suam priorem
-						dimidiam, <lb/> vel cum diiambo cum quo eam communiter habet, <lb/> collocatus, patitur
-						in fine metri esse iambum ; clcum <lb/> dichorio pateretur, si eidem dichorio talis
-						terminus <lb/> conveniret: cum cæteris autem non patitur, quibus <lb/> tali societate
-						non 2 jungitur.</p>
-					<ab>
-						<title type="sub">CAPUT XVII. — <hi rend="italic">De metrorum copulatione.</hi>
+						<pb n="1145"/> demnat. Id eliam in cadem sensu explorante facile <lb/> est
+						experiri. Ratio namque certissima cst, cum sibi <lb/> copulantur qui inter
+						se sunt copulabiles pedes, eas <lb/> partes debere in fine subjungi quæ
+						omnibus conve­ <lb/> niunt in illa serie collocatis, ne inter socios quodam­
+						<lb/> modo discordiae aliquid oriatur.</p>
+					<p>33. Illud magis mirandum est, quod cum spondeus <lb/> et diiambum et
+						dichorium suaviter claudat, tamen cum <lb/> hi duo pedes sive soli, sive cum
+						aliis copulabilibus <lb/> quoquo modo mixtis in una serie fuerint, spondeus
+						in <lb/> fine, approbante sensu, poni non potest. Quis enun <lb/> dubitet
+						aures libenter accipere ista singula repetita, <lb/>
+						<hi rend="italic">Timenda</hi> res <hi rend="italic">non eat :</hi> et item
+						separatim, <hi rend="italic">Jam timcre<lb/> noli?</hi> At si ita jungas,
+						Timenda <hi rend="italic">rea, jam</hi> timere <hi rend="italic">noli ;</hi>
+						<lb/> nisi in soluta oratione audire nolim. Nec absurdum <lb/> minus est, si
+						quolibet loco alium connectas, veluti <lb/> molossum hoc modo : <hi
+							rend="italic">Vir fortia, timenda res, jam</hi> ti­ <lb/>
+						<hi rend="italic">mere noli.</hi> Vel ita : <hi rend="italic">Timenda</hi>
+						res, <hi rend="italic">vir fortis, jam timere<lb/> voli.</hi> Vel etiam ita
+						: <hi rend="italic">Timenda res, jam timere vir fortis</hi>
+						<lb/> noli. Cujus absurditatis causa est, qnod pes diiambus <lb/> etiam ad
+						duplum et simp'um plaudi potest, ut ad sim­ <lb/> plum et duplum dichorius :
+						spondens autem duplre <lb/> parti corum sequalis est; sed cum eum ille
+						trabit ad <lb/> primam, hic ad extremam, existit nonnulla discordia; <lb/>
+						et ita ratio tollit admirationcm.</p>
+					<p>34. Nec minus miraculum edit antispastus, cui si <lb/> nullus alius pedum,
+						aut certe solus diiambus miscea­ <lb/> tur, pntitur iambo metrum claudi, cum
+						aliis autem po­ <lb/> situs nullo modo; et cum dichorio quidem propter <lb/>
+						ipsum dichorium; itaque hoc minime miror. Cum <lb/> cæteris vero senum
+						temporum pedibus, cur memo­ <lb/> ratum trium temporum pedem in fine
+						repudiet, nescio <lb/> quæ est causa secretior fortasse quam ut a nobis erui
+						<lb/> atque ostendi queat : sed hoc ita esse bis exemplis <lb/> proto. Nam
+						ista duo metra, <hi rend="italic">Potestate placet, potestate <lb/>
+							potentium placet,</hi> nemo ambigit suaviter singula repcu <lb/> cum
+						silentio trium temporum in fine. At ista insuavi­ <lb/> ter cum eodem
+						silentia : <hi rend="italic">Potestate præclara placet.</hi> Po­ <lb/>
+						testate <hi rend="italic">tibi multum placet. Potestate jam tibi sic
+							placet.</hi>
+						<lb/> 'Potestate <hi rend="italic">multum tibi placet. Potestatis magnitudo
+							pla­<lb/> cet.</hi> Quod ad sensum attinet, peregit officium suum in
+						<lb/> hac quæstione, et quid acceperit, et quid exploserit <lb/> indicavit:
+						sed de causa cur ita sit, ratio consulenda <lb/> est. Ac mea 1 quidem in
+						tanta obscuri:atc nihil aliud <lb/> videl, nisi cum diiambo anlispastum
+						dimidiam par­ <lb/> tem priorem babere communem : nam uterque a <lb/> brevi
+						et longa incipit; posteriorem autem cum dicho­ <lb/> rio • longa cnim et
+						brev i ambo finiuntur. Itaque anti­ <lb/> spastus vul solus tanquam suam
+						priorem dimidiam, <lb/> vel cum diiambo cum quo eam communiter habet, <lb/>
+						collocatus, patitur in fine metri esse iambum ; clcum <lb/> dichorio
+						pateretur, si eidem dichorio talis terminus <lb/> conveniret: cum cæteris
+						autem non patitur, quibus <lb/> tali societate non 2 jungitur.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT XVII. — <hi rend="italic">De metrorum
+								copulatione.</hi>
 						</title>
 					</ab>
-					<p>55. Quod vero ad metrorum copulationem attinet, <lb/> satis est in præsentia vidcre,
-						posse sibi diversa metra <note type="footnote">» MS. A addit, <hi rend="italic">ratio.</hi> M. </note><note type="footnote">* Fjt. et Lov. omittunt liic
-							ncgationcm, quam tamcn ex­ <lb/> bibent Мss et Am. </note>
-						<lb/> copulari, quæ tamen plausu, id est levatione ac posi­ <lb/> tione conveniant.
-						Diversa sunt autem vel quantitate, <lb/> ut cum majora copulantur minoribus, qualia ista
-						sunt, <lb/> videlicet: <lb/> Jam satis terris ulvis atque diræ <lb/> Grandinis misit
-						rater, et rubente <lb/> Dextera sacras jaculatus arces, <lb/> Terruit urhcm. <lb/>
-						<hi rend="italic">(Horat. lib.</hi> i <hi rend="italic">carminum, ode</hi> 2.) <lb/> Nam
-						hoc quartum, quod uno choriambo et una in fine <lb/> longa terminatur, quam parvum sit
-						tribus superiori­ <lb/> bus inter se aequalibus subjectum vides. Vel pedibus <lb/>
-						sicuti hæc : <lb/> Grato Pyrrba sub antro, <lb/> Cui Oavam religas comam. <lb/>
-						<hi rend="italic">( norat. lib.</hi> i <hi rend="italic">carminum, ode 5.)</hi>
-						<lb/> Cernis quippe horum dnorum superius constare spon­ <lb/> deo et choriambo, et
-						longa ultima, quae ad sex tem­ <lb/> pora implenda spondeo d <unclear>ubebatur</unclear>
-						: hoc autem poste­ <lb/> rius spondeo et choriambo, et duabus ultimis brevi­ <lb/> bus,
-						quae item cum primo spondeo implent sex tem­ <lb/> pora. Paria sunt ergo ista
-						temporibus, sed in pedibus <lb/> nonnihil diversitatis tenent.</p>
-					<p>56. Est et alia differentia istarum copulationum, <lb/> quod alia ita copulentur, ut
-						nulla sibi silentia inter­ <lb/> poni velint, sicut hæc duo recentissima; alia inter se
-						<lb/> sileri aliquid postulent, sicut haec : <lb/> vides ut alta stet nive candidum
-						<lb/> Soracte, nee jam sustineant onus <lb/> silvae laborantes, geluque <lb/> Flumina
-						constiterint acuto. <lb/>
-						<hi rend="italic">(Horat. lib.</hi> i <hi rend="italic">carminum, ode 9.)</hi>
-						<lb/> Nam si hæc singula rcpelanlur, priora duo unum lem­ <lb/> pus in fine sileri
-						flagitant, tertium duo, quartum tria. <lb/> Copulata vero a primo ad secundum
-						transeintem, <lb/> unum tempus silere cogunt; a secundo ad tertium <lb/> duo, a tertio
-						ad quartum tria. A quarto autem si ad <lb/> primum redeas, tempus unum silebis. Sed qu:c
-						est ra­ <lb/> tio est'redeundi ad primum, eadem est ad aliam talem <lb/> copulationem
-						transeundi. Hoc genus copulaLionum <lb/> recte nos appellamus circuitum, qui <foreign xml:lang="grc">περιόδος</foreign> graece di­ <lb/> citur. Circuitus ergo minor esse
-						non potest, quam <lb/> qui duobus meanbris constat, id est duobus metris : <lb/> nec
-						esse majorem volucrunL eo qui usque ad quatuor <lb/> membra procedit. Licet igitur
-						minimum bimembrem, <lb/> medium trimembrem, et ultimum quadrimembrem <lb/> vocare; hos
-						enim Graeci <foreign xml:lang="grc">δίϰωλον, τρίϰωλον, τετράϰωλον</foreign>
-						<lb/> vocant. De quo toto genere quoniam diligentius tra­ <lb/> ctaturi sumus, ut dixi,
-						in eo sermone qui nobis de ver­ <lb/> sibus erit, nunc interim hoc satis sit.</p>
-					<p>57. Sane arbitror jam te intelligcre, innumerabilia <lb/> genera esse metrorum, quae
-						quingenta sexaginta octo <lb/> inverieramus *, cum et de silentiis non nisi finalibus
-						<lb/> exempla essent data, et nulla pedum commixtio facta <lb/> esset, et nulla solutio
-						longarum in duas breves, quæ <lb/> pedem ultra syllabas quatuor porrigeret. At si adhi­
-						<lb/> bita omni silentiorum interpositione, et omni pedum <lb/> commixtione, et omni
-						solutione longarum colligere <lb/> numerum metrorum velis; tantus existit, ut nomen
-						<lb/> cjus fortasse non suppetat. Sed haec exempla quae a <note type="footnote"> 1 in
-							prius vulgatis et pluribus Mss. habetur, <hi rend="italic">quadraginta<lb/> septem
-								inveneranms.</hi> sed legendum cum Albinensi codice , <lb/>
-							<hi rend="italic">sexaginta octo.</hi> Confer locum lib. 4, nn. iS et 16, ubi me­
-							<lb/> troruin isthæc SUDlIUa censetur. </note>
+					<p>55. Quod vero ad metrorum copulationem attinet, <lb/> satis est in præsentia
+						vidcre, posse sibi diversa metra <note type="footnote">» MS. A addit, <hi
+								rend="italic">ratio.</hi> M. </note><note type="footnote">* Fjt. et
+							Lov. omittunt liic ncgationcm, quam tamcn ex­ <lb/> bibent Мss et Am. </note>
+						<lb/> copulari, quæ tamen plausu, id est levatione ac posi­ <lb/> tione
+						conveniant. Diversa sunt autem vel quantitate, <lb/> ut cum majora
+						copulantur minoribus, qualia ista sunt, <lb/> videlicet: <lb/> Jam satis
+						terris ulvis atque diræ <lb/> Grandinis misit rater, et rubente <lb/>
+						Dextera sacras jaculatus arces, <lb/> Terruit urhcm. <lb/>
+						<hi rend="italic">(Horat. lib.</hi> i <hi rend="italic">carminum, ode</hi>
+						2.) <lb/> Nam hoc quartum, quod uno choriambo et una in fine <lb/> longa
+						terminatur, quam parvum sit tribus superiori­ <lb/> bus inter se aequalibus
+						subjectum vides. Vel pedibus <lb/> sicuti hæc : <lb/> Grato Pyrrba sub
+						antro, <lb/> Cui Oavam religas comam. <lb/>
+						<hi rend="italic">( norat. lib.</hi> i <hi rend="italic">carminum, ode
+							5.)</hi>
+						<lb/> Cernis quippe horum dnorum superius constare spon­ <lb/> deo et
+						choriambo, et longa ultima, quae ad sex tem­ <lb/> pora implenda spondeo d
+							<unclear>ubebatur</unclear> : hoc autem poste­ <lb/> rius spondeo et
+						choriambo, et duabus ultimis brevi­ <lb/> bus, quae item cum primo spondeo
+						implent sex tem­ <lb/> pora. Paria sunt ergo ista temporibus, sed in pedibus
+						<lb/> nonnihil diversitatis tenent.</p>
+					<p>56. Est et alia differentia istarum copulationum, <lb/> quod alia ita
+						copulentur, ut nulla sibi silentia inter­ <lb/> poni velint, sicut hæc duo
+						recentissima; alia inter se <lb/> sileri aliquid postulent, sicut haec :
+						<lb/> vides ut alta stet nive candidum <lb/> Soracte, nee jam sustineant
+						onus <lb/> silvae laborantes, geluque <lb/> Flumina constiterint acuto. <lb/>
+						<hi rend="italic">(Horat. lib.</hi> i <hi rend="italic">carminum, ode
+							9.)</hi>
+						<lb/> Nam si hæc singula rcpelanlur, priora duo unum lem­ <lb/> pus in fine
+						sileri flagitant, tertium duo, quartum tria. <lb/> Copulata vero a primo ad
+						secundum transeintem, <lb/> unum tempus silere cogunt; a secundo ad tertium
+						<lb/> duo, a tertio ad quartum tria. A quarto autem si ad <lb/> primum
+						redeas, tempus unum silebis. Sed qu:c est ra­ <lb/> tio est'redeundi ad
+						primum, eadem est ad aliam talem <lb/> copulationem transeundi. Hoc genus
+						copulaLionum <lb/> recte nos appellamus circuitum, qui <foreign
+							xml:lang="grc">περιόδος</foreign> graece di­ <lb/> citur. Circuitus
+						ergo minor esse non potest, quam <lb/> qui duobus meanbris constat, id est
+						duobus metris : <lb/> nec esse majorem volucrunL eo qui usque ad quatuor
+						<lb/> membra procedit. Licet igitur minimum bimembrem, <lb/> medium
+						trimembrem, et ultimum quadrimembrem <lb/> vocare; hos enim Graeci <foreign
+							xml:lang="grc">δίϰωλον, τρίϰωλον, τετράϰωλον</foreign>
+						<lb/> vocant. De quo toto genere quoniam diligentius tra­ <lb/> ctaturi
+						sumus, ut dixi, in eo sermone qui nobis de ver­ <lb/> sibus erit, nunc
+						interim hoc satis sit.</p><!-- Reprendre ici -->
+					<p>57. Sane arbitror jam te intelligcre, innumerabilia <lb/> genera esse
+						metrorum, quae quingenta sexaginta octo <lb/> inverieramus *, cum et de
+						silentiis non nisi finalibus <lb/> exempla essent data, et nulla pedum
+						commixtio facta <lb/> esset, et nulla solutio longarum in duas breves, quæ
+						<lb/> pedem ultra syllabas quatuor porrigeret. At si adhi­ <lb/> bita omni
+						silentiorum interpositione, et omni pedum <lb/> commixtione, et omni
+						solutione longarum colligere <lb/> numerum metrorum velis; tantus existit,
+						ut nomen <lb/> cjus fortasse non suppetat. Sed haec exempla quae a <note
+							type="footnote"> 1 in prius vulgatis et pluribus Mss. habetur, <hi
+								rend="italic">quadraginta<lb/> septem inveneranms.</hi> sed legendum
+							cum Albinensi codice , <lb/>
+							<hi rend="italic">sexaginta octo.</hi> Confer locum lib. 4, nn. iS et
+							16, ubi me­ <lb/> troruin isthæc SUDlIUa censetur. </note>
 						<lb/>
-						<pb n="1147"/> nobis sunt posita, et quæcumque alia poni possunt, <lb/> quanquam ea et
-						poeta in erOciendo approbel. et in <lb/> audicndo 1 natura communis; tamen nisi ea docti
-						et <note type="footnote"> 1 ita Mss. At Am. Er. et Lov.: Quanquam <hi rend="italic">ea
-								et appetat</hi> in <lb/>
+						<pb n="1147"/> nobis sunt posita, et quæcumque alia poni possunt, <lb/>
+						quanquam ea et poeta in erOciendo approbel. et in <lb/> audicndo 1 natura
+						communis; tamen nisi ea docti et <note type="footnote"> 1 ita Mss. At Am.
+							Er. et Lov.: Quanquam <hi rend="italic">ea et appetat</hi> in <lb/>
 							<hi rend="italic">efficiendo, et approbet</hi> in audiendo. </note>
-						<lb/> exercitati hominis pronuntiatio commendet auribus , <lb/> sensusque audientium non
-						sit tardior quam humanitas <lb/> postulat, non possunt ea quae tractavimus vera judi -
-						<lb/> cari. Sed quiescamus aliquantulum, et de versu dein­ <lb/> ceps disseramus. <hi rend="italic">D.</hi> Ita fiat.</p>
+						<lb/> exercitati hominis pronuntiatio commendet auribus , <lb/> sensusque
+						audientium non sit tardior quam humanitas <lb/> postulat, non possunt ea
+						quae tractavimus vera judi - <lb/> cari. Sed quiescamus aliquantulum, et de
+						versu dein­ <lb/> ceps disseramus. <hi rend="italic">D.</hi> Ita fiat.</p>
 				</div>
-				<div type="textpart" subtype="chapter">
+				<div type="textpart" subtype="book">
 					<head>
 						<title type="main"><hi rend="italic">LIBER QUINTUS.</hi> In quo de versu
 							disseritur.</title>
 					</head>
-					<ab>
-						<title type="sub">CAPUT PRIMUM. - <hi rend="italic">Quomodo differant rhythmus ,</hi>
-							metrum <hi rend="italic">et versus.</hi>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT PRIMUM. - <hi rend="italic">Quomodo differant
+								rhythmus ,</hi> metrum <hi rend="italic">et versus.</hi>
 						</title>
 					</ab>
-					<p>1. M. Quid sit versus, inter doctos veteres non <lb/> parva luctatione quæsitum est,
-						nIC' fructus defuit. <lb/> Nam inventa res est, ei ad notitiam posterorum man­ <lb/>
-						data liueris, gravi atque certa non tantum auctori­ <lb/> tate, verum etiam ratione
-						firmata est. Interesse igitur <lb/> animadverterunt inter rhythmum et metrum aliquid,
-						<lb/> ut omne metrum rhythmus, non etiam omnis rhyth­ <lb/> mus metrum sit. Omnis enim
-						legitima pedum con­ <lb/> nexio numerosa est'; quam quoniam metrum babet, <lb/> non esse
-						numerus nullo modo potest, id est non esse <lb/> rhythmus. Sed quoniam non est idem,
-						quamvis legi­ <lb/> timis pedibus, nullo tamen certo fine provolvi, ct <lb/> item
-						legitimis progredi pedibus , sed certo fine coer- <lb/> cert; hæc duo genera etiam
-						vocabulis discernenda <lb/> erant, ut illud superius rhythmus tantum proprio <lb/> jam
-						nomine, hoc autcm alterum ita rhythmus ut me­ <lb/> trum ctiam vocaretur. Rursus,
-						quoniam eorum nu­ <lb/> merorum qui certo fine clauduntur, id est metrorum, <lb/> alia
-						sunt in quibus non habetur ratio cujusdam divi­ <lb/> sionis circa medium, alia in
-						quibus sedulo habctur; <lb/> erat etiam hæc differentia notanda vocabulis. Qua­ <lb/>
-						propter illud, ubi non habetur hæc ralio, rhythmi ge­ <lb/> nus proprie metrum vocatum
-						est: hoc autem ubi ha­ <lb/> betur, versum nominaverunt. Cnjus appellationis <lb/>
-						originem fortasse progredientibus nobis ratio ipsa <lb/> monstrabit. Neque hoc ila
-						præscriptum putes, ut illa <lb/> cHam metra versus vocare non liceat. Sed aliud est
-						<lb/> cum abutimur nomine, licentia cujusdam vicinitatis ; <lb/> aliud, cum rem vocabulo
-						suo enuntiamus. Sed nomi­ <lb/> num commemoratio hactenus facia sit; in quibus, ut <lb/>
-						jam didicimns, concessio interloquentium 2 et vetu­ <lb/> statis auctoritas totum valet.
-						Cætera, si placet, more <lb/> nostro investigemus sensu nuntio, indice rationc; ut il­
-						<lb/> los etiam vetercs auctores non inslituissc i£ta quasi quæ <lb/> in natura rerum
-						integra et perfecta non fuerint, sed ra­ <lb/> tiocinando invenisse, et appellando
+					<div type="textpart" subtype="dialog"><p>1. M. Quid sit versus, inter doctos veteres non <lb/> parva luctatione
+						quæsitum est, nIC' fructus defuit. <lb/> Nam inventa res est, ei ad notitiam
+						posterorum man­ <lb/> data liueris, gravi atque certa non tantum auctori­
+						<lb/> tate, verum etiam ratione firmata est. Interesse igitur <lb/>
+						animadverterunt inter rhythmum et metrum aliquid, <lb/> ut omne metrum
+						rhythmus, non etiam omnis rhyth­ <lb/> mus metrum sit. Omnis enim legitima
+						pedum con­ <lb/> nexio numerosa est'; quam quoniam metrum babet, <lb/> non
+						esse numerus nullo modo potest, id est non esse <lb/> rhythmus. Sed quoniam
+						non est idem, quamvis legi­ <lb/> timis pedibus, nullo tamen certo fine
+						provolvi, ct <lb/> item legitimis progredi pedibus , sed certo fine coer-
+						<lb/> cert; hæc duo genera etiam vocabulis discernenda <lb/> erant, ut illud
+						superius rhythmus tantum proprio <lb/> jam nomine, hoc autcm alterum ita
+						rhythmus ut me­ <lb/> trum ctiam vocaretur. Rursus, quoniam eorum nu­ <lb/>
+						merorum qui certo fine clauduntur, id est metrorum, <lb/> alia sunt in
+						quibus non habetur ratio cujusdam divi­ <lb/> sionis circa medium, alia in
+						quibus sedulo habctur; <lb/> erat etiam hæc differentia notanda vocabulis.
+						Qua­ <lb/> propter illud, ubi non habetur hæc ralio, rhythmi ge­ <lb/> nus
+						proprie metrum vocatum est: hoc autem ubi ha­ <lb/> betur, versum
+						nominaverunt. Cnjus appellationis <lb/> originem fortasse progredientibus
+						nobis ratio ipsa <lb/> monstrabit. Neque hoc ila præscriptum putes, ut illa
+						<lb/> cHam metra versus vocare non liceat. Sed aliud est <lb/> cum abutimur
+						nomine, licentia cujusdam vicinitatis ; <lb/> aliud, cum rem vocabulo suo
+						enuntiamus. Sed nomi­ <lb/> num commemoratio hactenus facia sit; in quibus,
+						ut <lb/> jam didicimns, concessio interloquentium 2 et vetu­ <lb/> statis
+						auctoritas totum valet. Cætera, si placet, more <lb/> nostro investigemus
+						sensu nuntio, indice rationc; ut il­ <lb/> los etiam vetercs auctores non
+						inslituissc i£ta quasi quæ <lb/> in natura rerum integra et perfecta non
+						fuerint, sed ra­ <lb/> tiocinando invenisse, et appellando
 						notassecognoscas.</p>
-					<ab>
-						<title type="sub">CAPUT II. <hi rend="italic">— Metro in duas partes</hi> divisibilia
-								<hi rend="italic">cæteris</hi> præstant.</title>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT II. <hi rend="italic">— Metro in duas partes</hi>
+							divisibilia <hi rend="italic">cæteris</hi> præstant.</title>
 					</ab>
-					<p>2. Quare primum a te quæro, utram ob aliud pes <lb/> aurem mulceat, nisi quod in eo
-						duae illæ partes, qua­ <lb/> rum una in levatione, altera in positione cst, nume­ <lb/>
-						rosa sibi concinnitate respondent? D. Jam hoc quidcm <lb/> mihi ante persuasum est atque
-						compertum. <hi rend="italic">M.</hi> Quid? <lb/> metrum, quod manifestum est pedum
-						collatione con­ <lb/> fici, num ex co rerum genere esse arbitrandum est <note type="footnote"> ' An. Er. et Lov., numerus est. Sed melius Mss.,numerosa <lb/> ,M.
-							</note><note type="footnote">I <hi rend="italic">mer se loqucniium,</hi> juxta Tauc.
+					<div type="textpart" subtype="dialog"><p>2. Quare primum a te quæro, utram ob aliud pes <lb/> aurem mulceat, nisi quod
+						in eo duae illæ partes, qua­ <lb/> rum una in levatione, altera in positione
+						cst, nume­ <lb/> rosa sibi concinnitate respondent? D. Jam hoc quidcm <lb/>
+						mihi ante persuasum est atque compertum. <hi rend="italic">M.</hi> Quid?
+						<lb/> metrum, quod manifestum est pedum collatione con­ <lb/> fici, num ex
+						co rerum genere esse arbitrandum est <note type="footnote"> ' An. Er. et
+							Lov., numerus est. Sed melius Mss.,numerosa <lb/> ,M. </note><note
+							type="footnote">I <hi rend="italic">mer se loqucniium,</hi> juxta Tauc.
 							M.</note>
-						<lb/> quod dividi non potest ; cum omnino et nihil indivi <lb/> duum per tempus tendi
-						queat, et quod ex dividuis <lb/> pedibus constat, absurdissime individuum putetur ?
-						<lb/> D. Nullo modo hoc genu. divisionem recipere abnuc­ <lb/> rim. <hi rend="italic">M.</hi> At omnia quæ recipiunt divisionem, nonne <lb/> pulchriora sunt si eorum
-						partes aliqua pariiitate con­ <lb/> cordent, quam si discordes et dissonae sint? <hi rend="italic">D.</hi> NuiK <lb/> ' dubium est. <hi rend="italic">M.</hi> Quid ? ipsius
-						parilis divisionis qui <lb/> tandem numerus auctor est? an dualis? D. Ita est. <lb/>
-						<hi rend="italic">M.</hi> Ut ergo in duas partes concinentes dividi pedem <lb/> et eo
-						ipso aurem delectare comperimus; si eliam me­ <lb/> trum tale inveniamus, nonne cæteris
-						non talibus jure <lb/> anteponetur? <hi rend="italic">D.</hi> Assentior.</p>
-					<ab>
+						<lb/> quod dividi non potest ; cum omnino et nihil indivi <lb/> duum per
+						tempus tendi queat, et quod ex dividuis <lb/> pedibus constat, absurdissime
+						individuum putetur ? <lb/> D. Nullo modo hoc genu. divisionem recipere
+						abnuc­ <lb/> rim. <hi rend="italic">M.</hi> At omnia quæ recipiunt
+						divisionem, nonne <lb/> pulchriora sunt si eorum partes aliqua pariiitate
+						con­ <lb/> cordent, quam si discordes et dissonae sint? <hi rend="italic"
+							>D.</hi> NuiK <lb/> ' dubium est. <hi rend="italic">M.</hi> Quid ?
+						ipsius parilis divisionis qui <lb/> tandem numerus auctor est? an dualis? D.
+						Ita est. <lb/>
+						<hi rend="italic">M.</hi> Ut ergo in duas partes concinentes dividi pedem
+						<lb/> et eo ipso aurem delectare comperimus; si eliam me­ <lb/> trum tale
+						inveniamus, nonne cæteris non talibus jure <lb/> anteponetur? <hi
+							rend="italic">D.</hi> Assentior.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT III. — <hi rend="italic">Versus unde dictus.</hi>
 						</title>
 					</ab>
-					<p>3. <hi rend="italic">M.</hi> Recte sane. Quare jam illud responde, cum <lb/> in omnibus
-						quæ aliqua temporis parte metimur, aliud <lb/> priccedat, aliud subsequatur, aliud
-						incipiat, aliud <lb/> terminet ; nihilne libi videatur inter partem præce­ <lb/> dentem
-						atque incipientem, et iIlam quae subsequatur <lb/> ac terminet I, interesse oportere.
-							<hi rend="italic">D.</hi> Interesse arbi­ <lb/> tror. <hi rend="italic">M.</hi> Dic
-						ergo quid intersit inter has duas partes <lb/> versus, quarum una est, <hi rend="italic">Cornua velalarum;</hi> altera vero <lb/> est, <hi rend="italic">vertimus antennarum
-							(Æneid. lib. 3,</hi> v. 549). <lb/> Non cnim ut idem poeta, <hi rend="italic">obvertimus,</hi> sed si ita versus <lb/> enuntictur, <hi rend="italic">Cornua
-							velatarum vertimus antennarum;</hi>
-						<lb/> nonne sæpius repetendo efficitur incertum, quæ pars <lb/> prior sil, quæ
-						posterior? Neque enin minus idem stat <lb/> versus, cum ita profertur : <hi rend="italic">Vertimus antennarum cor­</hi>
-						<lb/> nua <hi rend="italic">velatarum. D.</hi> Plane incertum fieri video. M. Cen­ <lb/>
-						sesne vitandum? <hi rend="italic">D.</hi> Censeo. <hi rend="italic">M.</hi> Vide igitur
-						utrumhic <lb/> satis vitatum sit. Una pars versus cst et ca præce- v <lb/> cedens , <hi rend="italic">Arma virumque cano;</hi> altera subsequens, <lb/>
-						<hi rend="italic">Trojm qui</hi> priMus <hi rend="italic">ab oris;</hi> qu.c usquc adeo
-						interse dif­ <lb/> ferunt, ut si ordincm vertas, et hoc modo pronun­ <lb/> ties , <hi rend="italic">Troja qui primus ab oria, arma virumque cano,</hi>
-						<lb/> alios pedes mctiri' necesse sit. <hi rend="italic">D.</hi> Intelligo. M. At <lb/>
-						vide, utrum ista ratio in aliis servata sit. Nam cujus <lb/> dimensionis est pars
-						incipiens, <hi rend="italic">Arma virumque caRo,</hi>
-						<lb/> ejusdem esse agnoscis, <hi rend="italic">llaliam fato. Littora</hi> multum <lb/>
-						<hi rend="italic">ille et. Vi superum sævæ. Multa quoque et bello. Infer­ <lb/> reique
-							deos. Albanique patres.</hi> Ne multa, persequere <lb/> cæteros quantum voles, has
-						priores partes versuum <lb/> ejusdem dimensionis invenies, id cst quinto semipede <lb/>
-						articulatas a. Rarissime omnino si non hoc ita cst; <lb/> ila ut posteriores sint istac
-						non minus inter se prriles: <lb/>
-						<hi rend="italic">Trojæ qui</hi> primus <hi rend="italic">ab oris. Profugus Lavinaque
-							venit. <lb/> Terris jactatus et alto. Memorcm Junonis ob iram. Pas-</hi>
-						<note type="footnote"><hi rend="italic">1 SubseQuitur ac</hi> terminat, juxta vatic. et
-							lis. A. a. </note><note type="footnote"> * <hi rend="italic">Metri,</hi> juxta Vatic.
-							M. </note><note type="footnote"> II Adjicit vatican., <hi rend="italic">et septem
+					<div type="textpart" subtype="dialog"><p>3. <hi rend="italic">M.</hi> Recte sane. Quare jam illud responde, cum <lb/>
+						in omnibus quæ aliqua temporis parte metimur, aliud <lb/> priccedat, aliud
+						subsequatur, aliud incipiat, aliud <lb/> terminet ; nihilne libi videatur
+						inter partem præce­ <lb/> dentem atque incipientem, et iIlam quae
+						subsequatur <lb/> ac terminet I, interesse oportere. <hi rend="italic"
+							>D.</hi> Interesse arbi­ <lb/> tror. <hi rend="italic">M.</hi> Dic ergo
+						quid intersit inter has duas partes <lb/> versus, quarum una est, <hi
+							rend="italic">Cornua velalarum;</hi> altera vero <lb/> est, <hi
+							rend="italic">vertimus antennarum (Æneid. lib. 3,</hi> v. 549). <lb/>
+						Non cnim ut idem poeta, <hi rend="italic">obvertimus,</hi> sed si ita versus
+						<lb/> enuntictur, <hi rend="italic">Cornua velatarum vertimus
+							antennarum;</hi>
+						<lb/> nonne sæpius repetendo efficitur incertum, quæ pars <lb/> prior sil,
+						quæ posterior? Neque enin minus idem stat <lb/> versus, cum ita profertur :
+							<hi rend="italic">Vertimus antennarum cor­</hi>
+						<lb/> nua <hi rend="italic">velatarum. D.</hi> Plane incertum fieri video.
+						M. Cen­ <lb/> sesne vitandum? <hi rend="italic">D.</hi> Censeo. <hi
+							rend="italic">M.</hi> Vide igitur utrumhic <lb/> satis vitatum sit. Una
+						pars versus cst et ca præce- v <lb/> cedens , <hi rend="italic">Arma
+							virumque cano;</hi> altera subsequens, <lb/>
+						<hi rend="italic">Trojm qui</hi> priMus <hi rend="italic">ab oris;</hi> qu.c
+						usquc adeo interse dif­ <lb/> ferunt, ut si ordincm vertas, et hoc modo
+						pronun­ <lb/> ties , <hi rend="italic">Troja qui primus ab oria, arma
+							virumque cano,</hi>
+						<lb/> alios pedes mctiri' necesse sit. <hi rend="italic">D.</hi> Intelligo.
+						M. At <lb/> vide, utrum ista ratio in aliis servata sit. Nam cujus <lb/>
+						dimensionis est pars incipiens, <hi rend="italic">Arma virumque caRo,</hi>
+						<lb/> ejusdem esse agnoscis, <hi rend="italic">llaliam fato. Littora</hi>
+						multum <lb/>
+						<hi rend="italic">ille et. Vi superum sævæ. Multa quoque et bello. Infer­
+							<lb/> reique deos. Albanique patres.</hi> Ne multa, persequere <lb/>
+						cæteros quantum voles, has priores partes versuum <lb/> ejusdem dimensionis
+						invenies, id cst quinto semipede <lb/> articulatas a. Rarissime omnino si
+						non hoc ita cst; <lb/> ila ut posteriores sint istac non minus inter se
+						prriles: <lb/>
+						<hi rend="italic">Trojæ qui</hi> primus <hi rend="italic">ab oris. Profugus
+							Lavinaque venit. <lb/> Terris jactatus et alto. Memorcm Junonis ob iram.
+							Pas-</hi>
+						<note type="footnote"><hi rend="italic">1 SubseQuitur ac</hi> terminat,
+							juxta vatic. et lis. A. a. </note><note type="footnote"> * <hi
+								rend="italic">Metri,</hi> juxta Vatic. M. </note><note
+							type="footnote"> II Adjicit vatican., <hi rend="italic">et septem
 								terminatas.</hi> )L </note>
 						<lb/>
-						<pb n="1149"/> sus <hi rend="italic">dum conderet</hi> urbem. <hi rend="italic">Latio
-							genus unde Latinum. <lb/> Atque altce mænia Romæ. D.</hi> Manifestissimum est.</p>
-					<p>4. <hi rend="italic">M</hi> Quinque igitur et septem semipedes versum <lb/> heroicum in
-						duo membra partiuntur, quem sex pedi­ <lb/> bus quaternorum temporum constare notissimum
-						est1: <lb/> et sine concinnitate quidem duorum membrorum, <lb/> sive ista, sive aliqua
-						alia, versus nullus est. In qui­ <lb/> busomnibus hoc ratio demonstravit esse servandum,
-						<lb/> ut non possit pars prior in posteriore, et posterior in <lb/> priore loco poni.
-						Qnod si aliter fuerit, non jam ver­ <lb/> sus, nisi nominis abusione, dicetur : erit
-						autem <lb/> rhythmus et metrum , qualia rarissime longis carmi­ <lb/> nibus interponere
-						quæ versibus contexuntur, non in­ <lb/> decorum est : quale idem ipsum est quod paulo
-						ante <lb/> commemoravi : <hi rend="italic">Cornua velatarum vertimus antennarum.</hi>
-						<lb/> Quamobrem non mihi versus ex eo appellatus videtur, <lb/> ut nonnulli putant, quod
-						a certo fine ad ejusdem nu­ <lb/> meri caput reditur, ut nomen ductum sit ab i s qui se
-						<lb/> vertunt dum via redeunt; nam hoc illi cum bis etiam <lb/> metris, quæ versus non
-						sunt, apparet esse commune: <lb/> scd magis fortasse a contrario nomen invenit, lit
-						<lb/> quemadmodum grammatici deponens verbum quod r <lb/> litteram nou deponit, sicuti
-						est, lucror, et, <hi rend="italic">conqueror,</hi>
-						<lb/> appellaverunt; ita quod duobus membris confit, quo­ <lb/> rum neutrum in alterius
-						loco salva lege numerorum <lb/> constituitur , quia verti non potest, versus vocetur.
-						<lb/> Sed utramlibet harum origincm vocabuli tu licet pro­ <lb/> bes, vel utramque
-						improbes, et aliam quæras, aut <lb/> contemnas mecum tutum hoc quæstionis genus; nihil
-						<lb/> ad boc tempus pertinet. Cum enim satis res ipsa <lb/> quæ hoc nomine significatur,
-						appareat, non est de <lb/> verbi stirpc laborandum. Nisi quid habes ad bac. <lb/> D. Ego
-						vero nihil, sed perge ad cætera.</p>
-					<ab>
-						<title type="sub">CAPUT IV. — <hi rend="italic">Terminus versuum varius.</hi>
+						<pb n="1149"/> sus <hi rend="italic">dum conderet</hi> urbem. <hi
+							rend="italic">Latio genus unde Latinum. <lb/> Atque altce mænia Romæ.
+							D.</hi> Manifestissimum est.</p>
+					</div><div type="textpart" subtype="dialog"><p>4. <hi rend="italic">M</hi> Quinque igitur et septem semipedes versum <lb/>
+						heroicum in duo membra partiuntur, quem sex pedi­ <lb/> bus quaternorum
+						temporum constare notissimum est1: <lb/> et sine concinnitate quidem duorum
+						membrorum, <lb/> sive ista, sive aliqua alia, versus nullus est. In qui­
+						<lb/> busomnibus hoc ratio demonstravit esse servandum, <lb/> ut non possit
+						pars prior in posteriore, et posterior in <lb/> priore loco poni. Qnod si
+						aliter fuerit, non jam ver­ <lb/> sus, nisi nominis abusione, dicetur : erit
+						autem <lb/> rhythmus et metrum , qualia rarissime longis carmi­ <lb/> nibus
+						interponere quæ versibus contexuntur, non in­ <lb/> decorum est : quale idem
+						ipsum est quod paulo ante <lb/> commemoravi : <hi rend="italic">Cornua
+							velatarum vertimus antennarum.</hi>
+						<lb/> Quamobrem non mihi versus ex eo appellatus videtur, <lb/> ut nonnulli
+						putant, quod a certo fine ad ejusdem nu­ <lb/> meri caput reditur, ut nomen
+						ductum sit ab i s qui se <lb/> vertunt dum via redeunt; nam hoc illi cum bis
+						etiam <lb/> metris, quæ versus non sunt, apparet esse commune: <lb/> scd
+						magis fortasse a contrario nomen invenit, lit <lb/> quemadmodum grammatici
+						deponens verbum quod r <lb/> litteram nou deponit, sicuti est, lucror, et,
+							<hi rend="italic">conqueror,</hi>
+						<lb/> appellaverunt; ita quod duobus membris confit, quo­ <lb/> rum neutrum
+						in alterius loco salva lege numerorum <lb/> constituitur , quia verti non
+						potest, versus vocetur. <lb/> Sed utramlibet harum origincm vocabuli tu
+						licet pro­ <lb/> bes, vel utramque improbes, et aliam quæras, aut <lb/>
+						contemnas mecum tutum hoc quæstionis genus; nihil <lb/> ad boc tempus
+						pertinet. Cum enim satis res ipsa <lb/> quæ hoc nomine significatur,
+						appareat, non est de <lb/> verbi stirpc laborandum. Nisi quid habes ad bac.
+						<lb/> D. Ego vero nihil, sed perge ad cætera.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT IV. — <hi rend="italic">Terminus versuum
+								varius.</hi>
 						</title>
 					</ab>
-					<p>5. <hi rend="italic">II.</hi> Sequitur ut de versus termino requiramus. <lb/> Nam et
-						hunc aliqua differentia noUtum atque insigni­ <lb/> tum esse voluernut, vel potius ipsa
-						ratio. An tu not <lb/> arbitraris melius esse ut finis, quo provolutio numen <lb/>
-						coercetur, non perturbata temporum aequalitate, ta­ <lb/> men I cmineal; quam si cum
-						cxteris par:ibus quae <lb/> finem non faciunt, confundatur? D. Quis dubitat hoc <lb/>
-						esse melius, quod est evidentius? M. Considera ergo, <lb/> utrum recte insignem linem
-						versus heroici spondeum <lb/> pedem quidam esse voluerint. Nam in quinque aliis <lb/>
-						locis vel hunc vel dactylum licet ponere; ; in line au­ <lb/> tem non nisi spondeum; nam
-						quod trochaeum putant, <lb/> propter indifferentiam fit ultimæ syllabæ, de qua in <lb/>
-						metris satis locuti sumus. Sed secundum hos iambi­ <lb/> cus- scnarius aut non erit
-						versus, aut erit sinc isla <lb/> finis eminentia ; utrumque autem absurdum est. Nam
-						<lb/> neque quisquam unquam , sive doctissimorum homi­ <lb/> num, sive mediocriter, vel
-						etiam tenuiter eruditorum <lb/> versum esse dubitavit, <hi rend="italic">Phaselus ille
-							quem videtis</hi> ho­ <lb/> spite. <hi rend="italic">(Catullus);</hi> ct quidquid in
-						verbis est tali nume­ <lb/> rositate formatum : et gravissimi auctores eo quo pe­ <lb/>
-						ritissimi, nullum sine insigni fine versum pntandum <lb/> esse censuerunt. <note type="footnote"> • sEquissimum <hi rend="italic">at,</hi> juxta vatic. II.
-							</note><note type="footnote"> ' Tunc, juxta vttic. M. </note>
+					<div type="textpart" subtype="dialog"><p>5. <hi rend="italic">II.</hi> Sequitur ut de versus termino requiramus. <lb/>
+						Nam et hunc aliqua differentia noUtum atque insigni­ <lb/> tum esse
+						voluernut, vel potius ipsa ratio. An tu not <lb/> arbitraris melius esse ut
+						finis, quo provolutio numen <lb/> coercetur, non perturbata temporum
+						aequalitate, ta­ <lb/> men I cmineal; quam si cum cxteris par:ibus quae
+						<lb/> finem non faciunt, confundatur? D. Quis dubitat hoc <lb/> esse melius,
+						quod est evidentius? M. Considera ergo, <lb/> utrum recte insignem linem
+						versus heroici spondeum <lb/> pedem quidam esse voluerint. Nam in quinque
+						aliis <lb/> locis vel hunc vel dactylum licet ponere; ; in line au­ <lb/>
+						tem non nisi spondeum; nam quod trochaeum putant, <lb/> propter
+						indifferentiam fit ultimæ syllabæ, de qua in <lb/> metris satis locuti
+						sumus. Sed secundum hos iambi­ <lb/> cus- scnarius aut non erit versus, aut
+						erit sinc isla <lb/> finis eminentia ; utrumque autem absurdum est. Nam
+						<lb/> neque quisquam unquam , sive doctissimorum homi­ <lb/> num, sive
+						mediocriter, vel etiam tenuiter eruditorum <lb/> versum esse dubitavit, <hi
+							rend="italic">Phaselus ille quem videtis</hi> ho­ <lb/> spite. <hi
+							rend="italic">(Catullus);</hi> ct quidquid in verbis est tali nume­
+						<lb/> rositate formatum : et gravissimi auctores eo quo pe­ <lb/> ritissimi,
+						nullum sine insigni fine versum pntandum <lb/> esse censuerunt. <note
+							type="footnote"> • sEquissimum <hi rend="italic">at,</hi> juxta vatic.
+							II. </note><note type="footnote"> ' Tunc, juxta vttic. M. </note>
 					</p>
-					<p>6. D. Verum dicis. Quare aliam termini hujus <lb/> notam quærendam esse autumo, non
-						hanc quas in <lb/> spondeo ponitur approbandam. <hi rend="italic">M.</hi> Quid hoc? num
-						<lb/> dubitas, quæcumque ista sit, ant in pedis esse, <lb/> aut in temporis differentia,
-						aut in utroque? D. Qui <lb/> aliter potest? M. Quid tandem horum trium pro­ <lb/> bas?
-						Ego enim, quoniam idipsum finire versum <lb/> ne longins quam oportet excurrat, non
-						pertinet <lb/> nisi ad temporis modum; non arbitror aliunde istam <lb/> notam debcre
-						sumi quam ex tempore. An tibi aliud <lb/> placet? D. Imo assentior. <hi rend="italic">M.</hi> Videsne etiam illud, <lb/> cum tempus hic differentiam babere non possit,
-						nisi <lb/> quod aliud cst longius, aliud brevias; quia cum ver­ <lb/> sus finitur , id
-						agitur ne pergat longius , in breviore <lb/> tempore notam finis esse oportere? <hi rend="italic">D.</hi> Video quidem : <lb/> sed quo pertinet quod additum est, Hic? M.
-						Eo sci­ <lb/> licet quod non ubique temporis differentiam in sola <lb/> brevitate ac
-						longitudine accipimus. An tu æstatis ac <lb/> hiemis differentiam, aut esse temporis
-						ncgas, aut in <lb/> spatio potius breviore vel longiore, ac non in vi fri­ <lb/> goris
-						calorisque constituis, vel humoris et siccitatis1, <lb/> ct si quid tale aliud? <hi rend="italic">D.</hi> Jam intelligo, et hanc quam <lb/> quærimus termini notam, a
-						temporis brevitate ducen­ <lb/> dam esse consentio.</p>
-					<p>7. M. Attende igitur hunc versum, <hi rend="italic">Roma, Roma, <lb/> cerne quanta sit
-							deum benignitas,</hi> qui trochaicus dici­ <lb/> tur, et metire illum, atque responde
-						quod inveneris <lb/> de membris ejus et numcro pedum. D. De pedibus <lb/> qnidem facile
-						responderim : liquet enim eos septem <lb/> et semis esse. De membris autem non satis
-						aperta <lb/> res est; multis enim locis partem orationis liniri vi­ <lb/> deo :
-						verumtamen opinor esse istam partitionem in <lb/> octavo semipede, ut præcedens membrum
-						sit, Roma, <lb/>
-						<hi rend="italic">Roma, cerne quanta;</hi> subsequens autem; <hi rend="italic">sit deum
-							beni­</hi>
-						<lb/> gnitas. <hi rend="italic">II.</hi> Quot semi pedes habet! <hi rend="italic">D.</hi> Septem. <hi rend="italic">M.</hi>
-						<lb/> Ipsa ratio te duxit omnino. Cum enim nihil sit aqua­ <lb/> litate melius, caroque
-						in dividendo appetere oporteat; <lb/> si minus potuerit obtineri, vicinitas ejus
-						quærenda est, <lb/> ne ab ea longius aberremus. Itaque cum hic versus <lb/> omnes
-						quindecim semipedes habcat, non potuit <lb/> æquius quam in octo et septem dividi: nam
-						cadem <lb/> est in septem et octo vicinitas. Sed ita non servaretur <lb/> nota finis in
-						tempore breviore, ut eam servandam ra­ <lb/> tio ipsa præcipit : nam si talis versus
-						esset, <hi rend="italic">Roma</hi>
+					</div><div type="textpart" subtype="dialog"><p>6. D. Verum dicis. Quare aliam termini hujus <lb/> notam quærendam esse
+						autumo, non hanc quas in <lb/> spondeo ponitur approbandam. <hi
+							rend="italic">M.</hi> Quid hoc? num <lb/> dubitas, quæcumque ista sit,
+						ant in pedis esse, <lb/> aut in temporis differentia, aut in utroque? D. Qui
+						<lb/> aliter potest? M. Quid tandem horum trium pro­ <lb/> bas? Ego enim,
+						quoniam idipsum finire versum <lb/> ne longins quam oportet excurrat, non
+						pertinet <lb/> nisi ad temporis modum; non arbitror aliunde istam <lb/>
+						notam debcre sumi quam ex tempore. An tibi aliud <lb/> placet? D. Imo
+						assentior. <hi rend="italic">M.</hi> Videsne etiam illud, <lb/> cum tempus
+						hic differentiam babere non possit, nisi <lb/> quod aliud cst longius, aliud
+						brevias; quia cum ver­ <lb/> sus finitur , id agitur ne pergat longius , in
+						breviore <lb/> tempore notam finis esse oportere? <hi rend="italic">D.</hi>
+						Video quidem : <lb/> sed quo pertinet quod additum est, Hic? M. Eo sci­
+						<lb/> licet quod non ubique temporis differentiam in sola <lb/> brevitate ac
+						longitudine accipimus. An tu æstatis ac <lb/> hiemis differentiam, aut esse
+						temporis ncgas, aut in <lb/> spatio potius breviore vel longiore, ac non in
+						vi fri­ <lb/> goris calorisque constituis, vel humoris et siccitatis1, <lb/>
+						ct si quid tale aliud? <hi rend="italic">D.</hi> Jam intelligo, et hanc quam
+						<lb/> quærimus termini notam, a temporis brevitate ducen­ <lb/> dam esse
+						consentio.</p>
+					</div><div type="textpart" subtype="dialog"><p>7. M. Attende igitur hunc versum, <hi rend="italic">Roma, Roma, <lb/> cerne
+							quanta sit deum benignitas,</hi> qui trochaicus dici­ <lb/> tur, et
+						metire illum, atque responde quod inveneris <lb/> de membris ejus et numcro
+						pedum. D. De pedibus <lb/> qnidem facile responderim : liquet enim eos
+						septem <lb/> et semis esse. De membris autem non satis aperta <lb/> res est;
+						multis enim locis partem orationis liniri vi­ <lb/> deo : verumtamen opinor
+						esse istam partitionem in <lb/> octavo semipede, ut præcedens membrum sit,
+						Roma, <lb/>
+						<hi rend="italic">Roma, cerne quanta;</hi> subsequens autem; <hi
+							rend="italic">sit deum beni­</hi>
+						<lb/> gnitas. <hi rend="italic">II.</hi> Quot semi pedes habet! <hi
+							rend="italic">D.</hi> Septem. <hi rend="italic">M.</hi>
+						<lb/> Ipsa ratio te duxit omnino. Cum enim nihil sit aqua­ <lb/> litate
+						melius, caroque in dividendo appetere oporteat; <lb/> si minus potuerit
+						obtineri, vicinitas ejus quærenda est, <lb/> ne ab ea longius aberremus.
+						Itaque cum hic versus <lb/> omnes quindecim semipedes habcat, non potuit
+						<lb/> æquius quam in octo et septem dividi: nam cadem <lb/> est in septem et
+						octo vicinitas. Sed ita non servaretur <lb/> nota finis in tempore breviore,
+						ut eam servandam ra­ <lb/> tio ipsa præcipit : nam si talis versus esset,
+							<hi rend="italic">Roma</hi>
 						<lb/> cerne <hi rend="italic">quanta</hi> sit <hi rend="italic">tibi deum
-							benignitas,</hi> ut inciperet <lb/> membrum in his semipedibus septem , <hi rend="italic">Roma cerne<lb/> quanta sit,</hi> et in his octo alterum terminaretur,
-							<hi rend="italic">tibi <lb/> deum benignitas;</hi> non posset versum semipes claudere:
-						<lb/> octo enim scmipcdes quatuor integros pedes faciunt. <lb/> Simul incideret alia
-						deformitas, ut non eosdem pedes <lb/> in membro extremo quos in primo metiremur, et
-						<lb/> prius membrum potius finirctur nota brevioris tempo­ <lb/> ris, id est semipede,
-						quam posterius, cui hoc finis <lb/> jure debetur. Nam in illo tres trochæi semis, <hi rend="italic">Roma<lb/> cerne quanta sit:</hi> in hoc quatuor iambi scanderentur, <lb/>
-						<hi rend="italic">tibi deum</hi> benignitas. Nunc vero et trochæos in utroque <lb/>
-						membro scandimus, et semipede versus clauditur, ut <lb/> spatii brevioris notam terminus
-						teneat. Nam sunt in <note type="footnote">1 in B., ,<hi rend="italic">vel
-								siccitatis.</hi> Rectius ex Ms. A, et siecttaUs. II. </note>
+							benignitas,</hi> ut inciperet <lb/> membrum in his semipedibus septem ,
+							<hi rend="italic">Roma cerne<lb/> quanta sit,</hi> et in his octo
+						alterum terminaretur, <hi rend="italic">tibi <lb/> deum benignitas;</hi> non
+						posset versum semipes claudere: <lb/> octo enim scmipcdes quatuor integros
+						pedes faciunt. <lb/> Simul incideret alia deformitas, ut non eosdem pedes
+						<lb/> in membro extremo quos in primo metiremur, et <lb/> prius membrum
+						potius finirctur nota brevioris tempo­ <lb/> ris, id est semipede, quam
+						posterius, cui hoc finis <lb/> jure debetur. Nam in illo tres trochæi semis,
+							<hi rend="italic">Roma<lb/> cerne quanta sit:</hi> in hoc quatuor iambi
+						scanderentur, <lb/>
+						<hi rend="italic">tibi deum</hi> benignitas. Nunc vero et trochæos in
+						utroque <lb/> membro scandimus, et semipede versus clauditur, ut <lb/>
+						spatii brevioris notam terminus teneat. Nam sunt in <note type="footnote">1
+							in B., ,<hi rend="italic">vel siccitatis.</hi> Rectius ex Ms. A, et
+							siecttaUs. II. </note>
 						<lb/>
-						<pb n="1151"/> priore quatuor, <hi rend="italic">Roma,</hi> Roma <hi rend="italic">cerne
-							quanta;</hi> iu posteriore <lb/> autem tres semis, <hi rend="italic">sit deum</hi>
-						benignitas. An contradicere <lb/> aliquid paras? <hi rend="italic">D.</hi> Nihil omnino,
-						et libenter assentior.</p>
-					<p>8. <hi rend="italic">M.</hi> Teneamus igitur has leges inconcussas, si <lb/> placet, ut
-						neque membrorum duorum tendens ad <lb/> aequalitatem partitio versui desit, sicuti huic
-						deest, <lb/>
-						<hi rend="italic">Cornua velatarum obvertimus antennarum.</hi> Neque ipsa <lb/>
-						æqualitas membrorum conversibilem , ut ita dicam, <lb/> faciat partitionem, ut in hoc
-						facit, <hi rend="italic">Cornua velaturum <lb/> vertimus antennarum.</hi> Neque cum ista
-						vitatur conver­ <lb/> sio, nimis a se membra discedant, sed quantum. pos­ <lb/> sunt
-						proximis numeris prope aequentur, ne dicamus <lb/> haec ita posse dividi, ut octo
-						semipedes præcedant, <lb/>
-						<hi rend="italic">Cornua velatarum vertimus;</hi> et quatuor subsequantur, <lb/> id est,
-							<hi rend="italic">antennarum.</hi> Nec membrum posterius p iris nu­ <lb/> meri
-						semipedes habeat, sicuti est, <hi rend="italic">tibi deum benignitas,</hi>
-						<lb/> ne pleno pede versus finitus non babeat terminum bre­ <lb/> viore tempore notatum.
-							<hi rend="italic">D.</hi> Habeo jam ista, et mando <lb/> memoriae quantum valeo.</p>
-					<ab>
+						<pb n="1151"/> priore quatuor, <hi rend="italic">Roma,</hi> Roma <hi
+							rend="italic">cerne quanta;</hi> iu posteriore <lb/> autem tres semis,
+							<hi rend="italic">sit deum</hi> benignitas. An contradicere <lb/>
+						aliquid paras? <hi rend="italic">D.</hi> Nihil omnino, et libenter
+						assentior.</p>
+					</div><div type="textpart" subtype="dialog"><p>8. <hi rend="italic">M.</hi> Teneamus igitur has leges inconcussas, si <lb/>
+						placet, ut neque membrorum duorum tendens ad <lb/> aequalitatem partitio
+						versui desit, sicuti huic deest, <lb/>
+						<hi rend="italic">Cornua velatarum obvertimus antennarum.</hi> Neque ipsa
+						<lb/> æqualitas membrorum conversibilem , ut ita dicam, <lb/> faciat
+						partitionem, ut in hoc facit, <hi rend="italic">Cornua velaturum <lb/>
+							vertimus antennarum.</hi> Neque cum ista vitatur conver­ <lb/> sio,
+						nimis a se membra discedant, sed quantum. pos­ <lb/> sunt proximis numeris
+						prope aequentur, ne dicamus <lb/> haec ita posse dividi, ut octo semipedes
+						præcedant, <lb/>
+						<hi rend="italic">Cornua velatarum vertimus;</hi> et quatuor subsequantur,
+						<lb/> id est, <hi rend="italic">antennarum.</hi> Nec membrum posterius p
+						iris nu­ <lb/> meri semipedes habeat, sicuti est, <hi rend="italic">tibi
+							deum benignitas,</hi>
+						<lb/> ne pleno pede versus finitus non babeat terminum bre­ <lb/> viore
+						tempore notatum. <hi rend="italic">D.</hi> Habeo jam ista, et mando <lb/>
+						memoriae quantum valeo.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT V. — <hi rend="italic">Heroici</hi> finis.</title>
 					</ab>
-					<p>9. <hi rend="italic">M.</hi> Quoniam igitur jam tenemus, non debere ver­ <lb/> sum
-						Gniri pleno pede, quomodo nobis heroicum ver­ <lb/> sum metiendum putas, ut ct membrorum
-						lex illa ser­ <lb/> vetnr, et hæc termini nota ? <hi rend="italic">D.</hi> Video
-						duodecim esse <lb/> semipedes; et quia propter illam conversionem vi­ <lb/> tandam senos
-						semipedes habere membra non possunt; <lb/> neque a se longe oportet discedere ut sint
-						tres et no­ <lb/> vem, aut novem et tres ; neque paris numeri semipe­ <lb/> des
-						posteriori membro dandi sunt ut sint octo et <lb/> quatuor, aut quatuor et octo, ne
-						pleno pede versus <lb/> liniatur : in quinque ct septem, aut septem et quinque <lb/>
-						divisio facienda est. Nam et hi numeri sunt ambo im­ <lb/> pares proximi, et certe
-						propinquius sibi accedunt <lb/> membra quam in quaternario et octonario numeris <lb/>
-						accederent. Quod ut firmissimum teneam , video par­ <lb/> tem orationis in quinto
-						semipede semper aut pene <lb/> semper terminari, ut est in primo Virgilii versu, <lb/>
-						Arma <hi rend="italic">virumque cano</hi> : et. in secundo, <hi rend="italic">Italiam
-							fato</hi> : et <lb/> in tertio, <hi rend="italic">Littora</hi> multum <hi rend="italic">ille et :</hi> in quarto item, <hi rend="italic">Vi<lb/> superum
-							sævæ</hi> : atque ita deinceps in toto pene car­ <lb/> mine. M. Verum dicis : sed
-						videndum tibi est, quos 1 <lb/> pedes metiaris, ut nihil superiorum legum jam in­ <lb/>
-						concusse coatstitutarum violare audeas. <hi rend="italic">D.</hi> Quanquam <lb/> niihi
-						satis ratio appareat, tamen novitate conturbor. <lb/> Nen enim solemus in hoc gencre
-						nisi spondeum pc­ <lb/> dem et dactylum scandere, quod nemo fere cst tam <lb/> indoctus
-						quin 2 audierit , ctiamsi minus id facere pos­ <lb/> sit. Hanc ergo pervulgatissimam
-						consuetudinem, nunc <lb/> si sequi voluero, lex illa termini est abrogand ia; præ­ <lb/>
-						cedens enim membrum semipede clauderetur, poste­ <lb/> rius autem pleno pede; quod
-						contra esse debuit. Sed <lb/> quia illum legein iniquissimum est tollere, et in nu­
-						<lb/> meris jam didici posse fieri, ut a non pleno pedc or­ <lb/> diamur 4; restat ut
-						non hic dactylum cum spondeo, <lb/> sed anapæstum locari judicemus; ut incipiat varsus a
-						<lb/> longa una syllaba, deinde duo pedes vel spondci vel <note type="footnote"> 1 <hi rend="italic">Qttos,</hi> juxta vatic. M. </note><note type="footnote"> I Qui <hi rend="italic">ROn,</hi> juxia vatic. M. </note><note type="footnote"> * sic Vatic. :
-								<hi rend="italic">Lex Ula terminata est abroganda.</hi> M. </note><note type="footnote">4 sic ex 'atie. In B., <hi rend="italic">non a pleno pede
-								ordiamur.</hi> M. </note>
-						<lb/> anapæsti vel altemi1 membrum superius terminent <lb/> tum I tres rursus alterum
-						vel anapaesti vel quolibet. <lb/> loco spondeus , sive omnibus, et in fnc una syllaba,
-						<lb/> qua versus legitime terminatur. Probasne et id?</p>
-					<p>10. <hi rend="italic">M.</hi> Ego quoquc rectissimum esse judlco, sed <lb/> non facile
-						ista populo persuadentur. Tanta cnim est <lb/> vis consueludinis , ut ca inveterata , si
-						falsa opinione <lb/> gcnita est, nihil sit inimicius veritati. Namque ad fa­ <lb/>
-						ciendum versum nihil interesse intelligis, utruin in <lb/> hoc genere anapæstus cum
-						spondeo, an d ctylus col­ <lb/> locetur : ad metiendum tamen rationabiliter I, quod
-						<lb/> non aurium sed mentis est proprium, vcra et certa ra­ <lb/> tione hoc, non
-						irrationabili opinione discernitur4: nc­ <lb/> que nunc a nobis primum inventa est, sed
-						multo c t <lb/> hac inveterata consuetudine antiquius animadversa 3, <lb/> Quare si eos
-						legant qui vel in greca vel in latina lin­ <lb/> gua disciplinæhujus doctissimi fucrunt,
-						non mira­ <lb/> buntur nimis qui forte hoc audierint: quanquam pu­ <lb/> det
-						imbecillitatis, cum rationi roborandæ hominum <lb/> auctoritasquneritur, cum ipsius
-						rationis ac veritatis an­ <lb/> ctoritate, quæ profecto est omni homine melior, nihil
-						<lb/> deberet esse præstantius. Non cnim ut in producenda <lb/> corripiendave syllaba
-						non nisi auctoritatem veterum <lb/> hon.inum quærimus, ut quemadmodum suntisi verbis
-						<lb/> quibus nos quoque loquimur, ita et nnsutamur; quia in <lb/> hujuscemodi re et
-						nullam observationem sequi disidiae <lb/> est, et novam instituere licentiæ : ita in
-						metiendo versu <lb/> inveterata voluntas hominum, ac non æterna rerum <lb/> ratio
-						cogitanda est, cum et modcratam ejus longitudi­ <lb/> nem prius naturaliter aure
-						sentiamus, dcinde appro­ <lb/> bemus rationabili consideratione numerorum, et eum <lb/>
-						insigni fine claudendum esse judiccl quisquis judicat <lb/> certius eum quam cætera
-						metra esse finiendum, eum­ <lb/> que finem in breviore tempore notandum esse manife­
-						<lb/> stum sit; siquidem temporis longitudinem coercet et <lb/> frenat quodammodo.</p>
-					<ab>
+					<div type="textpart" subtype="dialog"><p>9. <hi rend="italic">M.</hi> Quoniam igitur jam tenemus, non debere ver­
+						<lb/> sum Gniri pleno pede, quomodo nobis heroicum ver­ <lb/> sum metiendum
+						putas, ut ct membrorum lex illa ser­ <lb/> vetnr, et hæc termini nota ? <hi
+							rend="italic">D.</hi> Video duodecim esse <lb/> semipedes; et quia
+						propter illam conversionem vi­ <lb/> tandam senos semipedes habere membra
+						non possunt; <lb/> neque a se longe oportet discedere ut sint tres et no­
+						<lb/> vem, aut novem et tres ; neque paris numeri semipe­ <lb/> des
+						posteriori membro dandi sunt ut sint octo et <lb/> quatuor, aut quatuor et
+						octo, ne pleno pede versus <lb/> liniatur : in quinque ct septem, aut septem
+						et quinque <lb/> divisio facienda est. Nam et hi numeri sunt ambo im­ <lb/>
+						pares proximi, et certe propinquius sibi accedunt <lb/> membra quam in
+						quaternario et octonario numeris <lb/> accederent. Quod ut firmissimum
+						teneam , video par­ <lb/> tem orationis in quinto semipede semper aut pene
+						<lb/> semper terminari, ut est in primo Virgilii versu, <lb/> Arma <hi
+							rend="italic">virumque cano</hi> : et. in secundo, <hi rend="italic"
+							>Italiam fato</hi> : et <lb/> in tertio, <hi rend="italic">Littora</hi>
+						multum <hi rend="italic">ille et :</hi> in quarto item, <hi rend="italic"
+							>Vi<lb/> superum sævæ</hi> : atque ita deinceps in toto pene car­ <lb/>
+						mine. M. Verum dicis : sed videndum tibi est, quos 1 <lb/> pedes metiaris,
+						ut nihil superiorum legum jam in­ <lb/> concusse coatstitutarum violare
+						audeas. <hi rend="italic">D.</hi> Quanquam <lb/> niihi satis ratio appareat,
+						tamen novitate conturbor. <lb/> Nen enim solemus in hoc gencre nisi spondeum
+						pc­ <lb/> dem et dactylum scandere, quod nemo fere cst tam <lb/> indoctus
+						quin 2 audierit , ctiamsi minus id facere pos­ <lb/> sit. Hanc ergo
+						pervulgatissimam consuetudinem, nunc <lb/> si sequi voluero, lex illa
+						termini est abrogand ia; præ­ <lb/> cedens enim membrum semipede
+						clauderetur, poste­ <lb/> rius autem pleno pede; quod contra esse debuit.
+						Sed <lb/> quia illum legein iniquissimum est tollere, et in nu­ <lb/> meris
+						jam didici posse fieri, ut a non pleno pedc or­ <lb/> diamur 4; restat ut
+						non hic dactylum cum spondeo, <lb/> sed anapæstum locari judicemus; ut
+						incipiat varsus a <lb/> longa una syllaba, deinde duo pedes vel spondci vel
+							<note type="footnote"> 1 <hi rend="italic">Qttos,</hi> juxta vatic. M.
+							</note><note type="footnote"> I Qui <hi rend="italic">ROn,</hi> juxia
+							vatic. M. </note><note type="footnote"> * sic Vatic. : <hi rend="italic"
+								>Lex Ula terminata est abroganda.</hi> M. </note><note
+							type="footnote">4 sic ex 'atie. In B., <hi rend="italic">non a pleno
+								pede ordiamur.</hi> M. </note>
+						<lb/> anapæsti vel altemi1 membrum superius terminent <lb/> tum I tres
+						rursus alterum vel anapaesti vel quolibet. <lb/> loco spondeus , sive
+						omnibus, et in fnc una syllaba, <lb/> qua versus legitime terminatur.
+						Probasne et id?</p>
+					</div><div type="textpart" subtype="dialog"><p>10. <hi rend="italic">M.</hi> Ego quoquc rectissimum esse judlco, sed <lb/>
+						non facile ista populo persuadentur. Tanta cnim est <lb/> vis consueludinis
+						, ut ca inveterata , si falsa opinione <lb/> gcnita est, nihil sit inimicius
+						veritati. Namque ad fa­ <lb/> ciendum versum nihil interesse intelligis,
+						utruin in <lb/> hoc genere anapæstus cum spondeo, an d ctylus col­ <lb/>
+						locetur : ad metiendum tamen rationabiliter I, quod <lb/> non aurium sed
+						mentis est proprium, vcra et certa ra­ <lb/> tione hoc, non irrationabili
+						opinione discernitur4: nc­ <lb/> que nunc a nobis primum inventa est, sed
+						multo c t <lb/> hac inveterata consuetudine antiquius animadversa 3, <lb/>
+						Quare si eos legant qui vel in greca vel in latina lin­ <lb/> gua
+						disciplinæhujus doctissimi fucrunt, non mira­ <lb/> buntur nimis qui forte
+						hoc audierint: quanquam pu­ <lb/> det imbecillitatis, cum rationi roborandæ
+						hominum <lb/> auctoritasquneritur, cum ipsius rationis ac veritatis an­
+						<lb/> ctoritate, quæ profecto est omni homine melior, nihil <lb/> deberet
+						esse præstantius. Non cnim ut in producenda <lb/> corripiendave syllaba non
+						nisi auctoritatem veterum <lb/> hon.inum quærimus, ut quemadmodum suntisi
+						verbis <lb/> quibus nos quoque loquimur, ita et nnsutamur; quia in <lb/>
+						hujuscemodi re et nullam observationem sequi disidiae <lb/> est, et novam
+						instituere licentiæ : ita in metiendo versu <lb/> inveterata voluntas
+						hominum, ac non æterna rerum <lb/> ratio cogitanda est, cum et modcratam
+						ejus longitudi­ <lb/> nem prius naturaliter aure sentiamus, dcinde appro­
+						<lb/> bemus rationabili consideratione numerorum, et eum <lb/> insigni fine
+						claudendum esse judiccl quisquis judicat <lb/> certius eum quam cætera metra
+						esse finiendum, eum­ <lb/> que finem in breviore tempore notandum esse
+						manife­ <lb/> stum sit; siquidem temporis longitudinem coercet et <lb/>
+						frenat quodammodo.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT VI. — <hi rend="italic">Rursus de fine versus.</hi>
 						</title>
 					</ab>
-					<p>I I. Quæ cum ita sint, qui potest posterius ejus mem­ <lb/> brum nisi non pleno
-						terminari pede? Prioris autem <lb/> membri exordium aut plenum pedem esse, ut in ilio
-						<lb/> trochaico, <hi rend="italic">Roma,</hi> Roma, <hi rend="italic">cerne quanta sit
-							deum benigni­<lb/> tas;</hi> aut partem pedis oportet, ut in heroico, <hi rend="italic">Arma</hi> vi­ <lb/>
-						<hi rend="italic">rumque cano, Trojx qui primus ab oris.</hi> Quapropter, <lb/> omni jam
-						dubitatione sublata, etiam istum versum <lb/> metire, si placet, et mihi de membris ejus
-						pedibusque <lb/> responde, <hi rend="italic">Phaselus ille quem adetis, hospitcs.
-							D.</hi> Mem­ <lb/> braquidem hujus in quinque et septem scmipedes vi­ <lb/> deo
-						distributa, ut prius sit, <hi rend="italic">Phaselus ille;</hi> posterius <lb/> autem,
-							<hi rend="italic">quem videtis, hospites:</hi> edes vero iambos cerno-</p>
+					<div type="textpart" subtype="dialog"><p>11. Quæ cum ita sint, qui potest posterius ejus mem­ <lb/> brum nisi non
+						pleno terminari pede? Prioris autem <lb/> membri exordium aut plenum pedem
+						esse, ut in ilio <lb/> trochaico, <hi rend="italic">Roma,</hi> Roma, <hi
+							rend="italic">cerne quanta sit deum benigni­<lb/> tas;</hi> aut partem
+						pedis oportet, ut in heroico, <hi rend="italic">Arma</hi> vi­ <lb/>
+						<hi rend="italic">rumque cano, Trojx qui primus ab oris.</hi> Quapropter,
+						<lb/> omni jam dubitatione sublata, etiam istum versum <lb/> metire, si
+						placet, et mihi de membris ejus pedibusque <lb/> responde, <hi rend="italic"
+							>Phaselus ille quem adetis, hospitcs. D.</hi> Mem­ <lb/> braquidem hujus
+						in quinque et septem scmipedes vi­ <lb/> deo distributa, ut prius sit, <hi
+							rend="italic">Phaselus ille;</hi> posterius <lb/> autem, <hi
+							rend="italic">quem videtis, hospites:</hi> edes vero iambos cerno-</p>
 					<p><note type="footnote"> I sic ex vatic. et Ms. A. In B., <hi rend="italic">vel
-								anapcestiattenan mem-<lb/> Mum.</hi> M. </note><note type="footnote"> I In a., <hi rend="italic">cum.</hi> vatic., <hi rend="italic">dum.</hi> Dis, A, <hi rend="italic">tum.</hi> M. </note><note type="footnote"> 8 <hi rend="italic">Rationaliter,</hi> juxta vatic. M. </note><note type="footnote"> * Mss. veteres sic
-							babent: <hi rend="italic">rropvium, twiii.tm, quantam<lb/> hæc ratio ab illa opiniane
-								dUcernitur.</hi> — Juxta vatic. : .Y;­ <lb/>
-							<hi rend="italic">mium lucc ratio ab illa opinione discewitur.</hi> M. </note><note type="footnote"> I sic vatic. : <hi rend="italic">sed multo hæc est <foreign xml:lang="grc">ι</foreign>nverata comuetudine<lb/> antiquis animadversa.</hi> M.
-							</note><note type="footnote"> 6 Lov.: <hi rend="italic">Qvisquti judicat certius:
-								eumque quam c(etera</hi> me­ <lb/>
-							<hi rend="italic">tra esse insigniter fmendum, qui finem</hi> fiahct in <hi rend="italic">breviore</hi>
-							<lb/> temporum notarum <hi rend="italic">tnanifeslum : siqmdem,</hi> etc. Ita quoque
-							<lb/> cditiones aliæ, nisi quod hahet Am., <hi rend="italic">notatum manifestum
-								fit;</hi>
-							<lb/> Er., <hi rend="italic">notartwi manifestum sit.</hi> sed pricstal Mss. leclio
-							quam. <lb/> huc revocavimus. </note>
-						<pb n="1153"/> M. Quali o, nihilne caves pede pleno versum terminare? <lb/> D. Verum
-						dicis, et ubi fuerim nescio. Quis enim non <lb/> videret sicut in heroico exordiendum
-						esse a semi pede ? <lb/> quod cum in boc genere fit, non jam iambis, sed trochaeis <lb/>
-						versum metimur, ut eum legitime semipes claudat.</p>
-					<p>12. <hi rend="italic">M.</hi> Ita est ut dicis : sed vide quid tibi de hoc <lb/>
-						respondendum putes, quem asclepiadæum vocant, <lb/>
-						<hi rend="italic">Mæcenas atavis edite regibus ( Norat, lib.</hi> i <hi rend="italic">Carminum,<lb/> ode</hi> 1). Nam pars orationis in sexta syllaba terminatur, <lb/>
-						neque inconstanter, sed in omnibus fere hujus gene­ <lb/> ris versibus. Itaque ejus
-						primum est membrum, Mæ­ <lb/> cenas atavis : secundum, <hi rend="italic">edite
-							rrgibus,</hi> quod quanam <lb/> ratione fiat dubitari potest. Si enim metiaris in hoc
-						<lb/> pedes quaternorum temporum, erunt quinque in <lb/> priore, in posteriore autem
-						membro quatuor semipe­ <lb/> des: lex autem vetat membrum posterius pari nupero <lb/>
-						constare semipedum, ne pleno pede versus termine­ <lb/> tur. Restat ut pedes
-						consideremus senorum tempo­ <lb/> rum, ex quo fit ut membrum utrumque ternis semipe­
-						<lb/> dibus constet. Nam ut integro pede praecedens mem­ <lb/> brum finiatur, a duabus
-						longis incipiendum est : deinde <lb/> totus choriambus versum dividit, ut sequente etiam
-						<lb/> alio choriambo membrum posterius inchoctur, clau­ <lb/> dente versum semipede in
-						duabus brevibus syllabis : <lb/> tot enim tempora cum spondeo in capite locato, im­
+								anapcestiattenan mem-<lb/> Mum.</hi> M. </note><note type="footnote"
+							> I In a., <hi rend="italic">cum.</hi> vatic., <hi rend="italic"
+								>dum.</hi> Dis, A, <hi rend="italic">tum.</hi> M. </note><note
+							type="footnote"> 8 <hi rend="italic">Rationaliter,</hi> juxta vatic. M.
+							</note><note type="footnote"> * Mss. veteres sic babent: <hi
+								rend="italic">rropvium, twiii.tm, quantam<lb/> hæc ratio ab illa
+								opiniane dUcernitur.</hi> — Juxta vatic. : .Y;­ <lb/>
+							<hi rend="italic">mium lucc ratio ab illa opinione discewitur.</hi> M.
+							</note><note type="footnote"> I sic vatic. : <hi rend="italic">sed multo
+								hæc est <foreign xml:lang="grc">ι</foreign>nverata comuetudine<lb/>
+								antiquis animadversa.</hi> M. </note><note type="footnote"> 6 Lov.:
+								<hi rend="italic">Qvisquti judicat certius: eumque quam c(etera</hi>
+							me­ <lb/>
+							<hi rend="italic">tra esse insigniter fmendum, qui finem</hi> fiahct in
+								<hi rend="italic">breviore</hi>
+							<lb/> temporum notarum <hi rend="italic">tnanifeslum : siqmdem,</hi>
+							etc. Ita quoque <lb/> cditiones aliæ, nisi quod hahet Am., <hi
+								rend="italic">notatum manifestum fit;</hi>
+							<lb/> Er., <hi rend="italic">notartwi manifestum sit.</hi> sed pricstal
+							Mss. leclio quam. <lb/> huc revocavimus. </note>
+						<pb n="1153"/> M. Quali o, nihilne caves pede pleno versum terminare? <lb/>
+						D. Verum dicis, et ubi fuerim nescio. Quis enim non <lb/> videret sicut in
+						heroico exordiendum esse a semi pede ? <lb/> quod cum in boc genere fit, non
+						jam iambis, sed trochaeis <lb/> versum metimur, ut eum legitime semipes
+						claudat.</p>
+					</div><div type="textpart" subtype="dialog"><p>12. <hi rend="italic">M.</hi> Ita est ut dicis : sed vide quid tibi de hoc
+						<lb/> respondendum putes, quem asclepiadæum vocant, <lb/>
+						<hi rend="italic">Mæcenas atavis edite regibus ( Norat, lib.</hi> i <hi
+							rend="italic">Carminum,<lb/> ode</hi> 1). Nam pars orationis in sexta
+						syllaba terminatur, <lb/> neque inconstanter, sed in omnibus fere hujus
+						gene­ <lb/> ris versibus. Itaque ejus primum est membrum, Mæ­ <lb/> cenas
+						atavis : secundum, <hi rend="italic">edite rrgibus,</hi> quod quanam <lb/>
+						ratione fiat dubitari potest. Si enim metiaris in hoc <lb/> pedes
+						quaternorum temporum, erunt quinque in <lb/> priore, in posteriore autem
+						membro quatuor semipe­ <lb/> des: lex autem vetat membrum posterius pari
+						nupero <lb/> constare semipedum, ne pleno pede versus termine­ <lb/> tur.
+						Restat ut pedes consideremus senorum tempo­ <lb/> rum, ex quo fit ut membrum
+						utrumque ternis semipe­ <lb/> dibus constet. Nam ut integro pede praecedens
+						mem­ <lb/> brum finiatur, a duabus longis incipiendum est : deinde <lb/>
+						totus choriambus versum dividit, ut sequente etiam <lb/> alio choriambo
+						membrum posterius inchoctur, clau­ <lb/> dente versum semipede in duabus
+						brevibus syllabis : <lb/> tot enim tempora cum spondeo in capite locato, im­
 						<lb/> plent sex temporum pedem. Nisi quid habes ad haec. <lb/>
-						<hi rend="italic">D.</hi> Nihil prorsus. <hi rend="italic">M.</hi> Placet ergo, totidem
-						semipedi­ <lb/> bus constare utrumque membrum. <hi rend="italic">D.</hi> Cur non pla­
-						<lb/> ceat? Neque enim metucnda est hic illa conversio, <lb/> quia posito posteriore
-						membro in præcedentis loco, <lb/> ila ut quod est primum, secundum fiat, non eadem lex
-						<lb/> manebit pedum. Quapropter nul'a causa est, cur idem <lb/> semipedum numerus in hoc
-						genere membris negetur; <lb/> cum sine ullo conversionis vitio parilitas ista possit
-						<lb/> teneri, finis etiam insignioris lege servata, cum versus <lb/> non pleno pede
-						terminatur, quod constantissime ser­ <lb/> vandum est1.</p>
-					<ab>
-						<title type="sub">CAPUT VII.<hi rend="italic">Quomodo semipedum imparilitas in ver­</hi>
-							suum membris <hi rend="italic">ad parilitatem referatur. Conciliantur</hi> membra <hi rend="italic">semipedum quatuor</hi> et trium. <hi rend="italic">Membra semi­ pedum
-								quinque et trium.</hi>
+						<hi rend="italic">D.</hi> Nihil prorsus. <hi rend="italic">M.</hi> Placet
+						ergo, totidem semipedi­ <lb/> bus constare utrumque membrum. <hi
+							rend="italic">D.</hi> Cur non pla­ <lb/> ceat? Neque enim metucnda est
+						hic illa conversio, <lb/> quia posito posteriore membro in præcedentis loco,
+						<lb/> ila ut quod est primum, secundum fiat, non eadem lex <lb/> manebit
+						pedum. Quapropter nul'a causa est, cur idem <lb/> semipedum numerus in hoc
+						genere membris negetur; <lb/> cum sine ullo conversionis vitio parilitas
+						ista possit <lb/> teneri, finis etiam insignioris lege servata, cum versus
+						<lb/> non pleno pede terminatur, quod constantissime ser­ <lb/> vandum
+						est1.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT VII.<hi rend="italic">Quomodo semipedum imparilitas
+								in ver­</hi> suum membris <hi rend="italic">ad parilitatem
+								referatur. Conciliantur</hi> membra <hi rend="italic">semipedum
+								quatuor</hi> et trium. <hi rend="italic">Membra semi­ pedum quinque
+								et trium.</hi>
 						</title>
 					</ab>
-					<p>13. <hi rend="italic">M.</hi> Rem ipsam omnino vidisti : quare jam quo­ <lb/> niam
-						comperit ratio versuum esse duo ginera, unum <lb/> in quo idem numerus semipedum, aliud
-						in quo dispar <lb/> in membris sit; diligenter consideremus, si placet, <lb/> quonam
-						modo ista imparilitas semipedum ad quam­ <lb/> dam parilitatem referatur, obscuriore
-						aliquantum, sed <lb/> sane I subtilissima ratione numerorum. Nam quæro <lb/> ex te, cum
-						duo et tria dicam , quot numeros dicam- <lb/> D. Duos scilicet. <hi rend="italic">M.</hi> Ergo et duo unus, et tria unus <lb/> est numerus; et quemlibet alium
-						dixerimus. <hi rend="italic">D.</hi> Iia <lb/> est. M. Nonne tibi ex hoc videlur unum
-						cum quolibet <lb/> numero non absurde posse conferri ? Siquidem unum <lb/> duo esse non
-						possemus dicere ; duo autem unum <lb/> esse quodammodo : et itejn tria et quatuor unum
-						<lb/> esse, non falso diri <hi rend="italic">potest. D.</hi> Assentior. <hi rend="italic">M.</hi> Attende <lb/> aliud : dic mibi, duo ter ducta, quid faciunt in
-						summa? <note type="footnote"> I <hi rend="italic">servatidumesse perplacet,</hi> jutta
-							omnes Edd. et Me. A. M. </note><note type="footnote"> I <hi rend="italic">Ttunen,</hi>
-							juxta vatic. M. </note>
+					<div type="textpart" subtype="dialog"><p>13. <hi rend="italic">M.</hi> Rem ipsam omnino vidisti : quare jam quo­ <lb/>
+						niam comperit ratio versuum esse duo ginera, unum <lb/> in quo idem numerus
+						semipedum, aliud in quo dispar <lb/> in membris sit; diligenter
+						consideremus, si placet, <lb/> quonam modo ista imparilitas semipedum ad
+						quam­ <lb/> dam parilitatem referatur, obscuriore aliquantum, sed <lb/> sane
+						I subtilissima ratione numerorum. Nam quæro <lb/> ex te, cum duo et tria
+						dicam , quot numeros dicam- <lb/> D. Duos scilicet. <hi rend="italic"
+							>M.</hi> Ergo et duo unus, et tria unus <lb/> est numerus; et quemlibet
+						alium dixerimus. <hi rend="italic">D.</hi> Iia <lb/> est. M. Nonne tibi ex
+						hoc videlur unum cum quolibet <lb/> numero non absurde posse conferri ?
+						Siquidem unum <lb/> duo esse non possemus dicere ; duo autem unum <lb/> esse
+						quodammodo : et itejn tria et quatuor unum <lb/> esse, non falso diri <hi
+							rend="italic">potest. D.</hi> Assentior. <hi rend="italic">M.</hi>
+						Attende <lb/> aliud : dic mibi, duo ter ducta, quid faciunt in summa? <note
+							type="footnote"> I <hi rend="italic">servatidumesse perplacet,</hi>
+							jutta omnes Edd. et Me. A. M. </note><note type="footnote"> I <hi
+								rend="italic">Ttunen,</hi> juxta vatic. M. </note>
 						<lb/>
-						<hi rend="italic">D.</hi> Sex. <hi rend="italic">M.</hi> Num sex et tria totidem sunt?
-						D. Nullo <lb/> modo. <hi rend="italic">M.</hi> Nunc tria quater ducas velim, summamque
-						<lb/> respondeas. <hi rend="italic">D.</hi> Duodecim. <hi rend="italic">M.</hi> Vides
-						item duodecim <lb/> plures esse quam quatuor. D. Et longe sane. <hi rend="italic">M.</hi> Jam <lb/> ne immorer 1, figenda regula est : A duobus , et <lb/> deinceps
-						quoslibet numeros duos constitueris, minor <lb/> per majorem multiplicatus , eum excedat
-						necesse <lb/> est. <hi rend="italic">D.</hi> Quis hoc dubitaverit ? Quid enim tam parvum
-						<lb/> in plurali numero quam duo? quem tamen numerum <lb/> si millies duxero, ita
-						excedet mille, ut duplum fiat. <lb/> M. Verum dicis : sed constitue unum, et quemlibet
-						<lb/> deinde majorem numerum, et quemadmodum in illis <lb/> faciebamus, minorem per
-						majorem multiplica, num <lb/> eodem modo major superabitur? <hi rend="italic">D.</hi>
-						Non plane, sed <lb/> majori minor æquabitur. Nam unum bis, duo; et unum <lb/> decies,
-						decem; et unum millies, mille; et per quemlibet <lb/> aliurn numerum multiplicavero, un
-						am neresse est æque <lb/> tur. <hi rend="italic">II.</hi> Habet ergo unum cum cæteris
-						numeris jus <lb/> quoddam æqualitatis; non modo quod quicumque' <lb/> numerus est, sed
-						etiam quod toties ductus tantumdem <lb/> facit. <hi rend="italic">D.</hi>
-						Manifestissimum est.</p>
-					<p>i4. <hi rend="italic">M.</hi> Age nunc, refer animum ad semipedum <lb/> numeros, quibus
-						in versu fiunt membra inæqualia, et <lb/> miram quamdam æqualitatem ista quam
-						tractavimus <lb/> ratione reperies. Nam, uL opinor, versus minimus <lb/> inæquali
-						semipedum numero in membris est duobus, <lb/> habens semipedes quatuor et tres, ut in
-						hoc, <hi rend="italic">Hospes.<lb/> ille quem vides ;</hi> cujus primum membrum quod
-						est, <lb/>
-						<hi rend="italic">Hospes ille,</hi> secari aequaliter potest in duas partes <lb/>
-						binorum semipedum : secundum autem quod est, <lb/>
-						<hi rend="italic">quem</hi> vides, ita dividitur, ut una pars duos semipedes <lb/>
-						babeat, altera unum; quod ita est, quasi duo et duo <lb/> sint, jure illo aequalitatis,
-						de quo satis egimus, quod <lb/> habet unum cum omnibus numeris. Ex quo fit ut ista <lb/>
-						divisione tantum sit quodammodo superius membrum <lb/> quantum posterius. Itaque ubi
-						fuerint quatuor et quin­ <lb/> que semipedes, sicut hoc est, Roma, Roma, <hi rend="italic">cerne <lb/> quanta sit;</hi> non ita probatur, et propterea metrum <lb/>
-						erit potius quam versus, quia ita sunt membra in. <lb/> æqualia ut ad nullam aqualitatis
-						legem sectione aliqua <lb/> possint referri. Cernis quippe, ut opiuor, superioris <lb/>
-						membri quatuor semipedes, <hi rend="italic">Roma, Roma,</hi> in binos <lb/> posse
-						discederc8 : quinque autem posteriores, <hi rend="italic">cerne<lb/> quanta sit,</hi> in
-						duos et tres semipedes dividi; ubi nullo <lb/> jure apparet aequalitas. Neque enim
-						possunt aliquo <lb/> modo tantum valere quinque semipedes propter duos <lb/> et tres,
-						quantum quatuor valent; quomodo inveni­ <lb/> mus superius in breviore versu tantum
-						valere tres se­ <lb/> mipedes propter unum et duo, quantum quatuor va­ <lb/> lent. An
-						aliquid non es assecutus, aut non placet? <lb/>
+						<hi rend="italic">D.</hi> Sex. <hi rend="italic">M.</hi> Num sex et tria
+						totidem sunt? D. Nullo <lb/> modo. <hi rend="italic">M.</hi> Nunc tria
+						quater ducas velim, summamque <lb/> respondeas. <hi rend="italic">D.</hi>
+						Duodecim. <hi rend="italic">M.</hi> Vides item duodecim <lb/> plures esse
+						quam quatuor. D. Et longe sane. <hi rend="italic">M.</hi> Jam <lb/> ne
+						immorer 1, figenda regula est : A duobus , et <lb/> deinceps quoslibet
+						numeros duos constitueris, minor <lb/> per majorem multiplicatus , eum
+						excedat necesse <lb/> est. <hi rend="italic">D.</hi> Quis hoc dubitaverit ?
+						Quid enim tam parvum <lb/> in plurali numero quam duo? quem tamen numerum
+						<lb/> si millies duxero, ita excedet mille, ut duplum fiat. <lb/> M. Verum
+						dicis : sed constitue unum, et quemlibet <lb/> deinde majorem numerum, et
+						quemadmodum in illis <lb/> faciebamus, minorem per majorem multiplica, num
+						<lb/> eodem modo major superabitur? <hi rend="italic">D.</hi> Non plane, sed
+						<lb/> majori minor æquabitur. Nam unum bis, duo; et unum <lb/> decies,
+						decem; et unum millies, mille; et per quemlibet <lb/> aliurn numerum
+						multiplicavero, un am neresse est æque <lb/> tur. <hi rend="italic">II.</hi>
+						Habet ergo unum cum cæteris numeris jus <lb/> quoddam æqualitatis; non modo
+						quod quicumque' <lb/> numerus est, sed etiam quod toties ductus tantumdem
+						<lb/> facit. <hi rend="italic">D.</hi> Manifestissimum est.</p>
+					</div><div type="textpart" subtype="dialog"><p>14. <hi rend="italic">M.</hi> Age nunc, refer animum ad semipedum <lb/>
+						numeros, quibus in versu fiunt membra inæqualia, et <lb/> miram quamdam
+						æqualitatem ista quam tractavimus <lb/> ratione reperies. Nam, uL opinor,
+						versus minimus <lb/> inæquali semipedum numero in membris est duobus, <lb/>
+						habens semipedes quatuor et tres, ut in hoc, <hi rend="italic">Hospes.<lb/>
+							ille quem vides ;</hi> cujus primum membrum quod est, <lb/>
+						<hi rend="italic">Hospes ille,</hi> secari aequaliter potest in duas partes
+						<lb/> binorum semipedum : secundum autem quod est, <lb/>
+						<hi rend="italic">quem</hi> vides, ita dividitur, ut una pars duos semipedes
+						<lb/> babeat, altera unum; quod ita est, quasi duo et duo <lb/> sint, jure
+						illo aequalitatis, de quo satis egimus, quod <lb/> habet unum cum omnibus
+						numeris. Ex quo fit ut ista <lb/> divisione tantum sit quodammodo superius
+						membrum <lb/> quantum posterius. Itaque ubi fuerint quatuor et quin­ <lb/>
+						que semipedes, sicut hoc est, Roma, Roma, <hi rend="italic">cerne <lb/>
+							quanta sit;</hi> non ita probatur, et propterea metrum <lb/> erit potius
+						quam versus, quia ita sunt membra in. <lb/> æqualia ut ad nullam aqualitatis
+						legem sectione aliqua <lb/> possint referri. Cernis quippe, ut opiuor,
+						superioris <lb/> membri quatuor semipedes, <hi rend="italic">Roma,
+							Roma,</hi> in binos <lb/> posse discederc8 : quinque autem posteriores,
+							<hi rend="italic">cerne<lb/> quanta sit,</hi> in duos et tres semipedes
+						dividi; ubi nullo <lb/> jure apparet aequalitas. Neque enim possunt aliquo
+						<lb/> modo tantum valere quinque semipedes propter duos <lb/> et tres,
+						quantum quatuor valent; quomodo inveni­ <lb/> mus superius in breviore versu
+						tantum valere tres se­ <lb/> mipedes propter unum et duo, quantum quatuor
+						va­ <lb/> lent. An aliquid non es assecutus, aut non placet? <lb/>
 						<hi rend="italic">D.</hi> Imo vero et manifesta omnia et rata sunt.</p>
-					<p>15. <hi rend="italic">M.</hi> Age, nunc quinque et tres semipedes con­ <lb/> sideremus,
-						qualis est ille versiculus, <hi rend="italic">Phaselus ille <lb/> quem vides :</hi> et
-						videamus quomodo ista insequalitas <lb/> aliquo aequalitatis jure teneatur : nam boc
-						genus non <lb/> solum metrum, sed etiam versum esse, omnes con- <note type="footnote">1
-							Locum hunc restituimus ex lis. A. Sic in B. : <hi rend="italic">Et ionge. II.</hi>
-							<lb/> sane, ne jam inarnorer. M. </note><note type="footnote"> * <hi rend="italic">cwuscumque,</hi> juxta vatic. II. </note><note type="footnote"> I <hi rend="italic">Discindere,</hi> juxta vatic. II. </note>
+					</div><div type="textpart" subtype="dialog"><p>15. <hi rend="italic">M.</hi> Age, nunc quinque et tres semipedes con­ <lb/>
+						sideremus, qualis est ille versiculus, <hi rend="italic">Phaselus ille <lb/>
+							quem vides :</hi> et videamus quomodo ista insequalitas <lb/> aliquo
+						aequalitatis jure teneatur : nam boc genus non <lb/> solum metrum, sed etiam
+						versum esse, omnes con- <note type="footnote">1 Locum hunc restituimus ex
+							lis. A. Sic in B. : <hi rend="italic">Et ionge. II.</hi>
+							<lb/> sane, ne jam inarnorer. M. </note><note type="footnote"> * <hi
+								rend="italic">cwuscumque,</hi> juxta vatic. II. </note><note
+							type="footnote"> I <hi rend="italic">Discindere,</hi> juxta vatic. II. </note>
 						<lb/>
-						<pb n="1155"/> sentiunt. Itaque cum prirnum membrum in semipedes <lb/> duos et ires
-						secueris, et secundum in duos et unum ; <lb/> conjungas particulas quas ID utroque pares
-						inveneris1, <lb/> quia et in primo membro habemus duo, et in secundo <lb/> restaNt dux
-						particulae, una in tribus semipedibus de <lb/> priore membro, altera in uno de
-						posteriore. Has <lb/> ergo et sociabililor jungimus, quia unum cum omni­ <lb/> bus habet
-						societatem I; et in summa unum et tria, <lb/> quatuor fiunt, quod est tantumdem quantum
-						duo et <lb/> duo. Per hanc igitur sectionem eliam quinque et tres <lb/> semipcdes ad
-						concordiam rediguntur. Sed responde, <lb/> utrum intellexeris. <hi rend="italic">D.</hi>
-						Ila vero, et admodum probo.</p>
+						<pb n="1155"/> sentiunt. Itaque cum prirnum membrum in semipedes <lb/> duos
+						et ires secueris, et secundum in duos et unum ; <lb/> conjungas particulas
+						quas ID utroque pares inveneris1, <lb/> quia et in primo membro habemus duo,
+						et in secundo <lb/> restaNt dux particulae, una in tribus semipedibus de
+						<lb/> priore membro, altera in uno de posteriore. Has <lb/> ergo et
+						sociabililor jungimus, quia unum cum omni­ <lb/> bus habet societatem I; et
+						in summa unum et tria, <lb/> quatuor fiunt, quod est tantumdem quantum duo
+						et <lb/> duo. Per hanc igitur sectionem eliam quinque et tres <lb/>
+						semipcdes ad concordiam rediguntur. Sed responde, <lb/> utrum intellexeris.
+							<hi rend="italic">D.</hi> Ila vero, et admodum probo.</p>
 					<p>CAPUT VIII.— <hi rend="italic">Membra semipedum quinque et septem.</hi>
 					</p>
-					<p>i6. <hi rend="italic">M.</hi> Sequitur ut de quinque et septem semipedi­ <lb/> bus
-						disseramus, quales sunt versus duo illi nobilis­ <lb/> sini , heroicus et quem iambicum
-						vulgo vocant, etiam <lb/> ipse senarius. Nam, <hi rend="italic">Arma virumque cano,
-							Trojæ qui</hi>
-						<lb/> primus <hi rend="italic">ab</hi> oria, ita dividitur ut primum ejus membrum <lb/>
-						sit,Arma <hi rend="italic">virumque cano,</hi> qui sunt quinque; et secun­ <lb/> dum,
-							<hi rend="italic">Trojce qui</hi> primus <hi rend="italic">ab</hi> oria, qui sunt
-						septem se­ <lb/> mipedes. Et, <hi rend="italic">Phaselus ille quem videtis,
-							hospites,</hi> pri­ <lb/> mum membrum habet, <hi rend="italic">Phaselus ille,</hi> in
-						semipedibus <lb/> quinque ; secundum in septem, <hi rend="italic">quem videtis,
-							hos­</hi>
-						<lb/> pites. Sed tanta illa nobilitas in loge ista æqualitatis <lb/> laborat. Cnm enim
-						superiores quinque semipedes in <lb/> duos et tres diviserimus, posteriores autem septem
-						in <lb/> tres et quatuor; congruent sibi quidem particulæ terno­ <lb/> rum semipcdum :
-						sed si duae reliquae ita convenirent, <lb/> ut una earum constaret uno semipede, alia
-						quinque; <lb/> conjungerentur lege illa qua unum cum omnibus nu­ <lb/> meris conjungi
-						potest, et in summa sex fierent, quod <lb/> sunt etiam tres ct tres : nunc vero quia duo
-						et qua­ <lb/> tuor inveniuntur, summam quidem reddent senariam; <lb/> sed nullo
-						æqualitatis jure tantum valent duo quantum <lb/> quatuor, ut in hujuscemodi quasi
-						necessitudine copu­ <lb/> lentur. Nisi forte quis dixerit salis esse ad aliquam <lb/>
-						regulam parilitatis, quod ut tres et tres, ita duo et <lb/> quatuor sex fiunt. Cui
-						rationi repugnandum non arbi­ <lb/> tror : est enim ct haec aliqua aequalitas. Sed illud
-						<lb/> nollem ut majore congruentia quinque et tres quam <lb/> quinque et septem
-						semipedes convenirent. Non enim <lb/> tantum nomen est illius versus quantum istorum ;
-						et <lb/> vides in illo non modo tantam summam inventam <lb/> collatis uno et tribus,
-						quanta est in duobus et duo­ <lb/> bus; sed etiam multo concordiores partes esse, cum
-						<lb/> junguntur unum et tria, propter illam unius cum cæ­ <lb/> teris omnibus numeris
-						amicitiam, quam cum duo et <lb/> quatuor copulantur, sicut in istis est. An tibi aliquid
-						<lb/> obscurum est ? <hi rend="italic">D.</hi> Nihil prorsus. Sed nescio quomodo <lb/>
-						me offendit, quod isti senarii cum sint celebratiores <lb/> cæteris generibus, et
-						principatum quemdam in versi­ <lb/> bus habere dicantur, aliquid in membrorum concor­
-						<lb/> dia minus habent, quam illi famæ obscurioris versus. <lb/> II. Bono animo esto :
-						nam ego tibi tantam in illisos­ <lb/> tendam concordiam, quantam soli ex omnibus habere
-						<lb/> meruerunt, ut videas, non injuria cos esse prælatos. <note type="footnote"> I SIc
-							Vatic.: <hi rend="italic">conjungens</hi> particulas, quasab <hi rend="italic">mraqueparte</hi>
-							<lb/> vtvenerts. II. </note><note type="footnote"> I <hi rend="italic">consocietatem,</hi> juxta vatIc. M. </note>
-						<lb/> Sed quia ipsa tractatio aliquanto est longior, quam­ <lb/> vis omnino jucundior,
-						restare nobis debet extrema, ut <lb/> cum de cæteris, quantum satis videbitur,
-						disputave­ <lb/> rimus, jam omni cura liberati, ad horum scrutanda <lb/> penetralia
-						veniamus. <hi rend="italic">D.</hi> Mibi vero placet : sed jain <lb/> vellem ut ista
-						quae priora suscepimus, explicata es­ <lb/> sent, ut jam illud audirem commodius. <hi rend="italic">M.</hi> Istorum <lb/> comparatione quæ ante disseruimus, fiunt itia dul­
-						<lb/> ciora qu:e exspectas.</p>
-					<ab>
-						<title type="sub">CAPUT IX. — <hi rend="italic">Membra semipedum sex et septem. Membra
-								semipedum octo et septem. Membra semipe­ dnm novem ct septem.</hi>
+					<div type="textpart" subtype="dialog"><p>16. <hi rend="italic">M.</hi> Sequitur ut de quinque et septem semipedi­
+						<lb/> bus disseramus, quales sunt versus duo illi nobilis­ <lb/> sini ,
+						heroicus et quem iambicum vulgo vocant, etiam <lb/> ipse senarius. Nam, <hi
+							rend="italic">Arma virumque cano, Trojæ qui</hi>
+						<lb/> primus <hi rend="italic">ab</hi> oria, ita dividitur ut primum ejus
+						membrum <lb/> sit,Arma <hi rend="italic">virumque cano,</hi> qui sunt
+						quinque; et secun­ <lb/> dum, <hi rend="italic">Trojce qui</hi> primus <hi
+							rend="italic">ab</hi> oria, qui sunt septem se­ <lb/> mipedes. Et, <hi
+							rend="italic">Phaselus ille quem videtis, hospites,</hi> pri­ <lb/> mum
+						membrum habet, <hi rend="italic">Phaselus ille,</hi> in semipedibus <lb/>
+						quinque ; secundum in septem, <hi rend="italic">quem videtis, hos­</hi>
+						<lb/> pites. Sed tanta illa nobilitas in loge ista æqualitatis <lb/>
+						laborat. Cnm enim superiores quinque semipedes in <lb/> duos et tres
+						diviserimus, posteriores autem septem in <lb/> tres et quatuor; congruent
+						sibi quidem particulæ terno­ <lb/> rum semipcdum : sed si duae reliquae ita
+						convenirent, <lb/> ut una earum constaret uno semipede, alia quinque; <lb/>
+						conjungerentur lege illa qua unum cum omnibus nu­ <lb/> meris conjungi
+						potest, et in summa sex fierent, quod <lb/> sunt etiam tres ct tres : nunc
+						vero quia duo et qua­ <lb/> tuor inveniuntur, summam quidem reddent
+						senariam; <lb/> sed nullo æqualitatis jure tantum valent duo quantum <lb/>
+						quatuor, ut in hujuscemodi quasi necessitudine copu­ <lb/> lentur. Nisi
+						forte quis dixerit salis esse ad aliquam <lb/> regulam parilitatis, quod ut
+						tres et tres, ita duo et <lb/> quatuor sex fiunt. Cui rationi repugnandum
+						non arbi­ <lb/> tror : est enim ct haec aliqua aequalitas. Sed illud <lb/>
+						nollem ut majore congruentia quinque et tres quam <lb/> quinque et septem
+						semipedes convenirent. Non enim <lb/> tantum nomen est illius versus quantum
+						istorum ; et <lb/> vides in illo non modo tantam summam inventam <lb/>
+						collatis uno et tribus, quanta est in duobus et duo­ <lb/> bus; sed etiam
+						multo concordiores partes esse, cum <lb/> junguntur unum et tria, propter
+						illam unius cum cæ­ <lb/> teris omnibus numeris amicitiam, quam cum duo et
+						<lb/> quatuor copulantur, sicut in istis est. An tibi aliquid <lb/> obscurum
+						est ? <hi rend="italic">D.</hi> Nihil prorsus. Sed nescio quomodo <lb/> me
+						offendit, quod isti senarii cum sint celebratiores <lb/> cæteris generibus,
+						et principatum quemdam in versi­ <lb/> bus habere dicantur, aliquid in
+						membrorum concor­ <lb/> dia minus habent, quam illi famæ obscurioris versus.
+						<lb/> II. Bono animo esto : nam ego tibi tantam in illisos­ <lb/> tendam
+						concordiam, quantam soli ex omnibus habere <lb/> meruerunt, ut videas, non
+						injuria cos esse prælatos. <note type="footnote"> I SIc Vatic.: <hi
+								rend="italic">conjungens</hi> particulas, quasab <hi rend="italic"
+								>mraqueparte</hi>
+							<lb/> vtvenerts. II. </note><note type="footnote"> I <hi rend="italic"
+								>consocietatem,</hi> juxta vatIc. M. </note>
+						<lb/> Sed quia ipsa tractatio aliquanto est longior, quam­ <lb/> vis omnino
+						jucundior, restare nobis debet extrema, ut <lb/> cum de cæteris, quantum
+						satis videbitur, disputave­ <lb/> rimus, jam omni cura liberati, ad horum
+						scrutanda <lb/> penetralia veniamus. <hi rend="italic">D.</hi> Mibi vero
+						placet : sed jain <lb/> vellem ut ista quae priora suscepimus, explicata es­
+						<lb/> sent, ut jam illud audirem commodius. <hi rend="italic">M.</hi>
+						Istorum <lb/> comparatione quæ ante disseruimus, fiunt itia dul­ <lb/> ciora
+						qu:e exspectas.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT IX. — <hi rend="italic">Membra semipedum sex et
+								septem. Membra semipedum octo et septem. Membra semipe­ dnm novem ct
+								septem.</hi>
 						</title>
 					</ab>
-					<p>17. Nunc itaque considera, utrum in duobus mem­ <lb/> bris quorum primum cxhibeat
-						semipedes sex, alte. <lb/> rum septem, reperiatur ea æqualitas ut rile es se ver. <lb/>
-						sus queat. Nam post quinque ct septem semipedes <lb/> hunc esse discutiendum vides.
-						Ilujus autem exem­ <lb/> plum est : <hi rend="italic">Roma, cerne quanta sit deum
-							benignitas. <lb/> D.</hi> Video primum membrum posse in partes distribui, <lb/> quæ
-						habeant ternos semipedes, secundum in tres et <lb/> quatuor. Quare junctis aequalibus
-						fiunt sex semipe­ <lb/> des, tres vero et quatuor septem sunt, et non a'quan­ <lb/> tur
-						illi numero. Sed si duo et duo in ea parte ubi <lb/> quatuor sunt, et duo et unum in ea
-						parte ubi tres <lb/> sunt, consideremus, junctis portibus quae binos ha­ <lb/> bent, tit
-						summa quaternaria : junctis autem illis <lb/> quarum in una duo sunt, in alia unum, si
-						etiam ista <lb/> tanquam sint quatuor accipiamus , propter unius cum <lb/> cæteris
-						numeris concordiam, octo simul fiunt, ma­ <lb/> gisque excedunt summam scnariam, quam
-						cum se­ <lb/> ptem fuissent.</p>
-					<p>18. <hi rend="italic">M.</hi> Ita est, ut dicis: et idco isto genere copu­ <lb/>
-						lationis a lege versuum separato, attende ut ordo po­ <lb/> stulat, in ea nunc membra,
-						quorum primum habet <lb/> octo semipedes, septem secundum. Ista vero copulatio <lb/>
-						habet quod quaerimus. Nam pracedentis membri par­ <lb/> tem dimidiam cum parlc
-						subsequentis majore, quae <lb/> dimidiae proxima est, jungens, quoniam quaterni se­ <lb/>
-						<lb/> mipedes sunt, octonarii numeri summam facio. Re­ <lb/> stant ergo quatuor
-						semipedes de priore, tres de poste­ <lb/> riore membro. Duo inde, et duo hinc copulati,
-						fiunt <lb/> quatuor. Duo rursus inde residui, et unus hinc, ad <lb/> legem illius
-						convenientiae copulati, qua 'unum reliquis <lb/> par est, quodammodo sumuntur pro
-						quatuor. Ita jam <lb/> octonarius superiori oclouario congruit. D. Sed cur <lb/> hujus
-						exemplum non audio? M. Quia sæpe comme­ <lb/> moratum est : tamen ne suo loco
-						prætermissum pu­ <lb/> tes, ipsum est, <hi rend="italic">Roma, Roma, cerne</hi> quanta
-							<hi rend="italic">sit deum <lb/> benignitas;</hi> vel hoc etiam, <hi rend="italic">Optimus beatus ille qui pro­</hi>
+					<div type="textpart" subtype="dialog"><p>17. Nunc itaque considera, utrum in duobus mem­ <lb/> bris quorum primum
+						cxhibeat semipedes sex, alte. <lb/> rum septem, reperiatur ea æqualitas ut
+						rile es se ver. <lb/> sus queat. Nam post quinque ct septem semipedes <lb/>
+						hunc esse discutiendum vides. Ilujus autem exem­ <lb/> plum est : <hi
+							rend="italic">Roma, cerne quanta sit deum benignitas. <lb/> D.</hi>
+						Video primum membrum posse in partes distribui, <lb/> quæ habeant ternos
+						semipedes, secundum in tres et <lb/> quatuor. Quare junctis aequalibus fiunt
+						sex semipe­ <lb/> des, tres vero et quatuor septem sunt, et non a'quan­
+						<lb/> tur illi numero. Sed si duo et duo in ea parte ubi <lb/> quatuor sunt,
+						et duo et unum in ea parte ubi tres <lb/> sunt, consideremus, junctis
+						portibus quae binos ha­ <lb/> bent, tit summa quaternaria : junctis autem
+						illis <lb/> quarum in una duo sunt, in alia unum, si etiam ista <lb/>
+						tanquam sint quatuor accipiamus , propter unius cum <lb/> cæteris numeris
+						concordiam, octo simul fiunt, ma­ <lb/> gisque excedunt summam scnariam,
+						quam cum se­ <lb/> ptem fuissent.</p>
+					</div><div type="textpart" subtype="dialog"><p>18. <hi rend="italic">M.</hi> Ita est, ut dicis: et idco isto genere copu­
+						<lb/> lationis a lege versuum separato, attende ut ordo po­ <lb/> stulat, in
+						ea nunc membra, quorum primum habet <lb/> octo semipedes, septem secundum.
+						Ista vero copulatio <lb/> habet quod quaerimus. Nam pracedentis membri par­
+						<lb/> tem dimidiam cum parlc subsequentis majore, quae <lb/> dimidiae
+						proxima est, jungens, quoniam quaterni se­ <lb/>
+						<lb/> mipedes sunt, octonarii numeri summam facio. Re­ <lb/> stant ergo
+						quatuor semipedes de priore, tres de poste­ <lb/> riore membro. Duo inde, et
+						duo hinc copulati, fiunt <lb/> quatuor. Duo rursus inde residui, et unus
+						hinc, ad <lb/> legem illius convenientiae copulati, qua 'unum reliquis <lb/>
+						par est, quodammodo sumuntur pro quatuor. Ita jam <lb/> octonarius superiori
+						oclouario congruit. D. Sed cur <lb/> hujus exemplum non audio? M. Quia sæpe
+						comme­ <lb/> moratum est : tamen ne suo loco prætermissum pu­ <lb/> tes,
+						ipsum est, <hi rend="italic">Roma, Roma, cerne</hi> quanta <hi rend="italic"
+							>sit deum <lb/> benignitas;</hi> vel hoc etiam, <hi rend="italic"
+							>Optimus beatus ille qui pro­</hi>
 						<lb/> cul <hi rend="italic">negotio.</hi>
 					</p>
-					<p>19. Quare jam inspice novem et septem semipedum, <lb/> connexionem, cujus exemplum est
-						: <hi rend="italic">Vir</hi> optiMus <hi rend="italic">beatus<lb/> ille qui procul
-							negotio. D.</hi> Facilis est cognitu ista coa­ <lb/> gruenLia: superius enim membrum
-						in quatuor et quin­ <lb/> que, posterius inf tres et quatuor semipedes dividitur. <note type="footnote"> 1 In B., <hi rend="italic">roma,</hi> Roma, <hi rend="italic">cerne
-								quanta sit deum bmignila. :</hi>
-							<lb/> mala repetitione vocis, RDmIl, nam priori membro octo se­ <lb/> mipedes
-							concedit, septem vero posteriori: quod renugiiat <lb/> explicationi ab Augustino paulo
-							post subjectae. II. </note><note type="footnote"> I <hi rend="italic">Qttiu,</hi>
-							juxta vatic. </note>
+					</div><div type="textpart" subtype="dialog"><p>19. Quare jam inspice novem et septem semipedum, <lb/> connexionem, cujus
+						exemplum est : <hi rend="italic">Vir</hi> optiMus <hi rend="italic"
+							>beatus<lb/> ille qui procul negotio. D.</hi> Facilis est cognitu ista
+						coa­ <lb/> gruenLia: superius enim membrum in quatuor et quin­ <lb/> que,
+						posterius inf tres et quatuor semipedes dividitur. <note type="footnote"> 1
+							In B., <hi rend="italic">roma,</hi> Roma, <hi rend="italic">cerne quanta
+								sit deum bmignila. :</hi>
+							<lb/> mala repetitione vocis, RDmIl, nam priori membro octo se­ <lb/>
+							mipedes concedit, septem vero posteriori: quod renugiiat <lb/>
+							explicationi ab Augustino paulo post subjectae. II. </note><note
+							type="footnote"> I <hi rend="italic">Qttiu,</hi> juxta vatic. </note>
 						<lb/>
-						<pb n="1157"/> Pars ergosuperioris minor cum parte posterioris majore <lb/> conjuncta,
-						octonarium numerum facil : et inajor supe.. <lb/> rioris cum minore posterioris, item
-						octonarium : nam <lb/> illa conjunctio est quatuor et quatuor, ista quinque <lb/> et
-						tres semipedes. Huc accedit, quod quinque in duo <lb/> et tres semi pedes, tres autem in
-						duo et unum si divi­ <lb/> seris, apparet alia convenientia duorum cum duobus, <lb/> et
-						unius cum tribus, quia unum cum omnibus numeris <lb/> supcrius commemorata lege
-						confertur. Sed nisi me <lb/> ratio fallit, nihil restat ulterius quod de membrorum <lb/>
-						copulatione requiramus : jam enim ad octo perven­ <lb/> tum est pedes, quem numerum
-						versui , sicut satis co­ <lb/> gnovimus, non fas est excedere. Quare jam nac, illa <lb/>
-						senariorum versuum heroici et ialnbici vel trochaici, <lb/> quo intentionem meam et
-						excitasti et distulisti, pande <lb/> secreta.</p>
-					<ab>
-						<title type="sub">CAl'UT X.— <hi rend="italic">De senariorum versuum excel/entia : eoa
-								decentissimos non esse,</hi> nisi <hi rend="italic">vel heroici</hi> sint <hi rend="italic">vel iambici.</hi>
+						<pb n="1157"/> Pars ergosuperioris minor cum parte posterioris majore <lb/>
+						conjuncta, octonarium numerum facil : et inajor supe.. <lb/> rioris cum
+						minore posterioris, item octonarium : nam <lb/> illa conjunctio est quatuor
+						et quatuor, ista quinque <lb/> et tres semipedes. Huc accedit, quod quinque
+						in duo <lb/> et tres semi pedes, tres autem in duo et unum si divi­ <lb/>
+						seris, apparet alia convenientia duorum cum duobus, <lb/> et unius cum
+						tribus, quia unum cum omnibus numeris <lb/> supcrius commemorata lege
+						confertur. Sed nisi me <lb/> ratio fallit, nihil restat ulterius quod de
+						membrorum <lb/> copulatione requiramus : jam enim ad octo perven­ <lb/> tum
+						est pedes, quem numerum versui , sicut satis co­ <lb/> gnovimus, non fas est
+						excedere. Quare jam nac, illa <lb/> senariorum versuum heroici et ialnbici
+						vel trochaici, <lb/> quo intentionem meam et excitasti et distulisti, pande
+						<lb/> secreta.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT X.— <hi rend="italic">De senariorum versuum
+								excel/entia : eoa decentissimos non esse,</hi> nisi <hi
+								rend="italic">vel heroici</hi> sint <hi rend="italic">vel
+								iambici.</hi>
 						</title>
 					</ab>
-					<p>20. <hi rend="italic">M.</hi> Faciam, imo faciet ipsa ratio,quæ mihi <lb/> tibiquc
-						communis est. Sed meministine, quæso, cum <lb/> ageremus de metris, dixisse nos et ipso
-						sensu admo­ <lb/> dum probasse, illos pcdes quorum partes ad sesqua <lb/> conveniunt,
-						sive in duobus et tribus, ut est creticus <lb/> vel paeones, sive in tribus et quatuor,
-						ut epitriti, exclu­ <lb/> sos a poetis propter minoris veuustaLis sonum, solutæ <lb/>
-						orationis severitatem decorare congruentius, cum his <lb/> clausulæ colligantur? <hi rend="italic">D.</hi> Memini : sed quorsum hæc <lb/> spectant? <hi rend="italic">M.</hi> Quoniam illud volo prius intelligamus, <lb/> hujuscemodi pedibus a poetarum
-						tractatione sejunctis, <lb/> non remanere, nisi eos quibus ad tantumdem, ut spon­ <lb/>
-						deus est ; aut eos quibus ad duplum , ut iambus; aut <lb/> eos quibus ad utrumque partes
-						conveniunt, ut chor­ <lb/> iambus. <hi rend="italic">D</hi> Ita est. <hi rend="italic">M.</hi> At si hæc est poetarum mate­ <lb/> ries, et soluta oratio versibus inimica
-						est, non versus <lb/> ullus nisi ex hoc genere pedum faciendus cst. <hi rend="italic">D.</hi> As­ <lb/> sentior. Vidco cnim poemata versibus quam aliis ly­ <lb/> ricorum
-						poetarum metris fieri grandiora, sed adhuc <lb/> quo ratio ista tendat, ignoro.</p>
-					<p>- 21. M. Ne propera : disputamus euim jam de sena­ <lb/> riorum. versuum excellentia,
-						ct prius tibi cupio de­ <lb/> monstrare, si potero, decentissimos senarios, nisi <lb/>
-						duorum istorum generum esse nun posse, qiue omnium <lb/> etiam sunt celeberrima, quorum
-						unum cst heroicum, <lb/> ut, <hi rend="italic">Arma virumque cano, Trojce qui primus ab
-							ons,</hi>
-						<lb/> quod usus metitur spondeo et dactylo, subtilior ratio <lb/> spondeo et anapæsto :
-						alterum quod iambicum dici­ <lb/> tur, et eadem ratione invenitur trochaicum Nam credo
-						<lb/> libi manifestum esse longis syllabis, nisi breves in­ <lb/> terponantur, obtundi
-						quodam modo spatia sonorum; <lb/> item nisi brevibus longae, nimis concisa et quasi tre­
-						<lb/> mula fieri; neutra esse temperata, quamvis temporum <lb/> aequalitate aures
-						impleant'. Quamobrem nec illi ver­ <lb/> sus qui sex pyrrhichios, et sex proceleumaticos
-						ha­ <lb/> bent, aspirant ad heroici dignitatem, nec illi ad tro­ <lb/> ehaici qui sex
-						tribrachos habent. Huc accedit, quia <lb/> in istis quos caeteris ipsa ratio præponit,
-						si membra <lb/> praeposteres , totum ita commutabitur, ut alios etiam <note type="footnote"> I <hi rend="italic">impleantiar,</hi> juxta vatic4 M. </note>
-						<lb/> pedes necessario metiamur. Itaque inconversibiliores, <lb/> ut ita dicam, sunt
-						quam illi qui aut omnibus bre­ <lb/> vibus, aut longis omnibus constant. Et ideo sive
-						quin­ <lb/> que et septem, sive septem et quinque semipedibus <lb/> membra in his
-						temperatioribus ordinentur I, nihil <lb/> interest: neutro enim horum ordine converti
-						versus <lb/> potest sine tanta commutatione, ut aliis pedibus cur­ <lb/> rere videatur.
-						In illis autem si carmen coeptum erit <lb/> talibus versibus, quorum priora membra
-						quinos semi­ <lb/> pedes habeant, non oporteat eos miscere in quibus <lb/> septeni
-						priores sunt, ne jam liceal omnes convertere: <lb/> non eniin a conversione revocat ulla
-						pedum commu­ <lb/> tatio. Sed tamen heroicis conceditur spondcos omnes <lb/> rarissime
-						interponere, quod quidem posterior ætas <lb/> haec nostra minime- probavit. Trochaicis
-						autem sive <lb/> iambicis, cum pedem tribrachum quolibet loco inter­ <lb/> ponere
-						liceat, babere tamen in hujuscemodi carmini­ <lb/> bus versum solutum in omnes breves,
-						turpissimum <lb/> judicatum est.</p>
-					<p>ii. Remotis igitur epitritis pcdibus a lege versuum <lb/> senaria, non solum quod
-						solutæ orationi sunt aptio­ <lb/> res, verum etiam quod si sex fuerint, triginta ct duo
-						<lb/> tempora excedunt, sicut dispondei; remotis eMam <lb/> quinum temporum pedibus,
-						quod sibi cos libentius ad <lb/> chiusulas vindicavit oratio; molossis item et aliis
-						tem­ <lb/> porum senum , quamvis in poematis vcnustissime vi­ <lb/> gcant, ab hoc de quo
-						none agimus numero temporum <lb/> exclusis; restant versus omnium brevium syllabarum,
-						<lb/> qui vel pyrrhichios vel proceleumaticos vel tribrachos <lb/> habent, et omnium
-						longarum qui spondeos. Qui quan­ <lb/> quam admittantur ad senarium modum, dignilali ta­
-						<lb/> men ct temperationi horum qui brevibus longisque <lb/> variantur; et ob hoc multo
-						minus converti possunt, <lb/> cedant necesse est.</p>
-					<ab>
-						<title type="sub">CAPUT XI. — <hi rend="italic">Senarii quomodo</hi> commodius <hi rend="italic">metiendi.</hi>
+					<div type="textpart" subtype="dialog"><p>20. <hi rend="italic">M.</hi> Faciam, imo faciet ipsa ratio,quæ mihi <lb/>
+						tibiquc communis est. Sed meministine, quæso, cum <lb/> ageremus de metris,
+						dixisse nos et ipso sensu admo­ <lb/> dum probasse, illos pcdes quorum
+						partes ad sesqua <lb/> conveniunt, sive in duobus et tribus, ut est creticus
+						<lb/> vel paeones, sive in tribus et quatuor, ut epitriti, exclu­ <lb/> sos
+						a poetis propter minoris veuustaLis sonum, solutæ <lb/> orationis
+						severitatem decorare congruentius, cum his <lb/> clausulæ colligantur? <hi
+							rend="italic">D.</hi> Memini : sed quorsum hæc <lb/> spectant? <hi
+							rend="italic">M.</hi> Quoniam illud volo prius intelligamus, <lb/>
+						hujuscemodi pedibus a poetarum tractatione sejunctis, <lb/> non remanere,
+						nisi eos quibus ad tantumdem, ut spon­ <lb/> deus est ; aut eos quibus ad
+						duplum , ut iambus; aut <lb/> eos quibus ad utrumque partes conveniunt, ut
+						chor­ <lb/> iambus. <hi rend="italic">D</hi> Ita est. <hi rend="italic"
+							>M.</hi> At si hæc est poetarum mate­ <lb/> ries, et soluta oratio
+						versibus inimica est, non versus <lb/> ullus nisi ex hoc genere pedum
+						faciendus cst. <hi rend="italic">D.</hi> As­ <lb/> sentior. Vidco cnim
+						poemata versibus quam aliis ly­ <lb/> ricorum poetarum metris fieri
+						grandiora, sed adhuc <lb/> quo ratio ista tendat, ignoro.</p>
+					</div><div type="textpart" subtype="dialog"><p>- 21. M. Ne propera : disputamus euim jam de sena­ <lb/> riorum. versuum
+						excellentia, ct prius tibi cupio de­ <lb/> monstrare, si potero,
+						decentissimos senarios, nisi <lb/> duorum istorum generum esse nun posse,
+						qiue omnium <lb/> etiam sunt celeberrima, quorum unum cst heroicum, <lb/>
+						ut, <hi rend="italic">Arma virumque cano, Trojce qui primus ab ons,</hi>
+						<lb/> quod usus metitur spondeo et dactylo, subtilior ratio <lb/> spondeo et
+						anapæsto : alterum quod iambicum dici­ <lb/> tur, et eadem ratione invenitur
+						trochaicum Nam credo <lb/> libi manifestum esse longis syllabis, nisi breves
+						in­ <lb/> terponantur, obtundi quodam modo spatia sonorum; <lb/> item nisi
+						brevibus longae, nimis concisa et quasi tre­ <lb/> mula fieri; neutra esse
+						temperata, quamvis temporum <lb/> aequalitate aures impleant'. Quamobrem nec
+						illi ver­ <lb/> sus qui sex pyrrhichios, et sex proceleumaticos ha­ <lb/>
+						bent, aspirant ad heroici dignitatem, nec illi ad tro­ <lb/> ehaici qui sex
+						tribrachos habent. Huc accedit, quia <lb/> in istis quos caeteris ipsa ratio
+						præponit, si membra <lb/> praeposteres , totum ita commutabitur, ut alios
+						etiam <note type="footnote"> I <hi rend="italic">impleantiar,</hi> juxta
+							vatic4 M. </note>
+						<lb/> pedes necessario metiamur. Itaque inconversibiliores, <lb/> ut ita
+						dicam, sunt quam illi qui aut omnibus bre­ <lb/> vibus, aut longis omnibus
+						constant. Et ideo sive quin­ <lb/> que et septem, sive septem et quinque
+						semipedibus <lb/> membra in his temperatioribus ordinentur I, nihil <lb/>
+						interest: neutro enim horum ordine converti versus <lb/> potest sine tanta
+						commutatione, ut aliis pedibus cur­ <lb/> rere videatur. In illis autem si
+						carmen coeptum erit <lb/> talibus versibus, quorum priora membra quinos
+						semi­ <lb/> pedes habeant, non oporteat eos miscere in quibus <lb/> septeni
+						priores sunt, ne jam liceal omnes convertere: <lb/> non eniin a conversione
+						revocat ulla pedum commu­ <lb/> tatio. Sed tamen heroicis conceditur
+						spondcos omnes <lb/> rarissime interponere, quod quidem posterior ætas <lb/>
+						haec nostra minime- probavit. Trochaicis autem sive <lb/> iambicis, cum
+						pedem tribrachum quolibet loco inter­ <lb/> ponere liceat, babere tamen in
+						hujuscemodi carmini­ <lb/> bus versum solutum in omnes breves, turpissimum
+						<lb/> judicatum est.</p>
+					</div><div type="textpart" subtype="dialog"><p>22. Remotis igitur epitritis pcdibus a lege versuum <lb/> senaria, non solum
+						quod solutæ orationi sunt aptio­ <lb/> res, verum etiam quod si sex fuerint,
+						triginta ct duo <lb/> tempora excedunt, sicut dispondei; remotis eMam <lb/>
+						quinum temporum pedibus, quod sibi cos libentius ad <lb/> chiusulas
+						vindicavit oratio; molossis item et aliis tem­ <lb/> porum senum , quamvis
+						in poematis vcnustissime vi­ <lb/> gcant, ab hoc de quo none agimus numero
+						temporum <lb/> exclusis; restant versus omnium brevium syllabarum, <lb/> qui
+						vel pyrrhichios vel proceleumaticos vel tribrachos <lb/> habent, et omnium
+						longarum qui spondeos. Qui quan­ <lb/> quam admittantur ad senarium modum,
+						dignilali ta­ <lb/> men ct temperationi horum qui brevibus longisque <lb/>
+						variantur; et ob hoc multo minus converti possunt, <lb/> cedant necesse
+						est.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT XI. — <hi rend="italic">Senarii quomodo</hi>
+							commodius <hi rend="italic">metiendi.</hi>
 						</title>
 					</ab>
-					<p>25. Sed quæri potest cur meliores versus judicati ' <lb/> sintsenarii, in quibus
-						anapæstum subtilis illa ratio <lb/> metitur, et ii in quibus trochæum ; quam si dactylum
-						<lb/> ibi, ct hic iambum metiretur. Sine praejudicio caim <lb/> sententiæ, quoniam nunc
-						de numeris agimus, si ver­ <lb/> sus ita esset : <hi rend="italic">Trojae qui</hi>
-						primus <hi rend="italic">ab oris arma virumque<lb/> cano,</hi> vel de illo genere : Qui
-							<hi rend="italic">procul malo</hi> pius <hi rend="italic">beatus <lb/> ille;</hi>
-						uterque horum nec minus scnarius esset, nec <lb/> minus brevium longarumque syllabarum
-						temperatione <lb/> moderatus, nee magis converti poterat; et in utroque <lb/> membra ila
-						ordiuata sunt, ut et in quinto et in septi­ <lb/> mo semipede pars orationis termiuctur
-						: cur ergo <lb/> meliores istis putentur, si potius ita sint, Armavi­ <lb/>
-						<hi rend="italic">rumque cano, Trojæ qui</hi> primus <hi rend="italic">ab oris. Beatus
-							ille qui</hi>
-						<lb/> procul pius <hi rend="italic">malo ?</hi> In qua quæstione facilius et procli­
-						<lb/> vius dixerim forte evenisse, ut i£ ti prius animadver­ <lb/> terentur et
-						frequentarentur2; aut si id non cst fortui- <lb/> lum, melius credo visum fuisse, ut
-						heroicus duabus <lb/> longis, quam duabus brevibus et longa clauderetur, <lb/> quod in
-						longis aurcs commodins acquiescunt : ille au­ <lb/> tem alter in finali semipede longam
-						syllabam potius <lb/> haberet quam brevem. Res quidcm sic se babet, ut <note type="footnote">
-							<hi rend="italic">' remperaltonibaa ordinentur,</hi> juxta vatic. II. </note><note type="footnote"> I In B., aut frequentarecutur. vatic. et MSs. A, <hi rend="italic">ct
-								frequenta­ <lb/> rentur.</hi> AI. </note>
+					</div><div type="textpart" subtype="dialog"><p>23. Sed quæri potest cur meliores versus judicati ' <lb/> sintsenarii, in
+						quibus anapæstum subtilis illa ratio <lb/> metitur, et ii in quibus trochæum
+						; quam si dactylum <lb/> ibi, ct hic iambum metiretur. Sine praejudicio caim
+						<lb/> sententiæ, quoniam nunc de numeris agimus, si ver­ <lb/> sus ita esset
+						: <hi rend="italic">Trojae qui</hi> primus <hi rend="italic">ab oris arma
+							virumque<lb/> cano,</hi> vel de illo genere : Qui <hi rend="italic"
+							>procul malo</hi> pius <hi rend="italic">beatus <lb/> ille;</hi> uterque
+						horum nec minus scnarius esset, nec <lb/> minus brevium longarumque
+						syllabarum temperatione <lb/> moderatus, nee magis converti poterat; et in
+						utroque <lb/> membra ila ordiuata sunt, ut et in quinto et in septi­ <lb/>
+						mo semipede pars orationis termiuctur : cur ergo <lb/> meliores istis
+						putentur, si potius ita sint, Armavi­ <lb/>
+						<hi rend="italic">rumque cano, Trojæ qui</hi> primus <hi rend="italic">ab
+							oris. Beatus ille qui</hi>
+						<lb/> procul pius <hi rend="italic">malo ?</hi> In qua quæstione facilius et
+						procli­ <lb/> vius dixerim forte evenisse, ut i£ ti prius animadver­ <lb/>
+						terentur et frequentarentur2; aut si id non cst fortui- <lb/> lum, melius
+						credo visum fuisse, ut heroicus duabus <lb/> longis, quam duabus brevibus et
+						longa clauderetur, <lb/> quod in longis aurcs commodins acquiescunt : ille
+						au­ <lb/> tem alter in finali semipede longam syllabam potius <lb/> haberet
+						quam brevem. Res quidcm sic se babet, ut <note type="footnote">
+							<hi rend="italic">' remperaltonibaa ordinentur,</hi> juxta vatic. II.
+							</note><note type="footnote"> I In B., aut frequentarecutur. vatic. et
+							MSs. A, <hi rend="italic">ct frequenta­ <lb/> rentur.</hi> AI. </note>
 						<lb/>
-						<pb n="1159"/> quicumque horum priores eligcrentur, neccssario aliis <lb/> auferrent
-						locum, qui membris iisdem præposteratis <lb/> fieri possent. Quocirca si melior
-						judicatus est, cujus <lb/> exemplum est, <hi rend="italic">Arma virumque cano, Trojce
-							qui primus<lb/> ab oris;</hi> inepte jam fieret isto converso aliud genus, si­ <lb/>
-						cuti es!, <hi rend="italic">Trojce</hi> qui <hi rend="italic">primus ab oris, arma
+						<pb n="1159"/> quicumque horum priores eligcrentur, neccssario aliis <lb/>
+						auferrent locum, qui membris iisdem præposteratis <lb/> fieri possent.
+						Quocirca si melior judicatus est, cujus <lb/> exemplum est, <hi
+							rend="italic">Arma virumque cano, Trojce qui primus<lb/> ab oris;</hi>
+						inepte jam fieret isto converso aliud genus, si­ <lb/> cuti es!, <hi
+							rend="italic">Trojce</hi> qui <hi rend="italic">primus ab oris, arma
 							virumque cano.</hi>
-						<lb/> Quod etiam de trochaico genere intcUigendunl est. Nam <lb/> si est honestior, <hi rend="italic">Beatus ille qui procul negotio</hi> : qnod <lb/> genus isto
-						prærposterato fiercl, ut est, <hi rend="italic">Qui procul negotio<lb/> beatus
-							ille,</hi> fieri profecto non oportet1: tamen si quis <lb/> audeat et faciat tales
-						versus, manifestum est cum alia <lb/> gerera senariorum esse facturum, quibus sint ista
-						<lb/> meliora.</p>
-					<p>2t. Ili ergo senariorum omnium pulcherrimi, non <lb/> potuerunt ambo obtinere
-						sinceritatem suam adversus <lb/> hominum licentiam. Nam in trochaico geuere, non <lb/>
-						senario solo, sed unde minus incipit usque ad magni­ <lb/> tudinem extremam quae ocio
-						pedes habet, miscendus <lb/> poctæ putaverunt quatuor temporum pedes omnes, <lb/> qui
-						adhibentur ad numeros: ct Græci quidem alternis <lb/> locis primo et tertio, et ita
-						deinceps, si a semipede <lb/> versus incipit: sin ab integra trochæo, secundo et <lb/>
-						quarto loco, atque ita deinceps servatis intervallis, <lb/> memorati longiores
-						collocantur pedcs. Quæ corruptio <lb/> ut tolerabilis fieret, non singulos pedes in duas
-						par­ <lb/> tes, quorum una lcvationis, altera positionis est, <lb/> plaudc; do
-						diviserunt; sed unuin peJein lcvanles, al­ <lb/> terum poucnles, unde ipsum senarium
-						trimetrum vo­ <lb/> cant, ad epitritorum divisionem plausum rctulerunt. <lb/> Sed si hoc
-						sultem constanter tcnerclur, quamvis pe­ <lb/> des epitriti magis orationis siat quam
-						poematis, nec <lb/> jam senarius, scd ternarius versus inveniretur; non <lb/> tamen
-						omnimodo illa n imerorum labefactaretur æqua­ <lb/> litas. Nunc vero quatuor temporum
-						pedes, dummodo <lb/> in locis memoratis ponantur, licet non solum in om­ <lb/> nibus
-						ponere, sed ubi libet eorum, et quoties libet. <lb/> Nostri veru veteres, nec ipsa
-						locorum intervalla in­ <lb/> termiscendis hujuscemodi pedibus, servare potuerunt. <lb/>
-						Quare in hoc genere poetæ ista corruptione atque li­ <lb/> centia plane assecuti sunt,
-						quod eos voluisse arbitran­ <lb/> dum cst, ut essent in fabulis poemata solutae orationi
-						<lb/> simillima. Se d quoniam satis dictum est cur inter se­ <lb/> narios isti versus
-						magis nobilitati sint, nunc videa­ <lb/> mus cur ipsi senarii meliores sint versus quam
-						caeteri <lb/> in quolibet alio pedum numero constituti. Nisi quid <lb/> habes adversus
-						ista quædisseras. 'B. Prorsus assen­ <lb/> tiur : et jam illam membrorum æqualitatem,
-						cui me <lb/> attentissimum paulo ante reddidisti, si vel nunc fas <lb/> est, cognoscere
-						vehementer exspecto.</p>
-					<ab>
+						<lb/> Quod etiam de trochaico genere intcUigendunl est. Nam <lb/> si est
+						honestior, <hi rend="italic">Beatus ille qui procul negotio</hi> : qnod
+						<lb/> genus isto prærposterato fiercl, ut est, <hi rend="italic">Qui procul
+							negotio<lb/> beatus ille,</hi> fieri profecto non oportet1: tamen si
+						quis <lb/> audeat et faciat tales versus, manifestum est cum alia <lb/>
+						gerera senariorum esse facturum, quibus sint ista <lb/> meliora.</p>
+					</div><div type="textpart" subtype="dialog"><p>24. Ili ergo senariorum omnium pulcherrimi, non <lb/> potuerunt ambo obtinere
+						sinceritatem suam adversus <lb/> hominum licentiam. Nam in trochaico geuere,
+						non <lb/> senario solo, sed unde minus incipit usque ad magni­ <lb/> tudinem
+						extremam quae ocio pedes habet, miscendus <lb/> poctæ putaverunt quatuor
+						temporum pedes omnes, <lb/> qui adhibentur ad numeros: ct Græci quidem
+						alternis <lb/> locis primo et tertio, et ita deinceps, si a semipede <lb/>
+						versus incipit: sin ab integra trochæo, secundo et <lb/> quarto loco, atque
+						ita deinceps servatis intervallis, <lb/> memorati longiores collocantur
+						pedcs. Quæ corruptio <lb/> ut tolerabilis fieret, non singulos pedes in duas
+						par­ <lb/> tes, quorum una lcvationis, altera positionis est, <lb/> plaudc;
+						do diviserunt; sed unuin peJein lcvanles, al­ <lb/> terum poucnles, unde
+						ipsum senarium trimetrum vo­ <lb/> cant, ad epitritorum divisionem plausum
+						rctulerunt. <lb/> Sed si hoc sultem constanter tcnerclur, quamvis pe­ <lb/>
+						des epitriti magis orationis siat quam poematis, nec <lb/> jam senarius, scd
+						ternarius versus inveniretur; non <lb/> tamen omnimodo illa n imerorum
+						labefactaretur æqua­ <lb/> litas. Nunc vero quatuor temporum pedes, dummodo
+						<lb/> in locis memoratis ponantur, licet non solum in om­ <lb/> nibus
+						ponere, sed ubi libet eorum, et quoties libet. <lb/> Nostri veru veteres,
+						nec ipsa locorum intervalla in­ <lb/> termiscendis hujuscemodi pedibus,
+						servare potuerunt. <lb/> Quare in hoc genere poetæ ista corruptione atque
+						li­ <lb/> centia plane assecuti sunt, quod eos voluisse arbitran­ <lb/> dum
+						cst, ut essent in fabulis poemata solutae orationi <lb/> simillima. Se d
+						quoniam satis dictum est cur inter se­ <lb/> narios isti versus magis
+						nobilitati sint, nunc videa­ <lb/> mus cur ipsi senarii meliores sint versus
+						quam caeteri <lb/> in quolibet alio pedum numero constituti. Nisi quid <lb/>
+						habes adversus ista quædisseras. 'B. Prorsus assen­ <lb/> tiur : et jam
+						illam membrorum æqualitatem, cui me <lb/> attentissimum paulo ante
+						reddidisti, si vel nunc fas <lb/> est, cognoscere vehementer exspecto.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT XII. — <hi rend="italic">Senarii versus cur aliis
 								præstantiores.</hi>
 						</title>
 					</ab>
-					<p>25. M. Totus ergo adesto, atque responde, utrum <lb/> tibi videatur qunelibet longitudo
-						posse in quotlibet par­ <lb/> tes secari. <hi rend="italic">D.</hi> Satis milii ista
-						persuasa suut: nee du­ <lb/> bitari posse arbitror, quin omnis longitudo quæ linea <lb/>
-						dicitur, habeat dimidiam sui partem I, ac per hoc in <lb/> dura lineas dccussatim secari
-						queat : et quia ipsæ duæ <note type="footnote">1 In <hi rend="italic">K.toportere(.</hi>
-							vatic., <hi rend="italic">oportet.</hi> M. </note><note type="footnote"> * <hi rend="italic">Uabeul dimensam</hi> partem, juxta vatic. II. </note>
-						<lb/> lineæ quæ ista sectione fiunt1, procul dubio lineae <lb/> sunt, etiam in ipsis hoc
-						fieri posse manifestum est. <lb/> Itaque et quantulacumque longitudo in quotlibet par.
-						<lb/> tes secari potest. <hi rend="italic">M.</hi> Expeditissime atque verissime. <lb/>
-						Quare nunc illud vide, utrum recte asseveretur, om­ <lb/> nem longitudinem ad
-						latitudinem porrigendam, quæ <lb/> ab ipsa oritur, tantum valere quantum latitudinis
-						qua­ <lb/> dratum occupat. Si enim minus aut amplius in latum <lb/> spatium proceditur
-						quam longa est linea unde proce­ <lb/> ditur, quadratum non fit; sin tantum, nibilaliud
-						quam <lb/> quadratum fit. <hi rend="italic">D.</hi> Intelligo et assentior: quid enim
-						<lb/> verius? <hi rend="italic">M.</hi> Illud ergo jam sequi, ut opinor, vides, ut <lb/>
-						si pro linea in longum ordinati calculi pares ponantur, <lb/> non perveniat illa
-						longitudo ad quadratam forlnam, <lb/> nisi per eumdem numerum multiplicati calculi
-						fuerint: <lb/> ut si verbi gratia duos calculos ponas, quadratum nou <lb/> facias, nisi
-						aliis duobus ad latitudinem adjunctis: sin <lb/> tres, sex adjungendi sunt, sed terni
-						distributi ad duos <lb/> ordines similiter in lalitudinem2 : si enim ad longitu­ <lb/>
-						dinem additi fuerint, nulla figura fit. Longitudo enim <lb/> sine latitudine figura non
-						est*. Atque ita proportiono <lb/> licet considerare alios numeros: ut enim bis bina, et
-						<lb/> ter terna quadratas figuras in numeris faciunt, ita qua­ <lb/> ter quaterna,
-						quinquics quina, sexies sena, atque ita <lb/> per infinitum in cæteris. <hi rend="italic">D.</hi> Etium ista rata et mani­ <lb/> festa sunt. <hi rend="italic">JI.</hi> Attende nunc utrum sit aliqua temporis <lb/> longitudo. <hi rend="italic">D.</hi> Quis dubitaverit nullum esse tempus <lb/> sine aliqua longitudine? <hi rend="italic">M.</hi> Quid? versus potestne non <lb/> obtinere aliquam temporis
-						longitudinem? D. Imo ne­ <lb/> cesse est obtineat. <hi rend="italic">M.</hi> Quid in ca
-						longitudine pro cal­ <lb/> cutis melius collocamus? pcdesne, qui duas in partes. <lb/>
-						id est levationcm et positionem neccssario distrihuun­ <lb/> tur4; an ipsos semipedcs
-						potius, qui singulas levalio­ <lb/> ncs positionesque obtinent? <hi rend="italic">D.</hi> Semipedes congruen­ <lb/> lius judico pro illis calculis poni.</p>
-					<p>26. <hi rend="italic">M.</hi> Age, nunc commemora membrum versus <lb/> hcroici brevius,
-						quot semipcdes habcat. <hi rend="italic">D.</hi> Quinque. <lb/>
-						<hi rend="italic">M.</hi> Dic exemplum. <hi rend="italic">D. Arma virumque cano. M.</hi>
-						Num <lb/> igitur aliud dcsidcras, nisi ut alii septem semipedes <lb/> cum istis quinque
-						aliqua æqualitate conveniant? <hi rend="italic">D.</hi>
-						<lb/> Nihil prorsus aliud. M. Quid? septem semipedes pos­ <lb/> suntne aliquem versum
-						complere per se? <hi rend="italic">D.</hi> Possunt <lb/> vero: nam lot semipedes habet
-						primus ac minimus <lb/> versus, annumerato in fine silentio. <hi rend="italic">M.</hi>
-						Rectc dicis : <lb/> sed ut versus esse possit, quomodo in duo membra <lb/> dividitur?
-							<hi rend="italic">D.</hi> In quatuor scilicet, et tres semipedes. <lb/>
-						<hi rend="italic">M.</hi> Duc ergo in legem quadrati has partes singulas, et <lb/> vide
-						quid faciant quatuor quater. <hi rend="italic">D.</hi> Sexdecim. <hi rend="italic">M.</hi>
-						<lb/> Quid tria ter? <hi rend="italic">D.</hi> Novem. <hi rend="italic">M.</hi> Quid
-						totum simul? <hi rend="italic">D.</hi>
-						<lb/> Viginti quinque. <hi rend="italic">M.</hi> Septem ergo scmipedes quoniam <lb/>
-						possunt habere duo membra, singulis membris suis <lb/> ad quadratorum rationem rclatis,
-						vigesimum quintum <lb/> numerum in summa faciunt; et est una pars versus <lb/> heroici.
-							<hi rend="italic">D.</hi> Ita est. <hi rend="italic">M.</hi> Altera igitur pars quæ
-						babeL <lb/> quinque semipedes, quoniam non potest in duo mem- <note type="footnote">
-							<hi rend="italic">I secatione fiimt,</hi> juxta vatic. M. </note><note type="footnote"> * <hi rend="italic">Ad</hi> latitudinem, juXta vttic. X-</note><note type="footnote">
-							<hi rend="italic">I Figuratio est,</hi> juxta vatic. M. </note><note type="footnote">
-							4 <hi rend="italic">iribuimlur,</hi> juxta Ms. A. M. </note>
+					<div type="textpart" subtype="dialog"><p>25. M. Totus ergo adesto, atque responde, utrum <lb/> tibi videatur qunelibet
+						longitudo posse in quotlibet par­ <lb/> tes secari. <hi rend="italic"
+							>D.</hi> Satis milii ista persuasa suut: nee du­ <lb/> bitari posse
+						arbitror, quin omnis longitudo quæ linea <lb/> dicitur, habeat dimidiam sui
+						partem I, ac per hoc in <lb/> dura lineas dccussatim secari queat : et quia
+						ipsæ duæ <note type="footnote">1 In <hi rend="italic">K.toportere(.</hi>
+							vatic., <hi rend="italic">oportet.</hi> M. </note><note type="footnote">
+							* <hi rend="italic">Uabeul dimensam</hi> partem, juxta vatic. II. </note>
+						<lb/> lineæ quæ ista sectione fiunt1, procul dubio lineae <lb/> sunt, etiam
+						in ipsis hoc fieri posse manifestum est. <lb/> Itaque et quantulacumque
+						longitudo in quotlibet par. <lb/> tes secari potest. <hi rend="italic"
+							>M.</hi> Expeditissime atque verissime. <lb/> Quare nunc illud vide,
+						utrum recte asseveretur, om­ <lb/> nem longitudinem ad latitudinem
+						porrigendam, quæ <lb/> ab ipsa oritur, tantum valere quantum latitudinis
+						qua­ <lb/> dratum occupat. Si enim minus aut amplius in latum <lb/> spatium
+						proceditur quam longa est linea unde proce­ <lb/> ditur, quadratum non fit;
+						sin tantum, nibilaliud quam <lb/> quadratum fit. <hi rend="italic">D.</hi>
+						Intelligo et assentior: quid enim <lb/> verius? <hi rend="italic">M.</hi>
+						Illud ergo jam sequi, ut opinor, vides, ut <lb/> si pro linea in longum
+						ordinati calculi pares ponantur, <lb/> non perveniat illa longitudo ad
+						quadratam forlnam, <lb/> nisi per eumdem numerum multiplicati calculi
+						fuerint: <lb/> ut si verbi gratia duos calculos ponas, quadratum nou <lb/>
+						facias, nisi aliis duobus ad latitudinem adjunctis: sin <lb/> tres, sex
+						adjungendi sunt, sed terni distributi ad duos <lb/> ordines similiter in
+						lalitudinem2 : si enim ad longitu­ <lb/> dinem additi fuerint, nulla figura
+						fit. Longitudo enim <lb/> sine latitudine figura non est*. Atque ita
+						proportiono <lb/> licet considerare alios numeros: ut enim bis bina, et
+						<lb/> ter terna quadratas figuras in numeris faciunt, ita qua­ <lb/> ter
+						quaterna, quinquics quina, sexies sena, atque ita <lb/> per infinitum in
+						cæteris. <hi rend="italic">D.</hi> Etium ista rata et mani­ <lb/> festa
+						sunt. <hi rend="italic">JI.</hi> Attende nunc utrum sit aliqua temporis
+						<lb/> longitudo. <hi rend="italic">D.</hi> Quis dubitaverit nullum esse
+						tempus <lb/> sine aliqua longitudine? <hi rend="italic">M.</hi> Quid? versus
+						potestne non <lb/> obtinere aliquam temporis longitudinem? D. Imo ne­ <lb/>
+						cesse est obtineat. <hi rend="italic">M.</hi> Quid in ca longitudine pro
+						cal­ <lb/> cutis melius collocamus? pcdesne, qui duas in partes. <lb/> id
+						est levationcm et positionem neccssario distrihuun­ <lb/> tur4; an ipsos
+						semipedcs potius, qui singulas levalio­ <lb/> ncs positionesque obtinent?
+							<hi rend="italic">D.</hi> Semipedes congruen­ <lb/> lius judico pro
+						illis calculis poni.</p>
+					</div><div type="textpart" subtype="dialog"><p>26. <hi rend="italic">M.</hi> Age, nunc commemora membrum versus <lb/>
+						hcroici brevius, quot semipcdes habcat. <hi rend="italic">D.</hi> Quinque. <lb/>
+						<hi rend="italic">M.</hi> Dic exemplum. <hi rend="italic">D. Arma virumque
+							cano. M.</hi> Num <lb/> igitur aliud dcsidcras, nisi ut alii septem
+						semipedes <lb/> cum istis quinque aliqua æqualitate conveniant? <hi
+							rend="italic">D.</hi>
+						<lb/> Nihil prorsus aliud. M. Quid? septem semipedes pos­ <lb/> suntne
+						aliquem versum complere per se? <hi rend="italic">D.</hi> Possunt <lb/>
+						vero: nam lot semipedes habet primus ac minimus <lb/> versus, annumerato in
+						fine silentio. <hi rend="italic">M.</hi> Rectc dicis : <lb/> sed ut versus
+						esse possit, quomodo in duo membra <lb/> dividitur? <hi rend="italic"
+							>D.</hi> In quatuor scilicet, et tres semipedes. <lb/>
+						<hi rend="italic">M.</hi> Duc ergo in legem quadrati has partes singulas, et
+						<lb/> vide quid faciant quatuor quater. <hi rend="italic">D.</hi> Sexdecim.
+							<hi rend="italic">M.</hi>
+						<lb/> Quid tria ter? <hi rend="italic">D.</hi> Novem. <hi rend="italic"
+							>M.</hi> Quid totum simul? <hi rend="italic">D.</hi>
+						<lb/> Viginti quinque. <hi rend="italic">M.</hi> Septem ergo scmipedes
+						quoniam <lb/> possunt habere duo membra, singulis membris suis <lb/> ad
+						quadratorum rationem rclatis, vigesimum quintum <lb/> numerum in summa
+						faciunt; et est una pars versus <lb/> heroici. <hi rend="italic">D.</hi> Ita
+						est. <hi rend="italic">M.</hi> Altera igitur pars quæ babeL <lb/> quinque
+						semipedes, quoniam non potest in duo mem- <note type="footnote">
+							<hi rend="italic">I secatione fiimt,</hi> juxta vatic. M. </note><note
+							type="footnote"> * <hi rend="italic">Ad</hi> latitudinem, juXta vttic.
+							X-</note><note type="footnote">
+							<hi rend="italic">I Figuratio est,</hi> juxta vatic. M. </note><note
+							type="footnote"> 4 <hi rend="italic">iribuimlur,</hi> juxta Ms. A. M. </note>
 						<lb/>
-						<pb n="1161"/> brt dividi, ct debet aliqua æqualitate concinere, nonne <lb/> tota in
-						quadratum ducenda est? <hi rend="italic">D.</hi> Nihil aliud omnino <lb/> censeo, et jam
-						tandem agnosco æqualitatem mirabi­ <lb/> lem. Quinque enim quinquics ducta cadem viginti
-						<lb/> quinque consummant. Nec ergo immerito senarii ver­ <lb/> sus cæteris celebraLiores
-						nobilioresque facti sunt: <lb/> dici enim vix potest quantum inter illorum æquali­ <lb/>
-						tatem in membris imparibus, et aliorum omnium <lb/> intersit.</p>
-					<ab>
+						<pb n="1161"/> brt dividi, ct debet aliqua æqualitate concinere, nonne <lb/>
+						tota in quadratum ducenda est? <hi rend="italic">D.</hi> Nihil aliud omnino
+						<lb/> censeo, et jam tandem agnosco æqualitatem mirabi­ <lb/> lem. Quinque
+						enim quinquics ducta cadem viginti <lb/> quinque consummant. Nec ergo
+						immerito senarii ver­ <lb/> sus cæteris celebraLiores nobilioresque facti
+						sunt: <lb/> dici enim vix potest quantum inter illorum æquali­ <lb/> tatem
+						in membris imparibus, et aliorum omnium <lb/> intersit.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CAPUT XIII. — <hi rend="italic">Epiloqus.</hi>
 						</title>
 					</ab>
-					<p>27. <hi rend="italic">M.</hi> Non te ergo fefellit pollicitatio mea, vel <lb/> polius
-						ipsa nos, quam uterque nostrum sequitur, ra­ <lb/> tio. Quare ut istum jam sermonem
-						concludamus ali­ <lb/> quando, cernis certe cum sint metra pene innumera­ <lb/> bilia,
-						versum tamen esse non posse, nisi duobus mem­ <lb/> bris sibimet concinnatis, aut
-						totidem semipedibus, sed <lb/> non conversibilibus terminatis, ut est, <hi rend="italic">Mæcenas atavis</hi>
-						<lb/> edite <hi rend="italic">regibus;</hi> aut dispari numero etiam semipedum, <lb/>
-						sed tamen aliqua æqualitate conjunctis, ut sunt qua­ <lb/> tuor el tres, aut quinque ct
-						tres, vel quinquc et sc­ <lb/> ptem, aut sex et septem, ant octo et septem, vel se­
-						<lb/> plem et novem. A pleno cnim pede trochaicus, ut est, <lb/>
-						<hi rend="italic">Optimus beatus ille qui procul negotio;</hi> et a non pleno <lb/>
-						potest versus exordiri, ut est, Vir <hi rend="italic">optimus beatus ille <lb/> qui
-							procul negotio</hi> : terminari aulem nisi non pleno <lb/> prorsus non potest. Scd
-						isti non pleni pedes, sive in­ <lb/> tegros semipedes habeant, sicuti est iste quem nunc
-						<lb/> posui; sive minus quam dimidium pedem, sicut in illo <lb/> choriambico duae
-						ultimas breves, Macerias <hi rend="italic">atavis edite <lb/> regibus;</hi> sive plus
-						quam dimidium, ut in ejus capite <lb/> dux primae longæ, aut in fine alterius
-						choriambici <lb/> bacchius, cujus exemplum est, <hi rend="italic">Te domus Evandri</hi>
-						*, te <lb/>
-						<hi rend="italic">sedes celsa Latini (a).</hi> Omnes ergo isti non pleni pedes <lb/>
-						semipedes nuncupantur. <note type="footnote">
-							<hi rend="italic">I Te domus Evandrea,</hi> juxta Er. <hi rend="italic">Evandria,</hi>
-							juxta Lov. </note>
+					</div><div type="textpart" subtype="dialog"><p>27. <hi rend="italic">M.</hi> Non te ergo fefellit pollicitatio mea, vel
+						<lb/> polius ipsa nos, quam uterque nostrum sequitur, ra­ <lb/> tio. Quare
+						ut istum jam sermonem concludamus ali­ <lb/> quando, cernis certe cum sint
+						metra pene innumera­ <lb/> bilia, versum tamen esse non posse, nisi duobus
+						mem­ <lb/> bris sibimet concinnatis, aut totidem semipedibus, sed <lb/> non
+						conversibilibus terminatis, ut est, <hi rend="italic">Mæcenas atavis</hi>
+						<lb/> edite <hi rend="italic">regibus;</hi> aut dispari numero etiam
+						semipedum, <lb/> sed tamen aliqua æqualitate conjunctis, ut sunt qua­ <lb/>
+						tuor el tres, aut quinque ct tres, vel quinquc et sc­ <lb/> ptem, aut sex et
+						septem, ant octo et septem, vel se­ <lb/> plem et novem. A pleno cnim pede
+						trochaicus, ut est, <lb/>
+						<hi rend="italic">Optimus beatus ille qui procul negotio;</hi> et a non
+						pleno <lb/> potest versus exordiri, ut est, Vir <hi rend="italic">optimus
+							beatus ille <lb/> qui procul negotio</hi> : terminari aulem nisi non
+						pleno <lb/> prorsus non potest. Scd isti non pleni pedes, sive in­ <lb/>
+						tegros semipedes habeant, sicuti est iste quem nunc <lb/> posui; sive minus
+						quam dimidium pedem, sicut in illo <lb/> choriambico duae ultimas breves,
+						Macerias <hi rend="italic">atavis edite <lb/> regibus;</hi> sive plus quam
+						dimidium, ut in ejus capite <lb/> dux primae longæ, aut in fine alterius
+						choriambici <lb/> bacchius, cujus exemplum est, <hi rend="italic">Te domus
+							Evandri</hi> *, te <lb/>
+						<hi rend="italic">sedes celsa Latini (a).</hi> Omnes ergo isti non pleni
+						pedes <lb/> semipedes nuncupantur. <note type="footnote">
+							<hi rend="italic">I Te domus Evandrea,</hi> juxta Er. <hi rend="italic"
+								>Evandria,</hi> juxta Lov. </note>
 						<note type="footnote">
-							<hi rend="italic">(a)</hi> Hunc versum TerentianUs refert inter I halecios. </note>
+							<hi rend="italic">(a)</hi> Hunc versum TerentianUs refert inter I
+							halecios. </note>
 					</p>
-					<p>28. Janvero non solum talia poemata versibus Hunt, <lb/> ut in his unum gcnus teneatur,
-						qualia Epicorum poe­ <lb/> tarum sunt, vcl etiam Comicorum; sed illos quoqne <lb/>
-						ambitus quos <foreign xml:lang="grc">περιόδους</foreign> Graeci vocant, non tantum iliis
-						<lb/> metris quæ lege versuum non tenentur, Lyrici poctæ <lb/> faciunt, sed etiam
-						versibus. Nam iI!e Flacci, <lb/>
+					</div><div type="textpart" subtype="dialog"><p>28. Janvero non solum talia poemata versibus Hunt, <lb/> ut in his unum gcnus
+						teneatur, qualia Epicorum poe­ <lb/> tarum sunt, vcl etiam Comicorum; sed
+						illos quoqne <lb/> ambitus quos <foreign xml:lang="grc">περιόδους</foreign>
+						Graeci vocant, non tantum iliis <lb/> metris quæ lege versuum non tenentur,
+						Lyrici poctæ <lb/> faciunt, sed etiam versibus. Nam iI!e Flacci, <lb/>
 						<lb/> Nox erat, et carlo fulgebat lana sereno <lb/> Inter minora sidera. <lb/>
-						<hi rend="italic">(Horat. Epod. ode</hi> 15; ) <lb/> bimembris ambitus es!, et versibus
-						constans. Qui duo <lb/> versus sibimet convenire non possunt, nis! uterque ad <lb/>
-						senorum temporum rcferatur pedes. Nam modus he­ <lb/> roicus cum modo iambico vcl
-						trochaico non concinit, <lb/> quia illi pedes ad tantumdem, hi ad duplum partiun­ <lb/>
-						tur. Fiunt ergo ambitus aut omnibus metris non cum <lb/> versibus, ut il!i sunt de
-						quibus in supcriori sermone <lb/> disputatum cst, cum de ipsis metris agercmus; aut
-						<lb/> tantum versibus, ut ii de qubus nunc dictum est ; <lb/> aut ut ctversibus, et
-						aliis metris temperentur \ quale <lb/> illud cst: <lb/> Diffugere nives, redeunt jam
-						gramina aun; is, <lb/> Arborihusquc comae. <lb/>
+						<hi rend="italic">(Horat. Epod. ode</hi> 15; ) <lb/> bimembris ambitus es!,
+						et versibus constans. Qui duo <lb/> versus sibimet convenire non possunt,
+						nis! uterque ad <lb/> senorum temporum rcferatur pedes. Nam modus he­ <lb/>
+						roicus cum modo iambico vcl trochaico non concinit, <lb/> quia illi pedes ad
+						tantumdem, hi ad duplum partiun­ <lb/> tur. Fiunt ergo ambitus aut omnibus
+						metris non cum <lb/> versibus, ut il!i sunt de quibus in supcriori sermone
+						<lb/> disputatum cst, cum de ipsis metris agercmus; aut <lb/> tantum
+						versibus, ut ii de qubus nunc dictum est ; <lb/> aut ut ctversibus, et aliis
+						metris temperentur \ quale <lb/> illud cst: <lb/> Diffugere nives, redeunt
+						jam gramina aun; is, <lb/> Arborihusquc comae. <lb/>
 						<hi rend="italic">(Id. tib.</hi> 4 <hi rend="italic">carminum, ode 7.)</hi>
-						<lb/> Quo autem ordine lorentur vel versus cum aliis me­ <lb/> tris, vel majora membra
-						cum minoribus, nihil inter­ <lb/> est ad aurium voluptatem, dummodo non brevior <lb/>
-						quam bimembris, non amplior quam quadrimembris <lb/> sit ambitus. Scd jam si nihil habes
-						quod contradicas, <lb/> finis sit hujus disputationis, ut deinceps quod ad hanc <lb/>
-						partem musicæ attinet quæ in numeris temporum est, <lb/> ab his vestigiis ejus
-						sensibilibus, ad ipsa cubilia, ubi <lb/> ab omni corpore aliena est, quanta valemus
-						sagacitate <lb/> veniamus. <note type="footnote">4 Sic Ms. A: <hi rend="italic">fut et
-								l'ernbu, et aliis metns temperantur.</hi> II. </note></p>
-				</div>
-				<div type="textpart" subtype="chapter">
+						<lb/> Quo autem ordine lorentur vel versus cum aliis me­ <lb/> tris, vel
+						majora membra cum minoribus, nihil inter­ <lb/> est ad aurium voluptatem,
+						dummodo non brevior <lb/> quam bimembris, non amplior quam quadrimembris
+						<lb/> sit ambitus. Scd jam si nihil habes quod contradicas, <lb/> finis sit
+						hujus disputationis, ut deinceps quod ad hanc <lb/> partem musicæ attinet
+						quæ in numeris temporum est, <lb/> ab his vestigiis ejus sensibilibus, ad
+						ipsa cubilia, ubi <lb/> ab omni corpore aliena est, quanta valemus
+						sagacitate <lb/> veniamus. <note type="footnote">4 Sic Ms. A: <hi
+								rend="italic">fut et l'ernbu, et aliis metns temperantur.</hi> II.
+						</note></p>
+				</div><div type="textpart" subtype="book">
 					<head>
 						<title type="main">
 							<hi rend="italic">LIBER SEXTUS.</hi>
 						</title>
 					</head>
 					<ab>
-						<title type="sub">In quo ex mutabilium numerorum in inferioribus rebus consideratione
-							evehitur animus ad immutabiles numeros, qui ii ipsa sunt immutabili veritate.</title>
+						<title type="sub">In quo ex mutabilium numerorum in inferioribus rebus
+							consideratione evehitur animus ad immutabiles numeros, qui ii ipsa sunt
+							immutabili veritate.</title>
 					</ab>
-					<ab>
-						<title type="sub">CAPUT PRIMUM.— <hi rend="italic">Superiores libri quibus scripti sint,
-								quove consilio.</hi>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT PRIMUM.— <hi rend="italic">Superiores libri quibus
+								scripti sint, quove consilio.</hi>
 						</title>
 					</ab>
-					<p>1. M. Satis din pene1 atque adeo plane pueriliter <lb/> per quinque libros in vestigiis
-						numerorum ad moras <lb/> temporum pertinentium monli sumus:quam nostram <lb/>
-						nugacitatem apud benevolos homines facile fortassis <lb/> excuset officiosus labor; quem
-						non ob aliud suscipien­ <lb/> dum putavimus, nisi ut adolescentes, vel cujuslibet <lb/>
-						ætatis homines, quos bono ingenio donavit Deus, non <lb/> præpropere, sed quibusdam
-						gradibus a sensibus car­ <lb/> nis atque a carnalibus litteris, quibus eos non hærere
-						<lb/> difficile est, duce ratione avellerentur, atque um Dco <lb/> et Domino rerum
-						omnium, qui humanis mentibus <lb/> nulla natura interposita præsidet, incommutabilis ve­
-						<lb/> ritaiis amore adhærescerent. Illos igitur libros qui <note type="footnote"> ' <hi rend="italic">satis diu penes te,</hi> juxta Er. ven. et MS A. M. </note>
-						<lb/> leget, inveniet nos cum grammaticis et pocticis ani <lb/> mis, non habitandi
-						electione, sed itinerandi necessi­ <lb/> tate versatos. Ad hunc autcm librum cum
-						vcnerit, si, <lb/> ut spero et supplex deprecor, Deus et Dominus noster <lb/> propositum
-						meum voluntatemque gubernaverit, et co <lb/> quo est intenta perduxerit, intelliget non
-						vilis posses­ <lb/> sionis esse vilem viam, per quam nunc cum imbecil­ <lb/> lioribus,
-						nec nos ipsi admodum fortes ambulare ma­ <lb/> luimus, quam minus pennatos per
-						liberiores auras <lb/> præcipitare. Ita nos, quantum arbitror, ant nibil ant <lb/> non
-						inultum peccasse judicabit, si tamen de numero <lb/> spiritualium virorum iste fuerit.
-						Nam turba caetera de <lb/> scholis linguarum tumultuantium, et ad plaudentiuin <lb/>
-						strepitum vulgari levitate latantium, si Curte irruerit <lb/> in has liucras, aut
-						contemnet omnes, aut illos quin­ <lb/> que libros sufficere sibi arbitrabitur : istum
-						vero in <note type="footnote"> PATROI.. XXXII. </note>
+					<div type="textpart" subtype="dialog"><p>1. M. Satis din pene1 atque adeo plane pueriliter <lb/> per quinque libros in
+						vestigiis numerorum ad moras <lb/> temporum pertinentium monli sumus:quam
+						nostram <lb/> nugacitatem apud benevolos homines facile fortassis <lb/>
+						excuset officiosus labor; quem non ob aliud suscipien­ <lb/> dum putavimus,
+						nisi ut adolescentes, vel cujuslibet <lb/> ætatis homines, quos bono ingenio
+						donavit Deus, non <lb/> præpropere, sed quibusdam gradibus a sensibus car­
+						<lb/> nis atque a carnalibus litteris, quibus eos non hærere <lb/> difficile
+						est, duce ratione avellerentur, atque um Dco <lb/> et Domino rerum omnium,
+						qui humanis mentibus <lb/> nulla natura interposita præsidet, incommutabilis
+						ve­ <lb/> ritaiis amore adhærescerent. Illos igitur libros qui <note
+							type="footnote"> ' <hi rend="italic">satis diu penes te,</hi> juxta Er.
+							ven. et MS A. M. </note>
+						<lb/> leget, inveniet nos cum grammaticis et pocticis ani <lb/> mis, non
+						habitandi electione, sed itinerandi necessi­ <lb/> tate versatos. Ad hunc
+						autcm librum cum vcnerit, si, <lb/> ut spero et supplex deprecor, Deus et
+						Dominus noster <lb/> propositum meum voluntatemque gubernaverit, et co <lb/>
+						quo est intenta perduxerit, intelliget non vilis posses­ <lb/> sionis esse
+						vilem viam, per quam nunc cum imbecil­ <lb/> lioribus, nec nos ipsi admodum
+						fortes ambulare ma­ <lb/> luimus, quam minus pennatos per liberiores auras
+						<lb/> præcipitare. Ita nos, quantum arbitror, ant nibil ant <lb/> non
+						inultum peccasse judicabit, si tamen de numero <lb/> spiritualium virorum
+						iste fuerit. Nam turba caetera de <lb/> scholis linguarum tumultuantium, et
+						ad plaudentiuin <lb/> strepitum vulgari levitate latantium, si Curte
+						irruerit <lb/> in has liucras, aut contemnet omnes, aut illos quin­ <lb/>
+						que libros sufficere sibi arbitrabitur : istum vero in <note type="footnote"
+							> PATROI.. XXXII. </note>
 						<note type="footnote">
 							<hi rend="italic">(Trente-sept J</hi>
 						</note>
 						<lb/>
-						<pb n="1163"/> quo fructus illorum est, vel abjiciet quasi non neces­ <lb/> sarum, vel
-						differet quasi post necefsarium. Reliquos <lb/> vero qui ad ista intelligenda eruditi
-						non sunt, si sa­ <lb/> cramentis Christianæ puritatis imbuti1, in unum et <lb/> verum
-						Deum summa charitate nitentes, cuncta pueri­ <lb/> lia transvolaverunt, fraterne admoneo
-						ne ad ista de­ <lb/> scendant, et cum hie laborare corperint, de tarditate <lb/> sua
-						conquerantur, ignorantes itinera difficilia et mo­ <lb/> lesta pedibus suis, volando se
-						posse ctiam ignorata <lb/> transire. Si autem ii legunt qui et infirmis aut inexer­
-						<lb/> citatis gressibus hac ambulare non possont, et nullas <lb/> pietatis alas habent,
-						quibus ista neglecta .prætervo­ <lb/> lent, non se inserant inconvenienti ncgolio; sed
-						præ­ <lb/> ceptis saluberrimæ religionis, et nido fidei Christianae <lb/> pennas
-						nutriant, quibus subveti laborem ac pulvc­ <lb/> rem hujus itineris evadant, magis
-						ipsius patri.c quam <lb/> ,'tarum flexuosarum amore flagrantes. liis enim hæc <lb/>
-						scripta sunt, qui litteris sæcularibus dediti, magnis <lb/> implicantur erroribus, ct
-						bona ingenia in nugis ron­ <lb/> terunt, nescientes quid ibi delectet. Quod si animad­
-						<lb/> verterent, viderent qua effugerent illa retia, et quisnam <lb/> esset beatissimæ
-						securitatis locus.</p>
-					<ab>
-						<title type="sub">CAPUT II. — Sonorum numeri <hi rend="italic">quotuplicis, generis, et
-								an quodque eorum genus sine alio esse possit. Primum genus numerorum iti ipso sono.
-								Secundum genus in ipso sensu audientis.</hi>
+						<pb n="1163"/> quo fructus illorum est, vel abjiciet quasi non neces­ <lb/>
+						sarum, vel differet quasi post necefsarium. Reliquos <lb/> vero qui ad ista
+						intelligenda eruditi non sunt, si sa­ <lb/> cramentis Christianæ puritatis
+						imbuti1, in unum et <lb/> verum Deum summa charitate nitentes, cuncta pueri­
+						<lb/> lia transvolaverunt, fraterne admoneo ne ad ista de­ <lb/> scendant,
+						et cum hie laborare corperint, de tarditate <lb/> sua conquerantur,
+						ignorantes itinera difficilia et mo­ <lb/> lesta pedibus suis, volando se
+						posse ctiam ignorata <lb/> transire. Si autem ii legunt qui et infirmis aut
+						inexer­ <lb/> citatis gressibus hac ambulare non possont, et nullas <lb/>
+						pietatis alas habent, quibus ista neglecta .prætervo­ <lb/> lent, non se
+						inserant inconvenienti ncgolio; sed præ­ <lb/> ceptis saluberrimæ
+						religionis, et nido fidei Christianae <lb/> pennas nutriant, quibus subveti
+						laborem ac pulvc­ <lb/> rem hujus itineris evadant, magis ipsius patri.c
+						quam <lb/> ,'tarum flexuosarum amore flagrantes. liis enim hæc <lb/> scripta
+						sunt, qui litteris sæcularibus dediti, magnis <lb/> implicantur erroribus,
+						ct bona ingenia in nugis ron­ <lb/> terunt, nescientes quid ibi delectet.
+						Quod si animad­ <lb/> verterent, viderent qua effugerent illa retia, et
+						quisnam <lb/> esset beatissimæ securitatis locus.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT II. — Sonorum numeri <hi rend="italic">quotuplicis,
+								generis, et an quodque eorum genus sine alio esse possit. Primum
+								genus numerorum iti ipso sono. Secundum genus in ipso sensu
+								audientis.</hi>
 						</title>
 					</ab>
-					<p>2. <hi rend="italic">M.</hi> Quamobrem tu rum quo mihi nunc ratio est, <lb/> familiaris
-						meus, ut a corporcis ad incorporea trans­ <lb/> camus, responde, si videtur, cum istum
-						versum pro­ <lb/> nuntiamus, <hi rend="italic">Deus creator omnium,</hi> istos quatuor
-						iambos <lb/> quibus constat, et tempora duodecim ubinam esse <lb/> arbitreris, id est,
-						in sono tantum qui auditur, an <lb/> etiam in sensu audicntis qui ad aures pcriinet, an
-						in <lb/> actu etiam pronuntiantis, an quia notus versus est, <lb/> in mcmoria quoque
-						nostra hos numcros esse faten­ <lb/> dum est ? <hi rend="italic">D.</hi> In his omnibus
-						puto. <hi rend="italic">M.</hi> Nusquamne <lb/> amplius ? <hi rend="italic">D.</hi> Quid
-						aliud restet non video, nisi forte <lb/> interior et superior aliqua vis sit I unde ista
-						proce­ <lb/> dunt. 3/. Non ego quaero quid suspicandum sit: <lb/> quare si hæc quatuor
-						genera ita tibi apparent, ut nul­ <lb/> lum aliud videas quod æque manifestum sit,
-						discer­ <lb/> namus ea , si placet, ab invicem , et videamus utrum <lb/> singula esse
-						sine invicem possint. Nam credo non te <lb/> csse negaturum fieri posse, ut in aliquo
-						loco aliquis <lb/> sonus existat hujuscemodi morulis et dimensionibus <lb/> verberans
-						aerem vel stillicidio vel aliquo alio pulsu <lb/> corporum, ubi nullus adsit auditor.
-						Quod cum fit, <lb/> num præter illud primum geuus, cum ipse sonus hos <lb/> numcros
-						habet, ullum horum quatuor rcperitur ? <hi rend="italic">D.</hi>
+					<div type="textpart" subtype="dialog"><p>2. <hi rend="italic">M.</hi> Quamobrem tu rum quo mihi nunc ratio est, <lb/>
+						familiaris meus, ut a corporcis ad incorporea trans­ <lb/> camus, responde,
+						si videtur, cum istum versum pro­ <lb/> nuntiamus, <hi rend="italic">Deus
+							creator omnium,</hi> istos quatuor iambos <lb/> quibus constat, et
+						tempora duodecim ubinam esse <lb/> arbitreris, id est, in sono tantum qui
+						auditur, an <lb/> etiam in sensu audicntis qui ad aures pcriinet, an in
+						<lb/> actu etiam pronuntiantis, an quia notus versus est, <lb/> in mcmoria
+						quoque nostra hos numcros esse faten­ <lb/> dum est ? <hi rend="italic"
+							>D.</hi> In his omnibus puto. <hi rend="italic">M.</hi> Nusquamne <lb/>
+						amplius ? <hi rend="italic">D.</hi> Quid aliud restet non video, nisi forte
+						<lb/> interior et superior aliqua vis sit I unde ista proce­ <lb/> dunt. 3/.
+						Non ego quaero quid suspicandum sit: <lb/> quare si hæc quatuor genera ita
+						tibi apparent, ut nul­ <lb/> lum aliud videas quod æque manifestum sit,
+						discer­ <lb/> namus ea , si placet, ab invicem , et videamus utrum <lb/>
+						singula esse sine invicem possint. Nam credo non te <lb/> csse negaturum
+						fieri posse, ut in aliquo loco aliquis <lb/> sonus existat hujuscemodi
+						morulis et dimensionibus <lb/> verberans aerem vel stillicidio vel aliquo
+						alio pulsu <lb/> corporum, ubi nullus adsit auditor. Quod cum fit, <lb/> num
+						præter illud primum geuus, cum ipse sonus hos <lb/> numcros habet, ullum
+						horum quatuor rcperitur ? <hi rend="italic">D.</hi>
 						<lb/> Nullum aliud video.</p>
-					<p>5. <hi rend="italic">M.</hi> Quid iste alter, qui est in sensu audientis ? <lb/>
-						potestne esse si nihil sonct? Non enim quæro utrum <lb/> habeant illae aures vim
-						percipiendi si quidquam so­ <lb/> nuerit, qua utique non carent si desit sonus: non
-						<lb/> onim et cum silentium est, nihil a surdis differunt; <lb/> sed quæro utrum ipsos
-						numeros habeant, etiamsi nihil <note type="footnote">1 Er. et LOV., <hi rend="italic">veritatis imbutf;</hi> at Mss. habent cum Am., <lb/>
+					</div><div type="textpart" subtype="dialog"><p>3. <hi rend="italic">M.</hi> Quid iste alter, qui est in sensu audientis ?
+						<lb/> potestne esse si nihil sonct? Non enim quæro utrum <lb/> habeant illae
+						aures vim percipiendi si quidquam so­ <lb/> nuerit, qua utique non carent si
+						desit sonus: non <lb/> onim et cum silentium est, nihil a surdis differunt;
+						<lb/> sed quæro utrum ipsos numeros habeant, etiamsi nihil <note
+							type="footnote">1 Er. et LOV., <hi rend="italic">veritatis imbutf;</hi>
+							at Mss. habent cum Am., <lb/>
 							<hi rend="italic">puritatis.</hi>
 						</note><note type="footnote"> ' <hi rend="italic">ut.</hi> juxta 111. A. M. </note>
-						<lb/> sonet. Siquidem aliud est habere numeros, aliud <lb/> posse sentire numerosum
-						sonum. Nam et si sentien­ <lb/> tem corporis locum digito tangas, quotieslibet tangi­
-						<lb/> tur, toties sentitur tactu ille numerus : et cum senti­ <lb/> tur, non eo caret
-						sentiens : sed utrum insit etiam tan­ <lb/> gente nullo, non sensus ille , sed numerus,
-						similiter <lb/> quæritur. <hi rend="italic">D.</hi> Non facile dixerim, carere sensum
-						nu­ <lb/> meris talibus in se constitutis, etiam antequam aliquid <lb/> sonet: non enim
-						aliter aut corum mulceretur concin­ <lb/> nitale, aut absurditate offenderetur. Idipsum
-						ergo <lb/> quidquid est, quo aut annuimus aut abhorremus, nou <lb/> ratione sed natura,
-						cum aliquid sonat, ipsius sensus <lb/> numcrum voco. Non enim tunc fit in auribus mei;,
-						<lb/> cum sonum audio, hæc vis approbandi et improbandi. <lb/> Aures quippe non aliter
-						bonis sonis quam nolis pa­ <lb/> tent. <hi rend="italic">M.</hi> Vide potius ne ista duo
-						sint minime confun­ <lb/> denda. Nam si versus quilibet modo correptius, modo <lb/>
-						productius pronuntietur, spatium temporis non idem <lb/> teneat necesse est, quamvis
-						eadem pedum ratione <lb/> servata. Ut ergo ipso suo gcnere aures mulceat, illa <lb/> vis
-						facit qua concinna adsciscimus, et absurda re­ <lb/> spuimus. Ut autem breviore tempore
-						sentiatur cum <lb/> celerius, quam cum tardius promitur, non interest <lb/> aliquid nisi
-						quamdiu aures tangantur sono. Affectio <lb/> ergo hæc aurium cum tanguntur sono, nullo
-						modo <lb/> talis est ac si non tangantur. Ut cnim differt audire <lb/> ab eo quod est
-						non audire, ita differt hanc vocem au­ <lb/> dire ab eo quod est alteram audire. hæc
-						igitur affectio <lb/> nee ultra porrigitur, nec infra cohibetur; quoniam <lb/> est
-						mensura ejus soni qui facit eam. Altera est ergo <lb/> in ianibo, altera in tribracho;
-						productior in produ­ <lb/> ctiore iambo, correptior in correpliore ; nulla in si­ <lb/>
-						lentio. Quæ si numerosa voce fit, ctiam ipsa nume­ <lb/> rosa sit necesse est. Neque
-						esse potest, nisi cum <lb/> adest effector ejus sonus : similis est enim vestigio in
-						<lb/> aqua impresso, quod neque ante formatur quam cor­ <lb/> pus impresseris, neque
-						remanet cum detraxeris. Na­ <lb/> turalis vero illa vis quasi judiciaria, quai auribus
-						<lb/> adest, non desinit esse in silentio, nec nobis eam <lb/> sonus infert, sed ab ea
-						potius, sive probandus, sive <lb/> improbandus excipitur. Quare ista duo, nisi fallor,
-						<lb/> distinguenda sunt; et fatendum numeros, qui sunt in <lb/> ipsa passione aurium,
-						cum aliquid auditur , sono in­ <lb/> ferri, auferri silentio. Ex quo colligitur numeros
-						qui <lb/> sunt in ipso sono, posse esse sine istis qui sunt in eo <lb/> quod est audire.
-						cum hi siue illis esse non possint.</p>
-					<ab>
-						<title type="sub">CAPUT III. — Tertium <hi rend="italic">genus numerorum</hi> in <hi rend="italic">ipso actu pronuntiantis. Quartum genus numerorum</hi> in ipsa <hi rend="italic">memoria.</hi>
+						<lb/> sonet. Siquidem aliud est habere numeros, aliud <lb/> posse sentire
+						numerosum sonum. Nam et si sentien­ <lb/> tem corporis locum digito tangas,
+						quotieslibet tangi­ <lb/> tur, toties sentitur tactu ille numerus : et cum
+						senti­ <lb/> tur, non eo caret sentiens : sed utrum insit etiam tan­ <lb/>
+						gente nullo, non sensus ille , sed numerus, similiter <lb/> quæritur. <hi
+							rend="italic">D.</hi> Non facile dixerim, carere sensum nu­ <lb/> meris
+						talibus in se constitutis, etiam antequam aliquid <lb/> sonet: non enim
+						aliter aut corum mulceretur concin­ <lb/> nitale, aut absurditate
+						offenderetur. Idipsum ergo <lb/> quidquid est, quo aut annuimus aut
+						abhorremus, nou <lb/> ratione sed natura, cum aliquid sonat, ipsius sensus
+						<lb/> numcrum voco. Non enim tunc fit in auribus mei;, <lb/> cum sonum
+						audio, hæc vis approbandi et improbandi. <lb/> Aures quippe non aliter bonis
+						sonis quam nolis pa­ <lb/> tent. <hi rend="italic">M.</hi> Vide potius ne
+						ista duo sint minime confun­ <lb/> denda. Nam si versus quilibet modo
+						correptius, modo <lb/> productius pronuntietur, spatium temporis non idem
+						<lb/> teneat necesse est, quamvis eadem pedum ratione <lb/> servata. Ut ergo
+						ipso suo gcnere aures mulceat, illa <lb/> vis facit qua concinna
+						adsciscimus, et absurda re­ <lb/> spuimus. Ut autem breviore tempore
+						sentiatur cum <lb/> celerius, quam cum tardius promitur, non interest <lb/>
+						aliquid nisi quamdiu aures tangantur sono. Affectio <lb/> ergo hæc aurium
+						cum tanguntur sono, nullo modo <lb/> talis est ac si non tangantur. Ut cnim
+						differt audire <lb/> ab eo quod est non audire, ita differt hanc vocem au­
+						<lb/> dire ab eo quod est alteram audire. hæc igitur affectio <lb/> nee
+						ultra porrigitur, nec infra cohibetur; quoniam <lb/> est mensura ejus soni
+						qui facit eam. Altera est ergo <lb/> in ianibo, altera in tribracho;
+						productior in produ­ <lb/> ctiore iambo, correptior in correpliore ; nulla
+						in si­ <lb/> lentio. Quæ si numerosa voce fit, ctiam ipsa nume­ <lb/> rosa
+						sit necesse est. Neque esse potest, nisi cum <lb/> adest effector ejus sonus
+						: similis est enim vestigio in <lb/> aqua impresso, quod neque ante formatur
+						quam cor­ <lb/> pus impresseris, neque remanet cum detraxeris. Na­ <lb/>
+						turalis vero illa vis quasi judiciaria, quai auribus <lb/> adest, non
+						desinit esse in silentio, nec nobis eam <lb/> sonus infert, sed ab ea
+						potius, sive probandus, sive <lb/> improbandus excipitur. Quare ista duo,
+						nisi fallor, <lb/> distinguenda sunt; et fatendum numeros, qui sunt in <lb/>
+						ipsa passione aurium, cum aliquid auditur , sono in­ <lb/> ferri, auferri
+						silentio. Ex quo colligitur numeros qui <lb/> sunt in ipso sono, posse esse
+						sine istis qui sunt in eo <lb/> quod est audire. cum hi siue illis esse non
+						possint.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT III. — Tertium <hi rend="italic">genus
+								numerorum</hi> in <hi rend="italic">ipso actu pronuntiantis. Quartum
+								genus numerorum</hi> in ipsa <hi rend="italic">memoria.</hi>
 						</title>
 					</ab>
-					<p>4. <hi rend="italic">D.</hi> Assentior. <hi rend="italic">M.</hi> Atlende igitur hoc
-						tertium <lb/> gcnus, quod est in ipso usu 1et operatione pronun­ <lb/> tiantis; et vide
-						utrum possint esse hi numeri sine <lb/> illis qui sunt in memoria. Nam et taciti apud
-						nosmet­ <lb/> ipsos possumus aliquos numeros cogitando peragere <lb/> ca mora temporis,
-						qua etiam voce pcragerentur. Illos <lb/> in quadam operatione animi esse manifestum cst,
-						<lb/> quae quoniam nullum edit sonum, nihilque passionis <lb/> infert auribus, ostendit
-						hoc genus sinc illis duobus <note type="footnote"> I lrisu, juxta Ms. A. II. </note>
+					</div><div type="textpart" subtype="dialog"><p>4. <hi rend="italic">D.</hi> Assentior. <hi rend="italic">M.</hi> Atlende
+						igitur hoc tertium <lb/> gcnus, quod est in ipso usu 1et operatione pronun­
+						<lb/> tiantis; et vide utrum possint esse hi numeri sine <lb/> illis qui
+						sunt in memoria. Nam et taciti apud nosmet­ <lb/> ipsos possumus aliquos
+						numeros cogitando peragere <lb/> ca mora temporis, qua etiam voce
+						pcragerentur. Illos <lb/> in quadam operatione animi esse manifestum cst,
+						<lb/> quae quoniam nullum edit sonum, nihilque passionis <lb/> infert
+						auribus, ostendit hoc genus sinc illis duobus <note type="footnote"> I
+							lrisu, juxta Ms. A. II. </note>
 						<lb/>
-						<pb n="1165"/> esse posse, quorum unum in sono est, alterum in an. <lb/> diente, quando
-						audit. Sed utrum existerct, nisi ad­ <lb/> juvante memoria, quærimus. Quanquam si anima
-						hos <lb/> numeros agit, quos in venarum pulsu invenimus, <lb/> soluta quæstio est : nam
-						et in operatione hos esse <lb/> manifestum est, et nihil ad eos adjuvamur memoria. <lb/>
-						Quod si de his incertum est, utrum operantis animae <lb/> sint; de istis certe quos
-						reciproco spiritu agimus, <lb/> nulli dubium est, quin et temporum intervallis numeri
-						<lb/> sint, ei cos sic anima opcrelur, ut etiam voluntate <lb/> adhibita multis modis
-						variari queant: nec tamen ut <lb/> agantur, ulla opus cst memoria. <hi rend="italic">D.</hi> Videtur mihi hoc <lb/> genus sine tribus cæteris esse posse. Quamvis enim
-						<lb/> pro temperatione corporum varios venarum pulsus, <lb/> et respirationis intervalla
-						fieri non ambigam ; tamen <lb/> operante anima fieri, negare quis audeat ? Qui cursus
-						<lb/> et si pro diversitale corporum aliis celerior est, aliis <lb/> tardior; nisi tamen
-						adsit anima quæ id agat, nullus <lb/> est. Jf. Conidera igitur et quartum genus, eorum
-						<lb/> scilicet numerorum qui sunt in memoria : nam si eos <lb/> rccordatione depromimus,
-						et cum in alias cogitationes <lb/> deferimur, bos rursum relinquimus velut in suis se­
-						<lb/> cretis reconditos, non, opinor, occultum est cos esse <lb/> posse sinc cæteris.
-							<hi rend="italic">D.</hi> Non dubito eos esse sine cxte­ <lb/> ris ; sed tamen nisi
-						auditi, vel cogitati, non manda­ <lb/> rentur memoriæ : et idco quanquam illis desinen­
-						<lb/> tibus maneant, iisdem tamen præcedentibus impri­ <lb/> muntur.</p>
-					<ab>
-						<title type="sub">CAPUT IV. — Quintum <hi rend="italic">genus numerorum in ipso na­</hi>
-							turali <hi rend="italic">judicio sentiendi. Ex quinque recensitis nume­ rorum
-								generibus quodnam antecellat.</hi>
+						<pb n="1165"/> esse posse, quorum unum in sono est, alterum in an. <lb/>
+						diente, quando audit. Sed utrum existerct, nisi ad­ <lb/> juvante memoria,
+						quærimus. Quanquam si anima hos <lb/> numeros agit, quos in venarum pulsu
+						invenimus, <lb/> soluta quæstio est : nam et in operatione hos esse <lb/>
+						manifestum est, et nihil ad eos adjuvamur memoria. <lb/> Quod si de his
+						incertum est, utrum operantis animae <lb/> sint; de istis certe quos
+						reciproco spiritu agimus, <lb/> nulli dubium est, quin et temporum
+						intervallis numeri <lb/> sint, ei cos sic anima opcrelur, ut etiam voluntate
+						<lb/> adhibita multis modis variari queant: nec tamen ut <lb/> agantur, ulla
+						opus cst memoria. <hi rend="italic">D.</hi> Videtur mihi hoc <lb/> genus
+						sine tribus cæteris esse posse. Quamvis enim <lb/> pro temperatione corporum
+						varios venarum pulsus, <lb/> et respirationis intervalla fieri non ambigam ;
+						tamen <lb/> operante anima fieri, negare quis audeat ? Qui cursus <lb/> et
+						si pro diversitale corporum aliis celerior est, aliis <lb/> tardior; nisi
+						tamen adsit anima quæ id agat, nullus <lb/> est. Jf. Conidera igitur et
+						quartum genus, eorum <lb/> scilicet numerorum qui sunt in memoria : nam si
+						eos <lb/> rccordatione depromimus, et cum in alias cogitationes <lb/>
+						deferimur, bos rursum relinquimus velut in suis se­ <lb/> cretis reconditos,
+						non, opinor, occultum est cos esse <lb/> posse sinc cæteris. <hi
+							rend="italic">D.</hi> Non dubito eos esse sine cxte­ <lb/> ris ; sed
+						tamen nisi auditi, vel cogitati, non manda­ <lb/> rentur memoriæ : et idco
+						quanquam illis desinen­ <lb/> tibus maneant, iisdem tamen præcedentibus
+						impri­ <lb/> muntur.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT IV. — Quintum <hi rend="italic">genus numerorum in
+								ipso na­</hi> turali <hi rend="italic">judicio sentiendi. Ex quinque
+								recensitis nume­ rorum generibus quodnam antecellat.</hi>
 						</title>
 					</ab>
-					<p>5. <hi rend="italic">M.</hi> Non resisto tibi, ct vellem jam quaerere, <lb/> quod
-						tandem horum quatuor generum praestantissi­ <lb/> nium judices : nisi arbitrarer dum
-						illa tractamus, <lb/> nescio unde apparuisse nobis quintum genus, quod <lb/> est in ipso
-						naturali judicio sentiendi, cum delectamur <lb/> parilitale numerorum, vel cum in eis
-						peccatur, offen­ <lb/> dimur. Non enim contemno quod tibi visum cst, sinc <lb/>
-						quibusdam numeris in co latentibus , hoc sensum <lb/> nostrum nullo modo agere potuisse.
-						An forte ad <lb/> istorum quatuor aliquod genus hanc tantam vim per­ <lb/> tinere
-						arbitraris ? <hi rend="italic">D.</hi> Ego vero ab illis omnibus hoc <lb/> gcnus
-						distinguendum puto. S'quidem aliud est sonare, <lb/> quod corpori tribuitur, aliud
-						audire, quod in corpore <lb/> auima de sonis palilor, aliud operari numeros vel <lb/>
-						productius vel correptius, aliud ista memimsse, aliud <lb/> de his omnibus vel annuendo
-						vel abhorrendo quasi <lb/> quodam naturali jure ferre sententiam.</p>
-					<p>6. <hi rend="italic">M.</hi> Age, nunc dic mihi quinque horum quod <lb/> maxime
-						excellat. <hi rend="italic">D.</hi> Hoc quintum puto. <hi rend="italic">M.</hi> Recte
-						<lb/> putas: non enim de illis posset, nisi excelleret, judi­ <lb/> care. Sed rursus
-						quæro, caeterorum quatuor quod <lb/> maxime probes. <hi rend="italic">D.</hi> Illud
-						profecto quod est in memo­ <lb/> ria ; quia video ibi diaturniores esse numeros, quam
-						<lb/> cum sonant, vel cum audiantur, vel cum aguntur. <lb/> M. Præponis ergo factos
-						facientibus: nam istos qni <lb/> sunt in memoria, ab illis aliis imprimi paulo ante
-						<lb/> dixisti. <hi rend="italic">D.</hi> Nollem pranponere : sed rursus quomodo <lb/>
-						non præponam diuturniora minus diuturnis, non v i- <lb/> deo. <hi rend="italic">II.</hi>
-						Non te istuc movcat. Non enim sicut æterna <lb/> temporalibus, ita ea quæ diutius
-						abolentur, iis quæ <lb/> breviore tempore transeunt, præfereda sunt. Quia <lb/> et
-						sanitas unius dici profecto cst melior, qnam mul­ <lb/> torum dierum imbecilitas.Et si
-						optanda optandis <lb/> comparemus, melior est unius dici lectio, quam plu­ <lb/> rium
-						scriptio, si cadem res uno dic legatur, quæ <lb/> pluribus scribitur. Ita numeri qui
-						sunt in memoria, <lb/> etsi diutius manent quam illi a quibus imprimuntur, <lb/> non cos
-						tamen anteponere oportet cis quos agimus, <lb/> non in corpore, sed in anima : ulriquc
-						enim præter­ <lb/> eunt, alii cessatione, alii oblivione. Sed illi quos <lb/> operamur,
-						etiam nondum cessantibus nobis succes­ <lb/> sione sequentium videntur auferri, dum
-						primi secnn­ <lb/> dis, et secundi tertiis, atque ita dcinc ps priorcs po­ <lb/>
-						sterioribus prætereundo concedunt locum, donce <lb/> ultimos perimat ipsa cessatio.
-						Oblivione vero plures <lb/> simul numeri, quamvis paulatim, absterguntur : nam <lb/> nec
-						ipsi aliquandiu manent integri. Quod enim post <lb/> annum, verbi gratia, in memoria non
-						invenitur, etiam <lb/> post unum diem jam minus est: sed non sentitur ista <lb/>
-						diminutio : non tamcn falso ex eo conjicitur, quia non <lb/> utique pridie quam
-						compleatur annus repente totum <lb/> evolat: unde inteligi datur, ab illo tempore quo
-						in­ <lb/> hæret memoriæne, incipere labi. Hinc est illud quod <lb/> plerumque dicimus,
-						Tenuiter memini, cum aliquid <lb/> post tempus recordando repetimus, antequam plane
-						<lb/> totum excidat. Quapropter utrumque hoc numerorum <lb/> genus mortale est.
-						Ycrumtamcn facientes factis jure <lb/> anteponuntur. <hi rend="italic">D.</hi> Accipio,
-						et probo.</p>
-					<p>7. M. Jam ergo tria rcliqua intucre, et eorum quo­ <lb/> que quod sit optimum et
-						cæteris præferendum, edis­ <lb/> sere. <hi rend="italic">D.</hi> Non est hoc facile. Nam
-						ex illa regula qua <lb/> factis facicntes oportet anteferre, cogor sonautibus <lb/>
-						numeris palmam dare : hos enim scntimus audientes. <lb/> ct cum hos sentimus, bos
-						patimur. Ili ergo faciunt <lb/> eos qui sunt in aurium passione cnm audimus : hi au­
-						<lb/> tem rursus quos sentiendo habemus, faciunt alios in <lb/> memoria, quibus a se
-						factis recte præferuntur. Sed <lb/> hic quia et sentire et meminisse animæ est, non mo­
-						<lb/> veor, si aliquid quod in anima fit, alicui quod item in <lb/> ca fit anteponam.
-						Illud me conturbat, quomodo so­ <lb/> nantes numeri, qui certe corporei sunt, vel quoquo
-						<lb/> modo in corpore, magis laudandi sint quam illi, qui. <lb/> cum sentimus, in anima
-						esse rcperiuntur. Sed rursus <lb/> conturbat quomodo non magis laudandi sint, cum hi
-						<lb/> faciant, illi ab his Gant. <hi rend="italic">M.</hi> Mirarc potius qnod facere
-						<lb/> aliquid in anima corpus potest. Hoc emm fortasse <lb/> non posset, si non peccato
-						primo corpus iHud quod <lb/> nulla molestia et summa facilitate animabat et guber­ <lb/>
-						nabat, in deterius commutatum, et corruptioni subja­ <lb/> cerei et morti: quod tamen
-						habet sui generis pulchri­ <lb/> tudinem, ct eo ipso dignitatem animæ satis commea.
-						<lb/> dat, cujus nec plaga, nee morbus siDe honore alicujus <lb/> decoris meruit esse.
-						Quam plagam summa Dei Sapien­ <lb/> lia, mirabili et ineffabili sacramento dignata est
-						assu­ <lb/> mere, cum hominem sine peccato, non sine peccatoris <lb/> conditione
-						suscepit. Nam ct nasci humanitns, et pall <lb/> ci muri voluit. Nihil horuin merito, sed
+					</div><div type="textpart" subtype="dialog"><p>5. <hi rend="italic">M.</hi> Non resisto tibi, ct vellem jam quaerere, <lb/>
+						quod tandem horum quatuor generum praestantissi­ <lb/> nium judices : nisi
+						arbitrarer dum illa tractamus, <lb/> nescio unde apparuisse nobis quintum
+						genus, quod <lb/> est in ipso naturali judicio sentiendi, cum delectamur
+						<lb/> parilitale numerorum, vel cum in eis peccatur, offen­ <lb/> dimur. Non
+						enim contemno quod tibi visum cst, sinc <lb/> quibusdam numeris in co
+						latentibus , hoc sensum <lb/> nostrum nullo modo agere potuisse. An forte ad
+						<lb/> istorum quatuor aliquod genus hanc tantam vim per­ <lb/> tinere
+						arbitraris ? <hi rend="italic">D.</hi> Ego vero ab illis omnibus hoc <lb/>
+						gcnus distinguendum puto. S'quidem aliud est sonare, <lb/> quod corpori
+						tribuitur, aliud audire, quod in corpore <lb/> auima de sonis palilor, aliud
+						operari numeros vel <lb/> productius vel correptius, aliud ista memimsse,
+						aliud <lb/> de his omnibus vel annuendo vel abhorrendo quasi <lb/> quodam
+						naturali jure ferre sententiam.</p>
+					</div><div type="textpart" subtype="dialog"><p>6. <hi rend="italic">M.</hi> Age, nunc dic mihi quinque horum quod <lb/>
+						maxime excellat. <hi rend="italic">D.</hi> Hoc quintum puto. <hi
+							rend="italic">M.</hi> Recte <lb/> putas: non enim de illis posset, nisi
+						excelleret, judi­ <lb/> care. Sed rursus quæro, caeterorum quatuor quod
+						<lb/> maxime probes. <hi rend="italic">D.</hi> Illud profecto quod est in
+						memo­ <lb/> ria ; quia video ibi diaturniores esse numeros, quam <lb/> cum
+						sonant, vel cum audiantur, vel cum aguntur. <lb/> M. Præponis ergo factos
+						facientibus: nam istos qni <lb/> sunt in memoria, ab illis aliis imprimi
+						paulo ante <lb/> dixisti. <hi rend="italic">D.</hi> Nollem pranponere : sed
+						rursus quomodo <lb/> non præponam diuturniora minus diuturnis, non v i-
+						<lb/> deo. <hi rend="italic">II.</hi> Non te istuc movcat. Non enim sicut
+						æterna <lb/> temporalibus, ita ea quæ diutius abolentur, iis quæ <lb/>
+						breviore tempore transeunt, præfereda sunt. Quia <lb/> et sanitas unius dici
+						profecto cst melior, qnam mul­ <lb/> torum dierum imbecilitas.Et si optanda
+						optandis <lb/> comparemus, melior est unius dici lectio, quam plu­ <lb/>
+						rium scriptio, si cadem res uno dic legatur, quæ <lb/> pluribus scribitur.
+						Ita numeri qui sunt in memoria, <lb/> etsi diutius manent quam illi a quibus
+						imprimuntur, <lb/> non cos tamen anteponere oportet cis quos agimus, <lb/>
+						non in corpore, sed in anima : ulriquc enim præter­ <lb/> eunt, alii
+						cessatione, alii oblivione. Sed illi quos <lb/> operamur, etiam nondum
+						cessantibus nobis succes­ <lb/> sione sequentium videntur auferri, dum primi
+						secnn­ <lb/> dis, et secundi tertiis, atque ita dcinc ps priorcs po­ <lb/>
+						sterioribus prætereundo concedunt locum, donce <lb/> ultimos perimat ipsa
+						cessatio. Oblivione vero plures <lb/> simul numeri, quamvis paulatim,
+						absterguntur : nam <lb/> nec ipsi aliquandiu manent integri. Quod enim post
+						<lb/> annum, verbi gratia, in memoria non invenitur, etiam <lb/> post unum
+						diem jam minus est: sed non sentitur ista <lb/> diminutio : non tamcn falso
+						ex eo conjicitur, quia non <lb/> utique pridie quam compleatur annus repente
+						totum <lb/> evolat: unde inteligi datur, ab illo tempore quo in­ <lb/> hæret
+						memoriæne, incipere labi. Hinc est illud quod <lb/> plerumque dicimus,
+						Tenuiter memini, cum aliquid <lb/> post tempus recordando repetimus,
+						antequam plane <lb/> totum excidat. Quapropter utrumque hoc numerorum <lb/>
+						genus mortale est. Ycrumtamcn facientes factis jure <lb/> anteponuntur. <hi
+							rend="italic">D.</hi> Accipio, et probo.</p>
+					</div><div type="textpart" subtype="dialog"><p>7. M. Jam ergo tria rcliqua intucre, et eorum quo­ <lb/> que quod sit optimum
+						et cæteris præferendum, edis­ <lb/> sere. <hi rend="italic">D.</hi> Non est
+						hoc facile. Nam ex illa regula qua <lb/> factis facicntes oportet anteferre,
+						cogor sonautibus <lb/> numeris palmam dare : hos enim scntimus audientes.
+						<lb/> ct cum hos sentimus, bos patimur. Ili ergo faciunt <lb/> eos qui sunt
+						in aurium passione cnm audimus : hi au­ <lb/> tem rursus quos sentiendo
+						habemus, faciunt alios in <lb/> memoria, quibus a se factis recte
+						præferuntur. Sed <lb/> hic quia et sentire et meminisse animæ est, non mo­
+						<lb/> veor, si aliquid quod in anima fit, alicui quod item in <lb/> ca fit
+						anteponam. Illud me conturbat, quomodo so­ <lb/> nantes numeri, qui certe
+						corporei sunt, vel quoquo <lb/> modo in corpore, magis laudandi sint quam
+						illi, qui. <lb/> cum sentimus, in anima esse rcperiuntur. Sed rursus <lb/>
+						conturbat quomodo non magis laudandi sint, cum hi <lb/> faciant, illi ab his
+						Gant. <hi rend="italic">M.</hi> Mirarc potius qnod facere <lb/> aliquid in
+						anima corpus potest. Hoc emm fortasse <lb/> non posset, si non peccato primo
+						corpus iHud quod <lb/> nulla molestia et summa facilitate animabat et guber­
+						<lb/> nabat, in deterius commutatum, et corruptioni subja­ <lb/> cerei et
+						morti: quod tamen habet sui generis pulchri­ <lb/> tudinem, ct eo ipso
+						dignitatem animæ satis commea. <lb/> dat, cujus nec plaga, nee morbus siDe
+						honore alicujus <lb/> decoris meruit esse. Quam plagam summa Dei Sapien­
+						<lb/> lia, mirabili et ineffabili sacramento dignata est assu­ <lb/> mere,
+						cum hominem sine peccato, non sine peccatoris <lb/> conditione suscepit. Nam
+						ct nasci humanitns, et pall <lb/> ci muri voluit. Nihil horuin merito, sed
 						excellentissi­ <pb n="1167"/>
-						<unclear/><lb/> i;i.i honitate; ut nos caveremus magis superbiam, qua <lb/> dignissime
-						in ista <unclear>cecnfimus</unclear>, quam contumelias quas <lb/> indignus excepit; et
-						animo æquo mortem debitam sol­ <lb/> vercmus, si propter nos potuit etiam indebitam
-						susti­ <lb/> nere; et quidquid secretius atque purgatius in tali <lb/> sacramento a
-						sanctis et melioribus intelligi potest. <lb/> Ergo :ruinam in care mortali operantem,
-						passionem <lb/> corporum sentire non mirum est. Nec quia ipsa est <lb/> corpore melior,
-						melius putandum est omne quod in <lb/> ea fil, qnam omne quod lit iri corpore. Credo
-						enim <lb/> tibi ,Meri verum falso esse præponendum. D. Quis <lb/> dubitaverit? <hi rend="italic">M.</hi> Num vero est arbor, quam videmus <lb/> in somnis? <hi rend="italic">D.</hi> Nullo modo. <hi rend="italic">M.</hi> At ejus forma inaaima
-						<lb/> fit, hujus autem, quam nuuc videmus, in corpore <lb/> facta cst. Quare cnm ct
-						verum falso, et anima corpore <lb/> melior sit, verum in cerpore melius est quam falsum
-						<lb/> in anima. Sed ut hoc in quantum vcrum, non in quan­ <lb/> tum in corpore fit,
-						melius est; ita illud in quantum fal­ <lb/> sum, non in quanluln in anima fit, fortasse
-						est dete­ <lb/> rius. Nisi quid habes ad hæc. <hi rend="italic">D.</hi> N.hil cquidem.
-							<hi rend="italic">M.</hi> Au­ <lb/> di aHud quod sit, ut puto, vicinius quam melius1.
-						Neque <lb/> enimnegabis, quod dccet esse melius, quam id quod <lb/> non decet. <hi rend="italic">D.</hi> imo fatcor. M. At in qua veste decens <lb/> cst mulier, in cadem
-						virum indecentem esse posse, quis <lb/> ambigat? <hi rend="italic">D.</hi> Et hoc
-						manifestum est. M. Quid si ergo <lb/> forma ista numerorum decet in sonis, qui
-						allabuutur <lb/> auribus, et dedecet in anima, curO cos sentiendo ac <lb/> patiendo
-						habet, num magnopere mirandum esL? <lb/> D. Non opinor. M. Quid ergo dubitamus sonantes
-						no­ <lb/> meros atque corporeos præponere iis qui ab ipsis <lb/> fiunt, quamvis in anima
-						fiant, qunc corpore est me­ <lb/> lior? quia numeros numeris, efficientes factisnon
-						<lb/> corpus animæ præponimus. Corpora enim tanto me­ <lb/> liora sunt, quanto
-						numerosiora talibus uumeris. Anima <lb/> vero istis quæ per corpus accipit, carendo fit
-						melior, <lb/> cum sese avertit a carnalibus sensibus, et divinis sa­ <lb/> pientiæ
-						numeris reformatur (a). Ita quippe in Scripta­ <lb/> ris sanctis dicitur : <hi rend="italic">Circumivi ego, ut scirem et conside­ <lb/> rarem et qu</hi>æ<hi rend="italic">rerem sapientiam et numerum (Ercle.</hi> VII, <lb/> 26). Quod nu'lo modo
-						arbitrandum est de his nume­ <lb/> ris dictum, quibus etiam flagitiosa theatra
-						personant: <lb/> sed de illis, credo, quos non a corpore accipit anima, <lb/> scd
-						acceptos a sununo Dco ipsa potius imprimit cor­ <lb/> pori. Quod quale sit, non hoc loco
-						est considerandum.</p>
-					<ab>
-						<title type="sub">CAPUT V. — <hi rend="italic">Anima an a corpore patiatur, et quomodo
-								sentiat.</hi>
+						<unclear/><lb/> i;i.i honitate; ut nos caveremus magis superbiam, qua <lb/>
+						dignissime in ista <unclear>cecnfimus</unclear>, quam contumelias quas <lb/>
+						indignus excepit; et animo æquo mortem debitam sol­ <lb/> vercmus, si
+						propter nos potuit etiam indebitam susti­ <lb/> nere; et quidquid secretius
+						atque purgatius in tali <lb/> sacramento a sanctis et melioribus intelligi
+						potest. <lb/> Ergo :ruinam in care mortali operantem, passionem <lb/>
+						corporum sentire non mirum est. Nec quia ipsa est <lb/> corpore melior,
+						melius putandum est omne quod in <lb/> ea fil, qnam omne quod lit iri
+						corpore. Credo enim <lb/> tibi ,Meri verum falso esse præponendum. D. Quis
+						<lb/> dubitaverit? <hi rend="italic">M.</hi> Num vero est arbor, quam
+						videmus <lb/> in somnis? <hi rend="italic">D.</hi> Nullo modo. <hi
+							rend="italic">M.</hi> At ejus forma inaaima <lb/> fit, hujus autem, quam
+						nuuc videmus, in corpore <lb/> facta cst. Quare cnm ct verum falso, et anima
+						corpore <lb/> melior sit, verum in cerpore melius est quam falsum <lb/> in
+						anima. Sed ut hoc in quantum vcrum, non in quan­ <lb/> tum in corpore fit,
+						melius est; ita illud in quantum fal­ <lb/> sum, non in quanluln in anima
+						fit, fortasse est dete­ <lb/> rius. Nisi quid habes ad hæc. <hi
+							rend="italic">D.</hi> N.hil cquidem. <hi rend="italic">M.</hi> Au­ <lb/>
+						di aHud quod sit, ut puto, vicinius quam melius1. Neque <lb/> enimnegabis,
+						quod dccet esse melius, quam id quod <lb/> non decet. <hi rend="italic"
+							>D.</hi> imo fatcor. M. At in qua veste decens <lb/> cst mulier, in
+						cadem virum indecentem esse posse, quis <lb/> ambigat? <hi rend="italic"
+							>D.</hi> Et hoc manifestum est. M. Quid si ergo <lb/> forma ista
+						numerorum decet in sonis, qui allabuutur <lb/> auribus, et dedecet in anima,
+						curO cos sentiendo ac <lb/> patiendo habet, num magnopere mirandum esL?
+						<lb/> D. Non opinor. M. Quid ergo dubitamus sonantes no­ <lb/> meros atque
+						corporeos præponere iis qui ab ipsis <lb/> fiunt, quamvis in anima fiant,
+						qunc corpore est me­ <lb/> lior? quia numeros numeris, efficientes factisnon
+						<lb/> corpus animæ præponimus. Corpora enim tanto me­ <lb/> liora sunt,
+						quanto numerosiora talibus uumeris. Anima <lb/> vero istis quæ per corpus
+						accipit, carendo fit melior, <lb/> cum sese avertit a carnalibus sensibus,
+						et divinis sa­ <lb/> pientiæ numeris reformatur (a). Ita quippe in Scripta­
+						<lb/> ris sanctis dicitur : <hi rend="italic">Circumivi ego, ut scirem et
+							conside­ <lb/> rarem et qu</hi>æ<hi rend="italic">rerem sapientiam et
+							numerum (Ercle.</hi> VII, <lb/> 26). Quod nu'lo modo arbitrandum est de
+						his nume­ <lb/> ris dictum, quibus etiam flagitiosa theatra personant: <lb/>
+						sed de illis, credo, quos non a corpore accipit anima, <lb/> scd acceptos a
+						sununo Dco ipsa potius imprimit cor­ <lb/> pori. Quod quale sit, non hoc
+						loco est considerandum.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT V. — <hi rend="italic">Anima an a corpore patiatur,
+								et quomodo sentiat.</hi>
 						</title>
 					</ab>
-					<p>8. Verumtamen ne illud occurrat, arboris vitam <lb/> meliorem esse quam nostram,
-						quoniam non accipit <lb/> sentiendo a corpore numeros (nullus-enim ei sensus <lb/> est)
-						; diligenter considerandum est utrum revera nihil <lb/> sil aliud quod dicitur audire,
-						nisi aliquid a corpore in <lb/> anima fieri. Sed perabsurdum est fabricatori corpori
-						<lb/> materiam quoquo modo animam subdere. Nunqnam <lb/> enim anima est corpore
-						dclerior; et omnis materia <lb/> fabricatore deterior. Nullo modo igitur anima fa- <note type="footnote">1 Editi : <hi rend="italic">ft ptUo vtcinius. yeqite eniin
-								negabis;</hi> omisso <lb/> quan nteGas, quod ex MSS. restituimus. </note><note type="footnote"> * Juxta Ms. A : <hi rend="italic">At facienics fact s.</hi> M. </note>
-						<lb/> bricatori corpori est subjecta materies. Essa au­ <lb/> tem, si aliquos in ea
-						numeros corpus operaretur. <lb/> Non ergo, cum audimus, fiunt in anima numeri ab iia
-						<lb/> quos in sotiis cognoscimus. An aliquid renuis ? D. Quid <lb/> est ergo quod in
-						audiente contingit? <hi rend="italic">M.</hi> Quidquid i!. <lb/> lud sit quod fortasse
-						invenire aut explicare non pos­ <lb/> sumus, num ad hoc valebit, ut animam corpore me­
-						<lb/> liorem esse dubitemus ? Aut cum hoc fatemur, pote. <lb/> rimusne operanli corpori
-						et numeros imponenti cam <lb/> subdere; ut illud sit fabricans, haec autem materies
-						<lb/> de qua et in qua numerosum aliquid fabricetur ? Quod <lb/> si credimus, deteriorem
-						iilam credamus neccsse est. <lb/> Quo quid miserius , quid detestabilius credi potest?
-						<lb/> Quæ cum ita sint, conabor equidem 4, quantum Deus <lb/> adjuvare dignabitur,
-						quidnam ibi lateat conjectare at­ <lb/> que disserere. Sed si hoc propter utriusque aut
-						alte. <lb/> rius nostrum infirmitatem minus pro voluntate suc­ <lb/> cesserit, vel nos
-						ipsi alias sercniores id investigabimus, <lb/> vel intelligentioribus investiganda
-						deferemus, vel aequo <lb/> animo latere patiemur: non tamen ideo ista certiora <lb/> de
-						manibus debemus amittere. <hi rend="italic">D.</hi> Tenebo istud in­ <lb/> concussum si
-						potero, et tamen latebram istam non <lb/> esse impenetrabilem nobis velim.</p>
-					<p>9. <hi rend="italic">M.</hi> Cito dicam quid sentio : tu vero aut sequere, <lb/> aut
-						etiam præcede, si valebis, ubi me cunctari et hæ­ <lb/> sitare animadverteris. Ego enim
-						ab anima boc corpus <lb/> animari non puto, nisi intentione facientis. Nec ab <lb/> isto
-						quidquam illam pati arbitror, sed facere de illo et <lb/> in illo tanquam subjecto
-						divinitus dominationi suae : <lb/> aliquando tamen cum facilitate, aliquando cam difO­
-						<lb/> cultate operari, quanto pro ejus meritis magis minua­ <lb/> ve illi cedit natura
-						corporea. Corporalia ergo quæcum­ <lb/> que huic corpori ingeruntur aut objiciuntur
-						exlriuse­ <lb/> cus, non in anima, sed in ipso corpore aliquid faciunt, <lb/> quoJ operi
-						ejus aut adversetur, aut congruat. Ideo­ <lb/> que cum rcnitilur adversanti, et materiam
-						sibi sub­ <lb/> jectam in operis sui vias difficulier impingit, fit at­ <lb/> tcutior ex
-						difficultate in actionem; quæ difficultas <lb/> propter attentionem, eum eam non latet,
-						sentire di­ <lb/> citur, et hoc vocatur dolor aut labor. Cum autem con­ <lb/> gruit quod
-						infertur, aut adjacet, facile totum id vel <lb/> ex eo quantum opus est, in sui operis
-						itinera traducit. <lb/> Et ista ejus actio qua suum corpus convenienti ex­ <lb/>
-						trinsecus corpori adjungit, quoniam propter quiddam . <lb/> adventitium attentius
-						agitur, non latet; sed propter <lb/> convenientiam, cum voluptate sentitur. Atcum desunt
-						<lb/> ca quibus corporis detrimenta reficiat, egestas conse­ <lb/> quitur; et hac
-						actionis difficultate cuin fit attentior, <lb/> et talis ejus operatio non cam latet,
-						fames aut sitis, <lb/> aut tale aliquid appellatur. Cum aulcm supersuut in­ <lb/> gesta,
-						et ex eoram onere nascitur difficultas operandi, <lb/> neque hoc sine attentione fit; et
-						cum talis actio nun <lb/> latet, cruditas sentitur : attente etiam operatur cum <lb/>
-						ejicit superfluum, si leniicr, cum voluptate; si aspere, <lb/> cum dolore. Morbidam
-						quoque perturbationem cor­ <lb/> puris attente agit, succurrere appetens labenti atque
-						<lb/> diffluenti; et hac actione non latente morbos et ægro­ <lb/> tationes sentire
-						dicitur. <note type="footnote"> 1 Juxta Ms. A, <hi rend="italic">conabor</hi> etiam. M. </note>
+					</div><div type="textpart" subtype="dialog"><p>8. Verumtamen ne illud occurrat, arboris vitam <lb/> meliorem esse quam
+						nostram, quoniam non accipit <lb/> sentiendo a corpore numeros (nullus-enim
+						ei sensus <lb/> est) ; diligenter considerandum est utrum revera nihil <lb/>
+						sil aliud quod dicitur audire, nisi aliquid a corpore in <lb/> anima fieri.
+						Sed perabsurdum est fabricatori corpori <lb/> materiam quoquo modo animam
+						subdere. Nunqnam <lb/> enim anima est corpore dclerior; et omnis materia
+						<lb/> fabricatore deterior. Nullo modo igitur anima fa- <note
+							type="footnote">1 Editi : <hi rend="italic">ft ptUo vtcinius. yeqite
+								eniin negabis;</hi> omisso <lb/> quan nteGas, quod ex MSS.
+							restituimus. </note><note type="footnote"> * Juxta Ms. A : <hi
+								rend="italic">At facienics fact s.</hi> M. </note>
+						<lb/> bricatori corpori est subjecta materies. Essa au­ <lb/> tem, si
+						aliquos in ea numeros corpus operaretur. <lb/> Non ergo, cum audimus, fiunt
+						in anima numeri ab iia <lb/> quos in sotiis cognoscimus. An aliquid renuis ?
+						D. Quid <lb/> est ergo quod in audiente contingit? <hi rend="italic">M.</hi>
+						Quidquid i!. <lb/> lud sit quod fortasse invenire aut explicare non pos­
+						<lb/> sumus, num ad hoc valebit, ut animam corpore me­ <lb/> liorem esse
+						dubitemus ? Aut cum hoc fatemur, pote. <lb/> rimusne operanli corpori et
+						numeros imponenti cam <lb/> subdere; ut illud sit fabricans, haec autem
+						materies <lb/> de qua et in qua numerosum aliquid fabricetur ? Quod <lb/> si
+						credimus, deteriorem iilam credamus neccsse est. <lb/> Quo quid miserius ,
+						quid detestabilius credi potest? <lb/> Quæ cum ita sint, conabor equidem 4,
+						quantum Deus <lb/> adjuvare dignabitur, quidnam ibi lateat conjectare at­
+						<lb/> que disserere. Sed si hoc propter utriusque aut alte. <lb/> rius
+						nostrum infirmitatem minus pro voluntate suc­ <lb/> cesserit, vel nos ipsi
+						alias sercniores id investigabimus, <lb/> vel intelligentioribus
+						investiganda deferemus, vel aequo <lb/> animo latere patiemur: non tamen
+						ideo ista certiora <lb/> de manibus debemus amittere. <hi rend="italic"
+							>D.</hi> Tenebo istud in­ <lb/> concussum si potero, et tamen latebram
+						istam non <lb/> esse impenetrabilem nobis velim.</p>
+					</div><div type="textpart" subtype="dialog"><p>9. <hi rend="italic">M.</hi> Cito dicam quid sentio : tu vero aut sequere,
+						<lb/> aut etiam præcede, si valebis, ubi me cunctari et hæ­ <lb/> sitare
+						animadverteris. Ego enim ab anima boc corpus <lb/> animari non puto, nisi
+						intentione facientis. Nec ab <lb/> isto quidquam illam pati arbitror, sed
+						facere de illo et <lb/> in illo tanquam subjecto divinitus dominationi suae
+						: <lb/> aliquando tamen cum facilitate, aliquando cam difO­ <lb/> cultate
+						operari, quanto pro ejus meritis magis minua­ <lb/> ve illi cedit natura
+						corporea. Corporalia ergo quæcum­ <lb/> que huic corpori ingeruntur aut
+						objiciuntur exlriuse­ <lb/> cus, non in anima, sed in ipso corpore aliquid
+						faciunt, <lb/> quoJ operi ejus aut adversetur, aut congruat. Ideo­ <lb/> que
+						cum rcnitilur adversanti, et materiam sibi sub­ <lb/> jectam in operis sui
+						vias difficulier impingit, fit at­ <lb/> tcutior ex difficultate in
+						actionem; quæ difficultas <lb/> propter attentionem, eum eam non latet,
+						sentire di­ <lb/> citur, et hoc vocatur dolor aut labor. Cum autem con­
+						<lb/> gruit quod infertur, aut adjacet, facile totum id vel <lb/> ex eo
+						quantum opus est, in sui operis itinera traducit. <lb/> Et ista ejus actio
+						qua suum corpus convenienti ex­ <lb/> trinsecus corpori adjungit, quoniam
+						propter quiddam . <lb/> adventitium attentius agitur, non latet; sed propter
+						<lb/> convenientiam, cum voluptate sentitur. Atcum desunt <lb/> ca quibus
+						corporis detrimenta reficiat, egestas conse­ <lb/> quitur; et hac actionis
+						difficultate cuin fit attentior, <lb/> et talis ejus operatio non cam latet,
+						fames aut sitis, <lb/> aut tale aliquid appellatur. Cum aulcm supersuut in­
+						<lb/> gesta, et ex eoram onere nascitur difficultas operandi, <lb/> neque
+						hoc sine attentione fit; et cum talis actio nun <lb/> latet, cruditas
+						sentitur : attente etiam operatur cum <lb/> ejicit superfluum, si leniicr,
+						cum voluptate; si aspere, <lb/> cum dolore. Morbidam quoque perturbationem
+						cor­ <lb/> puris attente agit, succurrere appetens labenti atque <lb/>
+						diffluenti; et hac actione non latente morbos et ægro­ <lb/> tationes
+						sentire dicitur. <note type="footnote"> 1 Juxta Ms. A, <hi rend="italic"
+								>conabor</hi> etiam. M. </note>
 						<pb n="1169"/>
 					</p>
-					<p>10. Et ne longum faciam, videtur mibranima cum <lb/> sentit in corpore, non ab illo
-						aliquid pati, sed in ejus <lb/> passionibus attentius agere, et has actiones sive faci­
-						<lb/> les propter convenientiam, sive difficiles propter in­ <lb/> convenientiam, non
-						eam latere : et hoc totum est <lb/> quod sentire dicitur. Sed iste sensus, qui etiam dum
-						<lb/> nihil sentimus, inest tamen, instrumentum est corpo­ <lb/> ris , quod ea
-						temperatione agitur ab anima , ut In co <lb/> sit ad passiones corporis cum attentione
-						agendas pa­ <lb/> ratior, similia similibus ut adjungat, repellatque quod <lb/> noxium
-						est. Agit porro, ut opinor, luminosum aliquid <lb/> in oculis, aerium serenissimum et
-						mobilissimum in <lb/> auribus, caliginosum in naribus, in ore humidum, in <lb/> tactu
-						terrenum et quasi lutulentum. Sed sive hac sive <lb/> alia disiributione ista
-						conjiciantur; agit hæc anima <lb/> eum quiete ,. si ea quae insunt in unitate
-						vuletudmis, <lb/> quasi familiari quadam consensione cesserunt'. Cum <lb/> autem
-						adhibentur ea quae nonnulla, ut ita dicam, al­ <lb/> teritate corpus afficiunt; exserit
-						attentiores actiones, <lb/> suis quibusque locis atque instrumentis accommoda­ <lb/> tas
-						: tunc videre, vel audire, vel olfacere, vel gustare, <lb/> vel tangendo sentire
-						dicitur; quibus actionibus con­ <lb/> grua libenter associat, et moleste obsistit incon­
-						<lb/> gruis. Has operationes passionibus corporis puto ani­ <lb/> mam exhibere cutn
-						sentit, non easdem passiones <lb/> recipere.</p>
-					<p>ii. Quapropter cum de sonorum numeris in præ­ <lb/> sentia quæratur, et sensus aurium
-						vocetur in dubium, <lb/> non oportet per cætera diutius evagari. Referamus <lb/> itaquc
-						nos ad id de quo agitur, et videamus utrum <lb/> sonus in auribus aliquid faciat. An tu
-						id negabis! <lb/> 0. Nihil minus. <hi rend="italic">M.</hi> Quid? easdem aures animatum
-						<lb/> membrum esse nonne concedis? <hi rend="italic">D.</hi> Concedo. <hi rend="italic">M.</hi> Cum <lb/> ergo id quod in eo membro simile est aeri, moveatur <lb/> aere
-						percusso ; animam illam quæ ante istum sonum <lb/> vitali motu in silentio corpus aurium
-						vegetabat, num <lb/> putamus aut cessare posse ab opere movendi quod <lb/> animat, aut
-						eodem modo movere commotum extrin­ <lb/> secus aerem auris suæ , quo movebat antequam
-						ille <lb/> illaberetur sonus? <hi rend="italic">D.</hi> Non videtur nisi aliter. <hi rend="italic">M.</hi> noc <lb/> ergo aliter movere 2, nonne fatendum est facere esse,
-						<lb/> non pati? <hi rend="italic">D.</hi> Ita est. M. Non igllur absurde eredimus <lb/>
-						motus suns animam, vel actiones, vel operationes, vel <lb/> si quo alio nomine commodius
-						significari possunt, non <lb/> latere cum sentit.</p>
-					<p>12. Hae autem operationes, vel præcedentibus cor­ <lb/> porum passionibus adhibentur;
-						ut sust cum illae ocn­ <lb/> lorum nostrorum lucem formae interpellant, aut in <lb/>
-						aures influit sonus, aut naribus exhalationes, pal'ato <lb/> sapores, caetero corpori
-						qualibet solida et corpulenta <lb/> admoventur extrinsecus, vel in ipso corpore de loco
-						<lb/> in loeuro migrat aliqnid aive transit, vel totum ipsum <lb/> corpus suo alienove
-						pondere movetur: hac sunt opera­ <lb/> tiones quas adhibet anima præcedentibus
-						passionibus <lb/> corporis; quæ delectant eam associantem, offendunt <lb/> resistentem.
-						Cum autem ab eisdem suis operationi­ <note type="footnote">' Sic Mss. omnes praeter
-							vaticanum, qui cum Am. et Cr. <lb/> habet, <hi rend="italic">coh</hi>æ<hi rend="italic">serint.</hi> At tov., <hi rend="italic">concesserint.</hi>
-						</note><note type="footnote"> I In editis : <hi rend="italic">A&lt;w! videlwr mihi
-								aliler. M. noc ergo getwt</hi>
-							<lb/> Itiliter <hi rend="italic">movcre.</hi> At in melioribus Mss lectio nostra
-							cxhilctur. x </note>
-						<lb/> bus aliquid patitur , a seipsa patitur, non a corpore; <lb/> sed plane cum se
-						accommodat corpori: ct ideo apud <lb/> scipsam minus est, qnia corpus semper minus quam
-						<lb/> ipsa est.</p>
-					<p>13. Conversa ergo a Domino suo ad servum suum, <lb/> necessario deficit - conversa item
-						a servo suo ad Do <lb/> minum suum, nccessario proficit , et præbet cidem <lb/> seno
-						facillimam vitam, ct propterea minime opero­ <lb/> sam et negotiosam , ad quam propter
-						summam quio­ <lb/> tem nulla detorqueatur attentio ; sicut est alfeclio <lb/> corporis
-						quae sanitas dicitur : nulla quippe attentiono <lb/> nostra opus habet, non quia nihil
-						tunc agit anima in <lb/> corpore, sed quia nihil facilius agit. Nam in omnibus <lb/>
-						operibus nostris tanto quidquam attentius, quanto <lb/> difficilius operamur. Hæc autem
-						sanitas tunc firmis­ <lb/> sima erit atque certissima , cum pristinæ stabilitati, <lb/>
-						certo suo tempore atque ordinc, hoc corpus fucrit <lb/> restitutum (a), quæ resurrectio
-						ejus antequam plenis­ <lb/> sime intelligatur, salubriter creditur. Oportet enim <lb/>
-						animam et regi a superiore, et regere inferiorem. <lb/> Superior illa solus Deus cst,
-						inferius illa solum cor­ <lb/> pus, si ad omnem et totam : nininm intendas. Ut ergo
-						<lb/> tota esse sine Domino , sic excellere sine servo non <lb/> potest. Ut autem
-						Dominus ejus magis est quam ipsa, <lb/> ita servus minus. Quare intenta in Dominum
-						intelligit <lb/> aeterna ejus, et magis est, magisque est etiam ipse <lb/> servus in suo
-						genere per illam. Neglecto autcm Do­ <lb/> mino intenta in servum carnali qua ducitur
-						concu­ <lb/> piscentia 1, sentit motus suos quos illi cxhibct, et. <lb/> minus est : nec
-						tamen tantum niinus, quantum ipso <lb/> servus, etiam cum maxime cst in natura propria.
-						Hæc <lb/> antem delicto dominæ multo minus est quam crat, <lb/> cum illa ante delictum
-						magis esset *.</p>
-					<p>14. Quocirca mortali jam et fragili, cum magna <lb/> difficultate atque attentione
-						dominatur. Hinc illi error <lb/> incurrit, ut voluptatem corporis, quia ejus attention;
-						<lb/> cedit materies, pluris sestimct quam ipsam sanitatem, <lb/> cui attentione nulla
-						opus est. Nec mirum, si aerumnis <lb/> implicatur, præponens curam securitati.
-						Convertenti <lb/> se antem ad Dominum, major cura oritur, ne averta­ <lb/> lur; donec
-						carnalium negotiorum requiescat impetus, <lb/> effrenatus consuctudinc diuturna, et
-						tumultuosis rc­ <lb/> cordationibus conversioni ejus sese inserens : ita se­ <lb/> datis
-						motibus suis quibus in exteriora provehebatur, <lb/> agit otium intrinsecus libcruln,
-						quod significatur sab­ <lb/> bato; sic cognoscit solum Dcum esse Dominum suum, <lb/> cui
-						uni summa libertate servitur. Non autem illos <lb/> carnales motus, ut cum libct
-						exserit, ita etiam cum <lb/> libet exstinguit. Non enim sicut peccatum in ejas 1 o-
-						<lb/> testate est, ita etiam poena peccati. Magna quippe res <lb/> cst ipsa anima, nec
-						ad opprimendus lascivos molis <lb/> suO! idonea sibi remanet. Valentior emm peccat, et
-						<lb/> post peccatum divina lege facta imbecillior, minus <lb/> potens est auferre quod
+					</div><div type="textpart" subtype="dialog"><p>10. Et ne longum faciam, videtur mibranima cum <lb/> sentit in corpore, non
+						ab illo aliquid pati, sed in ejus <lb/> passionibus attentius agere, et has
+						actiones sive faci­ <lb/> les propter convenientiam, sive difficiles propter
+						in­ <lb/> convenientiam, non eam latere : et hoc totum est <lb/> quod
+						sentire dicitur. Sed iste sensus, qui etiam dum <lb/> nihil sentimus, inest
+						tamen, instrumentum est corpo­ <lb/> ris , quod ea temperatione agitur ab
+						anima , ut In co <lb/> sit ad passiones corporis cum attentione agendas pa­
+						<lb/> ratior, similia similibus ut adjungat, repellatque quod <lb/> noxium
+						est. Agit porro, ut opinor, luminosum aliquid <lb/> in oculis, aerium
+						serenissimum et mobilissimum in <lb/> auribus, caliginosum in naribus, in
+						ore humidum, in <lb/> tactu terrenum et quasi lutulentum. Sed sive hac sive
+						<lb/> alia disiributione ista conjiciantur; agit hæc anima <lb/> eum quiete
+						,. si ea quae insunt in unitate vuletudmis, <lb/> quasi familiari quadam
+						consensione cesserunt'. Cum <lb/> autem adhibentur ea quae nonnulla, ut ita
+						dicam, al­ <lb/> teritate corpus afficiunt; exserit attentiores actiones,
+						<lb/> suis quibusque locis atque instrumentis accommoda­ <lb/> tas : tunc
+						videre, vel audire, vel olfacere, vel gustare, <lb/> vel tangendo sentire
+						dicitur; quibus actionibus con­ <lb/> grua libenter associat, et moleste
+						obsistit incon­ <lb/> gruis. Has operationes passionibus corporis puto ani­
+						<lb/> mam exhibere cutn sentit, non easdem passiones <lb/> recipere.</p>
+					</div><div type="textpart" subtype="dialog"><p>11. Quapropter cum de sonorum numeris in præ­ <lb/> sentia quæratur, et
+						sensus aurium vocetur in dubium, <lb/> non oportet per cætera diutius
+						evagari. Referamus <lb/> itaquc nos ad id de quo agitur, et videamus utrum
+						<lb/> sonus in auribus aliquid faciat. An tu id negabis! <lb/> 0. Nihil
+						minus. <hi rend="italic">M.</hi> Quid? easdem aures animatum <lb/> membrum
+						esse nonne concedis? <hi rend="italic">D.</hi> Concedo. <hi rend="italic"
+							>M.</hi> Cum <lb/> ergo id quod in eo membro simile est aeri, moveatur
+						<lb/> aere percusso ; animam illam quæ ante istum sonum <lb/> vitali motu in
+						silentio corpus aurium vegetabat, num <lb/> putamus aut cessare posse ab
+						opere movendi quod <lb/> animat, aut eodem modo movere commotum extrin­
+						<lb/> secus aerem auris suæ , quo movebat antequam ille <lb/> illaberetur
+						sonus? <hi rend="italic">D.</hi> Non videtur nisi aliter. <hi rend="italic"
+							>M.</hi> noc <lb/> ergo aliter movere 2, nonne fatendum est facere esse,
+						<lb/> non pati? <hi rend="italic">D.</hi> Ita est. M. Non igllur absurde
+						eredimus <lb/> motus suns animam, vel actiones, vel operationes, vel <lb/>
+						si quo alio nomine commodius significari possunt, non <lb/> latere cum
+						sentit.</p>
+					</div><div type="textpart" subtype="dialog"><p>12. Hae autem operationes, vel præcedentibus cor­ <lb/> porum passionibus
+						adhibentur; ut sust cum illae ocn­ <lb/> lorum nostrorum lucem formae
+						interpellant, aut in <lb/> aures influit sonus, aut naribus exhalationes,
+						pal'ato <lb/> sapores, caetero corpori qualibet solida et corpulenta <lb/>
+						admoventur extrinsecus, vel in ipso corpore de loco <lb/> in loeuro migrat
+						aliqnid aive transit, vel totum ipsum <lb/> corpus suo alienove pondere
+						movetur: hac sunt opera­ <lb/> tiones quas adhibet anima præcedentibus
+						passionibus <lb/> corporis; quæ delectant eam associantem, offendunt <lb/>
+						resistentem. Cum autem ab eisdem suis operationi­ <note type="footnote">'
+							Sic Mss. omnes praeter vaticanum, qui cum Am. et Cr. <lb/> habet, <hi
+								rend="italic">coh</hi>æ<hi rend="italic">serint.</hi> At tov., <hi
+								rend="italic">concesserint.</hi>
+						</note><note type="footnote"> I In editis : <hi rend="italic">A&lt;w!
+								videlwr mihi aliler. M. noc ergo getwt</hi>
+							<lb/> Itiliter <hi rend="italic">movcre.</hi> At in melioribus Mss
+							lectio nostra cxhilctur. x </note>
+						<lb/> bus aliquid patitur , a seipsa patitur, non a corpore; <lb/> sed plane
+						cum se accommodat corpori: ct ideo apud <lb/> scipsam minus est, qnia corpus
+						semper minus quam <lb/> ipsa est.</p>
+					</div><div type="textpart" subtype="dialog"><p>13. Conversa ergo a Domino suo ad servum suum, <lb/> necessario deficit -
+						conversa item a servo suo ad Do <lb/> minum suum, nccessario proficit , et
+						præbet cidem <lb/> seno facillimam vitam, ct propterea minime opero­ <lb/>
+						sam et negotiosam , ad quam propter summam quio­ <lb/> tem nulla
+						detorqueatur attentio ; sicut est alfeclio <lb/> corporis quae sanitas
+						dicitur : nulla quippe attentiono <lb/> nostra opus habet, non quia nihil
+						tunc agit anima in <lb/> corpore, sed quia nihil facilius agit. Nam in
+						omnibus <lb/> operibus nostris tanto quidquam attentius, quanto <lb/>
+						difficilius operamur. Hæc autem sanitas tunc firmis­ <lb/> sima erit atque
+						certissima , cum pristinæ stabilitati, <lb/> certo suo tempore atque ordinc,
+						hoc corpus fucrit <lb/> restitutum (a), quæ resurrectio ejus antequam
+						plenis­ <lb/> sime intelligatur, salubriter creditur. Oportet enim <lb/>
+						animam et regi a superiore, et regere inferiorem. <lb/> Superior illa solus
+						Deus cst, inferius illa solum cor­ <lb/> pus, si ad omnem et totam : nininm
+						intendas. Ut ergo <lb/> tota esse sine Domino , sic excellere sine servo non
+						<lb/> potest. Ut autem Dominus ejus magis est quam ipsa, <lb/> ita servus
+						minus. Quare intenta in Dominum intelligit <lb/> aeterna ejus, et magis est,
+						magisque est etiam ipse <lb/> servus in suo genere per illam. Neglecto autcm
+						Do­ <lb/> mino intenta in servum carnali qua ducitur concu­ <lb/> piscentia
+						1, sentit motus suos quos illi cxhibct, et. <lb/> minus est : nec tamen
+						tantum niinus, quantum ipso <lb/> servus, etiam cum maxime cst in natura
+						propria. Hæc <lb/> antem delicto dominæ multo minus est quam crat, <lb/> cum
+						illa ante delictum magis esset *.</p>
+					</div><div type="textpart" subtype="dialog"><p>14. Quocirca mortali jam et fragili, cum magna <lb/> difficultate atque
+						attentione dominatur. Hinc illi error <lb/> incurrit, ut voluptatem
+						corporis, quia ejus attention; <lb/> cedit materies, pluris sestimct quam
+						ipsam sanitatem, <lb/> cui attentione nulla opus est. Nec mirum, si aerumnis
+						<lb/> implicatur, præponens curam securitati. Convertenti <lb/> se antem ad
+						Dominum, major cura oritur, ne averta­ <lb/> lur; donec carnalium negotiorum
+						requiescat impetus, <lb/> effrenatus consuctudinc diuturna, et tumultuosis
+						rc­ <lb/> cordationibus conversioni ejus sese inserens : ita se­ <lb/> datis
+						motibus suis quibus in exteriora provehebatur, <lb/> agit otium intrinsecus
+						libcruln, quod significatur sab­ <lb/> bato; sic cognoscit solum Dcum esse
+						Dominum suum, <lb/> cui uni summa libertate servitur. Non autem illos <lb/>
+						carnales motus, ut cum libct exserit, ita etiam cum <lb/> libet exstinguit.
+						Non enim sicut peccatum in ejas 1 o- <lb/> testate est, ita etiam poena
+						peccati. Magna quippe res <lb/> cst ipsa anima, nec ad opprimendus lascivos
+						molis <lb/> suO! idonea sibi remanet. Valentior emm peccat, et <lb/> post
+						peccatum divina lege facta imbecillior, minus <lb/> potens est auferre quod
 						lecit. <hi rend="italic">Infelix ego homo, quis</hi>
-						<note type="footnote">1 Er. hahet, <hi rend="italic">carnaletn;</hi> lov., <hi rend="italic">cartwlis:</hi> Am., <hi rend="italic">carnali,</hi> quo­ <lb/> modo
-							etiam octo Mss. supra Vaticanuui, qui unus sic prose­ <lb/> quitur : <hi rend="italic">carnali qua ducitur concupucetdia. [camali qtios di­ <lb/> Citur
-								concupiscentia.]</hi>
-						</note><note type="footnote"> I Sic legc;odu;n videtur juitaMss.At Am .£, et Lov. Ita-
-							<lb/> bent: <hi rend="italic">cum ille ante delictum nicgis esset.</hi>
+						<note type="footnote">1 Er. hahet, <hi rend="italic">carnaletn;</hi> lov.,
+								<hi rend="italic">cartwlis:</hi> Am., <hi rend="italic"
+								>carnali,</hi> quo­ <lb/> modo etiam octo Mss. supra Vaticanuui, qui
+							unus sic prose­ <lb/> quitur : <hi rend="italic">carnali qua ducitur
+								concupucetdia. [camali qtios di­ <lb/> Citur concupiscentia.]</hi>
+						</note><note type="footnote"> I Sic legc;odu;n videtur juitaMss.At Am .£, et
+							Lov. Ita- <lb/> bent: <hi rend="italic">cum ille ante delictum nicgis
+								esset.</hi>
 						</note>
 						<note type="footnote">
 							<hi rend="italic">(a)</hi> vid. Retract. lib. i, cap. ii, n. 3. </note>
 						<lb/>
 						<pb n="1171"/>
-						<hi rend="italic">me liberabil de corpore mortis hujus ? Gratia Dei per <lb/> Jesum</hi>
-						CAntum <hi rend="italic">Dominum nostrum (Hom.</hi> VII, 24, 25). <lb/> Motus igitur
-						animæ servans impetum suum, et non­ <lb/> dum exstinctus, in memoria esse dicitur : et
-						cnm in <lb/> alind intenditur animus, quasi non inest animo pristi­ <lb/> nus motus, et
-						revera minor fit, nisi antequam interci­ <lb/> dat, quadam similium vicinitate
-						renovetur.</p>
-					<p>15. Sed velim scire, utrum te adversus ista nihil <lb/> moveat. <hi rend="italic">D.</hi> Probabiliter mihi dicere videris, nec au­ <lb/> sim resistere. <hi rend="italic">M.</hi> Cum igitur ipsum sentire movere <lb/> sit corpus adversus illum
-						motum qui in eo factus est, <lb/> nonne existimas ideo nos non sentire cum ossa et <lb/>
-						ungues et capilli secantur, non quia ista in nobis <lb/> omnino non vivunt, non enim
-						aliter aut continerentur <lb/> aut nutrirentur aut crescerent, aut etiam vim suam <lb/>
-						in serenda prole monstrarent; sed quia minus libero <lb/> acre penetrantur, mobili
-						scilicet elemento, quam ut <lb/> motus ibi possit ab anima fleri tam celer, quam est
-						ille <lb/> adversus quem fit cum sentire dicitur. Talis quaedam <lb/> vita cum in
-						arboribus atque stirpibus cæteris esse in­ <lb/> telligatur, nullo modo eam non solum
-						nostro quæ ra­ <lb/> tione etiam præpollet, sed ne ipsi quidem belluinæ <lb/> decet
-						præponere. Aliud est enim summa stoliditatc, <lb/> aliud summa sanitate corporis nihil
-						sentirc. Nam in <lb/> altero instrumenta desunt, quae adversus passiones <lb/> corporis
+						<hi rend="italic">me liberabil de corpore mortis hujus ? Gratia Dei per
+							<lb/> Jesum</hi> CAntum <hi rend="italic">Dominum nostrum (Hom.</hi>
+						VII, 24, 25). <lb/> Motus igitur animæ servans impetum suum, et non­ <lb/>
+						dum exstinctus, in memoria esse dicitur : et cnm in <lb/> alind intenditur
+						animus, quasi non inest animo pristi­ <lb/> nus motus, et revera minor fit,
+						nisi antequam interci­ <lb/> dat, quadam similium vicinitate renovetur.</p>
+					</div><div type="textpart" subtype="dialog"><p>15. Sed velim scire, utrum te adversus ista nihil <lb/> moveat. <hi
+							rend="italic">D.</hi> Probabiliter mihi dicere videris, nec au­ <lb/>
+						sim resistere. <hi rend="italic">M.</hi> Cum igitur ipsum sentire movere
+						<lb/> sit corpus adversus illum motum qui in eo factus est, <lb/> nonne
+						existimas ideo nos non sentire cum ossa et <lb/> ungues et capilli secantur,
+						non quia ista in nobis <lb/> omnino non vivunt, non enim aliter aut
+						continerentur <lb/> aut nutrirentur aut crescerent, aut etiam vim suam <lb/>
+						in serenda prole monstrarent; sed quia minus libero <lb/> acre penetrantur,
+						mobili scilicet elemento, quam ut <lb/> motus ibi possit ab anima fleri tam
+						celer, quam est ille <lb/> adversus quem fit cum sentire dicitur. Talis
+						quaedam <lb/> vita cum in arboribus atque stirpibus cæteris esse in­ <lb/>
+						telligatur, nullo modo eam non solum nostro quæ ra­ <lb/> tione etiam
+						præpollet, sed ne ipsi quidem belluinæ <lb/> decet præponere. Aliud est enim
+						summa stoliditatc, <lb/> aliud summa sanitate corporis nihil sentirc. Nam in
+						<lb/> altero instrumenta desunt, quae adversus passiones <lb/> corporis
 						moveantur, in altero ipsae passiones.D. Probo <lb/> et assentior.</p>
-					<ab>
-						<title type="sub">CAPUT VI. — <hi rend="italic">Inter genera numerorum ordo, et eorum
-								nomina.</hi>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT VI. — <hi rend="italic">Inter genera numerorum ordo,
+								et eorum nomina.</hi>
 						</title>
 					</ab>
-					<p>16. M. Redi ergo mecum ad propositum, atque <lb/> responde de tribus illis generibus
-						numerorum, quo­ <lb/> rum alterum in memoria est, alterum in sentiendo, <lb/> alterum in
-						sono, quodnam tibi videatur excellere. <lb/>
-						<hi rend="italic">D.</hi> Sonum duobus illis postpono quæ in anima sunt <lb/> ct vivunt
-						quodammodo : ped horum duorum quod <lb/> præstantius judicem, incertus sum, nisi forte
-						quo­ <lb/> niam illos qui sunt in actione, non ob aliud præpo­ <lb/> nendos iis qui sunt
-						in memoria dixeramus, nisi quod- <lb/> illi facientes sunt, isti ab bis facti; eadem
-						ratione istos <lb/> etiam qui dum audimus insunt in anima, oportet iis <lb/> anteponere
-						qui ab iisdem in memoria fiunt, sicuti et <lb/> dudum mibi videbatur. M. Non puto
-						absurdam re­ <lb/> sponsionem tuam : sed quoniam disputatum est, bos <lb/> etiam qui
-						sunt in sentiendo numeros operationes esse <lb/> animae; quomodo eos ab illis discernis,
-						quos in actu <lb/> esse animadvertimus , etiam cum in silentio non re­ <lb/> cordans
-						agit aliquid anima per temporalia spatia nu­ <lb/> merosum' ? an quod illi sunt moventis
-						sese animæ ad <lb/> corpus suum, hi vero in audiendo moventis sese <lb/> animæ adyersus
-						passiones corporis sui ? <hi rend="italic">D.</hi> Accipio <lb/> istam differentiam. M.
-						Quid? in sententia manen­ <lb/> dumne arbitraris, ut præstantiores illi judicentur qui
-						<lb/> sunt ad corpus, quam illi qui sunt adversus passiones <lb/> corporis? <hi rend="italic">D.</hi> Liberiores mihi videntur illi qui sunt in <lb/> silentio, quam
-						ii qui non solum ad corpus, sed ad pas­ <lb/> siones etiam corporis exseruntur. <hi rend="italic">M.</hi> Distincta a nobis, <lb/> et quibusdam memorum gradibus ordinata
-						video quin­ <note type="footnote"> * Editi: <hi rend="italic">rer kmporalti spatia</hi>
-							numerorum. Reposuimusuu­ <lb/>
+					</div><div type="textpart" subtype="dialog"><p>16. M. Redi ergo mecum ad propositum, atque <lb/> responde de tribus illis
+						generibus numerorum, quo­ <lb/> rum alterum in memoria est, alterum in
+						sentiendo, <lb/> alterum in sono, quodnam tibi videatur excellere. <lb/>
+						<hi rend="italic">D.</hi> Sonum duobus illis postpono quæ in anima sunt
+						<lb/> ct vivunt quodammodo : ped horum duorum quod <lb/> præstantius
+						judicem, incertus sum, nisi forte quo­ <lb/> niam illos qui sunt in actione,
+						non ob aliud præpo­ <lb/> nendos iis qui sunt in memoria dixeramus, nisi
+						quod- <lb/> illi facientes sunt, isti ab bis facti; eadem ratione istos
+						<lb/> etiam qui dum audimus insunt in anima, oportet iis <lb/> anteponere
+						qui ab iisdem in memoria fiunt, sicuti et <lb/> dudum mibi videbatur. M. Non
+						puto absurdam re­ <lb/> sponsionem tuam : sed quoniam disputatum est, bos
+						<lb/> etiam qui sunt in sentiendo numeros operationes esse <lb/> animae;
+						quomodo eos ab illis discernis, quos in actu <lb/> esse animadvertimus ,
+						etiam cum in silentio non re­ <lb/> cordans agit aliquid anima per
+						temporalia spatia nu­ <lb/> merosum' ? an quod illi sunt moventis sese animæ
+						ad <lb/> corpus suum, hi vero in audiendo moventis sese <lb/> animæ adyersus
+						passiones corporis sui ? <hi rend="italic">D.</hi> Accipio <lb/> istam
+						differentiam. M. Quid? in sententia manen­ <lb/> dumne arbitraris, ut
+						præstantiores illi judicentur qui <lb/> sunt ad corpus, quam illi qui sunt
+						adversus passiones <lb/> corporis? <hi rend="italic">D.</hi> Liberiores mihi
+						videntur illi qui sunt in <lb/> silentio, quam ii qui non solum ad corpus,
+						sed ad pas­ <lb/> siones etiam corporis exseruntur. <hi rend="italic"
+							>M.</hi> Distincta a nobis, <lb/> et quibusdam memorum gradibus ordinata
+						video quin­ <note type="footnote"> * Editi: <hi rend="italic">rer kmporalti
+								spatia</hi> numerorum. Reposuimusuu­ <lb/>
 							<hi rend="italic">rnerosvm,</hi> ex auctoritate sex manuscrit torum. </note>
-						<lb/> que genera numerorum, quibus, si placet, imponamus <lb/> congrua vocabula, ne in
-						reliquo sermone pluribus <lb/> verbis quam rebus uti necesse sit. <hi rend="italic">D.</hi> Placet vero. <lb/>
-						<hi rend="italic">II.</hi> Vocentur ergo primi judiciales, secundi progresso­ <lb/> res,
-						tertii occursores, quarti recordabiles, quinti &amp;o­ <lb/> nantes. <hi rend="italic">D.</hi> Teneo, et his nominibus utar libentius.</p>
-					<ab>
-						<title type="sub">CAPUT VII. — <hi rend="italic">Numeri judiciales an</hi> siut im­ <hi rend="italic">mortales.</hi>
+						<lb/> que genera numerorum, quibus, si placet, imponamus <lb/> congrua
+						vocabula, ne in reliquo sermone pluribus <lb/> verbis quam rebus uti necesse
+						sit. <hi rend="italic">D.</hi> Placet vero. <lb/>
+						<hi rend="italic">II.</hi> Vocentur ergo primi judiciales, secundi
+						progresso­ <lb/> res, tertii occursores, quarti recordabiles, quinti &amp;o­
+						<lb/> nantes. <hi rend="italic">D.</hi> Teneo, et his nominibus utar
+						libentius.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT VII. — <hi rend="italic">Numeri judiciales an</hi>
+							siut im­ <hi rend="italic">mortales.</hi>
 						</title>
 					</ab>
-					<p>17. <hi rend="italic">M.</hi> Attende igitur de nceps, et dic mihi, qui­ <lb/> nam
-						istorum immortales tibi videantur, an omnes suis <lb/> temporibus labi atque occidere
-						existimes. <hi rend="italic">D.</hi> Judicia­ <lb/> les solos immortales puto; exteros
-						video vel transire <lb/> cum fiunt, vel de memoria oblivione deleri. M. Tam <lb/> certus
-						es de istorum immortalitate, quam de interitu <lb/> cæterorum; an diligentius, utrum
-						vere hi immortales <lb/> sint, oportet quærere? <hi rend="italic">D.</hi> Quæramus sane.
-						M. Dic <lb/> ergo, cum aliquanto correptius sive productius, dum <lb/> serviam temporum
-						legi qua simplo ad duplum pedes <lb/> conveniunt, versum pronuntio, num offendo ulla
-						<lb/> fraude judicium sensus tui? <hi rend="italic">D.</hi> Non omnino. <hi rend="italic">iI.</hi> Quid? <lb/> sanus ille qui correptioribus et quasi fugacioribus
-						syl­ <lb/> labis editur, num potest plus temporis occupare quam <lb/> sonat? D. Qui
-						potest? M. Judiciales ergo illi numcri <lb/> si vinculo temporis in tanto spatio
-						tenerentur, quanto <lb/> isti sonantes digesti suut; Fossentne ad eorum sonan­ <lb/>
-						tium qui paulo productius eadem iambica lege fundun­ <lb/> tur, aspirare judicium ? <hi rend="italic">D.</hi> Nullo modo. M. Igitur <lb/> apparet bos mora temporum, qni
-						judicando præsi­ <lb/> dent, non teneri. <hi rend="italic">D.</hi> Prorsus apparet.</p>
-					<p>18. <hi rend="italic">II.</hi> Recte annuis. Sed si nulla tenerentur, quan­ <lb/>
-						tolibet productius, legitimis intervallis iambicos pro­ <lb/> ferrem sonos, nihilominus
-						ad judicandum adhibcren­ <lb/> tur: nunc vero si ederem unam syllabam quanta mora <lb/>
-						peraguntur (ne multum dicam) tres passus incedentis, <lb/> et aliam duplo, atque ita
-						deinceps tam longos iambos <lb/> ordinarem; simpli et dupli lex illa nihilosecius serva­
-						<lb/> retur: nec tamen naturale illud judicium his dimen­ <lb/> sionibus approbandis
-						adhibere possemus. An tibi non <lb/> videtur ? <hi rend="italic">D.</hi> Negare non
-						pogsum ita videri: nam mea <lb/> quidem sententia res in aperto est. M. Tenentur ergo
-						<lb/> et hi judiciales nonnullis finibus temporalium spatio­ <lb/> rum, quos in
-						judicando excedere nequeunt , et quid­ <lb/> quid excedit haec spatia, non assequuntur
-						ut judicent : <lb/> atque ita si tenentur, quomodo sint immortales non <lb/> video. D.
-						Nec ego video quid respondeam. Sed quan- <lb/> quam de immortalitate horum jam minus
-						praesumam, <lb/> non tamen quo pacto hinc mortales convincantur in­ <lb/> telligo. Fieri
-						enim potest, ut quantacumque spatia <lb/> judicare possunt, semper id possint, quoniam
-						non <lb/> sicut caetcros, aut oblivione aboleri possum diceret <lb/> aut tamdiu esse vel
-						in tantum extendi, quamdiu sonus <lb/> appellitur et in quantum extenduntur occursores
-						illi, <lb/> aut quamdiu aguntur vel quantum producuntur quos <lb/> progressores
-						vocavimus; nam utrique cum ipso tem­ <lb/> pore operationis suae transeunt: hi autem
-						judiciales , <lb/> utrum et in anima nescio, in ipsa certe hominis <lb/> natura manent,
-						judicaturi de oblatis, quanquam a <lb/> certa brevitate usque ad certam longitudincm va-
+					</div><div type="textpart" subtype="dialog"><p>17. <hi rend="italic">M.</hi> Attende igitur de nceps, et dic mihi, qui­
+						<lb/> nam istorum immortales tibi videantur, an omnes suis <lb/> temporibus
+						labi atque occidere existimes. <hi rend="italic">D.</hi> Judicia­ <lb/> les
+						solos immortales puto; exteros video vel transire <lb/> cum fiunt, vel de
+						memoria oblivione deleri. M. Tam <lb/> certus es de istorum immortalitate,
+						quam de interitu <lb/> cæterorum; an diligentius, utrum vere hi immortales
+						<lb/> sint, oportet quærere? <hi rend="italic">D.</hi> Quæramus sane. M. Dic
+						<lb/> ergo, cum aliquanto correptius sive productius, dum <lb/> serviam
+						temporum legi qua simplo ad duplum pedes <lb/> conveniunt, versum pronuntio,
+						num offendo ulla <lb/> fraude judicium sensus tui? <hi rend="italic">D.</hi>
+						Non omnino. <hi rend="italic">iI.</hi> Quid? <lb/> sanus ille qui
+						correptioribus et quasi fugacioribus syl­ <lb/> labis editur, num potest
+						plus temporis occupare quam <lb/> sonat? D. Qui potest? M. Judiciales ergo
+						illi numcri <lb/> si vinculo temporis in tanto spatio tenerentur, quanto
+						<lb/> isti sonantes digesti suut; Fossentne ad eorum sonan­ <lb/> tium qui
+						paulo productius eadem iambica lege fundun­ <lb/> tur, aspirare judicium ?
+							<hi rend="italic">D.</hi> Nullo modo. M. Igitur <lb/> apparet bos mora
+						temporum, qni judicando præsi­ <lb/> dent, non teneri. <hi rend="italic"
+							>D.</hi> Prorsus apparet.</p>
+					</div><div type="textpart" subtype="dialog"><p>18. <hi rend="italic">II.</hi> Recte annuis. Sed si nulla tenerentur, quan­
+						<lb/> tolibet productius, legitimis intervallis iambicos pro­ <lb/> ferrem
+						sonos, nihilominus ad judicandum adhibcren­ <lb/> tur: nunc vero si ederem
+						unam syllabam quanta mora <lb/> peraguntur (ne multum dicam) tres passus
+						incedentis, <lb/> et aliam duplo, atque ita deinceps tam longos iambos <lb/>
+						ordinarem; simpli et dupli lex illa nihilosecius serva­ <lb/> retur: nec
+						tamen naturale illud judicium his dimen­ <lb/> sionibus approbandis adhibere
+						possemus. An tibi non <lb/> videtur ? <hi rend="italic">D.</hi> Negare non
+						pogsum ita videri: nam mea <lb/> quidem sententia res in aperto est. M.
+						Tenentur ergo <lb/> et hi judiciales nonnullis finibus temporalium spatio­
+						<lb/> rum, quos in judicando excedere nequeunt , et quid­ <lb/> quid excedit
+						haec spatia, non assequuntur ut judicent : <lb/> atque ita si tenentur,
+						quomodo sint immortales non <lb/> video. D. Nec ego video quid respondeam.
+						Sed quan- <lb/> quam de immortalitate horum jam minus praesumam, <lb/> non
+						tamen quo pacto hinc mortales convincantur in­ <lb/> telligo. Fieri enim
+						potest, ut quantacumque spatia <lb/> judicare possunt, semper id possint,
+						quoniam non <lb/> sicut caetcros, aut oblivione aboleri possum diceret <lb/>
+						aut tamdiu esse vel in tantum extendi, quamdiu sonus <lb/> appellitur et in
+						quantum extenduntur occursores illi, <lb/> aut quamdiu aguntur vel quantum
+						producuntur quos <lb/> progressores vocavimus; nam utrique cum ipso tem­
+						<lb/> pore operationis suae transeunt: hi autem judiciales , <lb/> utrum et
+						in anima nescio, in ipsa certe hominis <lb/> natura manent, judicaturi de
+						oblatis, quanquam a <lb/> certa brevitate usque ad certam longitudincm va-
 						<lb/> riertur, approbando in his numerosa, et perturbata <lb/> damnando.</p>
 					<pb n="1173"/>
 
-					<p>19. II. Saltem illud concedis, alios homines citius <lb/> offendi claudicantibus
-						numeris, alios tardius, et pIe­ <lb/> rosque nonnisi ex comparatione integrorum judicare
-						<lb/> vitiosos, cum et illos congruos et illos incongruos au­ <lb/> dierint. D. Concedo.
-						3/. Unde tandem hanc differen­ <lb/> tiam putas existere. nisi aut natura, aut
-						exercitatione, <lb/> aut utroquc? D. Sic arbitror. M. Quæro igitur utrum <lb/> possit
-						aliquis aliquando productiora intervalla judi­ <lb/> carc ct approbare, Quæ alius non
-						possit. <hi rend="italic">D.</hi> Credo <lb/> esse posse. M. Quid? ille qui non potest,
-						si sc excr­ <lb/> ceat congruenter, nec adeo tardus sit, nonne poterit? <lb/>
-						<hi rend="italic">D.</hi> Poterit vero. M. Num in tantum possunt isti pro­ <lb/> ficere
-						ad productiora judicanda, ut horarum, vel dic­ <lb/> rum, vcl etiam mensium annorumve
-						dupla et simpla <lb/> spatia, cum saltem somno interpediantur *, sensu illa <lb/>
-						judiciaria possint possint comprehendere, et tanquam illos <lb/> inmbos motionis nutibus
-						approbare? <hi rend="italic">D.</hi> Non possunt. <lb/> M. Quid ita non possunt, nisi
-						quia unicuique animanti <lb/> in genere proprio, proportione universitatis, sensus <lb/>
-						locorum temporumque tributus est; ut quomodo cor­ <lb/> pus ejus proportione universi
-						corporis tatum cst, <lb/> cujus pars est, et actas ejus proportione universi sae­ <lb/>
-						culi tanta est, cujus pars est; ita sensus ejus actioni <lb/> ejus congruat, quam
-						proportione agit universi tolus, <lb/> cujus hæc pars est? Sic habendo omnia magnus cst
-						<lb/> hic mundus, qui sæpe in Scripturis divinis coeli ct <lb/> terrænomine nuncupatur,
-						cujus omnes partes si pro­ <lb/> portione minuantur, tantus est; et si proporLionc aih
-						<lb/> Beantur, nihilominus tantus est : quia nihil in spatiis <lb/> locorum et temporum
-						per seipsum magnum est, sed. <lb/> ad aliquid brevius; et nihil rursus in his per
-						seipsum <lb/> breve est, sed ad aliquid majus. Quapropter si hu­ <lb/> manae naturae ad
-						carnalis vitæ actiones talis sensus <lb/> tributus est, quo majora temporum spatia
-						judicare <lb/> non possit, quam, intervalla postulant ad talis vitæ <lb/> uum
-						pertinentia; quoniam talis hominis natura mor­ <lb/> talis est, etiam talem sensum
-						mortalem puto. Non <lb/> enimtrustra consuetudo quasi secunda, et quasi af­ <lb/>
-						fabricata natura dicitur. Videmus autem velut quos­ <lb/> dam sensus novos in judicandis
-						cujuscemodi rebus <lb/> corporcis consuetudine affectos, alia consuetudine de­ <lb/>
-						perire.</p>
-					<ab>
-						<title type="sub">CAPUT VIII. — <hi rend="italic">Numeri cæteri judicialium examini
-								subjiciuntur.</hi>
+					</div><div type="textpart" subtype="dialog"><p>19. II. Saltem illud concedis, alios homines citius <lb/> offendi
+						claudicantibus numeris, alios tardius, et pIe­ <lb/> rosque nonnisi ex
+						comparatione integrorum judicare <lb/> vitiosos, cum et illos congruos et
+						illos incongruos au­ <lb/> dierint. D. Concedo. 3/. Unde tandem hanc
+						differen­ <lb/> tiam putas existere. nisi aut natura, aut exercitatione,
+						<lb/> aut utroquc? D. Sic arbitror. M. Quæro igitur utrum <lb/> possit
+						aliquis aliquando productiora intervalla judi­ <lb/> carc ct approbare, Quæ
+						alius non possit. <hi rend="italic">D.</hi> Credo <lb/> esse posse. M. Quid?
+						ille qui non potest, si sc excr­ <lb/> ceat congruenter, nec adeo tardus
+						sit, nonne poterit? <lb/>
+						<hi rend="italic">D.</hi> Poterit vero. M. Num in tantum possunt isti pro­
+						<lb/> ficere ad productiora judicanda, ut horarum, vel dic­ <lb/> rum, vcl
+						etiam mensium annorumve dupla et simpla <lb/> spatia, cum saltem somno
+						interpediantur *, sensu illa <lb/> judiciaria possint possint comprehendere,
+						et tanquam illos <lb/> inmbos motionis nutibus approbare? <hi rend="italic"
+							>D.</hi> Non possunt. <lb/> M. Quid ita non possunt, nisi quia unicuique
+						animanti <lb/> in genere proprio, proportione universitatis, sensus <lb/>
+						locorum temporumque tributus est; ut quomodo cor­ <lb/> pus ejus proportione
+						universi corporis tatum cst, <lb/> cujus pars est, et actas ejus proportione
+						universi sae­ <lb/> culi tanta est, cujus pars est; ita sensus ejus actioni
+						<lb/> ejus congruat, quam proportione agit universi tolus, <lb/> cujus hæc
+						pars est? Sic habendo omnia magnus cst <lb/> hic mundus, qui sæpe in
+						Scripturis divinis coeli ct <lb/> terrænomine nuncupatur, cujus omnes partes
+						si pro­ <lb/> portione minuantur, tantus est; et si proporLionc aih <lb/>
+						Beantur, nihilominus tantus est : quia nihil in spatiis <lb/> locorum et
+						temporum per seipsum magnum est, sed. <lb/> ad aliquid brevius; et nihil
+						rursus in his per seipsum <lb/> breve est, sed ad aliquid majus. Quapropter
+						si hu­ <lb/> manae naturae ad carnalis vitæ actiones talis sensus <lb/>
+						tributus est, quo majora temporum spatia judicare <lb/> non possit, quam,
+						intervalla postulant ad talis vitæ <lb/> uum pertinentia; quoniam talis
+						hominis natura mor­ <lb/> talis est, etiam talem sensum mortalem puto. Non
+						<lb/> enimtrustra consuetudo quasi secunda, et quasi af­ <lb/> fabricata
+						natura dicitur. Videmus autem velut quos­ <lb/> dam sensus novos in
+						judicandis cujuscemodi rebus <lb/> corporcis consuetudine affectos, alia
+						consuetudine de­ <lb/> perire.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT VIII. — <hi rend="italic">Numeri cæteri judicialium
+								examini subjiciuntur.</hi>
 						</title>
 					</ab>
-					<p>20. Sed quoquo modo se habeant hi numcri judi­ <lb/> ciales, eo certe præstant quod
-						dubitamus, vel difficile <lb/> pervestigamus utrum mortales sint. De cæteris autem <lb/>
-						quatuor gcneribus nec quicstio est quin mortales sint; <lb/> quorum etsi quosdam non
-						comprehendunt, quia ultra <lb/> ipsorum jura porrecti sunt, genera tamen ipsa suo <lb/>
-						examini vindicant. Nam et illi progressores cum ali­ <lb/> quam in corpore numerosam
-						operationem appetunt, <lb/> latente istorum judicialium nutu modificantur. Quod <lb/>
-						enim nos vel ambulantes ab imparibus passibus, vel <lb/> percutientes ab imparibus
-						intervallis plagarum, vel <lb/> edentes vel bibentes ab imparibus malarum motibus, <lb/>
-						scaluentes denique ab imparibus unguium ductibus ; <note type="footnote"> Edili: <hi rend="italic">somno non impediantur.</hi> At Mss. absque negatio­ <lb/> ne, <hi rend="italic">sommo interpediantur.</hi>
+					</div><div type="textpart" subtype="dialog"><p>20. Sed quoquo modo se habeant hi numcri judi­ <lb/> ciales, eo certe
+						præstant quod dubitamus, vel difficile <lb/> pervestigamus utrum mortales
+						sint. De cæteris autem <lb/> quatuor gcneribus nec quicstio est quin
+						mortales sint; <lb/> quorum etsi quosdam non comprehendunt, quia ultra <lb/>
+						ipsorum jura porrecti sunt, genera tamen ipsa suo <lb/> examini vindicant.
+						Nam et illi progressores cum ali­ <lb/> quam in corpore numerosam
+						operationem appetunt, <lb/> latente istorum judicialium nutu modificantur.
+						Quod <lb/> enim nos vel ambulantes ab imparibus passibus, vel <lb/>
+						percutientes ab imparibus intervallis plagarum, vel <lb/> edentes vel
+						bibentes ab imparibus malarum motibus, <lb/> scaluentes denique ab imparibus
+						unguium ductibus ; <note type="footnote"> Edili: <hi rend="italic">somno non
+								impediantur.</hi> At Mss. absque negatio­ <lb/> ne, <hi
+								rend="italic">sommo interpediantur.</hi>
 						</note>
-						<lb/> et ne per multas alias operationes percurram, quod <lb/> nos in qualibet
-						attentione agendi aliquid pcr corporis <lb/> membra ab imparibus motibus refrenat et
-						cohibet, et <lb/> quamdam parilitatem tacite imperat; idipsum cst ju­ <lb/> dicialc
-						nescio qnid, quod conditerem animalis insinuat <lb/> Dcum : quem certe decet credere
-						auctorem omnis con­ <lb/> venieutiæ atque concordiae.</p>
-					<p>21. Et illi occursores numeri, qui certe non pro sue <lb/> nutu, sed pro passionibus
-						corporis aguntur, in quan <lb/> tum corum intervalla potest memoria custodire, in <lb/>
-						tantum his judicialibus judicandi offeruntur atqne ju­ <lb/> dicantur. Numerus namque
-						iste qui intervallis tempo­ <lb/> rum constat, nisi adjuvemur in co memoria, judicari
-						<lb/> a nobis nullo pacto potest. Quamlibet cuim brevis syl­ <lb/> laba, cum et
-						incipiat, et desinat, alio tempore initium <lb/> ejus, et alio finis sonat. Tenditur
-						crgo ct ipsa quantu­ <lb/> locumquc temporis intevallo, et ab initio SilO per <lb/>
-						medium suum tendit ad fincm. Ita ratio invenit tam <lb/> localia quam temporalia spatia
-						infinitam divisionem <lb/> recipere; et idcirco nullius syllabæ cum initie finis <lb/>
-						auditur. In audicnda itaque vel brevissima syllaba, <lb/> nisi memoria nos adjuvet, ut
-						eo momento temporis <lb/> quo jam non initium, sed fiuis syllabæ sonat, maneat <lb/>
-						ille motus in animo, qui factus est cnm initium ipsum <lb/> sonuit; nibil nos audisse po
-						ssumus dIcere. Hinc est <lb/> illud quod plerumque alia cogitationc occupati, cornm
-						<lb/> loquentes non nobis videmur audisse: non qnia occur­ <lb/> sores illos numcros non
-						agit tunc anima, cum sine du­ <lb/> bio sonus ad aures perveniat, et illa in passione
-						cor­ <lb/> poris sui cessare non possit, nec possit nisi aliter <lb/> moveri quam si
-						illa non fieret; sed quia intentione iri <lb/> aliud subinde exstinguitur motionis
-						impetus, qui si <lb/> maneret, in memoria utique maneret, ut nos ct inve­ <lb/> niremus
-						et sentiremus audisse. Quod si de una syllaba <lb/> brevi minus sequitur mens tardior
-						quod invenit ratio, <lb/> de duabus certe nemo dubitat, quin eas simul nulla <lb/> anima
-						possit audire. Non enim sonat secunda, nisi <lb/> prima destiterit: quod autem simul
-						sonarc non potest, <lb/> simul audiri qui potest? Ut igitur nos ad capicnda <lb/> spatia
-						locorum diffusio radiorum juvat, qui e brevibus <lb/> p apulis in aperta emicant, ct
-						adeo sunt nostri corpn. <lb/> ris, ut quanquam in procul positis rebus quas vi­ <lb/>
-						demus, a nostra anima vegetentur; ut ergo eorum <lb/> effusione adjuvamur 1 ad capienda
-						spatia locorum : ita <lb/> memoria, quod quasi lumen est temporalium spatio­ <lb/> rum,
-						quantum in suo genere quodammodo extrudi po­ <lb/> test, tantum eorumdem spatiorum
-						capit. Cum autem <lb/> diutius aures pulsat sonus nullis distinctus articulis I <lb/> et
-						ab aliquo tandem finc conjunctus alter duplo, aut <lb/> etiam tanto editur spatio;
-						attentione in succedentem <lb/> perpetuo sonum motus ille animi, qui atlentione ad <lb/>
-						præteritum et elapsum sonum cum transibat est fa­ <lb/> ctus, reprimitur, id cst non ita
-						remanet, in memoria. <lb/> Quapropter judiciales illi numeri, qui numcros in in­ <lb/>
-						tervallis temporum sitos, exceptis progressoribus <lb/> quibus etiam ipsum progressum
-						modificant, judicare <lb/> non possunt nisi quos eis tanquam ministra memoria <note type="footnote"> 1 sic in Mss. At in editis legitur: il <hi rend="italic">ergo
-								effusione Lucis <lb/> adjuvamur.</hi>
+						<lb/> et ne per multas alias operationes percurram, quod <lb/> nos in
+						qualibet attentione agendi aliquid pcr corporis <lb/> membra ab imparibus
+						motibus refrenat et cohibet, et <lb/> quamdam parilitatem tacite imperat;
+						idipsum cst ju­ <lb/> dicialc nescio qnid, quod conditerem animalis insinuat
+						<lb/> Dcum : quem certe decet credere auctorem omnis con­ <lb/> venieutiæ
+						atque concordiae.</p>
+					</div><div type="textpart" subtype="dialog"><p>21. Et illi occursores numeri, qui certe non pro sue <lb/> nutu, sed pro
+						passionibus corporis aguntur, in quan <lb/> tum corum intervalla potest
+						memoria custodire, in <lb/> tantum his judicialibus judicandi offeruntur
+						atqne ju­ <lb/> dicantur. Numerus namque iste qui intervallis tempo­ <lb/>
+						rum constat, nisi adjuvemur in co memoria, judicari <lb/> a nobis nullo
+						pacto potest. Quamlibet cuim brevis syl­ <lb/> laba, cum et incipiat, et
+						desinat, alio tempore initium <lb/> ejus, et alio finis sonat. Tenditur crgo
+						ct ipsa quantu­ <lb/> locumquc temporis intevallo, et ab initio SilO per
+						<lb/> medium suum tendit ad fincm. Ita ratio invenit tam <lb/> localia quam
+						temporalia spatia infinitam divisionem <lb/> recipere; et idcirco nullius
+						syllabæ cum initie finis <lb/> auditur. In audicnda itaque vel brevissima
+						syllaba, <lb/> nisi memoria nos adjuvet, ut eo momento temporis <lb/> quo
+						jam non initium, sed fiuis syllabæ sonat, maneat <lb/> ille motus in animo,
+						qui factus est cnm initium ipsum <lb/> sonuit; nibil nos audisse po ssumus
+						dIcere. Hinc est <lb/> illud quod plerumque alia cogitationc occupati, cornm
+						<lb/> loquentes non nobis videmur audisse: non qnia occur­ <lb/> sores illos
+						numcros non agit tunc anima, cum sine du­ <lb/> bio sonus ad aures
+						perveniat, et illa in passione cor­ <lb/> poris sui cessare non possit, nec
+						possit nisi aliter <lb/> moveri quam si illa non fieret; sed quia intentione
+						iri <lb/> aliud subinde exstinguitur motionis impetus, qui si <lb/> maneret,
+						in memoria utique maneret, ut nos ct inve­ <lb/> niremus et sentiremus
+						audisse. Quod si de una syllaba <lb/> brevi minus sequitur mens tardior quod
+						invenit ratio, <lb/> de duabus certe nemo dubitat, quin eas simul nulla
+						<lb/> anima possit audire. Non enim sonat secunda, nisi <lb/> prima
+						destiterit: quod autem simul sonarc non potest, <lb/> simul audiri qui
+						potest? Ut igitur nos ad capicnda <lb/> spatia locorum diffusio radiorum
+						juvat, qui e brevibus <lb/> p apulis in aperta emicant, ct adeo sunt nostri
+						corpn. <lb/> ris, ut quanquam in procul positis rebus quas vi­ <lb/> demus,
+						a nostra anima vegetentur; ut ergo eorum <lb/> effusione adjuvamur 1 ad
+						capienda spatia locorum : ita <lb/> memoria, quod quasi lumen est
+						temporalium spatio­ <lb/> rum, quantum in suo genere quodammodo extrudi po­
+						<lb/> test, tantum eorumdem spatiorum capit. Cum autem <lb/> diutius aures
+						pulsat sonus nullis distinctus articulis I <lb/> et ab aliquo tandem finc
+						conjunctus alter duplo, aut <lb/> etiam tanto editur spatio; attentione in
+						succedentem <lb/> perpetuo sonum motus ille animi, qui atlentione ad <lb/>
+						præteritum et elapsum sonum cum transibat est fa­ <lb/> ctus, reprimitur, id
+						cst non ita remanet, in memoria. <lb/> Quapropter judiciales illi numeri,
+						qui numcros in in­ <lb/> tervallis temporum sitos, exceptis progressoribus
+						<lb/> quibus etiam ipsum progressum modificant, judicare <lb/> non possunt
+						nisi quos eis tanquam ministra memoria <note type="footnote"> 1 sic in Mss.
+							At in editis legitur: il <hi rend="italic">ergo effusione Lucis <lb/>
+								adjuvamur.</hi>
 						</note>
 						<lb/>
-						<pb n="1175"/> obtulerit; nonne ipsi existiimandi sunt pcr certum <lb/> spatium temporis
-						tendi?Sed interest quibus tempo.. <lb/> rum spatiis vel excidat nobis, vcl meminerimus
-						quod <lb/> judicant. Siquidem nee in ipsis corporum formis quai <lb/> ad oculos
-						pertinent , possumus rotunda vel quadra, <lb/> vel quæcumque alia solida et determinata
-						judicare, et <lb/> omnino sentire, nisi ea ob oculos versemus 1 : cun. <lb/> autem alia
-						pars aspicitur, si exciderit quod est aspe­ <lb/> ctum in alia , frustratur omnimo
-						judicantis intentio, <lb/> quia et h c aliqua mora temporis fit; cui variatæ <lb/> opus
-						est invigilare mmeoriam.</p>
-					<p>22. Record abiles vcro numeros multo evidentius <lb/> cst, quod eadem ipsa offerente
-						memoria, judicamus <lb/> his judicialibus. Nam sl occursores, quantum ab ea <lb/>
-						ofreruntur, tantum judicantur; multo magis ii, ad <lb/> quos tanquam repositos post
-						alias intentiones revoca­ <lb/> mur recordatione, in ipsa memoria vivereinveniuntur.
-						<lb/> Quid enim aliud agimus cum revocamus nos in me­ <lb/> moriam , nisi quodammodo
-						quod reposuimus quxri­ <lb/> mus? Rccurrit autem in cogitationem occasione si­ <lb/>
-						milium motus animi non exstinctus, et hxc est quæ <lb/> dicitur recordatio. Sic agimus
-						numeros, vel in sola <lb/> cogitatione, vel etiam in membrorum motu, quos <lb/> jam
-						egimus aliquando. Indc autem scimus non venisse, <lb/> sed redisse illos in
-						cogitationem, quia cum memorie <lb/> mandarentur, cum difficullato repetebantur, et
-						indi­ <lb/> gebamus aliqua præmonstratione ut sequeremur: qua <lb/> difficultate dempta,
-						cum sese ipsi accommodate vo- <lb/> Juntali offerunt, consequenter temporibus atque
-						ordine <lb/> suo, tam facile ut qui vehementius inhæserunt, etiam <lb/> aliunde
-						cogitantibus nobis, jam quasi proprio nutu <lb/> pcragantur, non cos utique novos esse
-						sentimus. Est <lb/> etiam aliud unde nos sentire arbitror præsentem mo­ <lb/> tum animi
-						aliquando jam fuisse, quod est recogno­ <lb/> scere, dum recentes motus rjus actionis in
-						qua sumus <lb/> cum rccordamur, qni certe vivaciores sunt, cum rc­ <lb/> cordabilibus
-						jam sedatioribus quodam interiore lu­ <lb/> mine comparamus : et talis agnitio,
-						recognitio cst ct <lb/> rccordalio. Judicantur ergo et recordabiles nnmeri <lb/> ab Ira
-						judicialibus, nunquam soli, sed adjunctis acti­ <lb/> vis, aut occursoribus, aut
-						utrisque, qui cos tanquam <lb/> e latebris suis in manifestum producant, et quasi re­
-						<lb/> dintegratos qui jam abolebantur, rursum recordan­ <lb/> tur. Ita cum occursores in
-						tantum judicentur, in quan­ <lb/> tum cos memoria judicantibus admoverit, possunt <lb/>
-						vicissim et recordabiles qui sunt in memoria occur­ <lb/> soribus eos exhibentibus
-						judicari : ut hoc intersit, <lb/> quod occursores ut judicentur, quasi recentia corum
-						<lb/> fugientium vestigia offert memoria; recordabiles au­ <lb/> tem quando eos andicndo
-						judicamus, quasi cadem <lb/> veestigia occursoribus transeuntibus revirescunt. Jam <lb/>
-						porro de sonantibus numeris quid opus est dicere, <lb/> cum in occursoribus judicentur,
-						si audiantur? Si vero <lb/> thi sonant uhi non audiuntur, quis dubitet eos a nohis <lb/>
-						non posse judicari? Sane ut in sonis per instrumen­ <lb/> tum aurium, ita in
-						saltationibus cæterisque visibilibus <lb/> motibus, quod ad temporales numeros allinct,
-						eadcm <note type="footnote"> ' Ann. Er. et !.ov.: <hi rend="italic">rossemusnii ex</hi>
-							obliqiio <hi rend="italic">oculo* ver­</hi>
+						<pb n="1175"/> obtulerit; nonne ipsi existiimandi sunt pcr certum <lb/>
+						spatium temporis tendi?Sed interest quibus tempo.. <lb/> rum spatiis vel
+						excidat nobis, vcl meminerimus quod <lb/> judicant. Siquidem nee in ipsis
+						corporum formis quai <lb/> ad oculos pertinent , possumus rotunda vel
+						quadra, <lb/> vel quæcumque alia solida et determinata judicare, et <lb/>
+						omnino sentire, nisi ea ob oculos versemus 1 : cun. <lb/> autem alia pars
+						aspicitur, si exciderit quod est aspe­ <lb/> ctum in alia , frustratur
+						omnimo judicantis intentio, <lb/> quia et h c aliqua mora temporis fit; cui
+						variatæ <lb/> opus est invigilare mmeoriam.</p>
+					</div><div type="textpart" subtype="dialog"><p>22. Record abiles vcro numeros multo evidentius <lb/> cst, quod eadem ipsa
+						offerente memoria, judicamus <lb/> his judicialibus. Nam sl occursores,
+						quantum ab ea <lb/> ofreruntur, tantum judicantur; multo magis ii, ad <lb/>
+						quos tanquam repositos post alias intentiones revoca­ <lb/> mur
+						recordatione, in ipsa memoria vivereinveniuntur. <lb/> Quid enim aliud
+						agimus cum revocamus nos in me­ <lb/> moriam , nisi quodammodo quod
+						reposuimus quxri­ <lb/> mus? Rccurrit autem in cogitationem occasione si­
+						<lb/> milium motus animi non exstinctus, et hxc est quæ <lb/> dicitur
+						recordatio. Sic agimus numeros, vel in sola <lb/> cogitatione, vel etiam in
+						membrorum motu, quos <lb/> jam egimus aliquando. Indc autem scimus non
+						venisse, <lb/> sed redisse illos in cogitationem, quia cum memorie <lb/>
+						mandarentur, cum difficullato repetebantur, et indi­ <lb/> gebamus aliqua
+						præmonstratione ut sequeremur: qua <lb/> difficultate dempta, cum sese ipsi
+						accommodate vo- <lb/> Juntali offerunt, consequenter temporibus atque ordine
+						<lb/> suo, tam facile ut qui vehementius inhæserunt, etiam <lb/> aliunde
+						cogitantibus nobis, jam quasi proprio nutu <lb/> pcragantur, non cos utique
+						novos esse sentimus. Est <lb/> etiam aliud unde nos sentire arbitror
+						præsentem mo­ <lb/> tum animi aliquando jam fuisse, quod est recogno­ <lb/>
+						scere, dum recentes motus rjus actionis in qua sumus <lb/> cum rccordamur,
+						qni certe vivaciores sunt, cum rc­ <lb/> cordabilibus jam sedatioribus
+						quodam interiore lu­ <lb/> mine comparamus : et talis agnitio, recognitio
+						cst ct <lb/> rccordalio. Judicantur ergo et recordabiles nnmeri <lb/> ab Ira
+						judicialibus, nunquam soli, sed adjunctis acti­ <lb/> vis, aut occursoribus,
+						aut utrisque, qui cos tanquam <lb/> e latebris suis in manifestum producant,
+						et quasi re­ <lb/> dintegratos qui jam abolebantur, rursum recordan­ <lb/>
+						tur. Ita cum occursores in tantum judicentur, in quan­ <lb/> tum cos memoria
+						judicantibus admoverit, possunt <lb/> vicissim et recordabiles qui sunt in
+						memoria occur­ <lb/> soribus eos exhibentibus judicari : ut hoc intersit,
+						<lb/> quod occursores ut judicentur, quasi recentia corum <lb/> fugientium
+						vestigia offert memoria; recordabiles au­ <lb/> tem quando eos andicndo
+						judicamus, quasi cadem <lb/> veestigia occursoribus transeuntibus
+						revirescunt. Jam <lb/> porro de sonantibus numeris quid opus est dicere,
+						<lb/> cum in occursoribus judicentur, si audiantur? Si vero <lb/> thi sonant
+						uhi non audiuntur, quis dubitet eos a nohis <lb/> non posse judicari? Sane
+						ut in sonis per instrumen­ <lb/> tum aurium, ita in saltationibus cæterisque
+						visibilibus <lb/> motibus, quod ad temporales numeros allinct, eadcm <note
+							type="footnote"> ' Ann. Er. et !.ov.: <hi rend="italic">rossemusnii
+								ex</hi> obliqiio <hi rend="italic">oculo* ver­</hi>
 							<lb/> mremuo. sed concinnior « st Mss. leclio quam amplectimur. </note>
 						<lb/> adjuvante memoria iisdem numeris judicialibus diju. <lb/> dicamus.</p>
-					<ab>
-						<title type="sub">CAPUT IX. — <hi rend="italic">Numeri alii in</hi> anima <hi rend="italic">illis</hi> judidalibus <hi rend="italic">præcellentes.</hi>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT IX. — <hi rend="italic">Numeri alii in</hi> anima
+								<hi rend="italic">illis</hi> judidalibus <hi rend="italic"
+								>præcellentes.</hi>
 						</title>
 					</ab>
-					<p>23. Hæc cum ita sint, conemur, si possumus, istos <lb/> numcros judiciales
-						transcendere, et quæramus utrum <lb/> sint superiores. In his enim quanquam spatia
-						tempo­ <lb/> rum jam minime videamus, non tamen adhibentur, <lb/> nisi ad ea judicanda
-						quæ in spatio temporis fiunt; net <lb/> ipsa quidem omnia, sed quæ possunt articulari
-						memo­ <lb/> riter. Nisi quid habes forte quod contra haec velis di­ <lb/> cere. D. Movet
-						me plurimum istorum judicialium vis <lb/> atque potentia : ipsi enim mihi videntur esse
-						ad quos <lb/> omnium sensuum ministeria referuntur. Itaque his <lb/> excellentius utrum
-						quidquam in numeris inveniri <lb/> possit, ignoro. M. Nihil deperit quod diligcutius
-						quae­ <lb/> rimus. Aut enim inveniemus superiores in anima ha­ <lb/> mana, aut hos in ea
-						summos esse firmabimus, si ta­ <lb/> men illud cJarueril, nullos in ea esse
-						præstantiores. <lb/> Aliud est enim non esse, aliud non posse inveniri, <lb/> sive ab
-						ullo homine. sive a nobis. Sed ego puto cum <lb/> ille a nobis propositus versus
-						canitur, <hi rend="italic">Deus creator<lb/> omnium;</hi> nos eum et occursoribus illis
-						numcris an­ <lb/> dire, et recordabilibus recognoscere, et progressori­ <lb/> bus
-						pronuntiare, et his judicialibus dcleclari, et nescio <lb/> quibus aliis æstimare, et de
-						ista delectatione quæ <lb/> quasi sententia est judicialium istorum, aliam secun­ <lb/>
-						dum hos latentiores certiorem ferre sententiam I. An <lb/> tibi unum atque idem videtur
-						delectari sensu, et <lb/> æstimare ratione? <hi rend="italic">D.</hi> Diversa esse
-						fateor. Sed primo <lb/> ipso moveor vocabulo, cur non potius isti vocentur <lb/>
-						judiciales quibus inest ratio, quam isti quibus inest <lb/> delectatio. Deinde vereor ne
-						nihil sit aliud æstimatio <lb/> isLi rationis, quam eorum de seipsis quædam diligcn­
-						<lb/> tior judicatio : ut non alii sint numeri in delectatione, <lb/> ani in ratione;
-						sed uni atque iidem alias judicent de <lb/> iis quae aguntur in corpore, cum eos, ut
-						supra de­ <lb/> monstratum est , offert memoria; alias de seipsis re­ <lb/> motius a
-						corpore atquc sincerius.</p>
-					<p>24. <hi rend="italic">M.</hi> De vocabulis quidcm nihil satagas; res in <lb/> potestate
-						cst : placito cnim, non natura imponuntur. <lb/> Quod autem eosdem csse arbitraris, nec
-						duo genera <lb/> numerorum hæc vis accipere; illud, ni fallor, te ra­ <lb/> pit, quod
-						eadem anima utrumque agit. Sed animad­ <lb/> vertere te opus est, et in progressoribus
-						camdem ani­ <lb/> mam corpus movere vel ad corpus moveri; et in oc­ <lb/> cursoribus
-						hanc eamdera passionibus ejus ire obviam ; <lb/> et in recordabilibus istam ipsam, donce
-						quodammodo <lb/> detumescant, ipsis quasi fluctuare motionibus. Nus <lb/> crgo in istis
-						generibus numerandis et distinguendis <lb/> unius naturæ, id est, anima; motuss
-						affectiones que <lb/> dispicimus. Quare si ut aliud cst ad ca qu:ccorpus pa­ <lb/> titur
-						moveri, quod fit in sentiondo; aliud movere <lb/> se ad corpus, quod fit in opcrando;
-						aliud quod cx his <lb/> motibus in anima factum cst continere, qnod cst mc­ <lb/>
-						minisse; ita est aliud annucrc, vel rcnucre his moti- <note type="footnote"> I Editi:
-								<hi rend="italic">Aliatn secundum hos latmtiorem, sed cettiorein <lb/> ferre
-								sentenlium.Mss.: secundum hos latentiores.</hi> Suj-i de,filii-- <lb/>
+					</div><div type="textpart" subtype="dialog"><p>23. Hæc cum ita sint, conemur, si possumus, istos <lb/> numcros judiciales
+						transcendere, et quæramus utrum <lb/> sint superiores. In his enim quanquam
+						spatia tempo­ <lb/> rum jam minime videamus, non tamen adhibentur, <lb/>
+						nisi ad ea judicanda quæ in spatio temporis fiunt; net <lb/> ipsa quidem
+						omnia, sed quæ possunt articulari memo­ <lb/> riter. Nisi quid habes forte
+						quod contra haec velis di­ <lb/> cere. D. Movet me plurimum istorum
+						judicialium vis <lb/> atque potentia : ipsi enim mihi videntur esse ad quos
+						<lb/> omnium sensuum ministeria referuntur. Itaque his <lb/> excellentius
+						utrum quidquam in numeris inveniri <lb/> possit, ignoro. M. Nihil deperit
+						quod diligcutius quae­ <lb/> rimus. Aut enim inveniemus superiores in anima
+						ha­ <lb/> mana, aut hos in ea summos esse firmabimus, si ta­ <lb/> men illud
+						cJarueril, nullos in ea esse præstantiores. <lb/> Aliud est enim non esse,
+						aliud non posse inveniri, <lb/> sive ab ullo homine. sive a nobis. Sed ego
+						puto cum <lb/> ille a nobis propositus versus canitur, <hi rend="italic"
+							>Deus creator<lb/> omnium;</hi> nos eum et occursoribus illis numcris
+						an­ <lb/> dire, et recordabilibus recognoscere, et progressori­ <lb/> bus
+						pronuntiare, et his judicialibus dcleclari, et nescio <lb/> quibus aliis
+						æstimare, et de ista delectatione quæ <lb/> quasi sententia est judicialium
+						istorum, aliam secun­ <lb/> dum hos latentiores certiorem ferre sententiam
+						I. An <lb/> tibi unum atque idem videtur delectari sensu, et <lb/> æstimare
+						ratione? <hi rend="italic">D.</hi> Diversa esse fateor. Sed primo <lb/> ipso
+						moveor vocabulo, cur non potius isti vocentur <lb/> judiciales quibus inest
+						ratio, quam isti quibus inest <lb/> delectatio. Deinde vereor ne nihil sit
+						aliud æstimatio <lb/> isLi rationis, quam eorum de seipsis quædam diligcn­
+						<lb/> tior judicatio : ut non alii sint numeri in delectatione, <lb/> ani in
+						ratione; sed uni atque iidem alias judicent de <lb/> iis quae aguntur in
+						corpore, cum eos, ut supra de­ <lb/> monstratum est , offert memoria; alias
+						de seipsis re­ <lb/> motius a corpore atquc sincerius.</p>
+					</div><div type="textpart" subtype="dialog"><p>24. <hi rend="italic">M.</hi> De vocabulis quidcm nihil satagas; res in <lb/>
+						potestate cst : placito cnim, non natura imponuntur. <lb/> Quod autem eosdem
+						csse arbitraris, nec duo genera <lb/> numerorum hæc vis accipere; illud, ni
+						fallor, te ra­ <lb/> pit, quod eadem anima utrumque agit. Sed animad­ <lb/>
+						vertere te opus est, et in progressoribus camdem ani­ <lb/> mam corpus
+						movere vel ad corpus moveri; et in oc­ <lb/> cursoribus hanc eamdera
+						passionibus ejus ire obviam ; <lb/> et in recordabilibus istam ipsam, donce
+						quodammodo <lb/> detumescant, ipsis quasi fluctuare motionibus. Nus <lb/>
+						crgo in istis generibus numerandis et distinguendis <lb/> unius naturæ, id
+						est, anima; motuss affectiones que <lb/> dispicimus. Quare si ut aliud cst
+						ad ca qu:ccorpus pa­ <lb/> titur moveri, quod fit in sentiondo; aliud movere
+						<lb/> se ad corpus, quod fit in opcrando; aliud quod cx his <lb/> motibus in
+						anima factum cst continere, qnod cst mc­ <lb/> minisse; ita est aliud
+						annucrc, vel rcnucre his moti- <note type="footnote"> I Editi: <hi
+								rend="italic">Aliatn secundum hos latmtiorem, sed cettiorein <lb/>
+								ferre sentenlium.Mss.: secundum hos latentiores.</hi> Suj-i
+							de,filii-- <lb/>
 							<hi rend="italic">meros</hi>
 						</note>
 						<lb/>
-						<pb n="1177"/> bus, aut cum priniilus exseruntur, aut cum rccorda­ <lb/> tione
-						resuscitantur, quod fit in delectatione conve­ <lb/> nientiæ, et offensione absurditatis
-						talium motionum <lb/> sive affectiouum; et aliud est æstimare utrum recte <lb/> an serus
-						ista delectent, quod fit ratiocinando : necesse <lb/> est fateamur ita haec esse duo
-						genera, ut illa sunt tria. <lb/> Et si recte nobis visum est, nist quibusdam numeris
-						<lb/> esset ipse delectationis sensus imbutus, nullo modo <lb/> cum potuisse annuere
-						paribus intervallis, et pertur­ <lb/> baLa respuere: recte etiam videri potest ratio,
-						quæ <lb/> nuic delectationi superimponitur, nullo modo sine <lb/> quibusdam numeris
-						vivocioribus, de numeris quos in­ <lb/> fra se habet posse judicare. Quæ si vera sunt,
-						apparet <lb/> inventa esse in anima quinque genera numerorum, <lb/> quibus cum addideris
-						corporales illos quos sonantes <lb/> vocavimus, sex genera numerorum disposita et ordi­
-						<lb/> nata cognosces. Jam nunc, si placet, illi qui nobis <lb/> subrepserant ad
-						principatum obtinendum, sensuales <lb/> nominentur, et judicialium nomen, qnoninm cst
-						lio­ <lb/> noratius, hi accipiant qui excellentiores comperti <lb/> sunt: quanquam et
-						sonantium nomen mutandum pu­ <lb/> tem, quoniam si corporales vocentur, manifestius si­
-						<lb/> gnificabunt etiam illos qui sunt in saltatione, et in <lb/> caetero motu visibili.
-						Si tamen ea quae dicta sunt pro­ <lb/> bas. D. Probo sane : nam et vera et manifesta
-						mihi <lb/> vid' ntur. Horum etiam emendationem vocabulorum <lb/> libenter accipio.</p>
-					<ab>
-						<title type="sub">CAPUT X. — <hi rend="italic">Rationis vis in perspiciendis quce ad
-								Musicam pertinent,</hi> uli <hi rend="italic">nthil aliud quam</hi> æqualitas <hi rend="italic">delectat.</hi>
+						<pb n="1177"/> bus, aut cum priniilus exseruntur, aut cum rccorda­ <lb/>
+						tione resuscitantur, quod fit in delectatione conve­ <lb/> nientiæ, et
+						offensione absurditatis talium motionum <lb/> sive affectiouum; et aliud est
+						æstimare utrum recte <lb/> an serus ista delectent, quod fit ratiocinando :
+						necesse <lb/> est fateamur ita haec esse duo genera, ut illa sunt tria.
+						<lb/> Et si recte nobis visum est, nist quibusdam numeris <lb/> esset ipse
+						delectationis sensus imbutus, nullo modo <lb/> cum potuisse annuere paribus
+						intervallis, et pertur­ <lb/> baLa respuere: recte etiam videri potest
+						ratio, quæ <lb/> nuic delectationi superimponitur, nullo modo sine <lb/>
+						quibusdam numeris vivocioribus, de numeris quos in­ <lb/> fra se habet posse
+						judicare. Quæ si vera sunt, apparet <lb/> inventa esse in anima quinque
+						genera numerorum, <lb/> quibus cum addideris corporales illos quos sonantes
+						<lb/> vocavimus, sex genera numerorum disposita et ordi­ <lb/> nata
+						cognosces. Jam nunc, si placet, illi qui nobis <lb/> subrepserant ad
+						principatum obtinendum, sensuales <lb/> nominentur, et judicialium nomen,
+						qnoninm cst lio­ <lb/> noratius, hi accipiant qui excellentiores comperti
+						<lb/> sunt: quanquam et sonantium nomen mutandum pu­ <lb/> tem, quoniam si
+						corporales vocentur, manifestius si­ <lb/> gnificabunt etiam illos qui sunt
+						in saltatione, et in <lb/> caetero motu visibili. Si tamen ea quae dicta
+						sunt pro­ <lb/> bas. D. Probo sane : nam et vera et manifesta mihi <lb/>
+						vid' ntur. Horum etiam emendationem vocabulorum <lb/> libenter accipio.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT X. — <hi rend="italic">Rationis vis in perspiciendis
+								quce ad Musicam pertinent,</hi> uli <hi rend="italic">nthil aliud
+								quam</hi> æqualitas <hi rend="italic">delectat.</hi>
 						</title>
 					</ab>
-					<p>25. <hi rend="italic">M.</hi> Age, nunc aspice in vim potentiamque ra­ <lb/> tionis,
-						quantum ex operibus ejus aspicere possumus. <lb/> Ipsa enim, ut id potissimum dicam quod
-						ad hujus <lb/> operis susceptionem attinet, primo quid sit ipsa bona <lb/> modulatio
-						consideravit, ct eam in quodam motu Ii... <lb/> bcro, ct ad suoe pulchritudinis finem
-						converso esse <lb/> perspexit. Deinde vidit in molibus corporum aliud <lb/> esse quod
-						brevitate ct productione temporis variarc­ <lb/> tur, in quantum magis esset minusve
-						diuturnum, aliud <lb/> localium spatiorum percussione1 in quibusdam gia­ <lb/> dibus
-						celcritalis et tarditatis : qua divisione faCIa, n- <lb/> lud quod in temporis mora
-						esset, modestis intervallis, <lb/> et humano sensui accommodatis articulatim varios
-						<lb/> efficeret numcros, eorumque genera et ordinem usque <lb/> ad modulos versuum
-						persecuta est. Postremo attendit <lb/> quid in his moderandis, operandis, sentiendis,
-						reti­ <lb/> nendis ageret anima cujus caput ipsa esset: hosque <lb/> omnes animales
-						numeros a corporalibus separavit: <lb/> seque ipsam hæc omnia ncquc animadvertere, neque
-						<lb/> distinguere, ncque recte numerare sine quibusdam <lb/> suis numeris potuisse
-						cognovit, eosque cæteris in­ <lb/> ferioris ordinis judiciaria quadam æstimatione præ­
-						<lb/> posuit.</p>
-					<p>i6. Et nunc cum ipsa sua delectatione, quæ 3 in <lb/> temporum momenta perpendit, et
-						talibus numeris <note type="footnote"> 4 septem Mss., <hi rend="italic">percussionem.</hi> ' </note><note type="footnote"> I Ita plerique Mss., cnm Am. At
-							Lov.habet: <hi rend="italic">In hts moae­</hi>
-							<lb/> randis, <hi rend="italic">sentiendis, relinendis, delectandis agerEt anima.</hi>
-						</note><note type="footnote"> I Duo Mss., <hi rend="italic">qnam.</hi> Alii tres, <hi rend="italic">qua.</hi> Paulo post, alter e victo­ <lb/> nnis codicibui: <hi rend="italic">Propendet, tfillbw numeris.</hi>
+					</div><div type="textpart" subtype="dialog"><p>25. <hi rend="italic">M.</hi> Age, nunc aspice in vim potentiamque ra­ <lb/>
+						tionis, quantum ex operibus ejus aspicere possumus. <lb/> Ipsa enim, ut id
+						potissimum dicam quod ad hujus <lb/> operis susceptionem attinet, primo quid
+						sit ipsa bona <lb/> modulatio consideravit, ct eam in quodam motu Ii...
+						<lb/> bcro, ct ad suoe pulchritudinis finem converso esse <lb/> perspexit.
+						Deinde vidit in molibus corporum aliud <lb/> esse quod brevitate ct
+						productione temporis variarc­ <lb/> tur, in quantum magis esset minusve
+						diuturnum, aliud <lb/> localium spatiorum percussione1 in quibusdam gia­
+						<lb/> dibus celcritalis et tarditatis : qua divisione faCIa, n- <lb/> lud
+						quod in temporis mora esset, modestis intervallis, <lb/> et humano sensui
+						accommodatis articulatim varios <lb/> efficeret numcros, eorumque genera et
+						ordinem usque <lb/> ad modulos versuum persecuta est. Postremo attendit
+						<lb/> quid in his moderandis, operandis, sentiendis, reti­ <lb/> nendis
+						ageret anima cujus caput ipsa esset: hosque <lb/> omnes animales numeros a
+						corporalibus separavit: <lb/> seque ipsam hæc omnia ncquc animadvertere,
+						neque <lb/> distinguere, ncque recte numerare sine quibusdam <lb/> suis
+						numeris potuisse cognovit, eosque cæteris in­ <lb/> ferioris ordinis
+						judiciaria quadam æstimatione præ­ <lb/> posuit.</p>
+					</div><div type="textpart" subtype="dialog"><p>26. Et nunc cum ipsa sua delectatione, quæ 3 in <lb/> temporum momenta
+						perpendit, et talibus numeris <note type="footnote"> 4 septem Mss., <hi
+								rend="italic">percussionem.</hi> ' </note><note type="footnote"> I
+							Ita plerique Mss., cnm Am. At Lov.habet: <hi rend="italic">In hts
+								moae­</hi>
+							<lb/> randis, <hi rend="italic">sentiendis, relinendis, delectandis
+								agerEt anima.</hi>
+						</note><note type="footnote"> I Duo Mss., <hi rend="italic">qnam.</hi> Alii
+							tres, <hi rend="italic">qua.</hi> Paulo post, alter e victo­ <lb/> nnis
+							codicibui: <hi rend="italic">Propendet, tfillbw numeris.</hi>
 						</note>
-						<lb/> modificandis nutus suos exhibet, sic agit; quid est <lb/> quod in sensibili
-						numerositate diligimus? Num aliud <lb/> praeter parilitatem quamdam et aequaliter
-						dimensa in­ <lb/> . tervalla? An ille pyrrhichius pes sive spondeus, sive <lb/>
-						anapaestus, sive dactylus, siveprocelensmaticus, sivo <lb/> dispondeus nos aliter
-						delectaret ; nisi partem suam <lb/> parti alteri æquali divisione conferret? Quid vero
-						<lb/> iambus, trochaRus, tribrachus pulchritudinis habent, <lb/> nisi quod minore sua
-						parte majorcm suam partem in <lb/> tantas dnas aequaliter dividunt? Jani porro sex tem­
-						<lb/> porum pedes, num I aliunde blandius sonant atque <lb/> festivius, nisi quod
-						utraque lege partiuntur; scilicet <lb/> aut in duas æquales partes terna tempora
-						possidentes, <lb/> ant in unam simplam ex æqualibus partem 2, et alte­ <lb/> ram duplam,
-						id est, ut major habeat bis minorem, ct <lb/> eo modo ab illa dividatur acqualiter,
-						duobus tempori­ <lb/> bus quatuor tempora in bina demetiente ac secante? <lb/> Quid illi
-						quinnm soptenumque temporum pedes? unde <lb/> solutae orationi, quam versibus videntur
-						aptiores, nisi <lb/> quod eorum pars minor in partos æquales majorem <lb/> non dividit?
-						Et hi tamen ipsi unde admittuntur in sui <lb/> generis ordine ad temporum numerositatem,
-						nisi quia <lb/> et in quinque temporibus tantas duas particulas habet <lb/> pars minor,
-						quantas major tres; et in septem tantas <lb/> tres minor, quantas major quatuor? Ita in
-						omnibus <lb/> pedibus nulla pars minima est alicujus dimcn ionis <lb/> articulo notata,
-						cui nou cæteræ quanta possunt æqua­ <lb/> liiatc consentiant.</p>
-					<p>27. Age, in conjunctis pcdibus sive libera perpe­ <lb/> tuitate porrigatur ista
-						conjunctio, sicut in rhythmis; <lb/> sive ab aliquo certo fine rcvocetur, sicut in
-						metris; <lb/> sive eliam in duo membra quadam lege sibimct con­ <lb/> gruentia
-						tribuatur, sicut in versibus; qua tandem nlia <lb/> re, nisi æqualitate pcs pedi amicus
-						est? Unde molossi, <lb/> et ionicorum syllaba media quæ longa est, non se­ <lb/> ctione,
-						sed nutu I ipso pronuntiantis atque plaudentis <lb/> in duo paria momenta distribui
-						potest; tit cHam ad <lb/> tcma tempora pes totus convenint, quando cæteris <lb/> qui
-						codem modo dividuntur, adjungitur; cur nisi <lb/> æqualitatis jure dominante, quod
-						scilicet aequalis (st <lb/> lateribus * suis, quæ binorum temporum sunt, cum <lb/> et
-						ipsa sit duum temporum? Cur idem fieri in amphi­ <lb/> bracho non potest, quando cæteris
-						quatuor temporum <lb/> adjungitur, nisi quia tanta ibi non invenitur aequalitas <lb/>
-						duplo medio, lateribus simplis? Cur in silentiorum in­ <lb/> tervallis nulla fraude
-						sensus offenditur, nisi qnia ei­ <lb/> dcm juri æqualitatis, etiamsi non sono, spatio
-						tamen <lb/> temporis quod dcbetnr, cxsolvitur? Cur sequente si­ <lb/> lentio etiam
-						brevis syllaba pro longa accipitur, non <lb/> in tituto, sed ipso naturali examinc quod
-						auribus <lb/> præsidet; nisi quia in spatio temporis longiore sonuin <lb/> coarctare in
-						angustias eadem illa æqualitatis lege pro­ <lb/> hibemur? Itaque syllabam ultra duo
-						tempora produ­ <lb/> cere, ut etiam sono impleatur quod silentio impleri <lb/> potest,
-						admittit natura audiendi et tacendi5: ut autem <note type="footnote"> 1 Ms. A sic: <hi rend="italic">Non aliunde blandius sonant atque festitius.</hi> M. </note><note type="footnote"> 1 Duodecim Mss., <hi rend="italic">ex qualibet parte.</hi>
-						</note><note type="footnote"> a Ila in Mss. At in prius editis, <hi rend="italic">motu.</hi> — Sic etiamMf. A. M. </note><note type="footnote"> * An. Er. et
-							l.os.ycrqualibus laleribus. St*J clarius aliqwot <lb/> Mss., <hi rend="italic">æqualis
-								est;</hi> scilicet, pes tum tnofoSSIIS, lum ionicus. </note><note type="footnote">
-							IS In plerisque Mss., <hi rend="italic">audiendi et canendi.</hi> Et mox ill editia </note>
+						<lb/> modificandis nutus suos exhibet, sic agit; quid est <lb/> quod in
+						sensibili numerositate diligimus? Num aliud <lb/> praeter parilitatem
+						quamdam et aequaliter dimensa in­ <lb/> . tervalla? An ille pyrrhichius pes
+						sive spondeus, sive <lb/> anapaestus, sive dactylus, siveprocelensmaticus,
+						sivo <lb/> dispondeus nos aliter delectaret ; nisi partem suam <lb/> parti
+						alteri æquali divisione conferret? Quid vero <lb/> iambus, trochaRus,
+						tribrachus pulchritudinis habent, <lb/> nisi quod minore sua parte majorcm
+						suam partem in <lb/> tantas dnas aequaliter dividunt? Jani porro sex tem­
+						<lb/> porum pedes, num I aliunde blandius sonant atque <lb/> festivius, nisi
+						quod utraque lege partiuntur; scilicet <lb/> aut in duas æquales partes
+						terna tempora possidentes, <lb/> ant in unam simplam ex æqualibus partem 2,
+						et alte­ <lb/> ram duplam, id est, ut major habeat bis minorem, ct <lb/> eo
+						modo ab illa dividatur acqualiter, duobus tempori­ <lb/> bus quatuor tempora
+						in bina demetiente ac secante? <lb/> Quid illi quinnm soptenumque temporum
+						pedes? unde <lb/> solutae orationi, quam versibus videntur aptiores, nisi
+						<lb/> quod eorum pars minor in partos æquales majorem <lb/> non dividit? Et
+						hi tamen ipsi unde admittuntur in sui <lb/> generis ordine ad temporum
+						numerositatem, nisi quia <lb/> et in quinque temporibus tantas duas
+						particulas habet <lb/> pars minor, quantas major tres; et in septem tantas
+						<lb/> tres minor, quantas major quatuor? Ita in omnibus <lb/> pedibus nulla
+						pars minima est alicujus dimcn ionis <lb/> articulo notata, cui nou cæteræ
+						quanta possunt æqua­ <lb/> liiatc consentiant.</p>
+					</div><div type="textpart" subtype="dialog"><p>27. Age, in conjunctis pcdibus sive libera perpe­ <lb/> tuitate porrigatur
+						ista conjunctio, sicut in rhythmis; <lb/> sive ab aliquo certo fine
+						rcvocetur, sicut in metris; <lb/> sive eliam in duo membra quadam lege
+						sibimct con­ <lb/> gruentia tribuatur, sicut in versibus; qua tandem nlia
+						<lb/> re, nisi æqualitate pcs pedi amicus est? Unde molossi, <lb/> et
+						ionicorum syllaba media quæ longa est, non se­ <lb/> ctione, sed nutu I ipso
+						pronuntiantis atque plaudentis <lb/> in duo paria momenta distribui potest;
+						tit cHam ad <lb/> tcma tempora pes totus convenint, quando cæteris <lb/> qui
+						codem modo dividuntur, adjungitur; cur nisi <lb/> æqualitatis jure
+						dominante, quod scilicet aequalis (st <lb/> lateribus * suis, quæ binorum
+						temporum sunt, cum <lb/> et ipsa sit duum temporum? Cur idem fieri in amphi­
+						<lb/> bracho non potest, quando cæteris quatuor temporum <lb/> adjungitur,
+						nisi quia tanta ibi non invenitur aequalitas <lb/> duplo medio, lateribus
+						simplis? Cur in silentiorum in­ <lb/> tervallis nulla fraude sensus
+						offenditur, nisi qnia ei­ <lb/> dcm juri æqualitatis, etiamsi non sono,
+						spatio tamen <lb/> temporis quod dcbetnr, cxsolvitur? Cur sequente si­ <lb/>
+						lentio etiam brevis syllaba pro longa accipitur, non <lb/> in tituto, sed
+						ipso naturali examinc quod auribus <lb/> præsidet; nisi quia in spatio
+						temporis longiore sonuin <lb/> coarctare in angustias eadem illa æqualitatis
+						lege pro­ <lb/> hibemur? Itaque syllabam ultra duo tempora produ­ <lb/>
+						cere, ut etiam sono impleatur quod silentio impleri <lb/> potest, admittit
+						natura audiendi et tacendi5: ut autem <note type="footnote"> 1 Ms. A sic:
+								<hi rend="italic">Non aliunde blandius sonant atque festitius.</hi>
+							M. </note><note type="footnote"> 1 Duodecim Mss., <hi rend="italic">ex
+								qualibet parte.</hi>
+						</note><note type="footnote"> a Ila in Mss. At in prius editis, <hi
+								rend="italic">motu.</hi> — Sic etiamMf. A. M. </note><note
+							type="footnote"> * An. Er. et l.os.ycrqualibus laleribus. St*J clarius
+							aliqwot <lb/> Mss., <hi rend="italic">æqualis est;</hi> scilicet, pes
+							tum tnofoSSIIS, lum ionicus. </note><note type="footnote"> IS In
+							plerisque Mss., <hi rend="italic">audiendi et canendi.</hi> Et mox ill
+							editia </note>
 						<lb/>
-						<pb n="1179"/> minos quam duo tempora occupet syllaba, dum restat <lb/> spatium tacitis
-						nutibus, quædam fraus aequalitatis <lb/> est, quia minus quam in duobus esse æqualitas
-						non <lb/> potest. Jam vero in ipsa aequalitate membrorum qua <lb/> variantur illi
-						ambitus, quos Graeci <foreign xml:lang="grc">περιὸδους</foreign> vocant, <lb/> versusque
-						figurantur, quomodo ad eamdem aequali­ <lb/> tatem secretius reditur; nisi ut in ambitu
-						brevius <lb/> membrum majori aequalibus pedibus ad plausum con­ <lb/> veniat, et in
-						versu occultiore consideratione nume. <lb/> rorum, ea quas inæqualia membra junguntur,
-						vim <lb/> aequalitatis habere inveniantur?</p>
-					<p>28. Quaerit ergo ratio, et carnalem animae de­ <lb/> lectationem, quae judiciales
-						partes sibi vindicabat, <lb/> interrogat, cum eam in spatiorum temporalium nu­ <lb/>
-						meri aequalitas mulceat, utrum duae syllaba breves <lb/> quascuinque audierit vere sint
-						æquales; an fieri pos­ <lb/> sit, ut una earum edatur productius , non usque ad <lb/>
-						longæ syllabæ modum, sed infra quantumlibet, quo <lb/> tamen excedat sociam suam. Nnm
-						negari potest, fieri <lb/> posse, cum hæc delectatio ista non sentiat, et in­ <lb/>
-						æqualibus velut æqualibus gaudeat? quo errore et in­ <lb/> arqualitate quid turpius? Ex
-						quo admonelnur ab his <lb/> avertere gaudium, quae imitantur a'qualitatem , et <lb/>
-						utrum impleant, comprebendere non possumus: imo <lb/> quod non impleant fortasse
-						comprehendimus; et <lb/> tamen in quantum imitantur, pulchra esse in suo ge­ <lb/> nere
-						et ordine suo, negare non possumus.</p>
-					<ab>
-						<title type="sub">CAPUT XI. — Inferioribus <hi rend="italic">non offendi, solis</hi>
-							superio­ <hi rend="italic">ribus numeris delectari</hi> conveni. <hi rend="italic">Differentia</hi> phanta- <hi rend="italic">siæ et phantasmatis.</hi>
+						<pb n="1179"/> minos quam duo tempora occupet syllaba, dum restat <lb/>
+						spatium tacitis nutibus, quædam fraus aequalitatis <lb/> est, quia minus
+						quam in duobus esse æqualitas non <lb/> potest. Jam vero in ipsa aequalitate
+						membrorum qua <lb/> variantur illi ambitus, quos Graeci <foreign
+							xml:lang="grc">περιὸδους</foreign> vocant, <lb/> versusque figurantur,
+						quomodo ad eamdem aequali­ <lb/> tatem secretius reditur; nisi ut in ambitu
+						brevius <lb/> membrum majori aequalibus pedibus ad plausum con­ <lb/>
+						veniat, et in versu occultiore consideratione nume. <lb/> rorum, ea quas
+						inæqualia membra junguntur, vim <lb/> aequalitatis habere inveniantur?</p>
+					</div><div type="textpart" subtype="dialog"><p>28. Quaerit ergo ratio, et carnalem animae de­ <lb/> lectationem, quae
+						judiciales partes sibi vindicabat, <lb/> interrogat, cum eam in spatiorum
+						temporalium nu­ <lb/> meri aequalitas mulceat, utrum duae syllaba breves
+						<lb/> quascuinque audierit vere sint æquales; an fieri pos­ <lb/> sit, ut
+						una earum edatur productius , non usque ad <lb/> longæ syllabæ modum, sed
+						infra quantumlibet, quo <lb/> tamen excedat sociam suam. Nnm negari potest,
+						fieri <lb/> posse, cum hæc delectatio ista non sentiat, et in­ <lb/>
+						æqualibus velut æqualibus gaudeat? quo errore et in­ <lb/> arqualitate quid
+						turpius? Ex quo admonelnur ab his <lb/> avertere gaudium, quae imitantur
+						a'qualitatem , et <lb/> utrum impleant, comprebendere non possumus: imo
+						<lb/> quod non impleant fortasse comprehendimus; et <lb/> tamen in quantum
+						imitantur, pulchra esse in suo ge­ <lb/> nere et ordine suo, negare non
+						possumus.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT XI. — Inferioribus <hi rend="italic">non offendi,
+								solis</hi> superio­ <hi rend="italic">ribus numeris delectari</hi>
+							conveni. <hi rend="italic">Differentia</hi> phanta- <hi rend="italic"
+								>siæ et phantasmatis.</hi>
 						</title>
 					</ab>
-					<p>29. Non ergo invideamus inferioribus quam nos <lb/> sumus, nosque ipsos inter iila quæ
-						infra nos sunt <lb/> et illa quae supra nos sunt, ita Deo et Domino nostro <lb/>
-						opitulante ordinemus, ut inferioribus non offendamur, <lb/> solis autem superioribus
-						delectemur. Delectatio quippe <lb/> quasi pondus est animae. Delectatio ergo ordiuat
-						ani­ <lb/> mam. <hi rend="italic">Ubi enim erit thesaurus tuus, ibi erit et cor</hi>
-						tuum <lb/>
-						<hi rend="italic">(Matth.</hi> vi, 21): ubi delectatio , ibi thesaurus: ubi <lb/> autem
-						cor, ibi beatitudo aut miseria. Quae vcro supe­ <lb/> riora sunt, nisi illa in quibus
-						summa, inconcussa, <lb/> incommutabilis, æterna manet æqualitas? Ubi nul­ <lb/> lum est
-						tempus, quia nulla mutabilitas est; et unde <lb/> tempora fabricantur et ordinantur et
-						modificantur <lb/> æternitatem imitantia , dum cœli conversio ad idem <lb/> redit1, et
-						cœlestia corpora ad idem revocat, diebus­ <lb/> que et mensinus et annis ct lusiris,
-						cæterisque side­ <lb/> rum orbibus, legibus æqualitatis et unitatis et ordi­ <lb/>
-						nationis obtemperat. Ita coelestibus terrena subjecta, <lb/> orbes temporum. suorum
-						numerosa successione quasi <lb/> carmini universitatis associant.</p>
-					<p>30. In quibus multa nobis videntur inordinata et <lb/> perturbata, quia eorum ordini
-						pro nostris meritis <lb/> assuti sumus', nescientes quid de nobis divina pro­ <lb/>
-						videntia pulchrum gerat. Quoniam si quls, verbi <lb/> gratia, in amplissimarum
-						pulcherrimarumque ædium <lb/> uno aliquo angulo tanquam statua collocetur, pul. <lb/>
-						cbritudincm illius fabricæ sentire non poterit, cyro <lb/> et ipse pars erit. Nec
-						universi exercitus ordinem mi­ <lb/> lus in acie valet intueri. Et in quolibet poemate
-						si <lb/> quanto spatio syllabae sonant, tanto viverent atque <lb/> sentirent. nullo modo
-						illa numerositas et contexti <lb/> operis pulchritudo cis placeret , quam tutam perspi-
-						<lb/> cere atque approbare non possent, cum de ipsis sin­ <lb/> gulis prætereuntibus
-						fabricata esset atque perfecta. <lb/> Ita peccantem hominem ordinavit Deus turpem, non
-						<lb/> turpiter. Turpis enim factus cst voluntate, univcr­ <lb/> sum amittendo quod Dei
-						præceptis obtemperans pos­ <lb/> sidebat, et ordinatus in parte est, ut qui legem agere
-						<lb/> noluit, a lege agatur. Quidquid autem legitime, uti- <lb/> que juste ; et quidquid
-						juste, non utique turpiter agi- ; <lb/> tur : quia et in malis operibus nostris Dei
-						opera bona <lb/> sunt. Homo namque in quantum homo est, aliquod <lb/> bonum est;
-						adulterium autem in quantum adulte­ <lb/> rium est, malum opus est: plerumque autem de
-						adul- <lb/> tcrio nascitur bomo, de malo scilicet hominis opere <lb/> bonum opus
-						Dei.</p>
-					<p>31. Quamobrem ut nos ad propositum, prop'er <lb/> quod hanc sunt dicta, referamus, hi
-						numeri rationis <lb/> pulchritudine praeminent, a quibus si prorsus absciu­ <lb/>
-						dcremur, cum inclinamur ad corpus, progressores <lb/> numeros sensuales non
-						modificarent: qui rursus mo­ <lb/> vendis corporibus agunt sensibiles temporum pul­
-						<lb/> chritudines: atque ita sonantibus obvii etiam occur­ <lb/> sores numeri
-						fabricantur; quos omnes impetus suus <lb/> eadem anima excipiens, quasi multiplicat in
-						seipsa, <lb/> et recordabiles facit: quae vis ejus memoria dicitur, <lb/> magnum quoddam
-						adjutorium in hujus vitæ negotio­ <lb/> sissimis actibus.</p>
-					<p>32. Haec igitur memoria quæcumque de motibus <lb/> animi tenet, qui adversus passiones
-						corporis acti <lb/> sunt, <foreign xml:lang="grc">ϕαντασιἑαι</foreign> græce vocantur;
-						nee invenio quid eas <lb/> latine malim vocare : quas pro cognitis habere atque <lb/>
-						pro perceptis opinabilis vita est 1, constituta in ipso <lb/> erroris introitu. Sed cam
-						sibi isti motus occursant, et <lb/> tanquam diversis et repugnantibus intentionis flati­
-						<lb/> bus æstuant, alios ex aliis motus pariunt; non jam <lb/> eos qui tenentur ex
-						occursionibus passionum corporis <lb/> impressi de sensibus, similes tamen tanquam
-						imagi­ <lb/> num imagines, quæ phantasmata dici <unclear>placuit</unclear> Alitcr <lb/>
-						enim cogito patrem meum quem sæpe vidi, aliter <lb/> arum quem nunquam vidi. Horum
-						pilu.um phantasia <lb/> est. alterum phantasma. Illud in memoria invenio, <lb/> hoc in
-						eo motu animi, qui ex iis ortus est quos habet <lb/> memoria. Quomodo autem oriantur
-						hæc, et invenire <lb/> et explicare difficile est. Arbitror tamen, quod si nun­ <lb/>
-						qnam humana corpora vidissem, nullo modo ea pos­ <lb/> sem visibili specie cogitando
-						figurare. Quod autem ex <note type="footnote">
-							<hi rend="italic">legitur, spatium taciturnitatis;</hi> ubi substituimus ex Mss., ta-
-							citis nulibus.</note>
-						<note type="footnote"> 1 Am. Er. ad et plores » ad <hi rend="italic">diem</hi> redit. Et
-							infra iidem ha­ <lb/>
-							<hi rend="italic">bent Mss., ad diem</hi> revocat. Paulo , ost in editis legitur,
-							side­ <lb/>
-							<hi rend="italic">rum ordinibus</hi> legibusque. At in mss., <hi rend="italic">siderum
-								orbibus, legi- busque.</hi>
-						</note><note type="footnote"> 2 Libri scripti et excuni ferunt, <hi rend="italic">asarceti sumut.</hi> sed incun­ <lb/> ctanter legendum, <hi rend="italic">assuti
-								sumus,</hi> ut in corbeiensi codice le- <lb/> gebatur antequam passus esxet secundam
-							manum, quæ in- <lb/> serta vocali fecit usuetf. vide librum de vera Relirione <lb/>
-							cap. 22, n. 43, ubi rem eamdem inculcans Augustinus, «Sæ­ <lb/> culorum, ail, partes
-							damnatione facti sumus.» </note><note type="footnote">1 Plurimum hic variant libri Et
-							Er, quidem editio Loo,habet, <lb/> pro certis opinatis visa est. At Am. Er. et aliquot
-							Mss., opina- bilis vita est. Alii., Mss., opinabilis via est. Quidam demum opi- nans ,
-							vel opinatius. </note>
+					</div><div type="textpart" subtype="dialog"><p>29. Non ergo invideamus inferioribus quam nos <lb/> sumus, nosque ipsos inter
+						iila quæ infra nos sunt <lb/> et illa quae supra nos sunt, ita Deo et Domino
+						nostro <lb/> opitulante ordinemus, ut inferioribus non offendamur, <lb/>
+						solis autem superioribus delectemur. Delectatio quippe <lb/> quasi pondus
+						est animae. Delectatio ergo ordiuat ani­ <lb/> mam. <hi rend="italic">Ubi
+							enim erit thesaurus tuus, ibi erit et cor</hi> tuum <lb/>
+						<hi rend="italic">(Matth.</hi> vi, 21): ubi delectatio , ibi thesaurus: ubi
+						<lb/> autem cor, ibi beatitudo aut miseria. Quae vcro supe­ <lb/> riora
+						sunt, nisi illa in quibus summa, inconcussa, <lb/> incommutabilis, æterna
+						manet æqualitas? Ubi nul­ <lb/> lum est tempus, quia nulla mutabilitas est;
+						et unde <lb/> tempora fabricantur et ordinantur et modificantur <lb/>
+						æternitatem imitantia , dum cœli conversio ad idem <lb/> redit1, et cœlestia
+						corpora ad idem revocat, diebus­ <lb/> que et mensinus et annis ct lusiris,
+						cæterisque side­ <lb/> rum orbibus, legibus æqualitatis et unitatis et ordi­
+						<lb/> nationis obtemperat. Ita coelestibus terrena subjecta, <lb/> orbes
+						temporum. suorum numerosa successione quasi <lb/> carmini universitatis
+						associant.</p>
+					</div><div type="textpart" subtype="dialog"><p>30. In quibus multa nobis videntur inordinata et <lb/> perturbata, quia eorum
+						ordini pro nostris meritis <lb/> assuti sumus', nescientes quid de nobis
+						divina pro­ <lb/> videntia pulchrum gerat. Quoniam si quls, verbi <lb/>
+						gratia, in amplissimarum pulcherrimarumque ædium <lb/> uno aliquo angulo
+						tanquam statua collocetur, pul. <lb/> cbritudincm illius fabricæ sentire non
+						poterit, cyro <lb/> et ipse pars erit. Nec universi exercitus ordinem mi­
+						<lb/> lus in acie valet intueri. Et in quolibet poemate si <lb/> quanto
+						spatio syllabae sonant, tanto viverent atque <lb/> sentirent. nullo modo
+						illa numerositas et contexti <lb/> operis pulchritudo cis placeret , quam
+						tutam perspi- <lb/> cere atque approbare non possent, cum de ipsis sin­
+						<lb/> gulis prætereuntibus fabricata esset atque perfecta. <lb/> Ita
+						peccantem hominem ordinavit Deus turpem, non <lb/> turpiter. Turpis enim
+						factus cst voluntate, univcr­ <lb/> sum amittendo quod Dei præceptis
+						obtemperans pos­ <lb/> sidebat, et ordinatus in parte est, ut qui legem
+						agere <lb/> noluit, a lege agatur. Quidquid autem legitime, uti- <lb/> que
+						juste ; et quidquid juste, non utique turpiter agi- ; <lb/> tur : quia et in
+						malis operibus nostris Dei opera bona <lb/> sunt. Homo namque in quantum
+						homo est, aliquod <lb/> bonum est; adulterium autem in quantum adulte­ <lb/>
+						rium est, malum opus est: plerumque autem de adul- <lb/> tcrio nascitur
+						bomo, de malo scilicet hominis opere <lb/> bonum opus Dei.</p>
+					</div><div type="textpart" subtype="dialog"><p>31. Quamobrem ut nos ad propositum, prop'er <lb/> quod hanc sunt dicta,
+						referamus, hi numeri rationis <lb/> pulchritudine praeminent, a quibus si
+						prorsus absciu­ <lb/> dcremur, cum inclinamur ad corpus, progressores <lb/>
+						numeros sensuales non modificarent: qui rursus mo­ <lb/> vendis corporibus
+						agunt sensibiles temporum pul­ <lb/> chritudines: atque ita sonantibus obvii
+						etiam occur­ <lb/> sores numeri fabricantur; quos omnes impetus suus <lb/>
+						eadem anima excipiens, quasi multiplicat in seipsa, <lb/> et recordabiles
+						facit: quae vis ejus memoria dicitur, <lb/> magnum quoddam adjutorium in
+						hujus vitæ negotio­ <lb/> sissimis actibus.</p>
+					</div><div type="textpart" subtype="dialog"><p>32. Haec igitur memoria quæcumque de motibus <lb/> animi tenet, qui adversus
+						passiones corporis acti <lb/> sunt, <foreign xml:lang="grc"
+							>ϕαντασιἑαι</foreign> græce vocantur; nee invenio quid eas <lb/> latine
+						malim vocare : quas pro cognitis habere atque <lb/> pro perceptis opinabilis
+						vita est 1, constituta in ipso <lb/> erroris introitu. Sed cam sibi isti
+						motus occursant, et <lb/> tanquam diversis et repugnantibus intentionis
+						flati­ <lb/> bus æstuant, alios ex aliis motus pariunt; non jam <lb/> eos
+						qui tenentur ex occursionibus passionum corporis <lb/> impressi de sensibus,
+						similes tamen tanquam imagi­ <lb/> num imagines, quæ phantasmata dici
+							<unclear>placuit</unclear> Alitcr <lb/> enim cogito patrem meum quem
+						sæpe vidi, aliter <lb/> arum quem nunquam vidi. Horum pilu.um phantasia
+						<lb/> est. alterum phantasma. Illud in memoria invenio, <lb/> hoc in eo motu
+						animi, qui ex iis ortus est quos habet <lb/> memoria. Quomodo autem oriantur
+						hæc, et invenire <lb/> et explicare difficile est. Arbitror tamen, quod si
+						nun­ <lb/> qnam humana corpora vidissem, nullo modo ea pos­ <lb/> sem
+						visibili specie cogitando figurare. Quod autem ex <note type="footnote">
+							<hi rend="italic">legitur, spatium taciturnitatis;</hi> ubi substituimus
+							ex Mss., ta- citis nulibus.</note>
+						<note type="footnote"> 1 Am. Er. ad et plores » ad <hi rend="italic"
+								>diem</hi> redit. Et infra iidem ha­ <lb/>
+							<hi rend="italic">bent Mss., ad diem</hi> revocat. Paulo , ost in editis
+							legitur, side­ <lb/>
+							<hi rend="italic">rum ordinibus</hi> legibusque. At in mss., <hi
+								rend="italic">siderum orbibus, legi- busque.</hi>
+						</note><note type="footnote"> 2 Libri scripti et excuni ferunt, <hi
+								rend="italic">asarceti sumut.</hi> sed incun­ <lb/> ctanter
+							legendum, <hi rend="italic">assuti sumus,</hi> ut in corbeiensi codice
+							le- <lb/> gebatur antequam passus esxet secundam manum, quæ in- <lb/>
+							serta vocali fecit usuetf. vide librum de vera Relirione <lb/> cap. 22,
+							n. 43, ubi rem eamdem inculcans Augustinus, «Sæ­ <lb/> culorum, ail,
+							partes damnatione facti sumus.» </note><note type="footnote">1 Plurimum
+							hic variant libri Et Er, quidem editio Loo,habet, <lb/> pro certis
+							opinatis visa est. At Am. Er. et aliquot Mss., opina- bilis vita est.
+							Alii., Mss., opinabilis via est. Quidam demum opi- nans , vel opinatius. </note>
 						<lb/>
-						<pb n="1181"/> eo quod vidi facio, memoria facio: et lamen aliud <lb/> est in memoria
-						invenire phantasiam, aliud de memo­ <lb/> ria facere phantasma. Quæ omnia vis animæ
-						potest. <lb/> Sed vera eliam phantasmata habere pro cognitis, <lb/> summus error est.
-						Quanquam sit in utroque genere <lb/> quod nos non absurde scire dicamus, id est,
-						sensisse <lb/> nos lalia, vel imaginari nos talia. Patrem denique me <lb/> babuisse et
-						avum, non temere possum dicere : ipsos <lb/> autem esse quos animus meus in phantasia
-						vel in <lb/> phantasmate tenet, dementissime dixerim. Sequun­ <lb/> tur autem nonnulli
-						phantasmata sua tam præcipites, <lb/> ut nulla sit alia materies omnium falsarum opinio­
-						<lb/> num, quam habere phantasias vel phantasmata pro <lb/> cognitis, quæ cognoscuntur
-						per sensam Quare his <lb/> potissimum resistamus, nee eis ita mentem accommo­ <lb/>
-						demus, ut dum in his est cogitatio, intelligentia ea <lb/> cerni arbitremur.</p>
-					<p>33. Cur autem si hujusmodi numeri qni nunt in <lb/> anima rebus temporalibus dedita,
-						habent sui generis <lb/> pulchritudinem , quamvis cam transcundo actitent, <lb/>
-						invideat huic pulchritudini divina providentia, quæ <lb/> de nostra poenali mortalitate
-						formatur, quam justis­ <lb/> sima Dei lege meruimus : in qua tamen nos non ita <lb/>
-						deseruit, ut non valeamus recurrere, et a carnalium <lb/> sensuum delectatione,
-						misericordia ejus maium por­ <lb/> rigente , revocari. Talis enim delectatio vehementer
-						<lb/> Infigit memoriae quod trahit a lubricis sensibus. Haec <lb/> autem animae
-						consuetudo facta cum carne, propter <lb/> carnalem affectionem, in Scripturis divinis
-						caro no­ <lb/> minatur. Hæc menti obluctatur, cum jam dici potest <lb/> apostolicum
-						illud: <hi rend="italic">Mente</hi> servio <hi rend="italic">legi Dei, carne autem<lb/>
-							legi peccati (Rom.</hi> VII, 25). Sed in spiritualia mente <lb/> suspensa atque ibi
-						fixa et manente, etiam hujus con­ <lb/> suetudinis impetus frangiiur, et paulatim
-						repressus <lb/> exstinguitur. Major euim erat cum sequeremur; uon <lb/> tamen omnino
-						nullus, sed certe minor est cum eum <lb/> refrenamus, atque ita certis regressibus ab
-						omni <lb/> lasciviente motu , in quo defectus essentiae est animae, <lb/> delectatione
-						in rationis nnmeros restituta ad Deum <lb/> tota vita nostra convertitur, dans corpori
-						nnmeros <lb/> sanitatis, non accipiens inde heliliam; quod cor­ <lb/> rupto exteriore
-						homine, et ejus in melius commuta­ <lb/> tione continget.</p>
-					<ab>
-						<title type="sub">CAPUT XII. — <hi rend="italic">De</hi> numeris <hi rend="italic">spiritualibus et æternis.</hi>
+						<pb n="1181"/> eo quod vidi facio, memoria facio: et lamen aliud <lb/> est
+						in memoria invenire phantasiam, aliud de memo­ <lb/> ria facere phantasma.
+						Quæ omnia vis animæ potest. <lb/> Sed vera eliam phantasmata habere pro
+						cognitis, <lb/> summus error est. Quanquam sit in utroque genere <lb/> quod
+						nos non absurde scire dicamus, id est, sensisse <lb/> nos lalia, vel
+						imaginari nos talia. Patrem denique me <lb/> babuisse et avum, non temere
+						possum dicere : ipsos <lb/> autem esse quos animus meus in phantasia vel in
+						<lb/> phantasmate tenet, dementissime dixerim. Sequun­ <lb/> tur autem
+						nonnulli phantasmata sua tam præcipites, <lb/> ut nulla sit alia materies
+						omnium falsarum opinio­ <lb/> num, quam habere phantasias vel phantasmata
+						pro <lb/> cognitis, quæ cognoscuntur per sensam Quare his <lb/> potissimum
+						resistamus, nee eis ita mentem accommo­ <lb/> demus, ut dum in his est
+						cogitatio, intelligentia ea <lb/> cerni arbitremur.</p>
+					</div><div type="textpart" subtype="dialog"><p>33. Cur autem si hujusmodi numeri qni nunt in <lb/> anima rebus temporalibus
+						dedita, habent sui generis <lb/> pulchritudinem , quamvis cam transcundo
+						actitent, <lb/> invideat huic pulchritudini divina providentia, quæ <lb/> de
+						nostra poenali mortalitate formatur, quam justis­ <lb/> sima Dei lege
+						meruimus : in qua tamen nos non ita <lb/> deseruit, ut non valeamus
+						recurrere, et a carnalium <lb/> sensuum delectatione, misericordia ejus
+						maium por­ <lb/> rigente , revocari. Talis enim delectatio vehementer <lb/>
+						Infigit memoriae quod trahit a lubricis sensibus. Haec <lb/> autem animae
+						consuetudo facta cum carne, propter <lb/> carnalem affectionem, in
+						Scripturis divinis caro no­ <lb/> minatur. Hæc menti obluctatur, cum jam
+						dici potest <lb/> apostolicum illud: <hi rend="italic">Mente</hi> servio <hi
+							rend="italic">legi Dei, carne autem<lb/> legi peccati (Rom.</hi> VII,
+						25). Sed in spiritualia mente <lb/> suspensa atque ibi fixa et manente,
+						etiam hujus con­ <lb/> suetudinis impetus frangiiur, et paulatim repressus
+						<lb/> exstinguitur. Major euim erat cum sequeremur; uon <lb/> tamen omnino
+						nullus, sed certe minor est cum eum <lb/> refrenamus, atque ita certis
+						regressibus ab omni <lb/> lasciviente motu , in quo defectus essentiae est
+						animae, <lb/> delectatione in rationis nnmeros restituta ad Deum <lb/> tota
+						vita nostra convertitur, dans corpori nnmeros <lb/> sanitatis, non accipiens
+						inde heliliam; quod cor­ <lb/> rupto exteriore homine, et ejus in melius
+						commuta­ <lb/> tione continget.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT XII. — <hi rend="italic">De</hi> numeris <hi
+								rend="italic">spiritualibus et æternis.</hi>
 						</title>
 					</ab>
-					<p>34. Excipit autem memoria non solum carnales <lb/> motus animi, de quibus numeris supra
-						jam diximus; <lb/> tcd etiam spirituales, de quibus breviter dicam. Quo <lb/> enim
-						simpliciores sunt, eo verborum minus, sed plu­ <lb/> rimum serena' mentis desiderant.
-						i£qualitatem illam <lb/> quam in sensibilibus numeris non reperiebamus cer­ <lb/> tam et
-						manentem, sed tamen adumbratam et præter­ <lb/> euntem agnoscebamus, nusquam profecto
-						appeteret <lb/> animus nisi alicubi nota esset: hoc autem alicubi non <lb/> in spatiis
-						locorum et temporum ; nam illa tument, et <lb/> ista prætereunt. Ubi ergo censes,
-						responde, quaeso, <note type="footnote">a A ( Icrisque Mss. absunt isthaec verba : <hi rend="italic">Qiuim</hi> habere <lb/>
-							<hi rend="italic">rhuntawis rei phantasmata pro cognitis, quæ coqnoscutUur</hi>
+					</div><div type="textpart" subtype="dialog"><p>34. Excipit autem memoria non solum carnales <lb/> motus animi, de quibus
+						numeris supra jam diximus; <lb/> tcd etiam spirituales, de quibus breviter
+						dicam. Quo <lb/> enim simpliciores sunt, eo verborum minus, sed plu­ <lb/>
+						rimum serena' mentis desiderant. i£qualitatem illam <lb/> quam in
+						sensibilibus numeris non reperiebamus cer­ <lb/> tam et manentem, sed tamen
+						adumbratam et præter­ <lb/> euntem agnoscebamus, nusquam profecto appeteret
+						<lb/> animus nisi alicubi nota esset: hoc autem alicubi non <lb/> in spatiis
+						locorum et temporum ; nam illa tument, et <lb/> ista prætereunt. Ubi ergo
+						censes, responde, quaeso, <note type="footnote">a A ( Icrisque Mss. absunt
+							isthaec verba : <hi rend="italic">Qiuim</hi> habere <lb/>
+							<hi rend="italic">rhuntawis rei phantasmata pro cognitis, quæ
+								coqnoscutUur</hi>
 							<lb/> ver settsum. </note>
-						<lb/> si potes. Non enim in corporum formis putas, quas. <lb/> liquido examine æquales
-						nunquam dicere audebis; <lb/> aut in temporum intervallis, in quibus similiter <lb/>
-						utruni sit aliquid aliquanto quam oportet productius <lb/> vel correptius quod sensum
-						fugiat, ignoramus. Illam <lb/> quippe æqualitatem quaero ubi esse arbitreris, quam <lb/>
-						intuentes cupimus æqualia esse quaedam corpora vcl <lb/> corporum motus, et diligentius
-						considerantes eis <lb/> fidere non audemus. <hi rend="italic">D.</hi> Ibi puto quod est
-						corpori­ <lb/> bus excellentius; sed utrum in ipsa anima, an edam <lb/> supra animam
-						nescio.</p>
-					<p>35. <hi rend="italic">M.</hi> Si ergo quaeramus artem istam rhythmicam <lb/> vel
-						metricam, qua utuntur qui versus faciunt, putasne <lb/> habere aliquos numeros, secundum
-						quos fabricant <lb/> versus? <hi rend="italic">D.</hi> Nihil aliud possum existimare.
-							<hi rend="italic">M.</hi> Qui­ <lb/> cumque isti sunt numeri, praeterire tibi videntur
-						cum <lb/> versibus, an manere? <hi rend="italic">D.</hi> Manere sane. M. Cousen­ <lb/>
-						ticndum est ergo, ab aliquibus manentibus numeris <lb/> prætereuntes aliquos fabricari?
-							<hi rend="italic">D.</hi> Cogit me ratio con­ <lb/> sentire. <hi rend="italic">M.</hi>
-						Quid? hanc artem num aliud putas quam <lb/> affectionem quamdam esse animi artificis?
-							<hi rend="italic">D.</hi> Ita <lb/> credo. <hi rend="italic">M.</hi> Credisne hanc
-						affectionem etiam esse in eo, <lb/> qui hujus artis imperitus cst? <hi rend="italic">D.</hi> Nullo modo. <hi rend="italic">M.</hi>
-						<lb/> Quid? in illo qui oblitus csl eam? D. Nec in illo qui­ <lb/> dem, quia ct ipse
-						imperitus est, etiamsi fuit peritus <lb/> aliquando. <hi rend="italic">M.</hi> Quid? si
-						eum quisquam interrogando <lb/> commemoret? remigrare ad eum putas illos numeros <lb/>
-						ab eo ipso qui interrogat; an illum intrinsecus apud <lb/> mentem suam movere se ad
-						aliquid, unde sibi quod <lb/> amiserat redhibeatur? <hi rend="italic">D.</hi> Apud
-						semetipsum puto id <lb/> agere. <hi rend="italic">M.</hi> Num eliam quæ corripiatur
-						syllaba, quævo <lb/> producatur si penitus excidit, commoneri eum inter­ <lb/> rogando
-						arbitraris; cum hominum prisco placito et <lb/> consuetudine, aliis minor, aliis major
-						mora syllabis <lb/> data sit? Nam profecto si natura vel disciplina id <lb/> fixum esset
-						ac stabile, non recentioris temporis docti <lb/> homines nonnullas produxissent quas
-						corripuerunt <lb/> antiqui, vel corripuissent quas produxerunt. D. Puto <lb/> et hoc
-						posse, quoniam quantumvis quidque excidat, <lb/> potest interrogatione commemorante
-						rcdire in memo­ <lb/> riam. <hi rend="italic">M.</hi> Mirum si opinaris, quovis
-						interrogante posse <lb/> te recordari quid ante annum coenavcris. <hi rend="italic">D.</hi> Fateor <lb/> me non posse, nec illum jam existimo de syllabis <lb/> posse,
-						quarum spatia penitns oblitus est, interrogando <lb/> admoneri. M. Cur ita, nisi quia in
-						hoc nomine quod <lb/>
-						<hi rend="italic">Italia</hi> dicitur, prima syllaba pro voluntate quorum­ <lb/> dam
-						hominum corripiebatur, ct nunc pro aliorum vo­ <lb/> luntate producitur? Ut autem unum
-						et dno non sint <lb/> tria, et ut duo uni non duplo respondeant, nullus <lb/> mortuorum
-						potuit, nullus vivorum potest, nullus po­ <lb/> sterorum poterit facere. <hi rend="italic">D.</hi> Nihil manifestius. <hi rend="italic">M.</hi>
-						<lb/> Quid si ergo isto modo quo de uno et de duobus <lb/> apertissime quævimus, cætera
-						omnia , qua; ad illos <lb/> numeros pertinent et ille interrogetur, qui non obli­ <lb/>
-						viscendo, sed quia nunqnam didicit, imperitus est ? <lb/> nonne eum censes similiter
-						hanc artem exceptis syl­ <lb/> labis posse cognoscere? <hi rend="italic">D.</hi> Quis
-						dubitaverit? <hi rend="italic">M.</hi> Quo <lb/> igitur se etiam istum moturum putas, nt
-						menti <lb/> ejus imprimantur hi numeri, et iilam faciant affectio­ <lb/>
-						<pb n="1183"/> nero quae ars dicitur? an huic saltem ille interrogator <lb/> eos dabit?
-							<hi rend="italic">D.</hi> Eo modo etiam istum arbitror apud <lb/> semetipsum agere, ut
-						ea quæ interrogantur, vera <lb/> esse intelligat atque respondeat..</p>
-					<p>36. <hi rend="italic">M.</hi> Age, nunc dic mihi utrum hi numeri de <lb/> quihus sic
-						quæritur, commutabiles esse tibi videan­ <lb/> tur. <hi rend="italic">D.</hi> Nullo
-						modo. 31. Ergo aeternos esse non negas. <lb/>
-						<hi rend="italic">D.</hi> Imo fateor. <hi rend="italic">M.</hi> Quid ? metus ille non
-						suberit, ne ali­ <lb/> qua nos in eis inaequalitas fallat1 ? <hi rend="italic">D.</hi>
-						Nihil me omnino <lb/> est de istorum aequalitate securius. <hi rend="italic">II.</hi>
-						Unde ergo cre­ <lb/> dendum est animae tribui quod æternum est et incom­ <lb/> mutabile,
-						nisi ab uno æterno et incommutabili Deo? <lb/>
-						<hi rend="italic">D.</hi> Non video quid aliud credi eporteat. M. Quid tan­ <lb/> dem ?
-						illud nonne manifestum est, eum qui alio in­ <lb/> terrogante sese intus ad Deum movet,
-						ut verum <lb/> incommutabile intelligat; nisi eumdem motum suum <lb/> memoria teneat,
-						non posse ad intuendum illud ve­ <lb/> rum, nullo extrinsecus admonente revocari ? <hi rend="italic">D.</hi> Ma­ <lb/> nifestum est.</p>
-					<ab>
-						<title type="sub">CAPUT XIII. — <hi rend="italic">Anumus unde fit ut a veritate incom­
-								mutabili avertatur.</hi>
+						<lb/> si potes. Non enim in corporum formis putas, quas. <lb/> liquido
+						examine æquales nunquam dicere audebis; <lb/> aut in temporum intervallis,
+						in quibus similiter <lb/> utruni sit aliquid aliquanto quam oportet
+						productius <lb/> vel correptius quod sensum fugiat, ignoramus. Illam <lb/>
+						quippe æqualitatem quaero ubi esse arbitreris, quam <lb/> intuentes cupimus
+						æqualia esse quaedam corpora vcl <lb/> corporum motus, et diligentius
+						considerantes eis <lb/> fidere non audemus. <hi rend="italic">D.</hi> Ibi
+						puto quod est corpori­ <lb/> bus excellentius; sed utrum in ipsa anima, an
+						edam <lb/> supra animam nescio.</p>
+					</div><div type="textpart" subtype="dialog"><p>35. <hi rend="italic">M.</hi> Si ergo quaeramus artem istam rhythmicam <lb/>
+						vel metricam, qua utuntur qui versus faciunt, putasne <lb/> habere aliquos
+						numeros, secundum quos fabricant <lb/> versus? <hi rend="italic">D.</hi>
+						Nihil aliud possum existimare. <hi rend="italic">M.</hi> Qui­ <lb/> cumque
+						isti sunt numeri, praeterire tibi videntur cum <lb/> versibus, an manere?
+							<hi rend="italic">D.</hi> Manere sane. M. Cousen­ <lb/> ticndum est
+						ergo, ab aliquibus manentibus numeris <lb/> prætereuntes aliquos fabricari?
+							<hi rend="italic">D.</hi> Cogit me ratio con­ <lb/> sentire. <hi
+							rend="italic">M.</hi> Quid? hanc artem num aliud putas quam <lb/>
+						affectionem quamdam esse animi artificis? <hi rend="italic">D.</hi> Ita
+						<lb/> credo. <hi rend="italic">M.</hi> Credisne hanc affectionem etiam esse
+						in eo, <lb/> qui hujus artis imperitus cst? <hi rend="italic">D.</hi> Nullo
+						modo. <hi rend="italic">M.</hi>
+						<lb/> Quid? in illo qui oblitus csl eam? D. Nec in illo qui­ <lb/> dem, quia
+						ct ipse imperitus est, etiamsi fuit peritus <lb/> aliquando. <hi
+							rend="italic">M.</hi> Quid? si eum quisquam interrogando <lb/>
+						commemoret? remigrare ad eum putas illos numeros <lb/> ab eo ipso qui
+						interrogat; an illum intrinsecus apud <lb/> mentem suam movere se ad
+						aliquid, unde sibi quod <lb/> amiserat redhibeatur? <hi rend="italic"
+							>D.</hi> Apud semetipsum puto id <lb/> agere. <hi rend="italic">M.</hi>
+						Num eliam quæ corripiatur syllaba, quævo <lb/> producatur si penitus
+						excidit, commoneri eum inter­ <lb/> rogando arbitraris; cum hominum prisco
+						placito et <lb/> consuetudine, aliis minor, aliis major mora syllabis <lb/>
+						data sit? Nam profecto si natura vel disciplina id <lb/> fixum esset ac
+						stabile, non recentioris temporis docti <lb/> homines nonnullas produxissent
+						quas corripuerunt <lb/> antiqui, vel corripuissent quas produxerunt. D. Puto
+						<lb/> et hoc posse, quoniam quantumvis quidque excidat, <lb/> potest
+						interrogatione commemorante rcdire in memo­ <lb/> riam. <hi rend="italic"
+							>M.</hi> Mirum si opinaris, quovis interrogante posse <lb/> te recordari
+						quid ante annum coenavcris. <hi rend="italic">D.</hi> Fateor <lb/> me non
+						posse, nec illum jam existimo de syllabis <lb/> posse, quarum spatia penitns
+						oblitus est, interrogando <lb/> admoneri. M. Cur ita, nisi quia in hoc
+						nomine quod <lb/>
+						<hi rend="italic">Italia</hi> dicitur, prima syllaba pro voluntate quorum­
+						<lb/> dam hominum corripiebatur, ct nunc pro aliorum vo­ <lb/> luntate
+						producitur? Ut autem unum et dno non sint <lb/> tria, et ut duo uni non
+						duplo respondeant, nullus <lb/> mortuorum potuit, nullus vivorum potest,
+						nullus po­ <lb/> sterorum poterit facere. <hi rend="italic">D.</hi> Nihil
+						manifestius. <hi rend="italic">M.</hi>
+						<lb/> Quid si ergo isto modo quo de uno et de duobus <lb/> apertissime
+						quævimus, cætera omnia , qua; ad illos <lb/> numeros pertinent et ille
+						interrogetur, qui non obli­ <lb/> viscendo, sed quia nunqnam didicit,
+						imperitus est ? <lb/> nonne eum censes similiter hanc artem exceptis syl­
+						<lb/> labis posse cognoscere? <hi rend="italic">D.</hi> Quis dubitaverit?
+							<hi rend="italic">M.</hi> Quo <lb/> igitur se etiam istum moturum putas,
+						nt menti <lb/> ejus imprimantur hi numeri, et iilam faciant affectio­ <lb/>
+						<pb n="1183"/> nero quae ars dicitur? an huic saltem ille interrogator <lb/>
+						eos dabit? <hi rend="italic">D.</hi> Eo modo etiam istum arbitror apud <lb/>
+						semetipsum agere, ut ea quæ interrogantur, vera <lb/> esse intelligat atque
+						respondeat..</p>
+					</div><div type="textpart" subtype="dialog"><p>36. <hi rend="italic">M.</hi> Age, nunc dic mihi utrum hi numeri de <lb/>
+						quihus sic quæritur, commutabiles esse tibi videan­ <lb/> tur. <hi
+							rend="italic">D.</hi> Nullo modo. 31. Ergo aeternos esse non negas. <lb/>
+						<hi rend="italic">D.</hi> Imo fateor. <hi rend="italic">M.</hi> Quid ? metus
+						ille non suberit, ne ali­ <lb/> qua nos in eis inaequalitas fallat1 ? <hi
+							rend="italic">D.</hi> Nihil me omnino <lb/> est de istorum aequalitate
+						securius. <hi rend="italic">II.</hi> Unde ergo cre­ <lb/> dendum est animae
+						tribui quod æternum est et incom­ <lb/> mutabile, nisi ab uno æterno et
+						incommutabili Deo? <lb/>
+						<hi rend="italic">D.</hi> Non video quid aliud credi eporteat. M. Quid tan­
+						<lb/> dem ? illud nonne manifestum est, eum qui alio in­ <lb/> terrogante
+						sese intus ad Deum movet, ut verum <lb/> incommutabile intelligat; nisi
+						eumdem motum suum <lb/> memoria teneat, non posse ad intuendum illud ve­
+						<lb/> rum, nullo extrinsecus admonente revocari ? <hi rend="italic">D.</hi>
+						Ma­ <lb/> nifestum est.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT XIII. — <hi rend="italic">Anumus unde fit ut a
+								veritate incom­ mutabili avertatur.</hi>
 						</title>
 					</ab>
-					<p>57. M. Quaero ergo quonam iste ab hujuscemodi <lb/> rerum contemplatione discedat, ut
-						illum ad cam ne. <lb/> cesse sit memoria revocari. An forte in aliud intentus <lb/>
-						animus tali reditu indigere putandus est? <hi rend="italic">D.</hi> Sic exi­ <lb/>
-						stimo. M. Videamus, si placet, quid tantum illud sit <lb/> quo possit intendi, ut ab
-						incommutabilis et summæ <lb/> , æqualitatis contemplatione avertatur. Nam tribus ge­
-						<lb/> neribus amplius nihil video. Aut enim ad aliquid par <lb/> atque ad ejusmodi aliud
-						se intendit animus, cum hinc <lb/> avertitur, aut ad superius, aut ad inferius. <hi rend="italic">D.</hi> De cic­ <lb/> teris duobus quærendum est : nan quid sit supcrius
-						<lb/> æterna æqualitate non video <hi rend="italic">M.</hi> Videsne illud, obse­ <lb/>
-						cro, quidnam ei par esse possit, quod tamen aliud <lb/> sit? <hi rend="italic">D.</hi>
-						Ne id quidem video. M. Restat ergo ut quæ­ <lb/> ramus, quid sit inferius. Sed nonne
-						tibi prius ipsa <lb/> anima occurrit, quai certa aequalitatcm illam incommu­ <lb/>
-						tabilem esse confitetur, se autcm agnoscit mutari co <lb/> ipso quod alias hanc, alias
-						aliud intuetur; ct hoc modo <lb/> aliud atque aliud sequens varietatem temporis opera­
-						<lb/> tur, qunc in a ternis et incommutahilibus nulla est? <hi rend="italic">D.</hi>
-						<lb/> Assontior. <hi rend="italic">M.</hi> Hxc igitur affectio animæ vel motus, <lb/>
-						quo intelligit aeterna, et his inferiora esse temporalia. <lb/> etiam in seipsa; et hæc
-						appetenda potius quæ supe­ <lb/> nora sunt, quam illa quæ inferiora sunt novit: nonne
-						<lb/> tibi prudentia videtur? <hi rend="italic">D.</hi> Nihil aliud videtur.</p>
-					<p>38. M. Quid illud? num minus considcrandum pu­ <lb/> tas quod nondum in ea simul est a
-						ternis inhærere, <lb/> cum jam in ca sit nosse his esse inhærendun}? I. Imo <lb/> maxime
-						ut id consideremus peto, et unde accidat scire <lb/> cupio. <hi rend="italic">M.</hi>
-						Facile id videbis, si animadverteris quibus <lb/> rebus maxime animum soleamus
-						intendere, et ma­ <lb/> gnam curam exhibere : nam eas opinor esse quas <lb/> multum
-						amamus : an tu alias opinaris? <hi rend="italic">D.</hi> Nullas <lb/> equidem alias. <hi rend="italic">M.</hi> Dic, oro te, num possumus amare <lb/> nisi pulchra? Nam etsi
-						quidam videntur amare dcfur­ <lb/> mia, quos vulgo Græci <foreign xml:lang="grc">σαπροϕίλους</foreign> vocant, interest <note type="footnote">11.0'. : <hi rend="italic">-"os in ci-, æqualitas</hi> fallet. Sex Mss., <hi rend="italic">inatqualilns.</hi>
+					</div><div type="textpart" subtype="dialog"><p>37. M. Quaero ergo quonam iste ab hujuscemodi <lb/> rerum contemplatione
+						discedat, ut illum ad cam ne. <lb/> cesse sit memoria revocari. An forte in
+						aliud intentus <lb/> animus tali reditu indigere putandus est? <hi
+							rend="italic">D.</hi> Sic exi­ <lb/> stimo. M. Videamus, si placet, quid
+						tantum illud sit <lb/> quo possit intendi, ut ab incommutabilis et summæ
+						<lb/> , æqualitatis contemplatione avertatur. Nam tribus ge­ <lb/> neribus
+						amplius nihil video. Aut enim ad aliquid par <lb/> atque ad ejusmodi aliud
+						se intendit animus, cum hinc <lb/> avertitur, aut ad superius, aut ad
+						inferius. <hi rend="italic">D.</hi> De cic­ <lb/> teris duobus quærendum est
+						: nan quid sit supcrius <lb/> æterna æqualitate non video <hi rend="italic"
+							>M.</hi> Videsne illud, obse­ <lb/> cro, quidnam ei par esse possit,
+						quod tamen aliud <lb/> sit? <hi rend="italic">D.</hi> Ne id quidem video. M.
+						Restat ergo ut quæ­ <lb/> ramus, quid sit inferius. Sed nonne tibi prius
+						ipsa <lb/> anima occurrit, quai certa aequalitatcm illam incommu­ <lb/>
+						tabilem esse confitetur, se autcm agnoscit mutari co <lb/> ipso quod alias
+						hanc, alias aliud intuetur; ct hoc modo <lb/> aliud atque aliud sequens
+						varietatem temporis opera­ <lb/> tur, qunc in a ternis et incommutahilibus
+						nulla est? <hi rend="italic">D.</hi>
+						<lb/> Assontior. <hi rend="italic">M.</hi> Hxc igitur affectio animæ vel
+						motus, <lb/> quo intelligit aeterna, et his inferiora esse temporalia. <lb/>
+						etiam in seipsa; et hæc appetenda potius quæ supe­ <lb/> nora sunt, quam
+						illa quæ inferiora sunt novit: nonne <lb/> tibi prudentia videtur? <hi
+							rend="italic">D.</hi> Nihil aliud videtur.</p>
+					</div><div type="textpart" subtype="dialog"><p>38. M. Quid illud? num minus considcrandum pu­ <lb/> tas quod nondum in ea
+						simul est a ternis inhærere, <lb/> cum jam in ca sit nosse his esse
+						inhærendun}? I. Imo <lb/> maxime ut id consideremus peto, et unde accidat
+						scire <lb/> cupio. <hi rend="italic">M.</hi> Facile id videbis, si
+						animadverteris quibus <lb/> rebus maxime animum soleamus intendere, et ma­
+						<lb/> gnam curam exhibere : nam eas opinor esse quas <lb/> multum amamus :
+						an tu alias opinaris? <hi rend="italic">D.</hi> Nullas <lb/> equidem alias.
+							<hi rend="italic">M.</hi> Dic, oro te, num possumus amare <lb/> nisi
+						pulchra? Nam etsi quidam videntur amare dcfur­ <lb/> mia, quos vulgo Græci
+							<foreign xml:lang="grc">σαπροϕίλους</foreign> vocant, interest <note
+							type="footnote">11.0'. : <hi rend="italic">-"os in ci-, æqualitas</hi>
+							fallet. Sex Mss., <hi rend="italic">inatqualilns.</hi>
 						</note>
-						<lb/> tamen quanto minus pulchra sint quam Hia qua; p!u- <lb/> ribus placent. Nam ea
-						neminem amare manifestum <lb/> est; quorum fceditate sensus oflenditur. <hi rend="italic">D.</hi> Ita est, at <lb/> dicis. M. Hæc igitur pulchra numero placent,
-						in quo <lb/> jam ostendimus aequalitatem appeti. Non enim boc <lb/> tantum in ea
-						pulchritudine quae ad aures pertinet , <lb/> atque in motu corporum est, invenitur, sed
-						in ipsis <lb/> etiam visibilibus formis, in quibus jam usitatius dici­ <lb/> tur
-						pulchritudo. An aliud quam aequalitatem numero­ <lb/> sam esse arbitraris, cum paria
-						paribus bimi membra <lb/> respondent: quæ autem singula sunt, medium locum <lb/> tenent,
-						ut ad ea de utraque parte paria intervalla <lb/> serventur? <hi rend="italic">D.</hi>
-						Non aliter puto. <hi rend="italic">M.</hi> Quid in ipsa luce <lb/> visibili quae omnium
-						colorum habet principatum, nam <lb/> et color nos delectat in corporum formis; quid ergo
-						<lb/> aliud in luce et coloribus, nisi quod nostris oculis <lb/> c ngruit, appetimus?
-						Etenim a nimio fulgore aversa­ <lb/> mur, et nimis obscura nolumus cernere, sicut etiam
-						<lb/> in sonis et a nimium sonantibus abhorremus, et quasi <lb/> susurranua non amamus.
-						Quod non in temporum in­ <lb/> tervallis est, sed in ipso sono, qui quasi lux est talium
-						<lb/> numerorum, cui sic est contrarium silentium, ut co­ <lb/> loribus tenebrae. In his
-						ergo cum appetimus conve­ <lb/> nientia pro naturæ nostrae modo, et inconvenientia <lb/>
-						respuimus, quoe aliis tamen animalibus convenire sen. <lb/> Limus, nonne bic etiam
-						quodam aequalitatis jure læ­ <lb/> tamur, cum occultioribus modis paria paribus tributa
-						<lb/> esse cognoscimus? Hoc in odoribus et in saporibus, <lb/> et in tangendi sensu
-						animadvertere licet, quæ longum <lb/> est enucleatius persequi, sed explorare
-						facillimum: <lb/> nihil enim est horum sensibilium, quod nobis non <lb/> æqualitate aut
-						similitudine placeat. Ubi autem æqua­ <lb/> litas aut similitudo, ibi numerositas; nibil
-						est quippe <lb/> tam aequale aut simile quam unum et unum : nisi quid <lb/> habes ad
+						<lb/> tamen quanto minus pulchra sint quam Hia qua; p!u- <lb/> ribus
+						placent. Nam ea neminem amare manifestum <lb/> est; quorum fceditate sensus
+						oflenditur. <hi rend="italic">D.</hi> Ita est, at <lb/> dicis. M. Hæc igitur
+						pulchra numero placent, in quo <lb/> jam ostendimus aequalitatem appeti. Non
+						enim boc <lb/> tantum in ea pulchritudine quae ad aures pertinet , <lb/>
+						atque in motu corporum est, invenitur, sed in ipsis <lb/> etiam visibilibus
+						formis, in quibus jam usitatius dici­ <lb/> tur pulchritudo. An aliud quam
+						aequalitatem numero­ <lb/> sam esse arbitraris, cum paria paribus bimi
+						membra <lb/> respondent: quæ autem singula sunt, medium locum <lb/> tenent,
+						ut ad ea de utraque parte paria intervalla <lb/> serventur? <hi
+							rend="italic">D.</hi> Non aliter puto. <hi rend="italic">M.</hi> Quid in
+						ipsa luce <lb/> visibili quae omnium colorum habet principatum, nam <lb/> et
+						color nos delectat in corporum formis; quid ergo <lb/> aliud in luce et
+						coloribus, nisi quod nostris oculis <lb/> c ngruit, appetimus? Etenim a
+						nimio fulgore aversa­ <lb/> mur, et nimis obscura nolumus cernere, sicut
+						etiam <lb/> in sonis et a nimium sonantibus abhorremus, et quasi <lb/>
+						susurranua non amamus. Quod non in temporum in­ <lb/> tervallis est, sed in
+						ipso sono, qui quasi lux est talium <lb/> numerorum, cui sic est contrarium
+						silentium, ut co­ <lb/> loribus tenebrae. In his ergo cum appetimus conve­
+						<lb/> nientia pro naturæ nostrae modo, et inconvenientia <lb/> respuimus,
+						quoe aliis tamen animalibus convenire sen. <lb/> Limus, nonne bic etiam
+						quodam aequalitatis jure læ­ <lb/> tamur, cum occultioribus modis paria
+						paribus tributa <lb/> esse cognoscimus? Hoc in odoribus et in saporibus,
+						<lb/> et in tangendi sensu animadvertere licet, quæ longum <lb/> est
+						enucleatius persequi, sed explorare facillimum: <lb/> nihil enim est horum
+						sensibilium, quod nobis non <lb/> æqualitate aut similitudine placeat. Ubi
+						autem æqua­ <lb/> litas aut similitudo, ibi numerositas; nibil est quippe
+						<lb/> tam aequale aut simile quam unum et unum : nisi quid <lb/> habes ad
 						hæc. <hi rend="italic">D.</hi> Omnino assentior.</p>
-					<p>39. M. Quid ? superior illa tractatio nonne persuasit <lb/> nobis agere hanc animam in
-						corporibus, non a corpo­ <lb/> ribus pati? <hi rend="italic">D.</hi> Persuasit sane. M.
-						Amor igitur agendi <lb/> adversus succedentes passiones corporis sui, avertit <lb/>
-						animam a contemplatione aeternorum, sensibilis vo­ <lb/> luptatis cura ejus avocans
-						intentionem :' hoc autem <lb/> agit occursoribus numeris. Avertit etiam amor de <lb/>
-						corporibus operandi, et inquietam facil: hoc autem <lb/> agit progressoribus numeris.
-						Avertunt phantasiæ at­ <lb/> que phantasmata : et hæc agit recordabilibus numeris. <lb/>
-						Avertit denique amor vanissimae cognitionis talium <lb/> rerum : et hoc agit sensualibus
-						numeris, quibus in­ <lb/> sunt quasi regulæ quaedam artis imitatione gaudentes: <lb/> et
-						ex his curiositas nascitur ipso curae nomine inimica <lb/> securitati, et vanitate impos
+					</div><div type="textpart" subtype="dialog"><p>39. M. Quid ? superior illa tractatio nonne persuasit <lb/> nobis agere hanc
+						animam in corporibus, non a corpo­ <lb/> ribus pati? <hi rend="italic"
+							>D.</hi> Persuasit sane. M. Amor igitur agendi <lb/> adversus
+						succedentes passiones corporis sui, avertit <lb/> animam a contemplatione
+						aeternorum, sensibilis vo­ <lb/> luptatis cura ejus avocans intentionem :'
+						hoc autem <lb/> agit occursoribus numeris. Avertit etiam amor de <lb/>
+						corporibus operandi, et inquietam facil: hoc autem <lb/> agit progressoribus
+						numeris. Avertunt phantasiæ at­ <lb/> que phantasmata : et hæc agit
+						recordabilibus numeris. <lb/> Avertit denique amor vanissimae cognitionis
+						talium <lb/> rerum : et hoc agit sensualibus numeris, quibus in­ <lb/> sunt
+						quasi regulæ quaedam artis imitatione gaudentes: <lb/> et ex his curiositas
+						nascitur ipso curae nomine inimica <lb/> securitati, et vanitate impos
 						veritatis1.</p>
-					<p>40. Generalis vero amor actionis, quae avertit a <lb/> vero, a superbia proficiscitur,
-						quo vitio Deum imitari; <lb/> qunm Deo servire anima maluit. Recte itaque scri­ <lb/>
-						ptum est in sanctis Libris : <hi rend="italic">Initium superbiæ</hi> homini <lb/>
-						<hi rend="italic">apostatare a Deo;</hi> et, <hi rend="italic">Initium</hi> omnis <hi rend="italic">percati</hi> superbiæ. <lb/> Non potuit autem melius demonstrari quid
-						sit super­ <lb/> bia, quam in eo quod ibi dictum est : <hi rend="italic">Quid</hi>
-						superbit <note type="footnote">1 sic meliores Mss. At Am. et Er. baheDt: <hi rend="italic">Et smritatit</hi> iiept <lb/> vc <hi rend="italic">it Ii q'e.</hi>
-							L&lt;w,: <hi rend="italic">1.t iunilus</hi> oppoiiti arrit:&lt;ti. </note>
+					</div><div type="textpart" subtype="dialog"><p>40. Generalis vero amor actionis, quae avertit a <lb/> vero, a superbia
+						proficiscitur, quo vitio Deum imitari; <lb/> qunm Deo servire anima maluit.
+						Recte itaque scri­ <lb/> ptum est in sanctis Libris : <hi rend="italic"
+							>Initium superbiæ</hi> homini <lb/>
+						<hi rend="italic">apostatare a Deo;</hi> et, <hi rend="italic">Initium</hi>
+						omnis <hi rend="italic">percati</hi> superbiæ. <lb/> Non potuit autem melius
+						demonstrari quid sit super­ <lb/> bia, quam in eo quod ibi dictum est : <hi
+							rend="italic">Quid</hi> superbit <note type="footnote">1 sic meliores
+							Mss. At Am. et Er. baheDt: <hi rend="italic">Et smritatit</hi> iiept
+							<lb/> vc <hi rend="italic">it Ii q'e.</hi> L&lt;w,: <hi rend="italic"
+								>1.t iunilus</hi> oppoiiti arrit:&lt;ti. </note>
 						<lb/>
 						<pb n="1185"/>
-						<hi rend="italic">terra et cinis, quoniam</hi> iii vita sua <hi rend="italic">projectt</hi> intima <hi rend="italic">sua?<lb/> (Eccli.</hi> x, 14,45, 9,10.) Caim
-						enim anima per seipsam <lb/> nihil sit; non enim aliter esset commutabilis, et pale­
-						<lb/> retur defectum ab essentia : cum ergo ipsa per se <lb/> nihil sit, quidquid autem
-						illi esse est, a Deo sit; in <lb/> ordine suo manens, ipsius Oei prærsentia vcgetalur in
-						<lb/> mente atque conscientia. itaque hoc bonum habet <lb/> intimum. Quare superbia
-						intumescere, hoc illi est in <lb/> extmna progredi, et ut ita dicam, inanescerc, quod
-						est <lb/> minus minusque esse. Progredi autcm in extima, quid <lb/> est aliud quam
-						intima projiccre; id est, longe a se fa­ <lb/> cere Deum, non locorum spatio, scd mentis
-						affectu?</p>
-					<p>41. Islc autem animæ appetitus est sub se habere <lb/> alias animas; non pecorum, quas
-						divino jure con­ <lb/> cessum est, sed rationales, id est, proximas suas, et <lb/> sub
-						cadem lege socias atque consortes. De bis autem <lb/> appetit operari anima superba , et
-						tanto excellentior <lb/> vidotur hæc actio qunm illa de corporibus, quanto <lb/> aaima
-						omnis omni corpore est melior. Sed operari de <lb/> animis rationalibus, non por corpus,
-						sed. per seipsum, <lb/> solus Deus potest. Peccatorum tamen condilione fit, <lb/> ut
-						permittantur anima? de animis aliquid agere , si­ <lb/> gnificando eas moventes per
-						alterutra corpora, vel <lb/> naturalibus signis, sicut est vultus vel nutus, vel pla­
-						<lb/> citis, sicut sunt verba. Nam et jubentes et suadentes <lb/> signis agunt, et si
-						quid est aliud preter jussionem et <lb/> suasionem, quo animæ de animis vel cum animis
-						a'i- <lb/> quid agunt. Jure autem secutum est, ut quæ superbia <lb/> c Heris excellere
-						cupierunt, nec suis partibus atque <lb/> corporibus sine difficultate et doloribus
-						imperent, par­ <lb/> titi stultæ in se, partim mortalibus membris aggra­ <lb/> vatæ. Et
-						his igitur numcris et motibus quibus animæ <lb/> ad animas agunt, honores laudesque
-						appetendo aver­ <lb/> tuntur a perspectione purae illius et sincerae veritatis. <lb/>
-						Solus enim honorat Deus animam beatam faciens in <lb/> occulto coram se juste et pie
-						viventem.</p>
-					<p>42. Motus igitur quos exserit anima de inhærenti­ <lb/> bus sibi, et subditis animis,
-						progressoribus illis sunt <lb/> similes; agit enim tanquam de corpore suo. Illi autem
-						<lb/> motus quos exserit, aggregare sibi aliquas vel subdere <lb/> cupicns, in
-						occursorum numero deputantur. Agit <lb/> enim tanquam in sensibus id moliens, ut unum
-						secum <lb/> Nat, quod velut extrinsecus admovetur, et quod non <lb/> p-test repellatur.
-						Et hos utrosque motus excipit me­ <lb/> moria, et recordabiles facit, simili modo in
-						phantasiis <lb/> ct phantasmatibus actionum talium tumultuosissimc <lb/> exæstuans. Nec
-						illi tanquam examinatores numeri <lb/> desunt, qui sentiant quid in his actibus commode
-						sive <lb/> incommode moveatur, quos itcm sensuales appellare <lb/> non pigeat, quia
-						sensibilia signa sunt quibus hoc modo <lb/> animae ad animas agunt. His tol et tantis
-						intentioni­ <lb/> bus anima implicata , quid mirum, si a contempla­ <lb/> tione
-						veritatis avertitur ? Et quantum quidem ab his <lb/> respirat videt illam ; sed quia
-						nondum eas evicit, in <lb/> illa manere non sinitur. Ex quo lit ut non simul ha­ <lb/>
-						beat anima nosse in quibus consistendum sit, et posse <lb/> consistere: sed numquid tu
-						forte adversus hæc? <hi rend="italic">D.</hi> Ni­ <lb/> hil est qnod contradicerc
-						audcam.</p>
-					<ab>
-						<title type="sub">CAPUT XIV. <hi rend="italic">- Ad Dei</hi> amorem <hi rend="italic">provocatur anima</hi> a <hi rend="italic">numerorum et ordinis ratione quam in
-								rebus diligit.</hi>
+						<hi rend="italic">terra et cinis, quoniam</hi> iii vita sua <hi
+							rend="italic">projectt</hi> intima <hi rend="italic">sua?<lb/>
+							(Eccli.</hi> x, 14,45, 9,10.) Caim enim anima per seipsam <lb/> nihil
+						sit; non enim aliter esset commutabilis, et pale­ <lb/> retur defectum ab
+						essentia : cum ergo ipsa per se <lb/> nihil sit, quidquid autem illi esse
+						est, a Deo sit; in <lb/> ordine suo manens, ipsius Oei prærsentia vcgetalur
+						in <lb/> mente atque conscientia. itaque hoc bonum habet <lb/> intimum.
+						Quare superbia intumescere, hoc illi est in <lb/> extmna progredi, et ut ita
+						dicam, inanescerc, quod est <lb/> minus minusque esse. Progredi autcm in
+						extima, quid <lb/> est aliud quam intima projiccre; id est, longe a se fa­
+						<lb/> cere Deum, non locorum spatio, scd mentis affectu?</p>
+					</div><div type="textpart" subtype="dialog"><p>41. Islc autem animæ appetitus est sub se habere <lb/> alias animas; non
+						pecorum, quas divino jure con­ <lb/> cessum est, sed rationales, id est,
+						proximas suas, et <lb/> sub cadem lege socias atque consortes. De bis autem
+						<lb/> appetit operari anima superba , et tanto excellentior <lb/> vidotur
+						hæc actio qunm illa de corporibus, quanto <lb/> aaima omnis omni corpore est
+						melior. Sed operari de <lb/> animis rationalibus, non por corpus, sed. per
+						seipsum, <lb/> solus Deus potest. Peccatorum tamen condilione fit, <lb/> ut
+						permittantur anima? de animis aliquid agere , si­ <lb/> gnificando eas
+						moventes per alterutra corpora, vel <lb/> naturalibus signis, sicut est
+						vultus vel nutus, vel pla­ <lb/> citis, sicut sunt verba. Nam et jubentes et
+						suadentes <lb/> signis agunt, et si quid est aliud preter jussionem et <lb/>
+						suasionem, quo animæ de animis vel cum animis a'i- <lb/> quid agunt. Jure
+						autem secutum est, ut quæ superbia <lb/> c Heris excellere cupierunt, nec
+						suis partibus atque <lb/> corporibus sine difficultate et doloribus
+						imperent, par­ <lb/> titi stultæ in se, partim mortalibus membris aggra­
+						<lb/> vatæ. Et his igitur numcris et motibus quibus animæ <lb/> ad animas
+						agunt, honores laudesque appetendo aver­ <lb/> tuntur a perspectione purae
+						illius et sincerae veritatis. <lb/> Solus enim honorat Deus animam beatam
+						faciens in <lb/> occulto coram se juste et pie viventem.</p>
+					</div><div type="textpart" subtype="dialog"><p>42. Motus igitur quos exserit anima de inhærenti­ <lb/> bus sibi, et subditis
+						animis, progressoribus illis sunt <lb/> similes; agit enim tanquam de
+						corpore suo. Illi autem <lb/> motus quos exserit, aggregare sibi aliquas vel
+						subdere <lb/> cupicns, in occursorum numero deputantur. Agit <lb/> enim
+						tanquam in sensibus id moliens, ut unum secum <lb/> Nat, quod velut
+						extrinsecus admovetur, et quod non <lb/> p-test repellatur. Et hos utrosque
+						motus excipit me­ <lb/> moria, et recordabiles facit, simili modo in
+						phantasiis <lb/> ct phantasmatibus actionum talium tumultuosissimc <lb/>
+						exæstuans. Nec illi tanquam examinatores numeri <lb/> desunt, qui sentiant
+						quid in his actibus commode sive <lb/> incommode moveatur, quos itcm
+						sensuales appellare <lb/> non pigeat, quia sensibilia signa sunt quibus hoc
+						modo <lb/> animae ad animas agunt. His tol et tantis intentioni­ <lb/> bus
+						anima implicata , quid mirum, si a contempla­ <lb/> tione veritatis
+						avertitur ? Et quantum quidem ab his <lb/> respirat videt illam ; sed quia
+						nondum eas evicit, in <lb/> illa manere non sinitur. Ex quo lit ut non simul
+						ha­ <lb/> beat anima nosse in quibus consistendum sit, et posse <lb/>
+						consistere: sed numquid tu forte adversus hæc? <hi rend="italic">D.</hi> Ni­
+						<lb/> hil est qnod contradicerc audcam.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT XIV. <hi rend="italic">- Ad Dei</hi> amorem <hi
+								rend="italic">provocatur anima</hi> a <hi rend="italic">numerorum et
+								ordinis ratione quam in rebus diligit.</hi>
 						</title>
 					</ab>
-					<p>43. M. Quid ergo restat? An ut, quoniam sicut po­ <lb/> tuimus inquinationem et
-						aggravationem animae con­ <lb/> sideravimus, videamus quænam illi actio divinitus <lb/>
-						imperetur, qua purgata atque exonerata revolet ad <lb/> quietem, et intret in gaudium
-						Domini sui?D. Ita fiat. <lb/>
-						<hi rend="italic">M.</hi> Quid me putas hinc diutius dobere dicere, cum di­ <lb/> vinc
-						Scripturæ tot voluminibus et tanta auctoritate <lb/> et sanctitate præditis, nihil
-						nobiscum aliud agant, nisi <lb/> ut diligamus Deum et Dominum nostrum ex toto <lb/>
-						corde, ex tota anima, et ex tota mentc; et diligamus <lb/> proximum nostrum tanquam
-						nosmetipsos? Ad hunc <lb/> igitur finem si omnes illos humanæ actionis motus, <lb/>
-						numerosque referamus, sine dubitatione mundalri­ <lb/> mur. An aliud existimas? <hi rend="italic">D.</hi> Nihil equidem aliud. Sed <lb/> quam hoc auditu breve est, tam
-						factu difficile atque <lb/> arduum.</p>
-					<p>44. <hi rend="italic">M.</hi> Quid ergo facile est ? an amare colores, et <lb/> voces,
-						et placentas, et rosas, et corpora leniter mol­ <lb/> lia ? hæccine amare facile est
-						animæ, in quibus nihil <lb/> nisi æqualitatem ac similitudinem appetit, et paulo <lb/>
-						diligentius considerans, vix ejus extremam umbram <lb/> vestigiumque cognoscit; et Deum
-						amare difficile est, <lb/> quem in quantum potest, adhuc saucia et sordida eo­ <lb/>
-						gitans, nihil in eo inaequale, nihil sui dissimile, nihil <lb/> disclusum locis, nihil
-						variatum tempore suspicatur ? <lb/> An exstruere moles ædificiorum, et hujuscemodi ope­
-						<lb/> ribus delectat extendi, in quibus si numeri placeut <lb/> ( non enim aliud
-						invenio) quid in his æquale ac si­ <lb/> mile dicitur quod non derideat ratio
-						disciplinae ? <lb/> Quod si ita est, cur ab illa verissima æqualitatis arce <lb/> ad
-						ista delabitur, et ruinis suis terrenas machinas <lb/> erigit? Non hoc promissum est ab
-						illo qui fallere <lb/> ignorat. <hi rend="italic">Jugum enim</hi> meum, inquit, <hi rend="italic">lere est (Matth.</hi> XI, <lb/> 50). Laboriosior est hujus mundi amor:
-						Quod enim <lb/> in illo anima quærit, constantiam scilicet aeternitatem­ <lb/> que, non
-						invenit: quoniam rerum transitu completur <lb/> infima pulchritudo, et quod in illa
-						imitatur constap­ <lb/> tiam, a summo Deo per animam trajicitur : quoniam <lb/> prior
-						est species tantummodo tempore commutabilis, <lb/> quam ea quae et tempore et locis (a).
-						Sicut itaque <lb/> præceptum est animis a Domino quid diligant, ita per <lb/> Joannem
-						apostolum quid non diligant. <hi rend="italic">Nolite,</hi> inquit, <lb/>
-						<hi rend="italic">diligere</hi> mundum : <hi rend="italic">quia omnia</hi> quæ in <hi rend="italic">mundo</hi> sunt, con­ <lb/>
-						<hi rend="italic">cupiscentia carnis est, et concupiscentia oculorum, et<lb/> ambitio
-							sœculi</hi> (I <hi rend="italic">Joan.</hi> II, 15, 16).</p>
-					<p>45. Sed qualis tibi humo vidctur, qui omnes illos <lb/> numeros qui sunt de corpore, et
-						adversus passiones <lb/> corporis, et qui ex bis memoria continentur, non ad <lb/>
-						carnalem voluptatem, sed ad salutem tautum corporis <lb/> refert: omnesque illos qui de
-						adjunctis animis ope­ <lb/> rantur, vel qui ad adjungendas exseruntur, ct qui ex <lb/>
-						bis inhaerent memor'ire, non ad superbam excelleu­ <lb/> tiam suam, sed ad ipsarum
-						animarum utilitalrm re- <note type="footnote">1 Er. et Lov.: In <hi rend="italic">aiibus
-								quid nisi numeri placent? AWi eram <lb/> aliud</hi> invenio <hi rend="italic">quoa</hi> iti <hi rend="italic">his wquale ac swule dia.tl..r</hi> Elcci- <lb/>
-							rous leCLionelD nianusciuptoruin. </note>
+					</div><div type="textpart" subtype="dialog"><p>43. M. Quid ergo restat? An ut, quoniam sicut po­ <lb/> tuimus inquinationem
+						et aggravationem animae con­ <lb/> sideravimus, videamus quænam illi actio
+						divinitus <lb/> imperetur, qua purgata atque exonerata revolet ad <lb/>
+						quietem, et intret in gaudium Domini sui?D. Ita fiat. <lb/>
+						<hi rend="italic">M.</hi> Quid me putas hinc diutius dobere dicere, cum di­
+						<lb/> vinc Scripturæ tot voluminibus et tanta auctoritate <lb/> et
+						sanctitate præditis, nihil nobiscum aliud agant, nisi <lb/> ut diligamus
+						Deum et Dominum nostrum ex toto <lb/> corde, ex tota anima, et ex tota
+						mentc; et diligamus <lb/> proximum nostrum tanquam nosmetipsos? Ad hunc
+						<lb/> igitur finem si omnes illos humanæ actionis motus, <lb/> numerosque
+						referamus, sine dubitatione mundalri­ <lb/> mur. An aliud existimas? <hi
+							rend="italic">D.</hi> Nihil equidem aliud. Sed <lb/> quam hoc auditu
+						breve est, tam factu difficile atque <lb/> arduum.</p>
+					</div><div type="textpart" subtype="dialog"><p>44. <hi rend="italic">M.</hi> Quid ergo facile est ? an amare colores, et
+						<lb/> voces, et placentas, et rosas, et corpora leniter mol­ <lb/> lia ?
+						hæccine amare facile est animæ, in quibus nihil <lb/> nisi æqualitatem ac
+						similitudinem appetit, et paulo <lb/> diligentius considerans, vix ejus
+						extremam umbram <lb/> vestigiumque cognoscit; et Deum amare difficile est,
+						<lb/> quem in quantum potest, adhuc saucia et sordida eo­ <lb/> gitans,
+						nihil in eo inaequale, nihil sui dissimile, nihil <lb/> disclusum locis,
+						nihil variatum tempore suspicatur ? <lb/> An exstruere moles ædificiorum, et
+						hujuscemodi ope­ <lb/> ribus delectat extendi, in quibus si numeri placeut
+						<lb/> ( non enim aliud invenio) quid in his æquale ac si­ <lb/> mile dicitur
+						quod non derideat ratio disciplinae ? <lb/> Quod si ita est, cur ab illa
+						verissima æqualitatis arce <lb/> ad ista delabitur, et ruinis suis terrenas
+						machinas <lb/> erigit? Non hoc promissum est ab illo qui fallere <lb/>
+						ignorat. <hi rend="italic">Jugum enim</hi> meum, inquit, <hi rend="italic"
+							>lere est (Matth.</hi> XI, <lb/> 50). Laboriosior est hujus mundi amor:
+						Quod enim <lb/> in illo anima quærit, constantiam scilicet aeternitatem­
+						<lb/> que, non invenit: quoniam rerum transitu completur <lb/> infima
+						pulchritudo, et quod in illa imitatur constap­ <lb/> tiam, a summo Deo per
+						animam trajicitur : quoniam <lb/> prior est species tantummodo tempore
+						commutabilis, <lb/> quam ea quae et tempore et locis (a). Sicut itaque <lb/>
+						præceptum est animis a Domino quid diligant, ita per <lb/> Joannem apostolum
+						quid non diligant. <hi rend="italic">Nolite,</hi> inquit, <lb/>
+						<hi rend="italic">diligere</hi> mundum : <hi rend="italic">quia omnia</hi>
+						quæ in <hi rend="italic">mundo</hi> sunt, con­ <lb/>
+						<hi rend="italic">cupiscentia carnis est, et concupiscentia oculorum,
+							et<lb/> ambitio sœculi</hi> (I <hi rend="italic">Joan.</hi> II, 15,
+						16).</p>
+					</div><div type="textpart" subtype="dialog"><p>45. Sed qualis tibi humo vidctur, qui omnes illos <lb/> numeros qui sunt de
+						corpore, et adversus passiones <lb/> corporis, et qui ex bis memoria
+						continentur, non ad <lb/> carnalem voluptatem, sed ad salutem tautum
+						corporis <lb/> refert: omnesque illos qui de adjunctis animis ope­ <lb/>
+						rantur, vel qui ad adjungendas exseruntur, ct qui ex <lb/> bis inhaerent
+						memor'ire, non ad superbam excelleu­ <lb/> tiam suam, sed ad ipsarum
+						animarum utilitalrm re- <note type="footnote">1 Er. et Lov.: In <hi
+								rend="italic">aiibus quid nisi numeri placent? AWi eram <lb/>
+								aliud</hi> invenio <hi rend="italic">quoa</hi> iti <hi rend="italic"
+								>his wquale ac swule dia.tl..r</hi> Elcci- <lb/> rous leCLionelD
+							nianusciuptoruin. </note>
 						<note type="footnote"> (a) vid. Retract, lib. 1, cap. U, a. 4. </note>
 						<lb/>
-						<pb n="1187"/> digit: illis etiam qui in utroque goncre quasi mode­ <lb/> ratores
-						exploratoresque cæterorum transcuntium in <lb/> sensu praesident, non ad superfluam vel
-						perniciosam <lb/> curiositatem, sed ad necessariam probationem vel im­ <lb/> probationem
-						utitur : nonne et istos omnes numeros <lb/> agit, et nullis eorum laqueis implicatur?
-						Quandoqui­ <lb/> dem et, salutem corporis ut non impediatur eligit, et <lb/> omnes eas
-						actiones ad utilitatem proximi revocat, <lb/> quem propter communis juris naturale
-						vinculum tan­ <lb/> quam seipsum diligere jussus est. <hi rend="italic">D.</hi> Magnum
-						quem­ <lb/> dam virum et vere humanissimum praedicas.</p>
-					<p>46. M. Non igitur numeri qui sunt infra rationem <lb/> et in suo genere pulchri sunt,
-						sed amor inferioris pul­ <lb/> chritudinis animam polluit : quæ cum in illa non <lb/>
-						modo æqualitatem , de qua pro suscepto opere salis <lb/> dictum est, sed etiam ordinem
-						diligat, amisit ipsa or­ <lb/> dinem . suum; nec tamen excessit ordinem rerum, <lb/>
-						quandoquidem ibi est, et ita est, ubi esse, et quo­ <lb/> modo esse tales,
-						ordinatissimam est. Aliud enim est <lb/> tenere ordinem, aliud ordine teneri. Tenet
-						ordinem, <lb/> seipsa tota diligens quod supra se est, id est Deum, <lb/> socias autem
-						animas tanquam scipsam. Hac quippe <lb/> dilectionis virtute inferiora ordinal, nee ab
-						inferiori­ <lb/> bus sordidatur I. Quod autem illam sordidat, non <lb/> est malum, quia
-						etiam corpus crcatura Dei cst, et <lb/> apecie sua quamvis infima decoratur, sed præ
-						animæ <lb/> dignitate contemnitur; sicuti anri dignitas, etiam pur­ <lb/> gaLissimi
-						argenti commixtione sordescit. Quapropter <lb/> quicumque do nostra quoque poenali I
-						mortalitate <lb/> numeri facti sunt, non eos abdicemus a fabricatione <lb/> divinae
-						providentiæ, cum sint in genere Suo pulchri. <lb/> Neque amemus eos, ut qUasi perfruendo
-						talibus beati <lb/> efficiamur. His etenim, quoniam temporales sunt, tan­ <lb/> quam
-						tabula in fluctibus, neque abjiciendo quasi one­ <lb/> rosos, ncque amplectendo quasi
-						fuudalos, sed bene <lb/> utendo carebimus. A dilectione autcm proximi tanta <lb/> quanta
-						præcipitur, certissimus gradus fit nobis, ut in­ <lb/> hæreamus Deo, et non teneamur
-						tantum ordinatione <lb/> illius, sed nostrUm eliam ordinem inconcussum cer­ <lb/> tumque
-						teneamus.</p>
-					<p>47. An fortasse ordinem non diligit anima illis etiam <lb/> numeris sensualibus
-						attestantibus? Unde crgo primus <lb/> pes est pyrrhichius, secundus iambus, tertius tro­
-						<lb/> chæus, et deinceps cæteri ? Sed jure hoc dixeris ratio­ <lb/> nem potius seculam
-						esse, non sensum. Quid itaque, <lb/> illud nonne sensualibus numeris dandum est, quod
-						<lb/> cum tantum temporis occupent, verbi gratia, octo <lb/> longæ syllabæ, quantum
-						sexdecim breves, in codem <lb/> tamen spatio breves longis potius misceri exspectant?
-						<lb/> De quo sensu cum ratio judicat, et ei proceleumatici <lb/> pedes esse æquales
-						spondcis pedibus renuntiantur, <lb/> nihil aliud hic valere invenit, quam ordinationis
-						po­ <lb/> tentiam, quia nec longæ syllabæ nisi brevium compa­ <lb/> ratione longæ sunt,
-						nec breves rursum breves sunt <lb/> nisi comparatione longarum : ideoque iambieus ver-
-							<note type="footnote"> J Ita Mss. undecim. At Am. Er. et Lov. habent, <hi rend="italic">ordinatur</hi>
-						</note><note type="footnote"> U)v., parili morta<foreign xml:lang="grc">ι̇ι̇</foreign>tate. Sed melius Ain. et hr. cium. MSS.! <lb/>
-							<hi rend="italic">'urmatur.uli</hi> supra, n. 53: Quæ <hi rend="italic">de wstro
-								pællali mortalitate</hi>
+						<pb n="1187"/> digit: illis etiam qui in utroque goncre quasi mode­ <lb/>
+						ratores exploratoresque cæterorum transcuntium in <lb/> sensu praesident,
+						non ad superfluam vel perniciosam <lb/> curiositatem, sed ad necessariam
+						probationem vel im­ <lb/> probationem utitur : nonne et istos omnes numeros
+						<lb/> agit, et nullis eorum laqueis implicatur? Quandoqui­ <lb/> dem et,
+						salutem corporis ut non impediatur eligit, et <lb/> omnes eas actiones ad
+						utilitatem proximi revocat, <lb/> quem propter communis juris naturale
+						vinculum tan­ <lb/> quam seipsum diligere jussus est. <hi rend="italic"
+							>D.</hi> Magnum quem­ <lb/> dam virum et vere humanissimum
+						praedicas.</p>
+					</div><div type="textpart" subtype="dialog"><p>46. M. Non igitur numeri qui sunt infra rationem <lb/> et in suo genere
+						pulchri sunt, sed amor inferioris pul­ <lb/> chritudinis animam polluit :
+						quæ cum in illa non <lb/> modo æqualitatem , de qua pro suscepto opere salis
+						<lb/> dictum est, sed etiam ordinem diligat, amisit ipsa or­ <lb/> dinem .
+						suum; nec tamen excessit ordinem rerum, <lb/> quandoquidem ibi est, et ita
+						est, ubi esse, et quo­ <lb/> modo esse tales, ordinatissimam est. Aliud enim
+						est <lb/> tenere ordinem, aliud ordine teneri. Tenet ordinem, <lb/> seipsa
+						tota diligens quod supra se est, id est Deum, <lb/> socias autem animas
+						tanquam scipsam. Hac quippe <lb/> dilectionis virtute inferiora ordinal, nee
+						ab inferiori­ <lb/> bus sordidatur I. Quod autem illam sordidat, non <lb/>
+						est malum, quia etiam corpus crcatura Dei cst, et <lb/> apecie sua quamvis
+						infima decoratur, sed præ animæ <lb/> dignitate contemnitur; sicuti anri
+						dignitas, etiam pur­ <lb/> gaLissimi argenti commixtione sordescit.
+						Quapropter <lb/> quicumque do nostra quoque poenali I mortalitate <lb/>
+						numeri facti sunt, non eos abdicemus a fabricatione <lb/> divinae
+						providentiæ, cum sint in genere Suo pulchri. <lb/> Neque amemus eos, ut
+						qUasi perfruendo talibus beati <lb/> efficiamur. His etenim, quoniam
+						temporales sunt, tan­ <lb/> quam tabula in fluctibus, neque abjiciendo quasi
+						one­ <lb/> rosos, ncque amplectendo quasi fuudalos, sed bene <lb/> utendo
+						carebimus. A dilectione autcm proximi tanta <lb/> quanta præcipitur,
+						certissimus gradus fit nobis, ut in­ <lb/> hæreamus Deo, et non teneamur
+						tantum ordinatione <lb/> illius, sed nostrUm eliam ordinem inconcussum cer­
+						<lb/> tumque teneamus.</p>
+					</div><div type="textpart" subtype="dialog"><p>47. An fortasse ordinem non diligit anima illis etiam <lb/> numeris
+						sensualibus attestantibus? Unde crgo primus <lb/> pes est pyrrhichius,
+						secundus iambus, tertius tro­ <lb/> chæus, et deinceps cæteri ? Sed jure hoc
+						dixeris ratio­ <lb/> nem potius seculam esse, non sensum. Quid itaque, <lb/>
+						illud nonne sensualibus numeris dandum est, quod <lb/> cum tantum temporis
+						occupent, verbi gratia, octo <lb/> longæ syllabæ, quantum sexdecim breves,
+						in codem <lb/> tamen spatio breves longis potius misceri exspectant? <lb/>
+						De quo sensu cum ratio judicat, et ei proceleumatici <lb/> pedes esse
+						æquales spondcis pedibus renuntiantur, <lb/> nihil aliud hic valere invenit,
+						quam ordinationis po­ <lb/> tentiam, quia nec longæ syllabæ nisi brevium
+						compa­ <lb/> ratione longæ sunt, nec breves rursum breves sunt <lb/> nisi
+						comparatione longarum : ideoque iambieus ver- <note type="footnote"> J Ita
+							Mss. undecim. At Am. Er. et Lov. habent, <hi rend="italic"
+								>ordinatur</hi>
+						</note><note type="footnote"> U)v., parili morta<foreign xml:lang="grc"
+								>ι̇ι̇</foreign>tate. Sed melius Ain. et hr. cium. MSS.! <lb/>
+							<hi rend="italic">'urmatur.uli</hi> supra, n. 53: Quæ <hi rend="italic"
+								>de wstro pællali mortalitate</hi>
 						</note>
-						<lb/> sus quamlibet productius pronuntiatus, non amissi <lb/> , regula simpli et dupli,
-						nec nomen amittit: at ille ver­ <lb/> sus qui pyrrbichiis pedibus constat, paulatim
-						addita <lb/> pronuntiandi mora, fit repente spondiacus, si noa <lb/> grammaticam, sed
-						musicam consulas. At vero si da­ <lb/> ctylicus aut annpaesticus sit, quoniam longæ
-						mixtarum <lb/> brevium comparatione sentiuntur, qualibet mora pro. <lb/> nuntietur,
-						servat nomen suum. Quid additamenta so- <lb/> mipedum non eadem lege in capite qua in
-						fine scr­ <lb/> vanda, nec omnia quamvis ad eumdem plausum <lb/> coaptentur, adhibenda?
-						quid duamm aliquando bre­ <lb/> vium potius, quam unius longæ in fine positio? nonne
-						<lb/> ipso sensu modificantur? Nec in his æqualitatis nu­ <lb/> merus, cui nibil
-						deperit, sive illud sive aliud sit, sed <lb/> ordinis vinculum reperitur. Longum est
-						percurrere <lb/> caetera ad eamdem vim pertinentia in numeris tempo­ <lb/> rum. Sed
-						nempe etiam formas visibiles sensus ipse <lb/> aspernatur, aut pronas contra quam decet,
-						aut capite <lb/> deorsum, et similia, in quibus non inaequalitas, ma­ <lb/> nente
-						partium parilitate, sed perversitas improbatur. <lb/> Postremo in omnibus sensibus et
-						operibus nostris, <lb/> cum insolita pleraque, et ob hoe injueuDda quibusdam <lb/>
-						gradibus appetitui nostro conciliamus, et ea primo <lb/> tolerabiliter, deinde libenter
-						accipimus; nonne ordine <lb/> conteximus voluptatem, et nisi priora mediis, et me­ <lb/>
-						dia postremis concorditer nexa sint, abhorremus?</p>
-					<p>48. Quamobrem neque in voluptate carnali, neque <lb/> in bonoribus et laudibus hominum
-						, neque in eurum <lb/> exploratione quae forinsecus corpus attingunt, nostra <lb/>
-						gaudia collocemus, habentes in intimo Deum, ubi cer­ <lb/> tum est et incommutabile omne
-						quod amamus. Ita fit, <lb/> ut et cum adsunt haec temporalia, non lamen eis im­ <lb/>
-						plicemur, et sine sensu doloris quae extra corpus sunt, <lb/> absint: ipsum autem
-						corpus, aut nullo, ant non gravi <lb/> sensu doloris adimatur, et reformandum naturæ suæ
-						<lb/> morte reddatur. Attentio namque animæ ad corporis <lb/> partem inquieta negotia
-						contrahit, et universali lege <lb/> neglecta privati cujusdam operis amor, quod ipsum
-						<lb/> tamcn ab universitate quam Deus regit non potest <lb/> alicnari. Itaque subditur
-						legibus qui non amat lcges.</p>
-					<ab>
-						<title type="sub">CAPUT XV. — <hi rend="italic">Corporales numeros postresurrectionem
-								aget anima quiete. Virtutes quatuor quibus hic</hi> anima <hi rend="italic">perficitur.</hi>
+						<lb/> sus quamlibet productius pronuntiatus, non amissi <lb/> , regula
+						simpli et dupli, nec nomen amittit: at ille ver­ <lb/> sus qui pyrrbichiis
+						pedibus constat, paulatim addita <lb/> pronuntiandi mora, fit repente
+						spondiacus, si noa <lb/> grammaticam, sed musicam consulas. At vero si da­
+						<lb/> ctylicus aut annpaesticus sit, quoniam longæ mixtarum <lb/> brevium
+						comparatione sentiuntur, qualibet mora pro. <lb/> nuntietur, servat nomen
+						suum. Quid additamenta so- <lb/> mipedum non eadem lege in capite qua in
+						fine scr­ <lb/> vanda, nec omnia quamvis ad eumdem plausum <lb/> coaptentur,
+						adhibenda? quid duamm aliquando bre­ <lb/> vium potius, quam unius longæ in
+						fine positio? nonne <lb/> ipso sensu modificantur? Nec in his æqualitatis
+						nu­ <lb/> merus, cui nibil deperit, sive illud sive aliud sit, sed <lb/>
+						ordinis vinculum reperitur. Longum est percurrere <lb/> caetera ad eamdem
+						vim pertinentia in numeris tempo­ <lb/> rum. Sed nempe etiam formas
+						visibiles sensus ipse <lb/> aspernatur, aut pronas contra quam decet, aut
+						capite <lb/> deorsum, et similia, in quibus non inaequalitas, ma­ <lb/>
+						nente partium parilitate, sed perversitas improbatur. <lb/> Postremo in
+						omnibus sensibus et operibus nostris, <lb/> cum insolita pleraque, et ob hoe
+						injueuDda quibusdam <lb/> gradibus appetitui nostro conciliamus, et ea primo
+						<lb/> tolerabiliter, deinde libenter accipimus; nonne ordine <lb/>
+						conteximus voluptatem, et nisi priora mediis, et me­ <lb/> dia postremis
+						concorditer nexa sint, abhorremus?</p>
+					</div><div type="textpart" subtype="dialog"><p>48. Quamobrem neque in voluptate carnali, neque <lb/> in bonoribus et
+						laudibus hominum , neque in eurum <lb/> exploratione quae forinsecus corpus
+						attingunt, nostra <lb/> gaudia collocemus, habentes in intimo Deum, ubi cer­
+						<lb/> tum est et incommutabile omne quod amamus. Ita fit, <lb/> ut et cum
+						adsunt haec temporalia, non lamen eis im­ <lb/> plicemur, et sine sensu
+						doloris quae extra corpus sunt, <lb/> absint: ipsum autem corpus, aut nullo,
+						ant non gravi <lb/> sensu doloris adimatur, et reformandum naturæ suæ <lb/>
+						morte reddatur. Attentio namque animæ ad corporis <lb/> partem inquieta
+						negotia contrahit, et universali lege <lb/> neglecta privati cujusdam operis
+						amor, quod ipsum <lb/> tamcn ab universitate quam Deus regit non potest
+						<lb/> alicnari. Itaque subditur legibus qui non amat lcges.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT XV. — <hi rend="italic">Corporales numeros
+								postresurrectionem aget anima quiete. Virtutes quatuor quibus
+								hic</hi> anima <hi rend="italic">perficitur.</hi>
 						</title>
 					</ab>
-					<p>49. Sed si de rebus incorporeis et eodem modo se <lb/> semper habeutibus, plerumque
-						attemissime cogitan­ <lb/> tes, si quos forte illo tempore agimus numeros tem­ <lb/>
-						porales iu quolibet corporis motu, facili sanc atque <lb/> usitatissimo, sivc
-						deambulantes, sive psalleates, pro.-­ <lb/> sus nobis ignorantibus transeunt, quamvis
-						nobis non <lb/> agentibus nulli essent: si denique in ipsis nostris <lb/> inanibus
-						phaatasmatibus cum occupati sums, simili­ <lb/> tcr isia prætereunt agentibus nec
-						sentientibus nobis, <lb/> quanto magis quantoque constantius, <hi rend="italic">cum
-							corruptibile <lb/> hoc induerit incorrupiionem, et mortale hoc induerit <lb/>
-							immortalitatem</hi> (I <hi rend="italic">Cor.</hi> XV, 53), id est, ut hoc ideut <lb/>
-						planius eloquar, cum Deus vivificaverit mortatia cor-. <lb/> pora nostra , sicut
-						Apostolus dicit, <hi rend="italic">propter spiritum <lb/> manentem</hi> in <hi rend="italic">nobis (Rom.</hi> VIII, 11): quanto ergo tunc <note type="footnote"> I I
-							fitur in [lluribus Mss., <hi rend="italic">in</hi> temporis <hi rend="italic">partem.</hi>
+					</div><div type="textpart" subtype="dialog"><p>49. Sed si de rebus incorporeis et eodem modo se <lb/> semper habeutibus,
+						plerumque attemissime cogitan­ <lb/> tes, si quos forte illo tempore agimus
+						numeros tem­ <lb/> porales iu quolibet corporis motu, facili sanc atque
+						<lb/> usitatissimo, sivc deambulantes, sive psalleates, pro.-­ <lb/> sus
+						nobis ignorantibus transeunt, quamvis nobis non <lb/> agentibus nulli
+						essent: si denique in ipsis nostris <lb/> inanibus phaatasmatibus cum
+						occupati sums, simili­ <lb/> tcr isia prætereunt agentibus nec sentientibus
+						nobis, <lb/> quanto magis quantoque constantius, <hi rend="italic">cum
+							corruptibile <lb/> hoc induerit incorrupiionem, et mortale hoc induerit
+							<lb/> immortalitatem</hi> (I <hi rend="italic">Cor.</hi> XV, 53), id
+						est, ut hoc ideut <lb/> planius eloquar, cum Deus vivificaverit mortatia
+						cor-. <lb/> pora nostra , sicut Apostolus dicit, <hi rend="italic">propter
+							spiritum <lb/> manentem</hi> in <hi rend="italic">nobis (Rom.</hi> VIII,
+						11): quanto ergo tunc <note type="footnote"> I I fitur in [lluribus Mss.,
+								<hi rend="italic">in</hi> temporis <hi rend="italic">partem.</hi>
 						</note>
 						<lb/>
-						<pb n="1189"/> magis in unum Dcum et perspicuam intenti veritatem, <lb/> ut dictum est,
-							<hi rend="italic">facie ad faciem,</hi> numeros quibus agimus <lb/> corpora, nulla
-						inquietudine sentiemus, et gaudebimus? <lb/> Nisi forte eredendum est, animam cum de iis
-						quæ <lb/> per ipsam bona suut, gaudere possit, de iis ex quibus <lb/> ipsa bona est, non
-						posse gaudere.</p>
-					<p>50. Sed hæc actio qua sese anima, opitulante Deo <lb/> ct Domino suo, ab amore
-						inferioris pulchritudinis <lb/> extrahit, debellans atque interficiens adversus se <lb/>
-						militantem consuetudinem suam, ea victoria trium­ <lb/> phatura ill semetipsa de
-						potestatibus aeris hujus, qui­ <lb/> bus invidentibus et præpedire cupientibus, cvolat
-						ad <lb/> suam stabilitatem et firmamentum Dcum ; nonne tibi <lb/> videtur ea csse virtus
-						quæ temperantia dicitur? <hi rend="italic">D.</hi>
-						<lb/> Agnosco ct intelligo. Jf. Quid porro? cum in boc <lb/> itinere prolicit, jam
-						æterna gaudia præsentientem ac <lb/> pene prehendentem, num amissiorerum temporalium,
-						<lb/> aut mors ulla deterret jam valentem dicere inferiori­ <lb/> bus sociis : <hi rend="italic">Bonum est mihi</hi> dissolvi, <hi rend="italic">et esse cum
-							Christo:</hi>
-						<lb/> manere <hi rend="italic">autem in carne, necessarium propter</hi> vos <hi rend="italic">? (Phi­ <lb/> lipp.</hi> i, i3, 24.) <hi rend="italic">D.</hi> Sic
-						existimo. <hi rend="italic">M</hi> At ista cjus <lb/> affectio qua nullas adversitates
-						mortemve formidat, <lb/> quid aliud quam fortitudo dicenda est? <hi rend="italic">D.</hi> Et' hoc <lb/> agnosco. <hi rend="italic">M.</hi> Jamvero ipsa ejus ordinatio
-						qua nulli <lb/> servit nisi uni Dco, nulli coæquari nisi purissimis <lb/> animis, nulli
-						dominari appetit nisi naturæ bestiali at­ <lb/> que corporeæ, quæ tandem virtus tibi
+						<pb n="1189"/> magis in unum Dcum et perspicuam intenti veritatem, <lb/> ut
+						dictum est, <hi rend="italic">facie ad faciem,</hi> numeros quibus agimus
+						<lb/> corpora, nulla inquietudine sentiemus, et gaudebimus? <lb/> Nisi forte
+						eredendum est, animam cum de iis quæ <lb/> per ipsam bona suut, gaudere
+						possit, de iis ex quibus <lb/> ipsa bona est, non posse gaudere.</p>
+					</div><div type="textpart" subtype="dialog"><p>50. Sed hæc actio qua sese anima, opitulante Deo <lb/> ct Domino suo, ab
+						amore inferioris pulchritudinis <lb/> extrahit, debellans atque interficiens
+						adversus se <lb/> militantem consuetudinem suam, ea victoria trium­ <lb/>
+						phatura ill semetipsa de potestatibus aeris hujus, qui­ <lb/> bus
+						invidentibus et præpedire cupientibus, cvolat ad <lb/> suam stabilitatem et
+						firmamentum Dcum ; nonne tibi <lb/> videtur ea csse virtus quæ temperantia
+						dicitur? <hi rend="italic">D.</hi>
+						<lb/> Agnosco ct intelligo. Jf. Quid porro? cum in boc <lb/> itinere
+						prolicit, jam æterna gaudia præsentientem ac <lb/> pene prehendentem, num
+						amissiorerum temporalium, <lb/> aut mors ulla deterret jam valentem dicere
+						inferiori­ <lb/> bus sociis : <hi rend="italic">Bonum est mihi</hi>
+						dissolvi, <hi rend="italic">et esse cum Christo:</hi>
+						<lb/> manere <hi rend="italic">autem in carne, necessarium propter</hi> vos
+							<hi rend="italic">? (Phi­ <lb/> lipp.</hi> i, i3, 24.) <hi rend="italic"
+							>D.</hi> Sic existimo. <hi rend="italic">M</hi> At ista cjus <lb/>
+						affectio qua nullas adversitates mortemve formidat, <lb/> quid aliud quam
+						fortitudo dicenda est? <hi rend="italic">D.</hi> Et' hoc <lb/> agnosco. <hi
+							rend="italic">M.</hi> Jamvero ipsa ejus ordinatio qua nulli <lb/> servit
+						nisi uni Dco, nulli coæquari nisi purissimis <lb/> animis, nulli dominari
+						appetit nisi naturæ bestiali at­ <lb/> que corporeæ, quæ tandem virtus tibi
 						esse videtur? <lb/>
-						<hi rend="italic">D.</hi> Quis non intelligat hanc esse justitiam? <hi rend="italic">M.</hi> Recte <lb/> intelligis.</p>
-					<ab>
-						<title type="sub">CAPUT XVI. — <hi rend="italic">De quatuor virtutibus an et quomodo
-								sint</hi> in <hi rend="italic">beatis.</hi>
+						<hi rend="italic">D.</hi> Quis non intelligat hanc esse justitiam? <hi
+							rend="italic">M.</hi> Recte <lb/> intelligis.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT XVI. — <hi rend="italic">De quatuor virtutibus an et
+								quomodo sint</hi> in <hi rend="italic">beatis.</hi>
 						</title>
 					</ab>
-					<p>51. Sed illud jam quæro, cum prudentiam superius <lb/>
-						<hi rend="italic">(a)</hi> cam esse constiterit inter nos, qua intelligit anima <lb/>
-						ubi ci consistendum sit, quo sese attollit per tempe­ <lb/> rantiam, id est,
-						conversionem amoris in Deum, quae <lb/> charitas dicitur, ct aversionem ab hoc sæculo,
-						quam <lb/> etiam fortitudo et justitia comitantur; utrum existi­ <lb/> mes cum ad suæ
-						dilectionis et conatus fructum per­ <lb/> fecta sanctific atione pervenerit, perfecta
-						etiam vivifi­ <lb/> catione illa corporis sui, et deletis de memoria phan­ <lb/>
-						tasmatum turbis, apud Deum ipsum solo Deo vivere <lb/> cæperit, cum impletum fuerit,
-						quod divinitus nobis <lb/> hoc modo proinittitur : <hi rend="italic">Dilectissimi,
-							nunc</hi> filii <hi rend="italic">Dei</hi>
-						<lb/> sumus, <hi rend="italic">ei nondum apparuit quid erimus. Scimus quia</hi>
-						<lb/> cum <hi rend="italic">apparuerit, similes illi</hi> erimus, quoniam videbimus
-						<lb/> eum <hi rend="italic">sicuti cst</hi> ( I <hi rend="italic">Joan.</hi> III, 2) :
-						quæro ergo, utrum <lb/> existimes has ibi virtutes quas commemoravimus, <lb/> cuam tunc
-						iuturas. D. Non vidco, cum adversa prae­ <lb/> terierint, quibus obluctalur, quomodo aut
-						prudentia <lb/> ibi esse possit, quæ non eligit quid sequatur nisi in <lb/> adversis ;
-						aut temperantia , quæ amorem non avertit <lb/> nisi ab adversis; aut fortitudo, quæ non
-						tolcrat nisi <lb/> adversa ; aut justitia, quae non appetit æquari beatis­ <lb/> simis
-						animis, et inferiori naturæ dominari, nisi in <lb/> adversis, id cst, nondum assecuta
-						idipsum quod <lb/> appeut.</p>
-					<p><hi rend="italic">52. M.</hi> Non usquequaque absurda est responsio <lb/> tua; et
-						quibusdam doctis visum hoc esse, non nego. <note type="footnote"> (a) tal" 55,37. </note>
-						<lb/> Sed ego consulens Libros, quos nulla antecellit aueto­ <lb/> mas, ita invenio
-						dictum esse : <hi rend="italic">Gustate et videte, quo­<lb/> niam suavis est Dominus
-							(Psal.</hi> XXXIII, 9). Quod aposto­ <lb/> lus etiam Petrus sic interposuit : Si <hi rend="italic">tamen gustastis, <lb/> quomam suavis eat Dominus (IPetr.</hi> n, 3). Hoc
-						esse <lb/> arbitror quod agitur in his virtutibus quæ ipsa con­ <lb/> versione animam
-						purgant. Non enim amor tempora­ <lb/> lium rerum expugnaretur, nisi aliqua suavitate
+					</div><div type="textpart" subtype="dialog"><p>51. Sed illud jam quæro, cum prudentiam superius <lb/>
+						<hi rend="italic">(a)</hi> cam esse constiterit inter nos, qua intelligit
+						anima <lb/> ubi ci consistendum sit, quo sese attollit per tempe­ <lb/>
+						rantiam, id est, conversionem amoris in Deum, quae <lb/> charitas dicitur,
+						ct aversionem ab hoc sæculo, quam <lb/> etiam fortitudo et justitia
+						comitantur; utrum existi­ <lb/> mes cum ad suæ dilectionis et conatus
+						fructum per­ <lb/> fecta sanctific atione pervenerit, perfecta etiam vivifi­
+						<lb/> catione illa corporis sui, et deletis de memoria phan­ <lb/> tasmatum
+						turbis, apud Deum ipsum solo Deo vivere <lb/> cæperit, cum impletum fuerit,
+						quod divinitus nobis <lb/> hoc modo proinittitur : <hi rend="italic"
+							>Dilectissimi, nunc</hi> filii <hi rend="italic">Dei</hi>
+						<lb/> sumus, <hi rend="italic">ei nondum apparuit quid erimus. Scimus
+							quia</hi>
+						<lb/> cum <hi rend="italic">apparuerit, similes illi</hi> erimus, quoniam
+						videbimus <lb/> eum <hi rend="italic">sicuti cst</hi> ( I <hi rend="italic"
+							>Joan.</hi> III, 2) : quæro ergo, utrum <lb/> existimes has ibi virtutes
+						quas commemoravimus, <lb/> cuam tunc iuturas. D. Non vidco, cum adversa
+						prae­ <lb/> terierint, quibus obluctalur, quomodo aut prudentia <lb/> ibi
+						esse possit, quæ non eligit quid sequatur nisi in <lb/> adversis ; aut
+						temperantia , quæ amorem non avertit <lb/> nisi ab adversis; aut fortitudo,
+						quæ non tolcrat nisi <lb/> adversa ; aut justitia, quae non appetit æquari
+						beatis­ <lb/> simis animis, et inferiori naturæ dominari, nisi in <lb/>
+						adversis, id cst, nondum assecuta idipsum quod <lb/> appeut.</p>
+					</div><div type="textpart" subtype="dialog"><p><hi rend="italic">52. M.</hi> Non usquequaque absurda est responsio <lb/>
+						tua; et quibusdam doctis visum hoc esse, non nego. <note type="footnote">
+							(a) tal" 55,37. </note>
+						<lb/> Sed ego consulens Libros, quos nulla antecellit aueto­ <lb/> mas, ita
+						invenio dictum esse : <hi rend="italic">Gustate et videte, quo­<lb/> niam
+							suavis est Dominus (Psal.</hi> XXXIII, 9). Quod aposto­ <lb/> lus etiam
+						Petrus sic interposuit : Si <hi rend="italic">tamen gustastis, <lb/> quomam
+							suavis eat Dominus (IPetr.</hi> n, 3). Hoc esse <lb/> arbitror quod
+						agitur in his virtutibus quæ ipsa con­ <lb/> versione animam purgant. Non
+						enim amor tempora­ <lb/> lium rerum expugnaretur, nisi aliqua suavitate
 						aeter­ <lb/> narum. Ubi autem ventum fuerit ad illud quod canitur: <lb/>
-						<hi rend="italic">bilii autem hominum sub tegmine alarum</hi> tuarum <hi rend="italic">spera­ <lb/> bunt; inebriabuntur ab ubertate domus</hi> tuae, <hi rend="italic">et
-							torrente <lb/> voluptatis tuas potabis eos; quoniam apud te eat fons <lb/> vitæ</hi> :
-						non jam gustatu suavem fore Dominum dicit; <lb/> sed vides quae inundatio et affluentia
-						praedicetur fon­ <lb/> tis acterni; quam etiam ebrietas quaedam consequitur: <lb/> quo
-						nomine mihi videtur mirabiliter signilicari oblivio <lb/> illa sæcularium vanitatum
-						atque phantasmatum. Con­ <lb/> texit deinde caetera, et dicit : <hi rend="italic">In</hi> lumine <hi rend="italic">tuo videbimus<lb/> lumen. Praetende misericordiam
-							tuam scientibus te. In, <lb/> lumine,</hi> scilicet in Christo accipiendum, qui
-						Sapicntia <lb/> Dei est, ct lumen totics appellatur. Ubi ergo dicitur, <lb/> V idebimus,
-						et, <hi rend="italic">scientibus te ,</hi> negari non potest futu­ <lb/> ram ibi esse
-						.prudentiam. An videri verum bonum <lb/> animæ etsciri potest, ubi nulla prudentia est?
-							<hi rend="italic">D.</hi> Jam <lb/> intelligo.</p>
-					<p>53. M. Quid ? recti corde possunt esse sine justitia ? <lb/>
-						<hi rend="italic">D.</hi> Recognosco isto nomine crebrius significari justi­ <lb/> tiam.
-							<hi rend="italic">M.</hi> Quid ergo admonet aliud propheta idcm <lb/> consequenter,
-						cum canit : <hi rend="italic">Et justitiam tuam iia qui <lb/> recto sunt corde? D.</hi>
-						Manifestum est. M. Age deinceps, <lb/> recordare, si placet, satis nos superius
-						tractasse, <lb/> superbia labi animam ad actiones quasdam potestatis <lb/> suae , et
-						universali lege neglecta in agenda quædam <lb/> privata cecidisse, quod dicitur
-						apostatare a Deo. <lb/>
-						<hi rend="italic">D.</hi> Memini vero. <hi rend="italic">M.</hi> Cum ergo id agit ne
-						ulterius id <lb/> delectet aliquando , nonne tibi videtur amorem suum <lb/> ligere in
-						Deo, et ab omni inquinamento temperatis­ <lb/> sime et castissime et securissime vivere?
-							<hi rend="italic">D.</hi> Videtur <lb/> sane. <hi rend="italic">M.</hi> Vide etiam
-						quemadmodum id quoque adjun­ <lb/> gat propheta, dicens : <hi rend="italic">Non veniat
-							mihi pes supeibiæ.</hi>
-						<lb/> Pedem enim appellans discessum ipsum lapsumve <lb/> significat, a quo anima
-						temperando, inhæreus Deo <lb/> vivit in æternum. <hi rend="italic">D.</hi> Accipio et
-						sequor.</p>
-					<p>54. <hi rend="italic">N.</hi> Restat igitur fortitudo. Sed ut temperantia <lb/> contra
-						lapsum qui est in libera voluntate ; sic forti­ <lb/> tudo contra vim valet, qua etiam
-						cogi quis potest, <lb/> si minus fortis sit ad ea quibus evertatur, et miserri­ <lb/>
-						mus jaceat. Hæc autem vis decenter in Scripturis <lb/> manus nomine significari solet.
-						Qui porro hanc vim, <lb/> nisi peccatores conantur inferre 9 Quod tunc per id­ <lb/>
-						ipsum 1 communitur anima, et custoditur firmamento <lb/> Dei, ut hoc illi nullo modo
-						undecumque possit acci­ <lb/> dere ; potentiam quamdam stabilem, et, ut ita dicam, <lb/>
-						impassibilem gerit, quæ, nisi quid libi displicet, recte <lb/> fortitudo nominatur, ct
-						cam dici arbitror cum adjun­ <lb/> gitur: <hi rend="italic">Neque manus peccatorum
-							dimoveat</hi> me <hi rend="italic">(Psal.</hi>
-						<note type="footnote"> 1 Ita editiones et melioris potae Mas. POrro in editis non­ <lb/>
-							nullis habetur: <hi rend="italic">Quod autem contra id</hi> ipsum torunaumu, <lb/>
+						<hi rend="italic">bilii autem hominum sub tegmine alarum</hi> tuarum <hi
+							rend="italic">spera­ <lb/> bunt; inebriabuntur ab ubertate domus</hi>
+						tuae, <hi rend="italic">et torrente <lb/> voluptatis tuas potabis eos;
+							quoniam apud te eat fons <lb/> vitæ</hi> : non jam gustatu suavem fore
+						Dominum dicit; <lb/> sed vides quae inundatio et affluentia praedicetur fon­
+						<lb/> tis acterni; quam etiam ebrietas quaedam consequitur: <lb/> quo nomine
+						mihi videtur mirabiliter signilicari oblivio <lb/> illa sæcularium vanitatum
+						atque phantasmatum. Con­ <lb/> texit deinde caetera, et dicit : <hi
+							rend="italic">In</hi> lumine <hi rend="italic">tuo videbimus<lb/> lumen.
+							Praetende misericordiam tuam scientibus te. In, <lb/> lumine,</hi>
+						scilicet in Christo accipiendum, qui Sapicntia <lb/> Dei est, ct lumen
+						totics appellatur. Ubi ergo dicitur, <lb/> V idebimus, et, <hi rend="italic"
+							>scientibus te ,</hi> negari non potest futu­ <lb/> ram ibi esse
+						.prudentiam. An videri verum bonum <lb/> animæ etsciri potest, ubi nulla
+						prudentia est? <hi rend="italic">D.</hi> Jam <lb/> intelligo.</p>
+					</div><div type="textpart" subtype="dialog"><p>53. M. Quid ? recti corde possunt esse sine justitia ? <lb/>
+						<hi rend="italic">D.</hi> Recognosco isto nomine crebrius significari justi­
+						<lb/> tiam. <hi rend="italic">M.</hi> Quid ergo admonet aliud propheta idcm
+						<lb/> consequenter, cum canit : <hi rend="italic">Et justitiam tuam iia qui
+							<lb/> recto sunt corde? D.</hi> Manifestum est. M. Age deinceps, <lb/>
+						recordare, si placet, satis nos superius tractasse, <lb/> superbia labi
+						animam ad actiones quasdam potestatis <lb/> suae , et universali lege
+						neglecta in agenda quædam <lb/> privata cecidisse, quod dicitur apostatare a
+						Deo. <lb/>
+						<hi rend="italic">D.</hi> Memini vero. <hi rend="italic">M.</hi> Cum ergo id
+						agit ne ulterius id <lb/> delectet aliquando , nonne tibi videtur amorem
+						suum <lb/> ligere in Deo, et ab omni inquinamento temperatis­ <lb/> sime et
+						castissime et securissime vivere? <hi rend="italic">D.</hi> Videtur <lb/>
+						sane. <hi rend="italic">M.</hi> Vide etiam quemadmodum id quoque adjun­
+						<lb/> gat propheta, dicens : <hi rend="italic">Non veniat mihi pes
+							supeibiæ.</hi>
+						<lb/> Pedem enim appellans discessum ipsum lapsumve <lb/> significat, a quo
+						anima temperando, inhæreus Deo <lb/> vivit in æternum. <hi rend="italic"
+							>D.</hi> Accipio et sequor.</p>
+					</div><div type="textpart" subtype="dialog"><p>54. <hi rend="italic">N.</hi> Restat igitur fortitudo. Sed ut temperantia
+						<lb/> contra lapsum qui est in libera voluntate ; sic forti­ <lb/> tudo
+						contra vim valet, qua etiam cogi quis potest, <lb/> si minus fortis sit ad
+						ea quibus evertatur, et miserri­ <lb/> mus jaceat. Hæc autem vis decenter in
+						Scripturis <lb/> manus nomine significari solet. Qui porro hanc vim, <lb/>
+						nisi peccatores conantur inferre 9 Quod tunc per id­ <lb/> ipsum 1
+						communitur anima, et custoditur firmamento <lb/> Dei, ut hoc illi nullo modo
+						undecumque possit acci­ <lb/> dere ; potentiam quamdam stabilem, et, ut ita
+						dicam, <lb/> impassibilem gerit, quæ, nisi quid libi displicet, recte <lb/>
+						fortitudo nominatur, ct cam dici arbitror cum adjun­ <lb/> gitur: <hi
+							rend="italic">Neque manus peccatorum dimoveat</hi> me <hi rend="italic"
+							>(Psal.</hi>
+						<note type="footnote"> 1 Ita editiones et melioris potae Mas. POrro in
+							editis non­ <lb/> nullis habetur: <hi rend="italic">Quod autem contra
+								id</hi> ipsum torunaumu, <lb/>
 							<hi rend="italic">anvna.</hi>
 						</note>
 						<lb/>
 						<pb n="1191"/> XXXV, 8 - 12).</p>
-					<p>55. Sed sive hoc sive aliud in his verbis intelligen­ <lb/> dum sii, tu negabis in illa
-						perfectione ac beatitate <lb/> animam constitutam , et conspicere veritatem, et im­
-						<lb/> maculatam manere , et nihil molestiae pati posse, et <lb/> uni Dio subdi, caeteris
-						vero supereminere naturis ? <lb/>
-						<hi rend="italic">D.</hi> Imo aliter eam perfectissimam et beatissimam esse <lb/> posse
-						non video. M. Haec ergo contemplatio, sanctifi­ <lb/> catio, impassibilitas, ordinatio
-						ejus, aut illæ suut <lb/> quatuor virtutes perfectæ atque consummatae; aut ne <lb/> da
-						nominibus cum res conveniant, frustra laboremus, <lb/> pro istis virtuLibus, quibus
-						constituta in laboribus <lb/> utitur anima, tales quædam potentiæ in æterna ei vita
-						<lb/> sporandæ suut.</p>
-					<ab>
-						<title type="sub">CAPUT XVII. — <hi rend="italic">Quod peccatrix anima numeros agat,
-								et</hi> numeris <hi rend="italic">agatur. Conclusio operit.</hi>
+					</div><div type="textpart" subtype="dialog"><p>55. Sed sive hoc sive aliud in his verbis intelligen­ <lb/> dum sii, tu
+						negabis in illa perfectione ac beatitate <lb/> animam constitutam , et
+						conspicere veritatem, et im­ <lb/> maculatam manere , et nihil molestiae
+						pati posse, et <lb/> uni Dio subdi, caeteris vero supereminere naturis ? <lb/>
+						<hi rend="italic">D.</hi> Imo aliter eam perfectissimam et beatissimam esse
+						<lb/> posse non video. M. Haec ergo contemplatio, sanctifi­ <lb/> catio,
+						impassibilitas, ordinatio ejus, aut illæ suut <lb/> quatuor virtutes
+						perfectæ atque consummatae; aut ne <lb/> da nominibus cum res conveniant,
+						frustra laboremus, <lb/> pro istis virtuLibus, quibus constituta in
+						laboribus <lb/> utitur anima, tales quædam potentiæ in æterna ei vita <lb/>
+						sporandæ suut.</p>
+					</div><div type="textpart" subtype="chapter"><ab>
+						<title type="sub">CAPUT XVII. — <hi rend="italic">Quod peccatrix anima
+								numeros agat, et</hi> numeris <hi rend="italic">agatur. Conclusio
+								operit.</hi>
 						</title>
 					</ab>
-					<p>56. Nos tantum meminerimus, quod ad susceptam <lb/> praesentem disputationem maxime
-						pertinet, id agi per <lb/> providentiam Dei, per quam cuncta creavit et regit, <lb/> ut
-						etiam peccatrix et aerumnosa anima numeris aga­ <lb/> tur, et numeros agat psque ad
-						infimam carnis corru­ <lb/> ptionem : qui certe numeri minus minusque pulchri <lb/> esse
-						possunt, penitus vero carere pulchritudine non <lb/> possunt. Deus autem summe bonus, et
-						summe justus, <lb/> nulli invidet pulchritudini, quae sive damnatione <lb/> animae, sive
-						regressione, sive permansione fabricator. <lb/> Numerus autem et ab uno incipit, et
-						æqualitate ac si­ <lb/> militudine pulcher est, et ordine copulatur. Quamob­ <lb/> rem
-						quisquis fatetur nullam esse naturam, quae non <lb/> ut sit quidquid est, appetat
-						unitatem, suique similis <lb/> in quantum potest esse conetur v atque ordinem pro­ <lb/>
-						prium vei locis vel temporibus, val in corpore 1 quo­ <lb/> dam libramento salutem suam
-						teneat : debet fateri <lb/> ab uno principio per æqualem illi ac similem speciem <lb/>
-						divitiis bonitatis ejus , qua inter se unum et de uno <lb/> unum charissima I, ut ita
-						dicam, charitate junguntur, <lb/> omnia facta esse atque condita quaecumque sunt, in
-						<lb/> quantumcumque sunt.</p>
-					<p>57. Quare ille versus a nobis propositus, <hi rend="italic">Deus crea­</hi>
-						<lb/> tor <hi rend="italic">omnium,</hi> non solum auribus sono numeroso, sed <lb/>
-						multo magis est animæ sententiae sanitate et veritate <lb/> gratissimus. Nisi forte
-						movet te tarditas eorum, ut <lb/> mitius loquar, qui negant de nihilo fieri posse
-						aliquid, <lb/> cum id omnipotens Deus fecisse dicatur. An vero fa­ <lb/> ber potest
-						rationabilibus numeris qui sunt in arte <lb/> ejus, sensuales numeros qui sunt in
-						consuetudine <lb/> ejus operari; et sensualibus numeris progressores <lb/> illos quibus
-						membra in operando movet, ad quos jam <lb/> intervalla temporum pertinent, et bis rursus
-						formas <lb/> visibiles de ligno fabricari, locorum intervallis nume­ <lb/> rosas: et
-						rerum natura Dei nutibus serviens, ipsum <lb/> lignum de terra et caeteris elementis
-						facere non po­ <note type="footnote">'Er. et Lov., incorporeo <hi rend="italic">quodam
-								libramento.</hi> Aliquot Mss., <lb/>
-							<hi rend="italic">In corporeo quodam.</hi> At Am. et codices plerique veteres <lb/>
-							praeferunt, in <hi rend="italic">corpore quodam :</hi> quod magis probamus.
-							</note><note type="footnote"> s Insignior iste de Trinitate locus in editionibus Er et
-							<lb/> toy. necnon in recentioribus aliquot Mss. ita corrupte legi­ <lb/> tui- : <hi rend="italic">Qua</hi> inter <hi rend="italic">se unum ei duo chamsima, vt itu
-								dicanl.</hi>
-							<lb/> ID editione autem Am.: <hi rend="italic">Qua inter se tmum et de 11110 mum<lb/>
-								chansma : et</hi> tU <hi rend="italic">ita dicam.</hi>
-								Red<unclear>integravimus</unclear> totum ad Ii­ <lb/> proa Toleres optimae notae. </note>
-						<lb/> test; et ipsa extrema non poterat de nullo 1 ? imo et <lb/> urboris locales
-						numeros, temporales numeri antece­ <lb/> dant necesse est. Nullum est enim stirpium
-						genus <lb/> quod non certis pro suo semine dimensionibus tem­ <lb/> porum et coalescat,
-						et germinet, et in auras cmicet, <lb/> et folia explicet, ct roborctur, et sive fructum
-						, sive <lb/> ipsius ligni occultissimis numeris vim rursus seminis <lb/> referat :
-						quanto magis animalium corpora, in quibus <lb/> intervalla membrorum numerosam
-						parilitatem multo <lb/> magis aspectibus offerunt? An ista de elementis fieri <lb/>
-						possunt, et ipsa elementa non potuerunt fieri de nihi­ <lb/> lo? Quasi vcro quidquam sit
-						in eis vilius et abjectius <lb/> quam terra est. Quæ primo generalem speciem cor­ <lb/>
-						pcris hahet, in qua unitas quandam et numeri et ordo <lb/> esse convincitur. Namque ab
-						aliqua impertili nota * <lb/> in longitudinem necesse est porrigatur quælibet ejus <lb/>
-						quantumvis parva particula, tertiam latitudinem su­ <lb/> mat, ct quartam altitudinem
-						qua corpus impletur. <lb/> Unde ergo iste a primo usque ad quartum progressionis <lb/>
-						modus? Unde et æqualitas quoque partium, quae in <lb/> longitudine et latitudine et
-						altitudine reperitur? Unde <lb/> corrationalitas quædam (ita euim malui analogiam vo­
-						<lb/> care), ut quam rationem habet longitudo ad imperti- <lb/> lem notam, eamdem
-						latitudo ad longitudinem, et ad <lb/> latitudinem babeat altitudo? Unde, quaeso, ista,
-						nisi <lb/> ab illo summo atque æterno principatu numerorum <lb/> et similitudinis et
-						æqualitatis et ordinis veniunt? <lb/> Atqui hæc si terrae ademeris, nihil erit. Quocirca
-						<lb/> omnipotens Deus terram fecit, et de nihilo terra facta <lb/> est.</p>
-					<p>. 58. Quid porro? ipsa species qua item a cæteris ele­ <lb/> mentis terra discernitur,
-						nonne et unum aliquid quan­ <lb/> tum accepit ostentat, et nulla pars ejus a toio est
-						dis­ <lb/> similis, et earumdem partium connexione atque con­ <lb/> cordia suo genere
-						saluberrimam sedem infimam tenet? <lb/> Cui superfunditur aquarum natura, nitens et ipsa
-						ad <lb/> unitatem, speciosior et perlucidior propter majorem <lb/> similitudinem
-						partium, et custodiens locum ordinis <lb/> ct salutis suæ. Quid de aeris natura dicam,
-						multo fa­ <lb/> ciliore complexu ad Hnitatem nitente, et tanto specio­ <lb/> siore
-						aquis, quam illæ terris sunt, tantoque superiore <lb/> ad salutem •? Quid de cœli
-						supremo ambitu, quo <lb/> tota universitas visibilium corporum terminatur, et <lb/>
-						summa in hoc genere species, ac saluberrima loci <lb/> excellentia? Ista certe omnia
-						quae carnalis sensus mi­ <lb/> nisterio numeramus, ct quæcumque in cis sunt, locales
-						<lb/> numeros qui videntur esse in aliquo statu, nisi præce­ <lb/> dentibus intimis et
-						in silentio temporalibus numeris <lb/> qui sunt in motu, nec accipere illos possunt, ner
-						ha­ <lb/> bere. Illos itidem temporum intervallis agiles praece­ <lb/>
+					</div><div type="textpart" subtype="dialog"><p>56. Nos tantum meminerimus, quod ad susceptam <lb/> praesentem disputationem
+						maxime pertinet, id agi per <lb/> providentiam Dei, per quam cuncta creavit
+						et regit, <lb/> ut etiam peccatrix et aerumnosa anima numeris aga­ <lb/>
+						tur, et numeros agat psque ad infimam carnis corru­ <lb/> ptionem : qui
+						certe numeri minus minusque pulchri <lb/> esse possunt, penitus vero carere
+						pulchritudine non <lb/> possunt. Deus autem summe bonus, et summe justus,
+						<lb/> nulli invidet pulchritudini, quae sive damnatione <lb/> animae, sive
+						regressione, sive permansione fabricator. <lb/> Numerus autem et ab uno
+						incipit, et æqualitate ac si­ <lb/> militudine pulcher est, et ordine
+						copulatur. Quamob­ <lb/> rem quisquis fatetur nullam esse naturam, quae non
+						<lb/> ut sit quidquid est, appetat unitatem, suique similis <lb/> in quantum
+						potest esse conetur v atque ordinem pro­ <lb/> prium vei locis vel
+						temporibus, val in corpore 1 quo­ <lb/> dam libramento salutem suam teneat :
+						debet fateri <lb/> ab uno principio per æqualem illi ac similem speciem
+						<lb/> divitiis bonitatis ejus , qua inter se unum et de uno <lb/> unum
+						charissima I, ut ita dicam, charitate junguntur, <lb/> omnia facta esse
+						atque condita quaecumque sunt, in <lb/> quantumcumque sunt.</p>
+					</div><div type="textpart" subtype="dialog"><p>57. Quare ille versus a nobis propositus, <hi rend="italic">Deus crea­</hi>
+						<lb/> tor <hi rend="italic">omnium,</hi> non solum auribus sono numeroso,
+						sed <lb/> multo magis est animæ sententiae sanitate et veritate <lb/>
+						gratissimus. Nisi forte movet te tarditas eorum, ut <lb/> mitius loquar, qui
+						negant de nihilo fieri posse aliquid, <lb/> cum id omnipotens Deus fecisse
+						dicatur. An vero fa­ <lb/> ber potest rationabilibus numeris qui sunt in
+						arte <lb/> ejus, sensuales numeros qui sunt in consuetudine <lb/> ejus
+						operari; et sensualibus numeris progressores <lb/> illos quibus membra in
+						operando movet, ad quos jam <lb/> intervalla temporum pertinent, et bis
+						rursus formas <lb/> visibiles de ligno fabricari, locorum intervallis nume­
+						<lb/> rosas: et rerum natura Dei nutibus serviens, ipsum <lb/> lignum de
+						terra et caeteris elementis facere non po­ <note type="footnote">'Er. et
+							Lov., incorporeo <hi rend="italic">quodam libramento.</hi> Aliquot Mss., <lb/>
+							<hi rend="italic">In corporeo quodam.</hi> At Am. et codices plerique
+							veteres <lb/> praeferunt, in <hi rend="italic">corpore quodam :</hi>
+							quod magis probamus. </note><note type="footnote"> s Insignior iste de
+							Trinitate locus in editionibus Er et <lb/> toy. necnon in recentioribus
+							aliquot Mss. ita corrupte legi­ <lb/> tui- : <hi rend="italic">Qua</hi>
+							inter <hi rend="italic">se unum ei duo chamsima, vt itu dicanl.</hi>
+							<lb/> ID editione autem Am.: <hi rend="italic">Qua inter se tmum et de
+								11110 mum<lb/> chansma : et</hi> tU <hi rend="italic">ita
+								dicam.</hi> Red<unclear>integravimus</unclear> totum ad Ii­ <lb/>
+							proa Toleres optimae notae. </note>
+						<lb/> test; et ipsa extrema non poterat de nullo 1 ? imo et <lb/> urboris
+						locales numeros, temporales numeri antece­ <lb/> dant necesse est. Nullum
+						est enim stirpium genus <lb/> quod non certis pro suo semine dimensionibus
+						tem­ <lb/> porum et coalescat, et germinet, et in auras cmicet, <lb/> et
+						folia explicet, ct roborctur, et sive fructum , sive <lb/> ipsius ligni
+						occultissimis numeris vim rursus seminis <lb/> referat : quanto magis
+						animalium corpora, in quibus <lb/> intervalla membrorum numerosam
+						parilitatem multo <lb/> magis aspectibus offerunt? An ista de elementis
+						fieri <lb/> possunt, et ipsa elementa non potuerunt fieri de nihi­ <lb/> lo?
+						Quasi vcro quidquam sit in eis vilius et abjectius <lb/> quam terra est. Quæ
+						primo generalem speciem cor­ <lb/> pcris hahet, in qua unitas quandam et
+						numeri et ordo <lb/> esse convincitur. Namque ab aliqua impertili nota *
+						<lb/> in longitudinem necesse est porrigatur quælibet ejus <lb/> quantumvis
+						parva particula, tertiam latitudinem su­ <lb/> mat, ct quartam altitudinem
+						qua corpus impletur. <lb/> Unde ergo iste a primo usque ad quartum
+						progressionis <lb/> modus? Unde et æqualitas quoque partium, quae in <lb/>
+						longitudine et latitudine et altitudine reperitur? Unde <lb/>
+						corrationalitas quædam (ita euim malui analogiam vo­ <lb/> care), ut quam
+						rationem habet longitudo ad imperti- <lb/> lem notam, eamdem latitudo ad
+						longitudinem, et ad <lb/> latitudinem babeat altitudo? Unde, quaeso, ista,
+						nisi <lb/> ab illo summo atque æterno principatu numerorum <lb/> et
+						similitudinis et æqualitatis et ordinis veniunt? <lb/> Atqui hæc si terrae
+						ademeris, nihil erit. Quocirca <lb/> omnipotens Deus terram fecit, et de
+						nihilo terra facta <lb/> est.</p>
+					</div><div type="textpart" subtype="dialog"><p>. 58. Quid porro? ipsa species qua item a cæteris ele­ <lb/> mentis terra
+						discernitur, nonne et unum aliquid quan­ <lb/> tum accepit ostentat, et
+						nulla pars ejus a toio est dis­ <lb/> similis, et earumdem partium
+						connexione atque con­ <lb/> cordia suo genere saluberrimam sedem infimam
+						tenet? <lb/> Cui superfunditur aquarum natura, nitens et ipsa ad <lb/>
+						unitatem, speciosior et perlucidior propter majorem <lb/> similitudinem
+						partium, et custodiens locum ordinis <lb/> ct salutis suæ. Quid de aeris
+						natura dicam, multo fa­ <lb/> ciliore complexu ad Hnitatem nitente, et tanto
+						specio­ <lb/> siore aquis, quam illæ terris sunt, tantoque superiore <lb/>
+						ad salutem •? Quid de cœli supremo ambitu, quo <lb/> tota universitas
+						visibilium corporum terminatur, et <lb/> summa in hoc genere species, ac
+						saluberrima loci <lb/> excellentia? Ista certe omnia quae carnalis sensus
+						mi­ <lb/> nisterio numeramus, ct quæcumque in cis sunt, locales <lb/>
+						numeros qui videntur esse in aliquo statu, nisi præce­ <lb/> dentibus
+						intimis et in silentio temporalibus numeris <lb/> qui sunt in motu, nec
+						accipere illos possunt, ner ha­ <lb/> bere. Illos itidem temporum
+						intervallis agiles praece­ <lb/>
 						<hi rend="italic">j</hi>
-						<note type="footnote">1 Exfungenda videretur particula negans, nisi exstaret in <lb/>
-							»'ss. a quihus tamen cum absint sequentia verba, scilicet, <lb/>
-							<hi rend="italic">et ipsa extrema non poterat de nullo,</hi> fatemur non tantam <lb/>
-							lis fidem esse tribuendam hoc loco, qui iibrai-ioruni lanso4 <lb/> vitialas sit.
-							</note><note type="footnote"> * Lov., <hi rend="italic">imparUi</hi> notajEi rursum
-							inferius, <hi rend="italic">inaparilml no. <lb/> Lrni.</hi> sed melus Am. et Er. cum
-							aliquot Mss., <hi rend="italic">intperlili</hi> et im­ <lb/> pertitu <hi rend="italic">m :</hi> nam hic nomine notae intelligitur PUUclUUl seu si­ <lb/> gnum unde linea
-							ducitur; quod in libro de Qua.llitate Ani­ <lb/> ina?, cap. ii, n. i8, sicdefinitur :
-							tKota sine lartibus.* </note><note type="footnote">a Lov.: <hi rend="italic">Et tanto
-								speciosiore, quanto speciostores aquæ stmi</hi>
-							<lb/> terris, <hi rend="italic">fI1umlOque ad superiorem salutem altior terra
-								nititur.</hi>
+						<note type="footnote">1 Exfungenda videretur particula negans, nisi exstaret
+							in <lb/> »'ss. a quihus tamen cum absint sequentia verba, scilicet, <lb/>
+							<hi rend="italic">et ipsa extrema non poterat de nullo,</hi> fatemur non
+							tantam <lb/> lis fidem esse tribuendam hoc loco, qui iibrai-ioruni
+							lanso4 <lb/> vitialas sit. </note><note type="footnote"> * Lov., <hi
+								rend="italic">imparUi</hi> notajEi rursum inferius, <hi
+								rend="italic">inaparilml no. <lb/> Lrni.</hi> sed melus Am. et Er.
+							cum aliquot Mss., <hi rend="italic">intperlili</hi> et im­ <lb/> pertitu
+								<hi rend="italic">m :</hi> nam hic nomine notae intelligitur
+							PUUclUUl seu si­ <lb/> gnum unde linea ducitur; quod in libro de
+							Qua.llitate Ani­ <lb/> ina?, cap. ii, n. i8, sicdefinitur : tKota sine
+							lartibus.* </note><note type="footnote">a Lov.: <hi rend="italic">Et
+								tanto speciosiore, quanto speciostores aquæ stmi</hi>
+							<lb/> terris, <hi rend="italic">fI1umlOque ad superiorem salutem altior
+								terra nititur.</hi>
 						</note>
 						<lb/>
-						<pb n="1193"/> dit et modificat vitalis motus, serviens Domino rerum <lb/> omnium, nun
-						temporalia habens digesta intervalla <lb/> numerorum suorum, sed tempora ministrante
-						poten­ <lb/> tia; supra quam rationales et intellectuales numeri <lb/> beatarum animarum
-						atque sanctarum, legem ipsam <lb/> Dei, sinc qua folium de arbore non cadit, et cui
-						nostri <lb/> capilli numerati sunt, nulla interposita natura exci­ <lb/> pientes, usque
-						ad terrena et inferna jura transmit­ <lb/> tunt (a).</p>
-					<ab>
+						<pb n="1193"/> dit et modificat vitalis motus, serviens Domino rerum <lb/>
+						omnium, nun temporalia habens digesta intervalla <lb/> numerorum suorum, sed
+						tempora ministrante poten­ <lb/> tia; supra quam rationales et
+						intellectuales numeri <lb/> beatarum animarum atque sanctarum, legem ipsam
+						<lb/> Dei, sinc qua folium de arbore non cadit, et cui nostri <lb/> capilli
+						numerati sunt, nulla interposita natura exci­ <lb/> pientes, usque ad
+						terrena et inferna jura transmit­ <lb/> tunt (a).</p>
+					</div><div type="textpart" subtype="chapter"><ab>
 						<title type="sub">CONCLUSIO OPERIS.</title>
 					</ab>
-					<p>; 59. Quæ potui et sicut potui de tantis tantillus te­ <lb/> cuin contuli. Sermonem
-						autem hunc nostrum manda­ <lb/> tum litteris si qui legunt, sciant multo infirmioribus
-						<lb/> hæc esse scripta, quam sunt illi qui unius summi De! <note type="footnote"> . <hi rend="italic">(a)</hi> vid. Retract. lib. i, cap. i, n. 4. </note>
-						<lb/> consubstantialem et incommutabilem Trinitatcm, cit <lb/> quo omnia, per quem
-						omnia, in quo omnia duorum Tc­ <lb/> stamentorum auctoritatem seculi venerantur et
-						colunt <lb/> eam credendo, sperando et diligendo. <unclear>Hi</unclear> enim non scin -
-						<lb/> tillantibus humanis ratiocinationibus, sed validissimo <lb/> et flagrantissimo
-						charitatis igne purgantur. Nos autem <lb/> dum negligendos esse non existimamus quos
-						hæretici <lb/> rationis et scientiæ fallaci pollicitatione decipiunt; <lb/> tardius
-						incedimus, consideratione ipsarum viarum , <lb/> qnam sancti viri qui cas volando nop
-						dignantur at­ <lb/> tendere. Quod tamen faccre non auderemus, nisi mill. <lb/> tos pios
-						Ecclesiæ catholicæ matris optimæ filios, qqi <lb/> pucrilibus studiis loquendi ac
-						disserendi facultatem <lb/> quantum satis est consecuti essent, eadcm refellen- <lb/>
-						dorum hæreticorum necessitate fecisse videremus.</p>
-				</div></div>
-
-				</body>
-  </text>
+					</div><div type="textpart" subtype="dialog"><p>59. Quæ potui et sicut potui de tantis tantillus te­ <lb/> cuin contuli.
+						Sermonem autem hunc nostrum manda­ <lb/> tum litteris si qui legunt, sciant
+						multo infirmioribus <lb/> hæc esse scripta, quam sunt illi qui unius summi
+						De! <note type="footnote"> . <hi rend="italic">(a)</hi> vid. Retract. lib.
+							i, cap. i, n. 4. </note>
+						<lb/> consubstantialem et incommutabilem Trinitatcm, cit <lb/> quo omnia,
+						per quem omnia, in quo omnia duorum Tc­ <lb/> stamentorum auctoritatem
+						seculi venerantur et colunt <lb/> eam credendo, sperando et diligendo.
+							<unclear>Hi</unclear> enim non scin - <lb/> tillantibus humanis
+						ratiocinationibus, sed validissimo <lb/> et flagrantissimo charitatis igne
+						purgantur. Nos autem <lb/> dum negligendos esse non existimamus quos
+						hæretici <lb/> rationis et scientiæ fallaci pollicitatione decipiunt; <lb/>
+						tardius incedimus, consideratione ipsarum viarum , <lb/> qnam sancti viri
+						qui cas volando nop dignantur at­ <lb/> tendere. Quod tamen faccre non
+						auderemus, nisi mill. <lb/> tos pios Ecclesiæ catholicæ matris optimæ
+						filios, qqi <lb/> pucrilibus studiis loquendi ac disserendi facultatem <lb/>
+						quantum satis est consecuti essent, eadcm refellen- <lb/> dorum hæreticorum
+						necessitate fecisse videremus.</p></div>
+				</div>
+			</div>
+			</div>
+		</body>
+	</text>
 </TEI>

--- a/data/stoa0040/stoa008/stoa0040.stoa008.opp-lat1.xml
+++ b/data/stoa0040/stoa008/stoa0040.stoa008.opp-lat1.xml
@@ -2592,7 +2592,7 @@
 							rend="italic">M.</hi> Inspiciamus igitur me­<lb/>tra illa quae a me
 						paulo ante commemorata sunt, et<lb/>videamus quibus pcdibus constent: non
 						enim te in hoc<lb/>generc animadvertendo rudem esse adhuc decet. Ea<lb/>
-						sunt autem :<lb/>Ite igitur, Camœnae<lb/>Fonticolx puellae,<lb/>Quae
+						sunt autem :<lb/>Ite igitur, Camoenae<lb/>Fonticolx puellae,<lb/>Quae
 						canitis sub antris<lb/>Mellifluos sonores.<lb/>Satis haec esse ad id quod
 						intendimus puto : tu jam<lb/>metire ista, et quos habeant pedes renuntia.
 						D.Omni­<lb/>no non possum : eos enim metiendos puto, qui sibi le­<lb/>
@@ -5644,7 +5644,7 @@
 						sunt, nisi illa in quibus summa, inconcussa,<lb/>incommutabilis, aeterna
 						manet aequalitas? Ubi nul­<lb/>lum est tempus, quia nulla mutabilitas est;
 						et unde<lb/>tempora fabricantur et ordinantur et modificantur<lb/>
-						aeternitatem imitantia , dum cœli conversio ad idem<lb/>redit1, et cœlestia
+						aeternitatem imitantia , dum coeli conversio ad idem<lb/>redit1, et coelestia
 						corpora ad idem revocat, diebus­<lb/>que et mensinus et annis ct lusiris,
 						caeterisque side­<lb/>rum orbibus, legibus aequalitatis et unitatis et ordi­
 						<lb/>nationis obtemperat. Ita coelestibus terrena subjecta,<lb/>orbes
@@ -6028,7 +6028,7 @@
 						<hi rend="italic">diligere</hi> mundum : <hi rend="italic">quia omnia</hi>
 						quae in <hi rend="italic">mundo</hi> sunt, con­<lb/>
 						<hi rend="italic">cupiscentia carnis est, et concupiscentia oculorum,
-							et<lb/>ambitio sœculi</hi> (I <hi rend="italic">Joan.</hi> II, 15,
+							et<lb/>ambitio soeculi</hi> (I <hi rend="italic">Joan.</hi> II, 15,
 						16).</p>
 					</div><div type="textpart" subtype="dialog"><p>45. Sed qualis tibi humo vidctur, qui omnes illos<lb/>numeros qui sunt de
 						corpore, et adversus passiones<lb/>corporis, et qui ex bis memoria
@@ -6360,7 +6360,7 @@
 						partium, et custodiens locum ordinis<lb/>ct salutis suae. Quid de aeris
 						natura dicam, multo fa­<lb/>ciliore complexu ad Hnitatem nitente, et tanto
 						specio­<lb/>siore aquis, quam illae terris sunt, tantoque superiore<lb/>
-						ad salutem •? Quid de cœli supremo ambitu, quo<lb/>tota universitas
+						ad salutem •? Quid de coeli supremo ambitu, quo<lb/>tota universitas
 						visibilium corporum terminatur, et<lb/>summa in hoc genere species, ac
 						saluberrima loci<lb/>excellentia? Ista certe omnia quae carnalis sensus
 						mi­<lb/>nisterio numeramus, ct quaecumque in cis sunt, locales<lb/>

--- a/data/stoa0040/stoa008/stoa0040.stoa008.opp-lat1.xml
+++ b/data/stoa0040/stoa008/stoa0040.stoa008.opp-lat1.xml
@@ -86,9 +86,18 @@
 			<p>The following text is encoded in accordance with EpiDoc standards and with the
 				CTS/CITE Architecture.</p>
 			<refsDecl n="CTS">
-				<cRefPattern n="no citable units founds" matchPattern="(.+)"
-					replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])"
-				/>
+				<cRefPattern n="dialog" matchPattern="(\w+).(\w+)"
+					replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1']/tei:div[@n='$2'])">
+					<p>This pointer pattern extracts sermons within collection</p>
+				</cRefPattern>
+				<cRefPattern n="chapter" matchPattern="(\w+)"
+					replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
+					<p>This pointer pattern extracts a collection of sermons</p>
+				</cRefPattern>
+			</refsDecl>
+			<refsDecl>
+				<refState unit="chapter"/>
+				<refState unit="dialog"/>
 			</refsDecl>
 		</encodingDesc>
 
@@ -97,11 +106,18 @@
 				<language ident="la">Latin</language>
 			</langUsage>
 		</profileDesc>
+		
+		<revisionDesc>
+			<change who="Louise" when="2019-03-31">Modification des hyphénisations et corrections de
+				l'OCR.</change>
+			<change who="Louise" when="2019-03-31">Structuration du texte selon les recommandations
+				des guidelines CapiTains.</change>
+		</revisionDesc>
 
 	</teiHeader>
 	<text>
 		<body>
-			<div type="edition" n="urn:cts:latinLit:stoa0040.stoa008.opp-lat1">
+			<div type="edition" n="urn:cts:latinLit:stoa0040.stoa008.opp-lat1" xml:lang="lat">
 				<head>
 					<title type="main">S. AURELII AUGUSTINI HIPPONENSIS EPISCOPI DE MUSICA LIBRI SEX
 						(a).</title>
@@ -1024,7 +1040,7 @@
 						<div type="textpart" subtype="dialog" n="23"> 
 							
 							
-							<!-- REPRENDRE ICI ***************************************************************************************** --> 
+							<!-- La structuration des dialogues a été effectuée jusqu'à cet endroit ********************************* --> 
 							
 							
 					<p>23. <hi rend="italic">M.</hi> Attende igitur ut hoc in ibta connexione vi­


### PR DESCRIPTION
Conformément à ce qui avait été signalé dans l'issue #60 , j'ai modifié le fichier stoa0040.stoa008 afin qu'il suive les recommandations des guidelines CapiTains, qui permettent de faciliter la citation du texte, en restructurant celui-ci grâce à des balises prévues à cet effet.

Attention : en raison de la longueur du texte, la structuration du second niveau de `div` n'a pas été réalisée en entier. Toutefois, l' `encodingdesc` a bien été modifié pour que les deux niveaux de structuration soient référencés.
Les ae et les oe ont été remplacés pour des questions de lisibilité, et les hyphénisations ont été collées pour des raisons similaires.
Enfin, le `revisiondesc` a été complété à l'aide d'une balise `change`.

Pour plus d'informations sur les recommandations, je vous invite à consulter les guidelines CapiTains.